### PR TITLE
HDDS-15550 Added an option to bypass bufferpool usage for large writes

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -87,9 +87,9 @@ public class OzoneClientConfig {
   @Config(key = "ozone.client.datastream.sync.size",
       defaultValue = "0B",
       type = ConfigType.SIZE,
-      description = "The minimum size of written data before forcing the datanodes " +
-          "in the pipeline to flush the pending data to underlying storage." +
-          " If set to zero or negative, the client will not force the datanodes to flush.",
+      description = "The minimum size of written data before forcing the datanodes "
+          + "in the pipeline to flush the pending data to underlying storage."
+          + " If set to zero or negative, the client will not force the datanodes to flush.",
       tags = ConfigTag.CLIENT)
   private int dataStreamSyncSize = 0;
 
@@ -172,13 +172,39 @@ public class OzoneClientConfig {
   private String checksumType = ChecksumType.CRC32.name();
 
   @Config(key = "ozone.client.bytes.per.checksum",
-      defaultValue = "16KB",
+      defaultValue = "1MB",
       type = ConfigType.SIZE,
       description = "Checksum will be computed for every bytes per checksum "
           + "number of bytes and stored sequentially. The minimum value for "
-          + "this config is 8KB.",
-      tags = {ConfigTag.CLIENT, ConfigTag.CRYPTO_COMPLIANCE})
-  private int bytesPerChecksum = 16 * 1024;
+          + "this config is 16KB.",
+      tags = { ConfigTag.CLIENT, ConfigTag.CRYPTO_COMPLIANCE })
+  private int bytesPerChecksum = 1024 * 1024;
+
+  @Config(key = "ozone.client.stream.buffer.reference.write",
+      defaultValue = "false",
+      type = ConfigType.BOOLEAN,
+      description = "When true, eligible write(byte[]) calls on "
+          + "BlockOutputStream use a read-only view over the caller array "
+          + "instead of copying into the BufferPool. Each such write sends "
+          + "one chunk, then synchronously flushes with putBlock and waits "
+          + "for Ratis commit before write() returns; the array slice may be "
+          + "reused after that. Not used while the stream has a partially "
+          + "filled pooled buffer. See "
+          + "ozone.client.stream.buffer.reference.write.min.size.",
+      tags = ConfigTag.CLIENT)
+  private boolean streamBufferReferenceWrite = false;
+
+  @Config(key = "ozone.client.stream.buffer.reference.write.min.size",
+      defaultValue = "1MB",
+      type = ConfigType.SIZE,
+      description = "Minimum length of a single write(byte[]) for the "
+          + "read-only fast path when "
+          + "ozone.client.stream.buffer.reference.write is true. The write "
+          + "must be at most ozone.client.stream.buffer.size and must not "
+          + "follow a partially filled stream buffer (no pending pooled "
+          + "chunk data in the stream).",
+      tags = ConfigTag.CLIENT)
+  private int streamBufferReferenceWriteMinSize = 1024 * 1024;
 
   @Config(key = "ozone.client.verify.checksum",
       defaultValue = "true",
@@ -189,11 +215,8 @@ public class OzoneClientConfig {
 
   @Config(key = "ozone.client.max.ec.stripe.write.retries",
       defaultValue = "10",
-      description = "When EC stripe write failed, client will request to allocate new block group "
-          + "and write the failed stripe into new block group. If the same stripe failure "
-          + "continued in newly acquired block group also, then it will retry by requesting "
-          + "to allocate new block group again. This configuration is used to limit these "
-          + "number of retries. By default the number of retries are 10.",
+      description = "Ozone EC client to retry stripe to new block group on" +
+          " failures.",
       tags = ConfigTag.CLIENT)
   private int maxECStripeWriteRetries = 10;
 
@@ -247,12 +270,8 @@ public class OzoneClientConfig {
   @Config(key = "ozone.client.fs.default.bucket.layout",
       defaultValue = "FILE_SYSTEM_OPTIMIZED",
       type = ConfigType.STRING,
-      description =
-          "Default bucket layout value used when buckets are created using OFS. "
-          + "Supported values are LEGACY and FILE_SYSTEM_OPTIMIZED. "
-          + "FILE_SYSTEM_OPTIMIZED: This layout allows the bucket to support atomic rename/delete operations and "
-          + "also allows interoperability between S3 and FS APIs. Keys written via S3 API with a '/' delimiter "
-          + "will create intermediate directories.",
+      description = "The bucket layout used by buckets created using OFS. " +
+          "Valid values include FILE_SYSTEM_OPTIMIZED and LEGACY",
       tags = ConfigTag.CLIENT)
   private String fsDefaultBucketLayout = "FILE_SYSTEM_OPTIMIZED";
 
@@ -335,6 +354,9 @@ public class OzoneClientConfig {
         "expected flush size (%s) to be a multiple of buffer size (%s)",
         streamBufferFlushSize, streamBufferSize);
 
+    Preconditions.checkArgument(streamBufferReferenceWriteMinSize > 0,
+        "ozone.client.stream.buffer.reference.write.min.size must be positive");
+
     if (bytesPerChecksum <
         OzoneConfigKeys.OZONE_CLIENT_BYTES_PER_CHECKSUM_MIN_SIZE) {
       LOG.warn("The checksum size ({}) is not allowed to be less than the " +
@@ -416,6 +438,23 @@ public class OzoneClientConfig {
 
   public void setStreamBufferSize(int streamBufferSize) {
     this.streamBufferSize = streamBufferSize;
+  }
+
+  public boolean getStreamBufferReferenceWrite() {
+    return streamBufferReferenceWrite;
+  }
+
+  public void setStreamBufferReferenceWrite(boolean streamBufferReferenceWrite) {
+    this.streamBufferReferenceWrite = streamBufferReferenceWrite;
+  }
+
+  public int getStreamBufferReferenceWriteMinSize() {
+    return streamBufferReferenceWriteMinSize;
+  }
+
+  public void setStreamBufferReferenceWriteMinSize(
+      int streamBufferReferenceWriteMinSize) {
+    this.streamBufferReferenceWriteMinSize = streamBufferReferenceWriteMinSize;
   }
 
   public boolean isStreamBufferFlushDelay() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -31,7 +31,6 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -381,6 +380,10 @@ public class BlockOutputStream extends OutputStream {
       return;
     }
     synchronized (this) {
+      if (canUseReadOnlyWrite(len)) {
+        writeReadOnlyChunk(b, off, len);
+        return;
+      }
       while (len > 0) {
         allocateNewBufferIfNeeded();
         final int writeLen = Math.min(currentBufferRemaining, len);
@@ -392,6 +395,44 @@ public class BlockOutputStream extends OutputStream {
         len -= writeLen;
         doFlushOrWatchIfNeeded();
       }
+    }
+  }
+
+  /**
+   * @return true when a single {@code write(byte[])} can reference caller
+   *     memory as one chunk without copying into the {@link BufferPool}.
+   */
+  private boolean canUseReadOnlyWrite(int len) {
+    return config.getStreamBufferReferenceWrite()
+        && currentBuffer == null
+        && len >= config.getStreamBufferReferenceWriteMinSize()
+        && len <= streamBufferArgs.getStreamBufferSize();
+  }
+
+  private void writeReadOnlyChunk(byte[] b, int off, int len)
+      throws IOException {
+    final ChunkBuffer chunk = ChunkBuffer.wrapReadOnly(b, off, len);
+    updateWrittenDataLength(len);
+    writeChunk(chunk);
+    updateWriteChunkLength();
+    currentBuffer = null;
+    currentBufferRemaining = 0;
+    flushAndWaitForCommit();
+  }
+
+  /**
+   * Flush pending chunks with putBlock and block until Ratis commits them.
+   * Caller-owned read-only buffers are safe to reuse once this returns.
+   */
+  private void flushAndWaitForCommit() throws IOException {
+    try {
+      updatePutBlockLength();
+      final PutBlockResult putBlockResult = executePutBlock(false, false).get();
+      watchForCommit(putBlockResult.commitIndex).get();
+    } catch (InterruptedException e) {
+      handleInterruptedException(e, false);
+    } catch (ExecutionException e) {
+      handleExecutionException(e);
     }
   }
 
@@ -574,10 +615,10 @@ public class BlockOutputStream extends OutputStream {
     long flushPos = totalWriteChunkLength;
     final List<ChunkBuffer> byteBufferList;
     if (!force) {
-      Objects.requireNonNull(bufferList, "bufferList == null");
+      Preconditions.checkNotNull(bufferList);
       byteBufferList = bufferList;
       bufferList = null;
-      Objects.requireNonNull(byteBufferList, "byteBufferList == null");
+      Preconditions.checkNotNull(byteBufferList);
     } else {
       byteBufferList = null;
     }
@@ -740,7 +781,7 @@ public class BlockOutputStream extends OutputStream {
     long start = Time.monotonicNowNanos();
     CompletableFuture<PutBlockResult> putBlockResultFuture = null;
     // flush the last chunk data residing on the currentBuffer
-    if (totalWriteChunkLength < writtenDataLength) {
+    if (totalWriteChunkLength < writtenDataLength && currentBuffer != null) {
       Preconditions.checkArgument(currentBuffer.position() > 0);
 
       // This can be a partially filled chunk. Since we are flushing the buffer
@@ -946,10 +987,10 @@ public class BlockOutputStream extends OutputStream {
         containerBlockData.addChunks(chunkInfo);
       }
       if (putBlockPiggybacking) {
-        Objects.requireNonNull(bufferList, "bufferList == null");
+        Preconditions.checkNotNull(bufferList);
         byteBufferList = bufferList;
         bufferList = null;
-        Objects.requireNonNull(byteBufferList, "byteBufferList == null");
+        Preconditions.checkNotNull(byteBufferList);
 
         blockData = containerBlockData.build();
         LOG.debug("piggyback chunk list {}", blockData);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
@@ -42,7 +42,9 @@ class CommitWatcher extends AbstractCommitWatcher<ChunkBuffer> {
     long acked = 0;
     for (ChunkBuffer buffer : remove(index)) {
       acked += buffer.position();
-      bufferPool.releaseBuffer(buffer);
+      if (!buffer.isReadOnly()) {
+        bufferPool.releaseBuffer(buffer);
+      }
     }
     // TODO move the flush future map to BOS:
     //  When there are concurrent watchForCommits, there's no guarantee of the order of execution

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BenchmarkMockXceiverClient.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BenchmarkMockXceiverClient.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.storage;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.GetCommittedBlockLengthResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutBlockResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.XceiverClientReply;
+import org.apache.hadoop.hdds.scm.XceiverClientSpi;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.ozone.ClientVersion;
+
+/**
+ * In-memory xceiver client for {@link BlockOutputStreamWriteBenchmark}.
+ */
+final class BenchmarkMockXceiverClient extends XceiverClientSpi {
+
+  private final Pipeline pipeline;
+  private final AtomicLong logIndex = new AtomicLong();
+
+  BenchmarkMockXceiverClient(Pipeline pipeline) {
+    this.pipeline = pipeline;
+  }
+
+  @Override
+  public void connect() {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public Pipeline getPipeline() {
+    return pipeline;
+  }
+
+  @Override
+  public XceiverClientReply sendCommandAsync(ContainerCommandRequestProto request) {
+    if (!request.hasVersion()) {
+      request = ContainerCommandRequestProto.newBuilder(request)
+          .setVersion(ClientVersion.CURRENT.toProtoValue()).build();
+    }
+    final ContainerCommandResponseProto.Builder builder =
+        ContainerCommandResponseProto.newBuilder()
+            .setResult(Result.SUCCESS)
+            .setCmdType(request.getCmdType());
+    if (request.getCmdType() == Type.PutBlock) {
+      builder.setPutBlock(PutBlockResponseProto.newBuilder()
+          .setCommittedBlockLength(
+              GetCommittedBlockLengthResponseProto.newBuilder()
+                  .setBlockID(request.getPutBlock().getBlockData().getBlockID())
+                  .setBlockLength(request.getPutBlock().getBlockData().getSize())
+                  .build())
+          .build());
+    }
+    final XceiverClientReply reply = new XceiverClientReply(
+        CompletableFuture.completedFuture(builder.build()));
+    reply.setLogIndex(logIndex.incrementAndGet());
+    return reply;
+  }
+
+  @Override
+  public ReplicationType getPipelineType() {
+    return pipeline.getType();
+  }
+
+  @Override
+  public CompletableFuture<XceiverClientReply> watchForCommit(long index) {
+    final ContainerCommandResponseProto response =
+        ContainerCommandResponseProto.newBuilder()
+            .setCmdType(Type.WriteChunk)
+            .setResult(Result.SUCCESS)
+            .build();
+    final XceiverClientReply reply =
+        new XceiverClientReply(CompletableFuture.completedFuture(response));
+    reply.setLogIndex(index);
+    return CompletableFuture.completedFuture(reply);
+  }
+
+  @Override
+  public long getReplicatedMinCommitIndex() {
+    return logIndex.get();
+  }
+
+  @Override
+  public Map<DatanodeDetails, ContainerCommandResponseProto> sendCommandOnAllNodes(
+      ContainerCommandRequestProto request) {
+    return null;
+  }
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStreamWriteBenchmark.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStreamWriteBenchmark.java
@@ -1,0 +1,487 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.storage;
+
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
+import org.apache.hadoop.hdds.scm.ContainerClientMetrics;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.StreamBufferArgs;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.ozone.test.GenericTestUtils;
+import org.slf4j.event.Level;
+
+/**
+ * Client-side {@link RatisBlockOutputStream} write benchmark using mocked
+ * container RPCs ({@link BenchmarkMockXceiverClient}).
+ *
+ * <p>On-demand benchmark (not part of {@code mvn test}). Run from the repo root:
+ * <pre>
+ *   mvn -pl hadoop-hdds/client -q test-compile exec:java \
+ *     -Dexec.mainClass=org.apache.hadoop.hdds.scm.storage.BlockOutputStreamWriteBenchmark \
+ *     -Dexec.classpathScope=test
+ * </pre>
+ *
+ * <p>Optional system properties:
+ * <ul>
+ *   <li>{@code benchmark.label} – profile label (default {@code workspace})</li>
+ *   <li>{@code benchmark.writeSize} – single write size in bytes (default: run
+ *       1MB, 2MB and 4MB)</li>
+ *   <li>{@code benchmark.referenceWrite} – {@code true} or {@code false}
+ *       (default: run both)</li>
+ *   <li>{@code benchmark.checksumType} – {@code NONE} or {@code CRC32}
+ *       (default {@code CRC32})</li>
+ *   <li>{@code benchmark.threads} – worker count (default {@code CPUs * 2})</li>
+ *   <li>{@code benchmark.scaling=true} – run multiple thread counts for both reference
+ *       modes and print scaling summary</li>
+ *   <li>{@code benchmark.scaling.threads} – comma-separated thread counts for scaling
+ *       (default {@code 1,2*CPUs,4*CPUs})</li>
+ *   <li>{@code benchmark.scaling.writeSizes} – comma-separated write sizes in bytes
+ *       (overrides default 1/2/4MB list when set)</li>
+ * </ul>
+ *
+ * <p>Or use {@code hadoop-hdds/client/dev-support/run-block-output-stream-write-benchmark.sh}.
+ */
+public final class BlockOutputStreamWriteBenchmark {
+
+  private static final int WARMUP_SECONDS = 10;
+  private static final int BENCHMARK_SECONDS = 20;
+  private static final int STREAM_BUFFER_SIZE = 4 * 1024 * 1024;
+  private static final int SOURCE_BUFFER_SIZE = STREAM_BUFFER_SIZE;
+  private static final int POOL_CAPACITY = 8;
+
+  private static final int[] DEFAULT_WRITE_SIZES = {
+      1024 * 1024,
+      2 * 1024 * 1024,
+      4 * 1024 * 1024
+  };
+
+  private static final DecimalFormat MBPS = new DecimalFormat("#,##0.0");
+  private static final DecimalFormat NS = new DecimalFormat("#,##0");
+  private static final DecimalFormat COUNT = new DecimalFormat("#,##0");
+
+  private BlockOutputStreamWriteBenchmark() {
+  }
+
+  public static void main(String[] args) throws Exception {
+    GenericTestUtils.setLogLevel(BufferPool.class, Level.INFO);
+    GenericTestUtils.setLogLevel(BlockOutputStream.class, Level.INFO);
+
+    final String label = System.getProperty("benchmark.label", "workspace");
+    final ChecksumType checksumType = ChecksumType.valueOf(
+        System.getProperty("benchmark.checksumType", ChecksumType.CRC32.name()));
+    final int cpus = Runtime.getRuntime().availableProcessors();
+
+    System.out.println("BlockOutputStream client write benchmark (mocked container RPCs)");
+    System.out.println("Profile: " + label);
+    System.out.println("Log level: INFO for BufferPool and BlockOutputStream");
+    System.out.println("JVM: " + System.getProperty("java.version")
+        + " on " + System.getProperty("os.arch"));
+    System.out.printf("CPUs=%d sourceBuffer=%dMB streamBuffer=%dMB poolCapacity=%d "
+            + "checksum=%s%n",
+        cpus, SOURCE_BUFFER_SIZE / (1024 * 1024),
+        STREAM_BUFFER_SIZE / (1024 * 1024), POOL_CAPACITY, checksumType);
+    System.out.println();
+
+    final byte[] sourceBuffer = new byte[SOURCE_BUFFER_SIZE];
+    ThreadLocalRandom.current().nextBytes(sourceBuffer);
+
+    if (Boolean.parseBoolean(System.getProperty("benchmark.scaling", "false"))) {
+      runScalingStudy(sourceBuffer, checksumType, cpus);
+    } else {
+      final int threadCount = resolveThreadCount(cpus);
+      System.out.printf("threads=%d%n%n", threadCount);
+      for (int writeSize : resolveWriteSizes()) {
+        for (boolean referenceWrite : resolveReferenceWriteModes()) {
+          runProfile(sourceBuffer, writeSize, referenceWrite, checksumType, threadCount);
+          System.out.println();
+        }
+      }
+    }
+  }
+
+  private static void runScalingStudy(byte[] sourceBuffer, ChecksumType checksumType,
+      int cpus) throws Exception {
+    final int[] threadCounts = resolveScalingThreadCounts(cpus);
+    System.out.printf("scaling thread counts: %s%n%n", formatThreadCounts(threadCounts));
+    final List<ScalingRow> rows = new ArrayList<>();
+
+    for (int writeSize : resolveWriteSizes()) {
+      System.out.printf("===== writeSize=%dKB scaling study =====%n%n", writeSize / 1024);
+      for (int threadCount : threadCounts) {
+        for (boolean referenceWrite : new boolean[] {false, true}) {
+          final Result result = runProfile(sourceBuffer, writeSize, referenceWrite,
+              checksumType, threadCount);
+          rows.add(new ScalingRow(writeSize, threadCount, referenceWrite, result.mbPerSec,
+              result.nsPerWrite));
+          System.out.println();
+        }
+      }
+      printScalingSummary(writeSize, threadCounts, rows);
+      System.out.println();
+    }
+  }
+
+  private static void printScalingSummary(int writeSize, int[] threadCounts,
+      List<ScalingRow> allRows) {
+    final List<ScalingRow> rows = new ArrayList<>();
+    for (ScalingRow row : allRows) {
+      if (row.writeSize == writeSize) {
+        rows.add(row);
+      }
+    }
+
+    final double pooledBaseline = findMbPerSec(rows, 1, false);
+    final double referencedBaseline = findMbPerSec(rows, 1, true);
+
+    System.out.printf("--- scaling summary writeSize=%dKB ---%n", writeSize / 1024);
+    System.out.printf("%8s | %12s | %12s | %10s | %10s | %10s%n",
+        "threads", "pooled MB/s", "ref MB/s", "ref/pooled", "pool eff.",
+        "ref eff.");
+    System.out.println("---------|--------------|--------------|----------|----------|----------");
+
+    for (int threadCount : threadCounts) {
+      final double pooled = findMbPerSec(rows, threadCount, false);
+      final double referenced = findMbPerSec(rows, threadCount, true);
+      final double refVsPooled = pooled == 0 ? 0 : referenced / pooled;
+      final double poolEff = pooledBaseline == 0 ? 0 : pooled / pooledBaseline / threadCount;
+      final double refEff = referencedBaseline == 0 ? 0
+          : referenced / referencedBaseline / threadCount;
+      System.out.printf("%8d | %12s | %12s | %9.2fx | %9.2f | %9.2f%n",
+          threadCount, MBPS.format(pooled), MBPS.format(referenced), refVsPooled,
+          poolEff, refEff);
+    }
+    System.out.println();
+    System.out.println("eff. = throughput vs 1-thread baseline / thread count (1.0 = linear)");
+  }
+
+  private static double findMbPerSec(List<ScalingRow> rows, int threadCount,
+      boolean referenceWrite) {
+    for (ScalingRow row : rows) {
+      if (row.threadCount == threadCount && row.referenceWrite == referenceWrite) {
+        return row.mbPerSec;
+      }
+    }
+    return 0;
+  }
+
+  private static final class ScalingRow {
+    private final int writeSize;
+    private final int threadCount;
+    private final boolean referenceWrite;
+    private final double mbPerSec;
+    private final double nsPerWrite;
+
+    private ScalingRow(int writeSize, int threadCount, boolean referenceWrite,
+        double mbPerSec, double nsPerWrite) {
+      this.writeSize = writeSize;
+      this.threadCount = threadCount;
+      this.referenceWrite = referenceWrite;
+      this.mbPerSec = mbPerSec;
+      this.nsPerWrite = nsPerWrite;
+    }
+  }
+
+  private static int resolveThreadCount(int cpus) {
+    final String property = System.getProperty("benchmark.threads");
+    if (property != null && !property.isEmpty()) {
+      return Integer.parseInt(property);
+    }
+    return cpus * 2;
+  }
+
+  private static int[] resolveScalingThreadCounts(int cpus) {
+    final String property = System.getProperty("benchmark.scaling.threads");
+    if (property == null || property.isEmpty()) {
+      return new int[] {1, cpus * 2, cpus * 4};
+    }
+    final String[] parts = property.split(",");
+    final int[] threadCounts = new int[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      threadCounts[i] = Integer.parseInt(parts[i].trim());
+    }
+    return threadCounts;
+  }
+
+  private static String formatThreadCounts(int[] threadCounts) {
+    final StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < threadCounts.length; i++) {
+      if (i > 0) {
+        builder.append(", ");
+      }
+      builder.append(threadCounts[i]);
+    }
+    return builder.toString();
+  }
+
+  private static Result runProfile(byte[] sourceBuffer, int writeSize,
+      boolean referenceWrite, ChecksumType checksumType, int threadCount)
+      throws Exception {
+    System.out.printf("--- writeSize=%dKB referenceWrite=%s threads=%d "
+            + "writes/stream=%d ---%n",
+        writeSize / 1024, referenceWrite, threadCount, SOURCE_BUFFER_SIZE / writeSize);
+
+    final Result result = runProfileMeasured(sourceBuffer, writeSize, referenceWrite,
+        checksumType, threadCount);
+
+    System.out.printf("elapsed: %.2fs%n", result.elapsedSeconds);
+    System.out.printf("bytes written: %s%n", COUNT.format(result.bytesWritten));
+    System.out.printf("write ops (%dKB): %s%n",
+        writeSize / 1024, COUNT.format(result.writeOps));
+    System.out.printf("blocks written: %s%n", COUNT.format(result.blocksWritten));
+    System.out.printf("aggregate throughput: %s MB/s%n", MBPS.format(result.mbPerSec));
+    System.out.printf("ns/write (aggregate): %s%n", NS.format(result.nsPerWrite));
+    System.out.printf("writeChunks metric: %s%n",
+        COUNT.format(result.writeChunksDuringWrite));
+    System.out.printf("flushes metric: %s%n",
+        COUNT.format(result.flushesDuringWrite));
+    return result;
+  }
+
+  private static Result runProfileMeasured(byte[] sourceBuffer, int writeSize,
+      boolean referenceWrite, ChecksumType checksumType, int threadCount)
+      throws Exception {
+    runTimedWrite(sourceBuffer, writeSize, referenceWrite, checksumType,
+        threadCount, WARMUP_SECONDS, "warmup");
+    return runTimedWrite(sourceBuffer, writeSize, referenceWrite, checksumType,
+        threadCount, BENCHMARK_SECONDS, "benchmark");
+  }
+
+  private static int[] resolveWriteSizes() {
+    final String scalingSizes = System.getProperty("benchmark.scaling.writeSizes");
+    if (scalingSizes != null && !scalingSizes.isEmpty()) {
+      return parseCommaSeparatedInts(scalingSizes);
+    }
+    final String property = System.getProperty("benchmark.writeSize");
+    if (property == null || property.isEmpty()) {
+      return DEFAULT_WRITE_SIZES;
+    }
+    return new int[] {Integer.parseInt(property)};
+  }
+
+  private static int[] parseCommaSeparatedInts(String property) {
+    final String[] parts = property.split(",");
+    final int[] values = new int[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      values[i] = Integer.parseInt(parts[i].trim());
+    }
+    return values;
+  }
+
+  private static boolean[] resolveReferenceWriteModes() {
+    final String property = System.getProperty("benchmark.referenceWrite");
+    if (property == null || property.isEmpty()) {
+      return new boolean[] {false, true};
+    }
+    return new boolean[] {Boolean.parseBoolean(property)};
+  }
+
+  private static Result runTimedWrite(byte[] sourceBuffer, int writeSize,
+      boolean referenceWrite, ChecksumType checksumType, int threadCount,
+      int seconds, String phase) throws Exception {
+    final long writeChunksBefore =
+        ContainerClientMetrics.acquire().getWriteChunksDuringWrite().value();
+    final long flushesBefore =
+        ContainerClientMetrics.acquire().getFlushesDuringWrite().value();
+
+    final long start = System.nanoTime();
+    final long deadline = start + seconds * 1_000_000_000L;
+
+    final ExecutorService workers = Executors.newFixedThreadPool(threadCount);
+    try {
+      final List<Future<WorkerResult>> futures = new ArrayList<>(threadCount);
+      for (int i = 0; i < threadCount; i++) {
+        futures.add(workers.submit(() ->
+            runWorker(sourceBuffer, writeSize, referenceWrite, checksumType, deadline)));
+      }
+
+      long bytesWritten = 0;
+      long writeOps = 0;
+      long blocksWritten = 0;
+      for (Future<WorkerResult> future : futures) {
+        final WorkerResult workerResult = future.get();
+        bytesWritten += workerResult.bytesWritten;
+        writeOps += workerResult.writeOps;
+        blocksWritten += workerResult.blocksWritten;
+      }
+
+      final long elapsedNanos = System.nanoTime() - start;
+      final double elapsedSeconds = elapsedNanos / 1_000_000_000.0;
+      System.out.printf("%s complete (%.2fs)%n", phase, elapsedSeconds);
+
+      return new Result(
+          bytesWritten,
+          writeOps,
+          blocksWritten,
+          elapsedSeconds,
+          bytesWritten / elapsedSeconds / (1024.0 * 1024.0),
+          writeOps == 0 ? 0 : (double) elapsedNanos / writeOps,
+          ContainerClientMetrics.acquire().getWriteChunksDuringWrite().value()
+              - writeChunksBefore,
+          ContainerClientMetrics.acquire().getFlushesDuringWrite().value()
+              - flushesBefore);
+    } finally {
+      workers.shutdownNow();
+    }
+  }
+
+  private static WorkerResult runWorker(byte[] sourceBuffer, int writeSize,
+      boolean referenceWrite, ChecksumType checksumType, long deadline)
+      throws Exception {
+    long bytesWritten = 0;
+    long writeOps = 0;
+    long blocksWritten = 0;
+
+    try (BenchmarkSession session = BenchmarkSession.open(referenceWrite, checksumType)) {
+      while (System.nanoTime() < deadline) {
+        try (BlockOutputStream stream = session.newStream()) {
+          for (int offset = 0; offset + writeSize <= sourceBuffer.length
+              && System.nanoTime() < deadline; offset += writeSize) {
+            stream.write(sourceBuffer, offset, writeSize);
+            bytesWritten += writeSize;
+            writeOps++;
+          }
+        }
+        blocksWritten++;
+      }
+    }
+    return new WorkerResult(bytesWritten, writeOps, blocksWritten);
+  }
+
+  private static final class WorkerResult {
+    private final long bytesWritten;
+    private final long writeOps;
+    private final long blocksWritten;
+
+    private WorkerResult(long bytesWritten, long writeOps, long blocksWritten) {
+      this.bytesWritten = bytesWritten;
+      this.writeOps = writeOps;
+      this.blocksWritten = blocksWritten;
+    }
+  }
+
+  private static final class BenchmarkSession implements AutoCloseable {
+    private final Pipeline pipeline;
+    private final ContainerClientMetrics metrics;
+    private final BufferPool bufferPool;
+    private final OzoneClientConfig config;
+    private final StreamBufferArgs streamBufferArgs;
+    private final XceiverClientManager xceiverClientManager;
+    private final ExecutorService responseExecutor;
+
+    private BenchmarkSession(Pipeline pipeline, ContainerClientMetrics metrics,
+        BufferPool bufferPool, OzoneClientConfig config, StreamBufferArgs streamBufferArgs,
+        XceiverClientManager xceiverClientManager, ExecutorService responseExecutor) {
+      this.pipeline = pipeline;
+      this.metrics = metrics;
+      this.bufferPool = bufferPool;
+      this.config = config;
+      this.streamBufferArgs = streamBufferArgs;
+      this.xceiverClientManager = xceiverClientManager;
+      this.responseExecutor = responseExecutor;
+    }
+
+    static BenchmarkSession open(boolean referenceWrite,
+        ChecksumType checksumType) throws IOException {
+      final Pipeline pipeline = MockPipeline.createRatisPipeline();
+      final XceiverClientManager xcm = mock(XceiverClientManager.class);
+      when(xcm.acquireClient(any())).thenReturn(new BenchmarkMockXceiverClient(pipeline));
+
+      final OzoneClientConfig config = new OzoneClientConfig();
+      config.setStreamBufferSize(STREAM_BUFFER_SIZE);
+      config.setStreamBufferMaxSize(32 * 1024 * 1024);
+      config.setStreamBufferFlushDelay(false);
+      config.setStreamBufferFlushSize(16 * 1024 * 1024);
+      config.setChecksumType(checksumType);
+      config.setBytesPerChecksum(64 * 1024);
+      config.setStreamBufferReferenceWrite(referenceWrite);
+      config.validate();
+
+      final StreamBufferArgs streamBufferArgs =
+          StreamBufferArgs.getDefaultStreamBufferArgs(pipeline.getReplicationConfig(), config);
+
+      return new BenchmarkSession(
+          pipeline,
+          ContainerClientMetrics.acquire(),
+          new BufferPool(STREAM_BUFFER_SIZE, POOL_CAPACITY),
+          config,
+          streamBufferArgs,
+          xcm,
+          newSingleThreadExecutor());
+    }
+
+    BlockOutputStream newStream() throws IOException {
+      return new RatisBlockOutputStream(
+          new BlockID(1L, 1L),
+          -1,
+          xceiverClientManager,
+          pipeline,
+          bufferPool,
+          config,
+          null,
+          metrics,
+          streamBufferArgs,
+          () -> responseExecutor);
+    }
+
+    @Override
+    public void close() {
+      bufferPool.clearBufferPool();
+      responseExecutor.shutdownNow();
+    }
+  }
+
+  private static final class Result {
+    private final long bytesWritten;
+    private final long writeOps;
+    private final long blocksWritten;
+    private final double elapsedSeconds;
+    private final double mbPerSec;
+    private final double nsPerWrite;
+    private final long writeChunksDuringWrite;
+    private final long flushesDuringWrite;
+
+    private Result(long bytesWritten, long writeOps, long blocksWritten, double elapsedSeconds,
+        double mbPerSec, double nsPerWrite, long writeChunksDuringWrite,
+        long flushesDuringWrite) {
+      this.bytesWritten = bytesWritten;
+      this.writeOps = writeOps;
+      this.blocksWritten = blocksWritten;
+      this.elapsedSeconds = elapsedSeconds;
+      this.mbPerSec = mbPerSec;
+      this.nsPerWrite = nsPerWrite;
+      this.writeChunksDuringWrite = writeChunksDuringWrite;
+      this.flushesDuringWrite = flushesDuringWrite;
+    }
+  }
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamReferencedWrite.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamReferencedWrite.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.storage;
+
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static org.apache.hadoop.ozone.OzoneConsts.INCREMENTAL_CHUNK_LIST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.BlockData;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.GetCommittedBlockLengthResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutBlockResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ContainerClientMetrics;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.StreamBufferArgs;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.XceiverClientReply;
+import org.apache.hadoop.hdds.scm.XceiverClientSpi;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link BlockOutputStream} referenced-buffer fast path.
+ */
+class TestBlockOutputStreamReferencedWrite {
+
+  private static final int CHUNK_SIZE = 256 * 1024;
+
+  @Test
+  void referencedChunkSafeWrapMatchesWriteChunkPath() {
+    final byte[] data = RandomUtils.secure().randomBytes(CHUNK_SIZE);
+    final BufferPool bufferPool = new BufferPool(CHUNK_SIZE, 4);
+    final ChunkBuffer original = ChunkBuffer.wrapReadOnly(data, 0, CHUNK_SIZE);
+    final ChunkBuffer chunk = original.duplicate(0, original.position());
+    assertEquals(CHUNK_SIZE, chunk.remaining());
+    assertEquals(CHUNK_SIZE,
+        chunk.toByteString(bufferPool.byteStringConversion()).size());
+  }
+
+  @Test
+  void fullChunkWriteUsesReferencedBuffer() throws IOException {
+    final byte[] data = RandomUtils.secure().randomBytes(CHUNK_SIZE * 4);
+    final BufferPool bufferPool = new BufferPool(CHUNK_SIZE, 4);
+    final CapturingXceiverClient client = new CapturingXceiverClient(
+        MockPipeline.createRatisPipeline());
+
+    try (BlockOutputStream stream = createStream(bufferPool, client, true,
+        CHUNK_SIZE, CHUNK_SIZE)) {
+      for (int i = 0; i < 4; i++) {
+        stream.write(data, i * CHUNK_SIZE, CHUNK_SIZE);
+      }
+    }
+
+    assertEquals(4, client.writeChunkPayloads.size());
+    for (int i = 0; i < 4; i++) {
+      final byte[] expected = new byte[CHUNK_SIZE];
+      System.arraycopy(data, i * CHUNK_SIZE, expected, 0, CHUNK_SIZE);
+      assertArrayPrefix(expected, client.writeChunkPayloads.get(i));
+    }
+    assertEquals(0, bufferPool.getNumberOfUsedBuffers());
+  }
+
+  @Test
+  void subStreamBufferWriteUsesReferencedBufferWithDefaultMinSize()
+      throws IOException {
+    final int writeSize = 1024 * 1024;
+    final int streamBufferSize = 4 * 1024 * 1024;
+    final byte[] data = RandomUtils.secure().randomBytes(writeSize * 4);
+    final BufferPool bufferPool = new BufferPool(streamBufferSize, 8);
+    final CapturingXceiverClient client = new CapturingXceiverClient(
+        MockPipeline.createRatisPipeline());
+
+    try (BlockOutputStream stream = createStream(bufferPool, client, true,
+        streamBufferSize, writeSize)) {
+      for (int i = 0; i < 4; i++) {
+        stream.write(data, i * writeSize, writeSize);
+      }
+    }
+
+    assertEquals(4, client.writeChunkPayloads.size());
+    for (int i = 0; i < 4; i++) {
+      final byte[] expected = new byte[writeSize];
+      System.arraycopy(data, i * writeSize, expected, 0, writeSize);
+      assertArrayPrefix(expected, client.writeChunkPayloads.get(i));
+    }
+    assertEquals(0, bufferPool.getNumberOfUsedBuffers());
+  }
+
+  @Test
+  void readOnlyWriteReturnsAfterCommit() throws IOException {
+    final byte[] data = RandomUtils.secure().randomBytes(CHUNK_SIZE);
+    final BufferPool bufferPool = new BufferPool(CHUNK_SIZE, 4);
+    final CapturingXceiverClient client = new CapturingXceiverClient(
+        MockPipeline.createRatisPipeline());
+
+    try (BlockOutputStream stream = createStream(bufferPool, client, true,
+        CHUNK_SIZE, CHUNK_SIZE)) {
+      stream.write(data, 0, CHUNK_SIZE);
+      data[0] = (byte) 0x7A;
+      stream.write(data, 0, CHUNK_SIZE);
+    }
+
+    assertEquals(2, client.writeChunkPayloads.size());
+    assertEquals((byte) 0x7A, client.writeChunkPayloads.get(1).byteAt(0));
+    assertEquals(0, bufferPool.getNumberOfUsedBuffers());
+  }
+
+  @Test
+  void readOnlyWriteWithNonZeroBufferIncrement() throws IOException {
+    final byte[] data = RandomUtils.secure().randomBytes(CHUNK_SIZE);
+    final BufferPool bufferPool = new BufferPool(CHUNK_SIZE, 4);
+    final CapturingXceiverClient client = new CapturingXceiverClient(
+        MockPipeline.createRatisPipeline());
+
+    try (BlockOutputStream stream = createStream(bufferPool, client, true,
+        CHUNK_SIZE, CHUNK_SIZE, 64 * 1024)) {
+      stream.write(data, 0, CHUNK_SIZE);
+    }
+
+    assertEquals(1, client.writeChunkPayloads.size());
+    assertArrayPrefix(data, client.writeChunkPayloads.get(0));
+    assertEquals(0, bufferPool.getNumberOfUsedBuffers());
+  }
+
+  @Test
+  void readOnlyWriteWithIncrementalChunkList() throws IOException {
+    final byte[] data = RandomUtils.secure().randomBytes(CHUNK_SIZE * 2);
+    final BufferPool bufferPool = new BufferPool(CHUNK_SIZE, 4);
+    final CapturingXceiverClient client = new CapturingXceiverClient(
+        MockPipeline.createRatisPipeline());
+
+    try (BlockOutputStream stream = createStream(bufferPool, client, true,
+        CHUNK_SIZE, CHUNK_SIZE, 0, true)) {
+      stream.write(data, 0, CHUNK_SIZE);
+      stream.write(data, CHUNK_SIZE, CHUNK_SIZE);
+    }
+
+    assertEquals(2, client.writeChunkPayloads.size());
+    assertArrayPrefix(data, 0, CHUNK_SIZE, client.writeChunkPayloads.get(0));
+    assertArrayPrefix(data, CHUNK_SIZE, CHUNK_SIZE, client.writeChunkPayloads.get(1));
+    assertTrue(client.putBlockDataList.size() >= 2);
+    for (BlockData blockData : client.putBlockDataList) {
+      assertIncrementalChunkListMetadata(blockData);
+    }
+    assertEquals(0, bufferPool.getNumberOfUsedBuffers());
+  }
+
+  @Test
+  void readOnlyWriteReturnsAfterCommitWithIncrementalChunkList() throws IOException {
+    final byte[] data = RandomUtils.secure().randomBytes(CHUNK_SIZE);
+    final BufferPool bufferPool = new BufferPool(CHUNK_SIZE, 4);
+    final CapturingXceiverClient client = new CapturingXceiverClient(
+        MockPipeline.createRatisPipeline());
+
+    try (BlockOutputStream stream = createStream(bufferPool, client, true,
+        CHUNK_SIZE, CHUNK_SIZE, 0, true)) {
+      stream.write(data, 0, CHUNK_SIZE);
+      data[0] = (byte) 0x7A;
+      stream.write(data, 0, CHUNK_SIZE);
+    }
+
+    assertEquals(2, client.writeChunkPayloads.size());
+    assertEquals((byte) 0x7A, client.writeChunkPayloads.get(1).byteAt(0));
+    assertEquals(0, bufferPool.getNumberOfUsedBuffers());
+  }
+
+  @Test
+  void fullPooledChunkPrecedesReferencedWrite() throws IOException {
+    final byte[] data = RandomUtils.secure().randomBytes(CHUNK_SIZE * 2);
+    final BufferPool bufferPool = new BufferPool(CHUNK_SIZE, 4);
+    final CapturingXceiverClient client = new CapturingXceiverClient(
+        MockPipeline.createRatisPipeline());
+
+    try (BlockOutputStream stream = createStream(bufferPool, client, true,
+        CHUNK_SIZE, CHUNK_SIZE)) {
+      for (int i = 0; i < CHUNK_SIZE; i++) {
+        stream.write((byte) data[i]);
+      }
+      stream.write(data, CHUNK_SIZE, CHUNK_SIZE);
+    }
+
+    assertEquals(2, client.writeChunkPayloads.size());
+    assertArrayPrefix(data, 0, CHUNK_SIZE, client.writeChunkPayloads.get(0));
+    assertArrayPrefix(data, CHUNK_SIZE, CHUNK_SIZE, client.writeChunkPayloads.get(1));
+    assertEquals(0, bufferPool.getNumberOfUsedBuffers());
+  }
+
+  @Test
+  void partialChunkWriteUsesPooledBuffer() throws IOException {
+    final byte[] data = RandomUtils.secure().randomBytes(CHUNK_SIZE / 2);
+    final BufferPool bufferPool = new BufferPool(CHUNK_SIZE, 4);
+    final CapturingXceiverClient client = new CapturingXceiverClient(
+        MockPipeline.createRatisPipeline());
+
+    try (BlockOutputStream stream = createStream(bufferPool, client, true,
+        CHUNK_SIZE, CHUNK_SIZE)) {
+      stream.write(data);
+      stream.close();
+    }
+
+    assertEquals(1, client.writeChunkPayloads.size());
+    assertArrayPrefix(data, client.writeChunkPayloads.get(0));
+    assertEquals(1, bufferPool.getSize());
+  }
+
+  private static BlockOutputStream createStream(BufferPool bufferPool,
+      CapturingXceiverClient client, boolean referenceWrite) throws IOException {
+    return createStream(bufferPool, client, referenceWrite, CHUNK_SIZE,
+        CHUNK_SIZE);
+  }
+
+  private static BlockOutputStream createStream(BufferPool bufferPool,
+      CapturingXceiverClient client, boolean referenceWrite, int streamBufferSize,
+      int referenceWriteMinSize) throws IOException {
+    return createStream(bufferPool, client, referenceWrite, streamBufferSize,
+        referenceWriteMinSize, 0);
+  }
+
+  private static BlockOutputStream createStream(BufferPool bufferPool,
+      CapturingXceiverClient client, boolean referenceWrite, int streamBufferSize,
+      int referenceWriteMinSize, int bufferIncrement) throws IOException {
+    return createStream(bufferPool, client, referenceWrite, streamBufferSize,
+        referenceWriteMinSize, bufferIncrement, false);
+  }
+
+  private static BlockOutputStream createStream(BufferPool bufferPool,
+      CapturingXceiverClient client, boolean referenceWrite, int streamBufferSize,
+      int referenceWriteMinSize, int bufferIncrement,
+      boolean incrementalChunkList) throws IOException {
+    final Pipeline pipeline = client.getPipeline();
+    final XceiverClientManager xcm = mock(XceiverClientManager.class);
+    when(xcm.acquireClient(any())).thenReturn(client);
+
+    OzoneClientConfig config = new OzoneClientConfig();
+    config.setStreamBufferSize(streamBufferSize);
+    config.setStreamBufferMaxSize(streamBufferSize * 4);
+    config.setStreamBufferFlushSize(streamBufferSize * 4);
+    config.setStreamBufferFlushDelay(false);
+    config.setChecksumType(ChecksumType.CRC32);
+    config.setBytesPerChecksum(64 * 1024);
+    config.setStreamBufferReferenceWrite(referenceWrite);
+    config.setStreamBufferReferenceWriteMinSize(referenceWriteMinSize);
+    if (bufferIncrement > 0) {
+      config = configWithBufferIncrement(config, bufferIncrement);
+    }
+    if (incrementalChunkList) {
+      config = configWithIncrementalChunkList(config);
+    }
+
+    final StreamBufferArgs streamBufferArgs =
+        StreamBufferArgs.getDefaultStreamBufferArgs(pipeline.getReplicationConfig(),
+            config);
+
+    return new RatisBlockOutputStream(
+        new BlockID(1L, 1L),
+        -1,
+        xcm,
+        pipeline,
+        bufferPool,
+        config,
+        null,
+        ContainerClientMetrics.acquire(),
+        streamBufferArgs,
+        () -> newSingleThreadExecutor());
+  }
+
+  private static OzoneClientConfig configWithBufferIncrement(OzoneClientConfig base,
+      int bufferIncrement) {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setFromObject(base);
+    conf.setInt("ozone.client.stream.buffer.increment", bufferIncrement);
+    return conf.getObject(OzoneClientConfig.class);
+  }
+
+  private static OzoneClientConfig configWithIncrementalChunkList(OzoneClientConfig base) {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setFromObject(base);
+    conf.setBoolean("ozone.client.hbase.enhancements.allowed", true);
+    conf.setBoolean("ozone.client.incremental.chunk.list", true);
+    return conf.getObject(OzoneClientConfig.class);
+  }
+
+  private static void assertArrayPrefix(byte[] expected, ByteString actual) {
+    assertArrayPrefix(expected, 0, expected.length, actual);
+  }
+
+  private static void assertArrayPrefix(byte[] expected, int offset, int length,
+      ByteString actual) {
+    assertEquals(length, actual.size());
+    final byte[] received = actual.toByteArray();
+    for (int i = 0; i < length; i++) {
+      assertEquals(expected[offset + i], received[i], "byte mismatch at index " + i);
+    }
+  }
+
+  private static void assertIncrementalChunkListMetadata(BlockData blockData) {
+    assertTrue(blockData.getMetadataList().stream()
+        .anyMatch(kv -> INCREMENTAL_CHUNK_LIST.equals(kv.getKey())));
+  }
+
+  private static final class CapturingXceiverClient extends XceiverClientSpi {
+    private final Pipeline pipeline;
+    private final AtomicInteger logIndex = new AtomicInteger();
+    private final List<ByteString> writeChunkPayloads = new ArrayList<>();
+    private final List<BlockData> putBlockDataList = new ArrayList<>();
+    private CapturingXceiverClient(Pipeline pipeline) {
+      this.pipeline = pipeline;
+    }
+
+    @Override
+    public void connect() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public Pipeline getPipeline() {
+      return pipeline;
+    }
+
+    @Override
+    public XceiverClientReply sendCommandAsync(
+        ContainerCommandRequestProto request) {
+      if (!request.hasVersion()) {
+        request = ContainerCommandRequestProto.newBuilder(request)
+            .setVersion(ClientVersion.CURRENT.toProtoValue()).build();
+      }
+      if (request.getCmdType() == Type.WriteChunk) {
+        writeChunkPayloads.add(request.getWriteChunk().getData());
+      } else if (request.getCmdType() == Type.PutBlock) {
+        putBlockDataList.add(request.getPutBlock().getBlockData());
+      }
+      final ContainerCommandResponseProto.Builder builder =
+          ContainerCommandResponseProto.newBuilder()
+              .setResult(Result.SUCCESS)
+              .setCmdType(request.getCmdType());
+      if (request.getCmdType() == Type.PutBlock) {
+        builder.setPutBlock(PutBlockResponseProto.newBuilder()
+            .setCommittedBlockLength(
+                GetCommittedBlockLengthResponseProto.newBuilder()
+                    .setBlockID(request.getPutBlock().getBlockData().getBlockID())
+                    .setBlockLength(request.getPutBlock().getBlockData().getSize())
+                    .build())
+            .build());
+      }
+      final XceiverClientReply reply = new XceiverClientReply(
+          CompletableFuture.completedFuture(builder.build()));
+      reply.setLogIndex(logIndex.incrementAndGet());
+      return reply;
+    }
+
+    @Override
+    public ReplicationType getPipelineType() {
+      return pipeline.getType();
+    }
+
+    @Override
+    public CompletableFuture<XceiverClientReply> watchForCommit(long index) {
+      final ContainerCommandResponseProto response =
+          ContainerCommandResponseProto.newBuilder()
+              .setCmdType(Type.WriteChunk)
+              .setResult(Result.SUCCESS)
+              .build();
+      final XceiverClientReply reply =
+          new XceiverClientReply(CompletableFuture.completedFuture(response));
+      reply.setLogIndex(index);
+      return CompletableFuture.completedFuture(reply);
+    }
+
+    @Override
+    public long getReplicatedMinCommitIndex() {
+      return logIndex.get();
+    }
+
+    @Override
+    public Map<DatanodeDetails, ContainerCommandResponseProto> sendCommandOnAllNodes(
+        ContainerCommandRequestProto request) {
+      return null;
+    }
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
@@ -64,6 +64,24 @@ public interface ChunkBuffer extends ChunkBufferToByteString, UncheckedAutoClose
     return new ChunkBufferImplWithByteBufferList(buffers);
   }
 
+  /**
+   * Wrap a caller-owned {@code byte[]} slice without copying.
+   *
+   * <p>The returned buffer is read-only. The caller must not modify the array
+   * until the buffer is released from the write pipeline.
+   */
+  static ChunkBuffer wrapReadOnly(byte[] array, int offset, int length) {
+    return new ReadOnlyChunkBuffer(array, offset, length);
+  }
+
+  /**
+   * @return true if this buffer is a read-only view over caller-owned memory
+   *     rather than a pooled copy.
+   */
+  default boolean isReadOnly() {
+    return false;
+  }
+
   /** Similar to {@link ByteBuffer#position()}. */
   int position();
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ReadOnlyChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ReadOnlyChunkBuffer.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.common;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.ReadOnlyBufferException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import org.apache.hadoop.ozone.common.utils.BufferUtils;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+
+/**
+ * A read-only {@link ChunkBuffer} view over caller-owned {@code byte[]} memory.
+ *
+ * <p>Used by {@link BlockOutputStream} to skip copying a full stream-buffer
+ * write into the {@link org.apache.hadoop.hdds.scm.storage.BufferPool}.
+ * The backing array must remain unchanged until the buffer is released after
+ * Ratis commit (or RPC completion on standalone clients).
+ */
+final class ReadOnlyChunkBuffer implements ChunkBuffer {
+
+  private final byte[] array;
+  private final ByteBuffer buffer;
+
+  ReadOnlyChunkBuffer(byte[] array, int offset, int length) {
+    validateBounds(array, offset, length);
+    this.array = array;
+    this.buffer = ByteBuffer.wrap(array, offset, length).slice();
+    this.buffer.position(length);
+  }
+
+  private ReadOnlyChunkBuffer(byte[] array, ByteBuffer buffer) {
+    this.array = array;
+    this.buffer = buffer;
+  }
+
+  @Override
+  public boolean isReadOnly() {
+    return true;
+  }
+
+  @Override
+  public int position() {
+    return buffer.position();
+  }
+
+  @Override
+  public int remaining() {
+    return buffer.remaining();
+  }
+
+  @Override
+  public int limit() {
+    return buffer.limit();
+  }
+
+  @Override
+  public ChunkBuffer rewind() {
+    buffer.rewind();
+    return this;
+  }
+
+  @Override
+  public ChunkBuffer clear() {
+    buffer.clear();
+    return this;
+  }
+
+  @Override
+  public ChunkBuffer put(ByteBuffer b) {
+    throw new ReadOnlyBufferException();
+  }
+
+  @Override
+  public ChunkBuffer put(byte b) {
+    throw new ReadOnlyBufferException();
+  }
+
+  @Override
+  public ChunkBuffer put(byte[] b, int srcOffset, int srcLength) {
+    throw new ReadOnlyBufferException();
+  }
+
+  @Override
+  public ChunkBuffer duplicate(int newPosition, int newLimit) {
+    if (newPosition < 0 || newLimit < newPosition || newLimit > buffer.limit()) {
+      throw new IndexOutOfBoundsException("newPosition=" + newPosition
+          + ", newLimit=" + newLimit + ", limit=" + buffer.limit());
+    }
+    final ByteBuffer duplicated = buffer.duplicate();
+    duplicated.position(newPosition).limit(newLimit);
+    return new ReadOnlyChunkBuffer(array, duplicated);
+  }
+
+  @Override
+  public Iterable<ByteBuffer> iterate(int bufferSize) {
+    return () -> new Iterator<ByteBuffer>() {
+      @Override
+      public boolean hasNext() {
+        return buffer.hasRemaining();
+      }
+
+      @Override
+      public ByteBuffer next() {
+        if (!buffer.hasRemaining()) {
+          throw new NoSuchElementException();
+        }
+        final ByteBuffer duplicated = buffer.duplicate();
+        final int min = Math.min(buffer.position() + bufferSize, buffer.limit());
+        duplicated.limit(min);
+        buffer.position(min);
+        return duplicated.asReadOnlyBuffer();
+      }
+    };
+  }
+
+  @Override
+  public List<ByteBuffer> asByteBufferList() {
+    return Collections.singletonList(buffer.duplicate().asReadOnlyBuffer());
+  }
+
+  @Override
+  public long writeTo(GatheringByteChannel channel) throws IOException {
+    return BufferUtils.writeFully(channel, buffer.duplicate().asReadOnlyBuffer());
+  }
+
+  @Override
+  public ByteString toByteStringImpl(Function<ByteBuffer, ByteString> f) {
+    return f.apply(buffer.duplicate());
+  }
+
+  @Override
+  public List<ByteString> toByteStringListImpl(
+      Function<ByteBuffer, ByteString> f) {
+    return Collections.singletonList(toByteStringImpl(f));
+  }
+
+  private static void validateBounds(byte[] array, int offset, int length) {
+    if (array == null) {
+      throw new NullPointerException("array is null");
+    }
+    if (offset < 0 || length < 0 || offset > array.length - length) {
+      throw new IndexOutOfBoundsException("offset=" + offset + ", length="
+          + length + ", array.length=" + array.length);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + ":length=" + buffer.limit()
+        + "@" + Integer.toHexString(System.identityHashCode(this));
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestReadOnlyChunkBuffer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestReadOnlyChunkBuffer.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.common;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
+import org.apache.hadoop.hdds.scm.ByteStringConversion;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ReadOnlyChunkBuffer}.
+ */
+class TestReadOnlyChunkBuffer {
+
+  @Test
+  void readOnlyBufferMatchesSourceAndRejectsWrites() throws Exception {
+    final byte[] source = {1, 2, 3, 4, 5, 6};
+    final ChunkBuffer buffer = ChunkBuffer.wrapReadOnly(source, 1, 4);
+    assertTrue(buffer.isReadOnly());
+    assertEquals(4, buffer.position());
+    assertEquals(0, buffer.remaining());
+
+    buffer.rewind();
+    final List<byte[]> iterated = new ArrayList<>();
+    for (ByteBuffer slice : buffer.iterate(2)) {
+      final byte[] copy = new byte[slice.remaining()];
+      slice.get(copy);
+      iterated.add(copy);
+    }
+    assertEquals(2, iterated.size());
+    assertArrayEquals(new byte[] {2, 3}, iterated.get(0));
+    assertArrayEquals(new byte[] {4, 5}, iterated.get(1));
+
+    final Checksum checksum = new Checksum(ChecksumType.CRC32, 2, false);
+    final ChecksumData checksumData =
+        checksum.computeChecksum(buffer.duplicate(0, buffer.position()), false);
+    assertEquals(2, checksumData.getChecksums().size());
+
+    buffer.rewind();
+    assertArrayEquals(new byte[] {2, 3, 4, 5},
+        buffer.toByteString(
+            ByteStringConversion.createByteBufferConversion(true)).toByteArray());
+
+    assertThrows(ReadOnlyBufferException.class, () -> buffer.put((byte) 1));
+    assertThrows(ReadOnlyBufferException.class,
+        () -> buffer.put(new byte[] {9}, 0, 1));
+    assertThrows(ReadOnlyBufferException.class,
+        () -> buffer.put(ByteBuffer.wrap(new byte[] {9})));
+  }
+
+  @Test
+  void duplicateMatchesWriteChunkPathWithSafeWrap() {
+    final byte[] data = new byte[262144];
+    final ChunkBuffer original = ChunkBuffer.wrapReadOnly(data, 0, data.length);
+    final ChunkBuffer chunk = original.duplicate(0, original.position());
+    assertEquals(data.length, chunk.remaining());
+    assertEquals(data.length,
+        chunk.toByteString(
+            ByteStringConversion.createByteBufferConversion(false)).size());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added an option to bypass bufferpool usage for large writes: if write is 1+MB in size the buffer pool usage might overweight the benefit of larger writes, instead the client can send the client's buffer to netty directly and wait for async send completion. With a constant cost of the send/processing writes on the backend, the approach without pool shows better throughput and better scaling with increasing number of threads.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15550

## How was this patch tested?

Run synthetic benchmark that trying to mimic 'ozone dreon dfsg' workflow. 

Results for running on ARM based mac with 14 CPUs:

--- scaling summary writeSize=4096KB ---
 threads |  pooled MB/s |     ref MB/s | ref/pooled |  pool eff. |   ref eff.
---------|--------------|--------------|----------|----------|----------
       1 |      7,005.2 |      7,075.5 |      1.01x |      1.00 |      1.00
       2 |     13,754.9 |     14,253.6 |      1.04x |      0.98 |      1.01
       7 |     37,531.7 |     43,381.8 |      1.16x |      0.77 |      0.88
      14 |     32,056.2 |     36,420.4 |      1.14x |      0.33 |      0.37
      28 |     27,205.8 |     47,208.2 |      1.74x |      0.14 |      0.24

--- scaling summary writeSize=3072KB ---
 threads |  pooled MB/s |     ref MB/s | ref/pooled |  pool eff. |   ref eff.
---------|--------------|--------------|----------|----------|----------
       1 |      7,158.3 |      7,434.5 |      1.04x |      1.00 |      1.00
       2 |     13,550.2 |     10,898.3 |      0.80x |      0.95 |      0.73
       7 |     44,841.0 |     47,059.0 |      1.05x |      0.89 |      0.90
      14 |     45,307.1 |     63,610.4 |      1.40x |      0.45 |      0.61
      28 |     43,916.4 |     50,250.6 |      1.14x |      0.22 |      0.24

--- scaling summary writeSize=2048KB ---
 threads |  pooled MB/s |     ref MB/s | ref/pooled |  pool eff. |   ref eff.
---------|--------------|--------------|----------|----------|----------
       1 |      7,174.5 |      7,374.9 |      1.03x |      1.00 |      1.00
       2 |     13,896.8 |     14,049.3 |      1.01x |      0.97 |      0.95
       7 |     40,723.9 |     46,376.9 |      1.14x |      0.81 |      0.90
      14 |     39,079.7 |     66,200.4 |      1.69x |      0.39 |      0.64
      28 |     35,713.0 |     66,226.4 |      1.85x |      0.18 |      0.32

--- scaling summary writeSize=1024KB ---
 threads |  pooled MB/s |     ref MB/s | ref/pooled |  pool eff. |   ref eff.
---------|--------------|--------------|----------|----------|----------
       1 |      7,081.8 |      7,038.9 |      0.99x |      1.00 |      1.00
       2 |     13,808.5 |     13,238.7 |      0.96x |      0.97 |      0.94
       7 |     42,239.6 |     43,045.3 |      1.02x |      0.85 |      0.87
      14 |     41,534.1 |     64,251.4 |      1.55x |      0.42 |      0.65
      28 |     41,600.6 |     60,394.1 |      1.45x |      0.21 |      0.31