### PR TITLE
HDDS-15559. Add libhadoop to DYLD_LIBRARY_PATH or LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
       pre-script: sudo hostname localhost
       ratis-args: ${{ inputs.ratis_args }}
       script: integration
-      script-args: -Ptest-${{ matrix.profile }} -Drocks_tools_native
+      script-args: -Ptest-${{ matrix.profile }} -Phadoop-native-lib -Drocks_tools_native
       sha: ${{ needs.build-info.outputs.sha }}
       split: ${{ matrix.profile }}
       timeout-minutes: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
       pre-script: sudo hostname localhost
       ratis-args: ${{ inputs.ratis_args }}
       script: integration
-      script-args: -Ptest-${{ matrix.profile }} -Phadoop-native-lib -Drocks_tools_native
+      script-args: -Ptest-${{ matrix.profile }} -Drocks_tools_native
       sha: ${{ needs.build-info.outputs.sha }}
       split: ${{ matrix.profile }}
       timeout-minutes: 90

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -214,7 +214,7 @@
                 <goals>
                   <goal>wget</goal>
                 </goals>
-                <phase>generate-sources</phase>
+                <phase>initialize</phase>
                 <configuration>
                   <url>https://github.com/facebook/rocksdb/archive/refs/tags/v${rocksdb.source.version}.tar.gz</url>
                   <outputFileName>rocksdb-v${rocksdb.source.version}.tar.gz</outputFileName>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -250,7 +250,7 @@
                 <goals>
                   <goal>run</goal>
                 </goals>
-                <phase>generate-sources</phase>
+                <phase>initialize</phase>
                 <configuration>
                   <target>
                     <untar compression="gzip" dest="${project.build.directory}/rocksdb/" src="${project.build.directory}/rocksdb/rocksdb-v${rocksdb.source.version}.tar.gz" />

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -152,7 +152,7 @@
                 <goals>
                   <goal>java</goal>
                 </goals>
-                <phase>initialize</phase>
+                <phase>generate-resources</phase>
                 <configuration>
                   <mainClass>org.apache.hadoop.hdds.utils.db.managed.JniLibNamePropertyWriter</mainClass>
                   <arguments>
@@ -171,7 +171,7 @@
                 <goals>
                   <goal>read-project-properties</goal>
                 </goals>
-                <phase>initialize</phase>
+                <phase>generate-resources</phase>
                 <configuration>
                   <files>
                     <file>${project.build.directory}/propertyFile.txt</file>
@@ -250,7 +250,7 @@
                 <goals>
                   <goal>run</goal>
                 </goals>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <configuration>
                   <target>
                     <untar compression="gzip" dest="${project.build.directory}/rocksdb/" src="${project.build.directory}/rocksdb/rocksdb-v${rocksdb.source.version}.tar.gz" />

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1360,8 +1360,8 @@ function ozone_os_tricks
         echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2
       else
         LINK_FILE="libhadoop.dylib"
-        if [ ! -f "$LINK_FILE" ]; then
-          ln -s "$TARGET_FILE" "$LINK_FILE"
+        if [ ! -L "$LINK_FILE" ] && [ ! -f "$LINK_FILE" ]; then
+          ln -s "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
         fi
         export DYLD_LIBRARY_PATH=$OZONE_HOME/lib/native:$DYLD_LIBRARY_PATH
       fi
@@ -1407,8 +1407,8 @@ function ozone_os_tricks
       else
         LINK_FILE="libhadoop.so"
         # If the symbolic file is already exist, skip create it again
-        if [ ! -f "$LINK_FILE" ]; then
-          ln -s "$TARGET_FILE" "$LINK_FILE"
+        if [ ! -L "$LINK_FILE" ] && [ ! -f "$LINK_FILE" ]; then
+          ln -s "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
         fi
         export LD_LIBRARY_PATH=$OZONE_HOME/lib/native:$LD_LIBRARY_PATH
       fi

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1337,6 +1337,7 @@ function ozone_os_tricks
   local bindv6only
 
   OZONE_IS_CYGWIN=false
+  ARCH_TYPE=$(uname -m)
   case ${OZONE_OS_TYPE} in
     Darwin)
       if [[ -z "${JAVA_HOME}" ]]; then
@@ -1348,6 +1349,23 @@ function ozone_os_tricks
           export JAVA_HOME
         fi
       fi
+
+      if [ "$ARCH_TYPE" = "arm64" ]; then
+        TARGET_FILE="libhadoop_osx_aarch_64.dylib"
+      fi
+
+     pushd . > /dev/null && cd lib/native
+      # If no matching file variant was found for the current environment
+      if [ -z "$TARGET_FILE" ]; then
+        echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2
+      else
+        LINK_FILE="libhadoop.dylib"
+        if [ ! -f "$LINK_FILE" ]; then
+          ln -s "$TARGET_FILE" "$LINK_FILE"
+        fi
+        export DYLD_LIBRARY_PATH=$OZONE_HOME/lib/native:$DYLD_LIBRARY_PATH
+      fi
+      popd > /dev/null
     ;;
     Linux)
 
@@ -1375,6 +1393,26 @@ function ozone_os_tricks
         ozone_error "ERROR: For more info: http://wiki.apache.org/hadoop/HadoopIPv6"
         exit 1
       fi
+
+      if [ "$ARCH_TYPE" = "aarch64" ]; then
+        TARGET_FILE="libhadoop_linux_aarch_64.so"
+      elif [ "$ARCH_TYPE" = "x86_64" ]; then
+        TARGET_FILE="libhadoop_linux_x86_64.so"
+      fi
+
+      pushd . > /dev/null && cd lib/native
+      # If no matching file variant was found for the current environment
+      if [ -z "$TARGET_FILE" ]; then
+        echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2
+      else
+        LINK_FILE="libhadoop.so"
+        # If the symbolic file is already exist, skip create it again
+        if [ ! -f "$LINK_FILE" ]; then
+          ln -s "$TARGET_FILE" "$LINK_FILE"
+        fi
+        export LD_LIBRARY_PATH=$OZONE_HOME/lib/native:$LD_LIBRARY_PATH
+      fi
+      popd > /dev/null
     ;;
     CYGWIN*)
       # Flag that we're running on Cygwin to trigger path translation later.

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1360,7 +1360,9 @@ function ozone_os_tricks
         echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2
       else
         LINK_FILE="libhadoop.dylib"
-        if [ ! -L "$LINK_FILE" ] && [ ! -f "$LINK_FILE" ]; then
+        # Check if it already exists but points to the wrong target
+        if [ -L "$LINK_FILE" ] && [ "$(readlink "$LINK_FILE")" != "$TARGET_FILE" ]; then
+          # Forcefully recreate it so it points to the correct target file
           ln -sf "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
         fi
         export DYLD_LIBRARY_PATH=$OZONE_HOME/lib/native:$DYLD_LIBRARY_PATH
@@ -1406,8 +1408,10 @@ function ozone_os_tricks
         echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2
       else
         LINK_FILE="libhadoop.so"
-        # If the symbolic file is already exist, skip create it again
-        if [ ! -L "$LINK_FILE" ] && [ ! -f "$LINK_FILE" ]; then
+
+        # Check if it already exists but points to the wrong target
+        if [ -L "$LINK_FILE" ] && [ "$(readlink "$LINK_FILE")" != "$TARGET_FILE" ]; then
+          # Forcefully recreate it so it points to the correct target file
           ln -sf "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
         fi
         export LD_LIBRARY_PATH=$OZONE_HOME/lib/native:$LD_LIBRARY_PATH

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1361,7 +1361,7 @@ function ozone_os_tricks
       else
         LINK_FILE="libhadoop.dylib"
         if [ ! -L "$LINK_FILE" ] && [ ! -f "$LINK_FILE" ]; then
-          ln -s "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
+          ln -sf "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
         fi
         export DYLD_LIBRARY_PATH=$OZONE_HOME/lib/native:$DYLD_LIBRARY_PATH
       fi
@@ -1408,7 +1408,7 @@ function ozone_os_tricks
         LINK_FILE="libhadoop.so"
         # If the symbolic file is already exist, skip create it again
         if [ ! -L "$LINK_FILE" ] && [ ! -f "$LINK_FILE" ]; then
-          ln -s "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
+          ln -sf "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
         fi
         export LD_LIBRARY_PATH=$OZONE_HOME/lib/native:$LD_LIBRARY_PATH
       fi

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1354,7 +1354,7 @@ function ozone_os_tricks
         TARGET_FILE="libhadoop_osx_aarch_64.dylib"
       fi
 
-     pushd . > /dev/null && cd lib/native
+      pushd lib/native > /dev/null
       # If no matching file variant was found for the current environment
       if [ -z "$TARGET_FILE" ]; then
         echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2

--- a/pom.xml
+++ b/pom.xml
@@ -2675,7 +2675,7 @@
                 <goals>
                   <goal>run</goal>
                 </goals>
-                <phase>prepare-package</phase>
+                <phase>generate-resources</phase>
                 <configuration>
                   <target>
                     <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
@@ -2690,7 +2690,7 @@
                 <goals>
                   <goal>run</goal>
                 </goals>
-                <phase>prepare-package</phase>
+                <phase>generate-resources</phase>
                 <configuration>
                   <target>
                     <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
@@ -2992,60 +2992,6 @@
               <groups>flaky</groups>
               <excludedGroups>slow | unhealthy</excludedGroups>
             </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>hadoop-native-lib</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.googlecode.maven-download-plugin</groupId>
-            <artifactId>download-maven-plugin</artifactId>
-            <version>${download-maven-plugin.version}</version>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <id>fetch-linux-x86_64-library</id>
-                <goals>
-                  <goal>wget</goal>
-                </goals>
-                <phase>generate-resources</phase>
-                <configuration>
-                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_linux_x86_64.so</url>
-                  <unpack>false</unpack>
-                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
-                  <skipCache>false</skipCache>
-                </configuration>
-              </execution>
-              <execution>
-                <id>fetch-linux-aarch64-library</id>
-                <goals>
-                  <goal>wget</goal>
-                </goals>
-                <phase>generate-resources</phase>
-                <configuration>
-                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_linux_aarch_64.so</url>
-                  <unpack>false</unpack>
-                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
-                  <skipCache>false</skipCache>
-                </configuration>
-              </execution>
-              <execution>
-                <id>fetch-darwin-aarch64-library</id>
-                <goals>
-                  <goal>wget</goal>
-                </goals>
-                <phase>generate-resources</phase>
-                <configuration>
-                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_osx_aarch_64.dylib</url>
-                  <unpack>false</unpack>
-                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
-                  <skipCache>false</skipCache>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -2624,7 +2624,7 @@
             <inherited>false</inherited>
             <executions>
               <execution>
-                <id>fetch-linux-library</id>
+                <id>fetch-linux-x86_64-library</id>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -2637,7 +2637,20 @@
                 </configuration>
               </execution>
               <execution>
-                <id>fetch-mac-library</id>
+                <id>fetch-linux-aarch64-library</id>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_linux_aarch_64.so</url>
+                  <unpack>false</unpack>
+                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
+                  <skipCache>false</skipCache>
+                </configuration>
+              </execution>
+              <execution>
+                <id>fetch-darwin-aarch64-library</id>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -2647,45 +2660,6 @@
                   <unpack>false</unpack>
                   <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
                   <skipCache>false</skipCache>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <version>${maven-antrun-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>extract-linux-library</id>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <phase>prepare-package</phase>
-                <inherited>false</inherited>
-                <configuration>
-                  <target>
-                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
-                      <arg value="-c" />
-                      <arg value="ln -sf libhadoop_linux_x86_64.so libhadoop.so" />
-                    </exec>
-                  </target>
-                </configuration>
-              </execution>
-              <execution>
-                <id>extract-mac-library</id>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <phase>prepare-package</phase>
-                <inherited>false</inherited>
-                <configuration>
-                  <target>
-                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
-                      <arg value="-c" />
-                      <arg value="ln -sf libhadoop_osx_aarch_64.dylib libhadoop.dylib" />
-                    </exec>
-                  </target>
                 </configuration>
               </execution>
             </executions>
@@ -2995,7 +2969,7 @@
             <inherited>false</inherited>
             <executions>
               <execution>
-                <id>fetch-linux-library</id>
+                <id>fetch-linux-x86_64-library</id>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -3008,7 +2982,20 @@
                 </configuration>
               </execution>
               <execution>
-                <id>fetch-mac-library</id>
+                <id>fetch-linux-aarch64-library</id>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_linux_aarch_64.so</url>
+                  <unpack>false</unpack>
+                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
+                  <skipCache>false</skipCache>
+                </configuration>
+              </execution>
+              <execution>
+                <id>fetch-darwin-aarch64-library</id>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -3018,45 +3005,6 @@
                   <unpack>false</unpack>
                   <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
                   <skipCache>false</skipCache>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <version>${maven-antrun-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>extract-linux-library</id>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <phase>prepare-package</phase>
-                <inherited>false</inherited>
-                <configuration>
-                  <target>
-                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
-                      <arg value="-c" />
-                      <arg value="ln -sf libhadoop_linux_x86_64.so libhadoop.so" />
-                    </exec>
-                  </target>
-                </configuration>
-              </execution>
-              <execution>
-                <id>extract-mac-library</id>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <phase>prepare-package</phase>
-                <inherited>false</inherited>
-                <configuration>
-                  <target>
-                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
-                      <arg value="-c" />
-                      <arg value="ln -sf libhadoop_osx_aarch_64.dylib libhadoop.dylib" />
-                    </exec>
-                  </target>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2664,6 +2664,44 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>${maven-antrun-plugin.version}</version>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>extract-linux-x86_64-library</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <target>
+                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
+                      <arg value="-c" />
+                      <arg value="ln -sf libhadoop_linux_x86_64.so libhadoop.so" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>extract-darwin-aarch64-library</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <target>
+                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
+                      <arg value="-c" />
+                      <arg value="ln -sf libhadoop_osx_aarch_64.dylib libhadoop.dylib" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -2996,5 +2996,97 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>hadoop-native-lib</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.googlecode.maven-download-plugin</groupId>
+            <artifactId>download-maven-plugin</artifactId>
+            <version>${download-maven-plugin.version}</version>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>fetch-linux-x86_64-library</id>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_linux_x86_64.so</url>
+                  <unpack>false</unpack>
+                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
+                  <skipCache>false</skipCache>
+                </configuration>
+              </execution>
+              <execution>
+                <id>fetch-linux-aarch64-library</id>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_linux_aarch_64.so</url>
+                  <unpack>false</unpack>
+                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
+                  <skipCache>false</skipCache>
+                </configuration>
+              </execution>
+              <execution>
+                <id>fetch-darwin-aarch64-library</id>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <url>https://raw.githubusercontent.com/apache/ozone-thirdparty/master/hadoop-native-lib/${hadoop.version}/libhadoop_osx_aarch_64.dylib</url>
+                  <unpack>false</unpack>
+                  <outputDirectory>${project.build.directory}/native-lib</outputDirectory>
+                  <skipCache>false</skipCache>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>${maven-antrun-plugin.version}</version>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>extract-linux-x86_64-library</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <target>
+                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
+                      <arg value="-c" />
+                      <arg value="ln -sf libhadoop_linux_x86_64.so libhadoop.so" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>extract-darwin-aarch64-library</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <target>
+                    <exec dir="${project.build.directory}/native-lib" executable="bash" failonerror="true">
+                      <arg value="-c" />
+                      <arg value="ln -sf libhadoop_osx_aarch_64.dylib libhadoop.dylib" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, three platform hadoop native library is supported,

    linux, x86_64
    linux, aarch64
    Mac, arm64(aarch64)

1. download all three platform native library during mvn build
2. create libhadoop.so pointing to linux x86_64 native library file during mvn build
3. create libhadoop.dylib pointing to mac arm64 native library file during mvn build
4. at runtime, if it's linux aarch64 platform, recreate the libhadoop.so pointing to linux aarch64 native library file
5. add libhadoop to DYLD_LIBRARY_PATH or LD_LIBRARY_PATH, so that libhadoop can be found and loaded during Ozone service and client startup if short-circuit is enabled. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15559

## How was this patch tested?

Tested locally for aarch64 platform, and CI for x86_64 platform.  

// use ozone docker image hadoop native library under /usr/lib
```
bash-5.1$ ozone debug checknative
Native library checking:
     hadoop:  true   /usr/lib/libhadoop.so.1.0.0
      ISA-L:  false  libhadoop was built without ISA-L support
    OpenSSL:  false  Cannot load libcrypto.so (libcrypto.so: cannot open shared object file: No such file or directory)!
rocks-tools:  false 
```

// mvn clean package -DskipTests -Dmaven.javadoc.skip=true -Pdist -Plinux-aarch64 // on MacOS M1
// use ozone package hadoop native library under ./lib/native/
```
bash-5.1$ ozone debug checknative
Native library checking:
     hadoop:  true   /opt/hadoop/lib/native/libhadoop_linux_aarch_64.so
      ISA-L:  false  libhadoop was built without ISA-L support
    OpenSSL:  false  Cannot load libcrypto.so (libcrypto.so: cannot open shared object file: No such file or directory)!
rocks-tools:  false
```

