### PR TITLE
HDDS-15564. EventNotification: async kafka notification sending

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/eventlistener/NotificationCheckpointStrategy.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/eventlistener/NotificationCheckpointStrategy.java
@@ -18,23 +18,14 @@
 package org.apache.hadoop.ozone.om.eventlistener;
 
 import java.io.IOException;
-import java.util.List;
-import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
 
 /**
- * A narrow set of functionality we are ok with exposing to plugin
- * implementations.
+ * Interface for implementations which load/save the current checkpoint
+ * transaction log index used by an event poller.
  */
-public interface OMEventListenerPluginContext {
+public interface NotificationCheckpointStrategy {
 
-  boolean isLeaderReady();
+  String load() throws IOException;
 
-  // TODO: should we allow plugins to pass in maxResults or just limit
-  // them to some predefined value for safety?  e.g. 10K
-  List<OmCompletedRequestInfo> listCompletedRequestInfo(Long startKey, int maxResults) throws IOException;
-
-  // XXX: this probably doesn't belong here
-  String getThreadNamePrefix();
-
-  NotificationCheckpointStrategy getNotificationCheckpointStrategy();
+  void save(String val) throws IOException;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContext.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContext.java
@@ -37,4 +37,14 @@ public interface OMEventListenerPluginContext {
   String getThreadNamePrefix();
 
   NotificationCheckpointStrategy getNotificationCheckpointStrategy();
+
+  /**
+   * Prunes records from completedRequestInfoTable using a hybrid soft and hard retention limit.
+   *
+   * @param checkpointKey the current consumer checkpoint (startKey).
+   * @param softLimit the soft retention keep limit behind the checkpoint.
+   * @param hardLimit the hard retention cap limit behind the latest transaction in database.
+   * @throws IOException if any database error occurs.
+   */
+  void pruneCompletedRequestInfo(long checkpointKey, long softLimit, long hardLimit) throws IOException;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMCompletedRequestPrunedException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMCompletedRequestPrunedException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.exceptions;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when a requested completed request info record
+ * is not found because it has already been pruned by the retention policy.
+ */
+public class OMCompletedRequestPrunedException extends IOException {
+
+  public OMCompletedRequestPrunedException(String message) {
+    super(message);
+  }
+}

--- a/hadoop-ozone/ozone-manager-plugins/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerKafkaPublisher.java
+++ b/hadoop-ozone/ozone-manager-plugins/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerKafkaPublisher.java
@@ -23,14 +23,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneIllegalArgumentException;
 import org.apache.hadoop.ozone.om.eventlistener.s3.S3EventNotificationStrategy;
 import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
@@ -52,11 +56,13 @@ public class OMEventListenerKafkaPublisher implements OMEventListener {
   private static final String KAFKA_SERVICE_INTERVAL_CONFIG = KAFKA_CONFIG_PREFIX + "service.interval";
   private static final String KAFKA_SERVICE_TIMEOUT_CONFIG = KAFKA_CONFIG_PREFIX + "service.timeout";
   private static final int COMPLETED_REQUEST_CONSUMER_CORE_POOL_SIZE = 1;
+  private static final int MAX_PENDING_TRANSACTIONS = 1000;
 
   private OMEventListenerLedgerPoller ledgerPoller;
   private KafkaClientWrapper kafkaClient;
   private OMEventListenerNotificationStrategy notificationStrategy;
   private OMEventListenerLedgerPollerSeekPosition seekPosition;
+  private PendingTransactionTracker tracker;
 
   @Override
   public void initialize(OzoneConfiguration conf, OMEventListenerPluginContext pluginContext) {
@@ -87,6 +93,8 @@ public class OMEventListenerKafkaPublisher implements OMEventListener {
     this.seekPosition = new OMEventListenerLedgerPollerSeekPosition(
         pluginContext.getNotificationCheckpointStrategy());
 
+    this.tracker = new PendingTransactionTracker(seekPosition, MAX_PENDING_TRANSACTIONS);
+
     LOG.info("Creating OMEventListenerLedgerPoller with serviceInterval={}," +
         "serviceTimeout={}, seekPosition={}",
         kafkaServiceInterval, kafkaServiceTimeout,
@@ -114,6 +122,7 @@ public class OMEventListenerKafkaPublisher implements OMEventListener {
 
   @Override
   public void stop() {
+    tracker.stop();
     try {
       kafkaClient.shutdown();
     } catch (IOException ex) {
@@ -123,28 +132,126 @@ public class OMEventListenerKafkaPublisher implements OMEventListener {
     ledgerPoller.shutdown();
   }
 
+  OMEventListenerLedgerPollerSeekPosition getSeekPosition() {
+    return seekPosition;
+  }
+
   // callback called by OMEventListenerLedgerPoller
   public void handleCompletedRequest(OmCompletedRequestInfo completedRequestInfo) {
-    LOG.debug("Processing {}", completedRequestInfo);
+    long trxIndex = completedRequestInfo.getTrxLogIndex();
+    LOG.debug("Processing {}, trxIndex={}", completedRequestInfo, trxIndex);
+
+    // Apply backpressure / high watermark
+    try {
+      tracker.acquirePermit();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return;
+    }
+
+    if (tracker.isStopped()) {
+      return;
+    }
 
     List<String> eventsToSend = notificationStrategy.determineEventsForOperation(completedRequestInfo);
 
-    // loop over events and send them to our kafka sink
+    if (eventsToSend.isEmpty()) {
+      tracker.complete(trxIndex);
+      return;
+    }
+
+    tracker.track(trxIndex);
+    AtomicInteger remainingEvents = new AtomicInteger(eventsToSend.size());
+
+    // loop over events and send them to our kafka sink asynchronously
     for (String event : eventsToSend) {
       if (event == null) {
-        LOG.warn("Skipping null event for transaction {}", completedRequestInfo.getTrxLogIndex());
+        if (remainingEvents.decrementAndGet() == 0) {
+          tracker.complete(trxIndex);
+        }
         continue;
       }
-      try {
-        kafkaClient.send(event);
-      } catch (IOException ex) {
-        LOG.error("Failure to send event {}", event, ex);
-        return;
+
+      kafkaClient.sendAsync(event, (metadata, exception) -> {
+        if (exception != null) {
+          LOG.error("Failure to send event {} for transaction {} - checkpointing halted", event, trxIndex, exception);
+        } else {
+          if (remainingEvents.decrementAndGet() == 0) {
+            tracker.complete(trxIndex);
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Helper class to track pending transactions and apply backpressure
+   * while ensuring contiguous checkpoint (seek) updates.
+   */
+  static class PendingTransactionTracker {
+    private final ConcurrentSkipListMap<Long, Boolean> pendingTransactions = new ConcurrentSkipListMap<>();
+    private final AtomicInteger pendingCount = new AtomicInteger(0);
+    private final int maxPendingTransactions;
+    private final Object lock = new Object();
+    private final OMEventListenerLedgerPollerSeekPosition seekPosition;
+    private volatile boolean stopped = false;
+
+    PendingTransactionTracker(OMEventListenerLedgerPollerSeekPosition seekPosition, int maxPendingTransactions) {
+      this.seekPosition = seekPosition;
+      this.maxPendingTransactions = maxPendingTransactions;
+    }
+
+    public void track(long trxIndex) {
+      if (pendingTransactions.put(trxIndex, false) == null) {
+        pendingCount.incrementAndGet();
       }
     }
 
-    // no errors so we can update the seek position
-    seekPosition.set(String.valueOf(completedRequestInfo.getTrxLogIndex()));
+    public void complete(long trxIndex) {
+      Boolean prev = pendingTransactions.put(trxIndex, true);
+      if (prev != null && prev) {
+        return;
+      }
+
+      long newSeek = -1;
+      synchronized (lock) {
+        while (!pendingTransactions.isEmpty()) {
+          Map.Entry<Long, Boolean> first = pendingTransactions.firstEntry();
+          if (first.getValue()) {
+            newSeek = first.getKey();
+            pendingTransactions.pollFirstEntry();
+            pendingCount.decrementAndGet();
+          } else {
+            break;
+          }
+        }
+        lock.notifyAll();
+      }
+
+      if (newSeek != -1) {
+        seekPosition.set(String.valueOf(newSeek));
+        LOG.debug("Updated checkpoint seek position to {}", newSeek);
+      }
+    }
+
+    public void acquirePermit() throws InterruptedException {
+      synchronized (lock) {
+        while (pendingCount.get() >= maxPendingTransactions && !stopped) {
+          lock.wait(100);
+        }
+      }
+    }
+
+    public void stop() {
+      stopped = true;
+      synchronized (lock) {
+        lock.notifyAll();
+      }
+    }
+
+    public boolean isStopped() {
+      return stopped;
+    }
   }
 
   static class KafkaClientWrapper {
@@ -174,25 +281,34 @@ public class OMEventListenerKafkaPublisher implements OMEventListener {
       }
     }
 
-    public void send(String message) throws IOException {
+    public void sendAsync(String message, Callback callback) {
       if (producer != null) {
-        LOG.debug("Producing event {}", message);
+        LOG.debug("Producing event asynchronously {}", message);
         ProducerRecord<String, String> producerRecord =
             new ProducerRecord<>(topic, message);
-        try {
-          // TODO: Sequential blocking for every event ensures at-least-once delivery
-          // but limits throughput. Consider batching async sends and calling
-          // producer.flush() before updating the seek position for high-volume use cases.
-          producer.send(producerRecord).get();
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new IOException("Interrupted while sending message to Kafka", e);
-        } catch (ExecutionException e) {
-          throw new IOException("Failed to send message to Kafka", e);
-        }
+        producer.send(producerRecord, callback);
       } else {
         LOG.warn("Producing event {} [KAFKA DOWN]", message);
-        throw new IOException("Kafka producer is not initialized");
+        callback.onCompletion(null, new IOException("Kafka producer is not initialized"));
+      }
+    }
+
+    public void send(String message) throws IOException {
+      CompletableFuture<Void> future = new CompletableFuture<>();
+      sendAsync(message, (metadata, exception) -> {
+        if (exception != null) {
+          future.completeExceptionally(exception);
+        } else {
+          future.complete(null);
+        }
+      });
+      try {
+        future.get();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while sending message", e);
+      } catch (ExecutionException e) {
+        throw new IOException("Failed to send message", e);
       }
     }
 

--- a/hadoop-ozone/ozone-manager-plugins/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerKafkaPublisher.java
+++ b/hadoop-ozone/ozone-manager-plugins/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerKafkaPublisher.java
@@ -84,7 +84,8 @@ public class OMEventListenerKafkaPublisher implements OMEventListener {
       exception.initCause(ex);
       throw exception;
     }
-    this.seekPosition = new OMEventListenerLedgerPollerSeekPosition();
+    this.seekPosition = new OMEventListenerLedgerPollerSeekPosition(
+        pluginContext.getNotificationCheckpointStrategy());
 
     LOG.info("Creating OMEventListenerLedgerPoller with serviceInterval={}," +
         "serviceTimeout={}, seekPosition={}",

--- a/hadoop-ozone/ozone-manager-plugins/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerLedgerPoller.java
+++ b/hadoop-ozone/ozone-manager-plugins/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerLedgerPoller.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
+import org.apache.hadoop.ozone.om.exceptions.OMCompletedRequestPrunedException;
 import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,8 @@ public class OMEventListenerLedgerPoller extends BackgroundService {
   private final OMEventListenerPluginContext pluginContext;
   private final OMEventListenerLedgerPollerSeekPosition seekPosition;
   private final Consumer<OmCompletedRequestInfo> callback;
+  private final long softRetentionLimit;
+  private final long hardRetentionLimit;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public OMEventListenerLedgerPoller(long interval, TimeUnit unit,
@@ -70,6 +73,10 @@ public class OMEventListenerLedgerPoller extends BackgroundService {
     this.pluginContext = pluginContext;
     this.seekPosition = seekPosition;
     this.callback = callback;
+    this.softRetentionLimit = configuration.getLong(
+        "ozone.om.plugin.kafka.ledger.retention.soft.limit", 100_000L);
+    this.hardRetentionLimit = configuration.getLong(
+        "ozone.om.plugin.kafka.ledger.retention.hard.limit", 1_000_000L);
   }
 
   private boolean shouldRun() {
@@ -121,14 +128,21 @@ public class OMEventListenerLedgerPoller extends BackgroundService {
         }
         getRunCount().incrementAndGet();
 
+        String startKeyStr = seekPosition.get();
         try {
-          String startKeyStr = seekPosition.get();
           Long startKey = StringUtils.isNotBlank(startKeyStr) ? Long.valueOf(startKeyStr) : null;
           for (OmCompletedRequestInfo requestInfo : pluginContext.listCompletedRequestInfo(
                   startKey, MAX_RESULTS)) {
             callback.accept(requestInfo);
           }
           successRunCount.incrementAndGet();
+
+          if (startKey != null) {
+            pluginContext.pruneCompletedRequestInfo(startKey, softRetentionLimit, hardRetentionLimit);
+          }
+        } catch (OMCompletedRequestPrunedException e) {
+          LOG.warn("Consumer checkpoint {} has been hard-pruned. Fast-forwarding and self-healing...", startKeyStr);
+          seekPosition.set(null); // Clear checkpoint to fast-forward
         } catch (IOException e) {
           LOG.error("Error while running completed operation consumer " +
               "background task. Will retry at next run.", e);

--- a/hadoop-ozone/ozone-manager-plugins/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerLedgerPollerSeekPosition.java
+++ b/hadoop-ozone/ozone-manager-plugins/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerLedgerPollerSeekPosition.java
@@ -24,21 +24,26 @@ import org.slf4j.LoggerFactory;
 /**
  * This is a helper class to get/set the seek position used by the
  * OMEventListenerLedgerPoller.
- *
- * XXX: the seek position should be persisted (and ideally distributed to
- * all OMs) but at the moment it only lives in memory
  */
 public class OMEventListenerLedgerPollerSeekPosition {
   public static final Logger LOG = LoggerFactory.getLogger(OMEventListenerLedgerPollerSeekPosition.class);
 
   private final AtomicReference<String> seekPosition;
+  private final NotificationCheckpointStrategy checkpointStrategy;
 
-  public OMEventListenerLedgerPollerSeekPosition() {
-    this.seekPosition = new AtomicReference(initSeekPosition());
+  public OMEventListenerLedgerPollerSeekPosition(NotificationCheckpointStrategy checkpointStrategy) {
+    this.checkpointStrategy = checkpointStrategy;
+    this.seekPosition = new AtomicReference<>(initSeekPosition());
   }
 
-  // TODO: load this from persistent storage
   public String initSeekPosition() {
+    try {
+      if (checkpointStrategy != null) {
+        return checkpointStrategy.load();
+      }
+    } catch (Exception ex) {
+      LOG.error("Failed to load initial seek position from checkpoint strategy", ex);
+    }
     return null;
   }
 
@@ -48,10 +53,17 @@ public class OMEventListenerLedgerPollerSeekPosition {
 
   public void set(String val) {
     LOG.debug("Setting seek position {}", val);
-    // NOTE: this in-memory view of the seek position needs to be kept
-    // up to date because the OMEventListenerLedgerPoller has a
-    // reference to it
-    seekPosition.set(val);
+    try {
+      if (checkpointStrategy != null) {
+        checkpointStrategy.save(val);
+      }
+      // NOTE: this in-memory view of the seek position must only be kept
+      // up to date after we successfully persist it, so that any save
+      // failures prevent the poller from advancing and running away.
+      seekPosition.set(val);
+    } catch (Exception ex) {
+      LOG.error("Failed to save seek position checkpoint {}. Progress will not be advanced in-memory.", val, ex);
+    }
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager-plugins/src/test/java/org/apache/hadoop/ozone/om/eventlistener/TestOMEventListenerKafkaPublisher.java
+++ b/hadoop-ozone/ozone-manager-plugins/src/test/java/org/apache/hadoop/ozone/om/eventlistener/TestOMEventListenerKafkaPublisher.java
@@ -18,6 +18,11 @@
 package org.apache.hadoop.ozone.om.eventlistener;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,6 +43,7 @@ import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
 import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo.OperationArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.util.Time;
+import org.apache.kafka.clients.producer.Callback;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -87,7 +93,7 @@ public class TestOMEventListenerKafkaPublisher {
 
       OMEventListenerKafkaPublisher.KafkaClientWrapper mock = mockedKafkaClientWrapper.constructed().get(0);
       ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
-      verify(mock, times(expectEvents)).send(argument.capture());
+      verify(mock, times(expectEvents)).sendAsync(argument.capture(), any(Callback.class));
 
       events.addAll(argument.getAllValues());
     }
@@ -275,6 +281,107 @@ public class TestOMEventListenerKafkaPublisher {
 
     // Also ensure it is actually parsable by the standard Java 8 API
     java.time.OffsetDateTime.parse(eventTimeStr);
+  }
+
+  @Test
+  public void testAsyncSlidingWindowWatermark() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.om.plugin.kafka.topic", "abc");
+
+    OMEventListenerKafkaPublisher plugin = new OMEventListenerKafkaPublisher();
+    List<Callback> callbacks = new ArrayList<>();
+
+    try (MockedConstruction<OMEventListenerKafkaPublisher.KafkaClientWrapper> mockedKafkaClientWrapper =
+             mockConstruction(OMEventListenerKafkaPublisher.KafkaClientWrapper.class, (mock, context) -> {
+               doAnswer(invocation -> {
+                 Callback cb = invocation.getArgument(1, Callback.class);
+                 synchronized (callbacks) {
+                   callbacks.add(cb);
+                 }
+                 return null;
+               }).when(mock).sendAsync(anyString(), any(Callback.class));
+             })) {
+
+      plugin.initialize(conf, pluginContext);
+
+      OmCompletedRequestInfo op1 = buildCompletedRequestInfo(1L, Type.CreateKey, "key1", new OperationArgs.NoArgs());
+      OmCompletedRequestInfo op2 = buildCompletedRequestInfo(2L, Type.CreateKey, "key2", new OperationArgs.NoArgs());
+      OmCompletedRequestInfo op3 = buildCompletedRequestInfo(3L, Type.CreateKey, "key3", new OperationArgs.NoArgs());
+
+      plugin.handleCompletedRequest(op1);
+      plugin.handleCompletedRequest(op2);
+      plugin.handleCompletedRequest(op3);
+
+      OMEventListenerKafkaPublisher.KafkaClientWrapper mock = mockedKafkaClientWrapper.constructed().get(0);
+      verify(mock, times(3)).sendAsync(anyString(), any(Callback.class));
+
+      assertNull(plugin.getSeekPosition().get());
+
+      callbacks.get(1).onCompletion(null, null);
+      assertNull(plugin.getSeekPosition().get());
+
+      callbacks.get(0).onCompletion(null, null);
+      assertEquals("2", plugin.getSeekPosition().get());
+
+      callbacks.get(2).onCompletion(null, null);
+      assertEquals("3", plugin.getSeekPosition().get());
+    }
+  }
+
+  @Test
+  public void testAsyncSendFailureHaltsWatermark() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.om.plugin.kafka.topic", "abc");
+
+    OMEventListenerKafkaPublisher plugin = new OMEventListenerKafkaPublisher();
+    List<Callback> callbacks = new ArrayList<>();
+
+    try (MockedConstruction<OMEventListenerKafkaPublisher.KafkaClientWrapper> mockedKafkaClientWrapper =
+             mockConstruction(OMEventListenerKafkaPublisher.KafkaClientWrapper.class, (mock, context) -> {
+               doAnswer(invocation -> {
+                 Callback cb = invocation.getArgument(1, Callback.class);
+                 synchronized (callbacks) {
+                   callbacks.add(cb);
+                 }
+                 return null;
+               }).when(mock).sendAsync(anyString(), any(Callback.class));
+             })) {
+
+      plugin.initialize(conf, pluginContext);
+
+      OmCompletedRequestInfo op1 = buildCompletedRequestInfo(1L, Type.CreateKey, "key1", new OperationArgs.NoArgs());
+      OmCompletedRequestInfo op2 = buildCompletedRequestInfo(2L, Type.CreateKey, "key2", new OperationArgs.NoArgs());
+
+      plugin.handleCompletedRequest(op1);
+      plugin.handleCompletedRequest(op2);
+
+      assertNull(plugin.getSeekPosition().get());
+
+      // Simulate failure on Transaction 1
+      callbacks.get(0).onCompletion(null, new IOException("Simulated Kafka send failure"));
+
+      // Simulate success on Transaction 2
+      callbacks.get(1).onCompletion(null, null);
+
+      // Even though Transaction 2 succeeded, the seek position must NOT advance because Transaction 1 failed.
+      // The checkpoint remains null, preserving at-least-once safety!
+      assertNull(plugin.getSeekPosition().get());
+
+      // Simulate a retry of Transaction 1 (poller re-processing from startKey)
+      plugin.handleCompletedRequest(op1);
+
+      OMEventListenerKafkaPublisher.KafkaClientWrapper mock = mockedKafkaClientWrapper.constructed().get(0);
+
+      // Verify a new send was triggered (callbacks size should grow to 3)
+      verify(mock, times(3)).sendAsync(anyString(), any(Callback.class));
+
+      // Complete the retried Transaction 1 successfully
+      callbacks.get(2).onCompletion(null, null);
+
+      // Since Transaction 2 is already successfully completed, the sliding window should
+      // now successfully advance to 2!
+      assertEquals("2", plugin.getSeekPosition().get());
+    }
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager-plugins/src/test/java/org/apache/hadoop/ozone/om/eventlistener/TestOMEventListenerLedgerPoller.java
+++ b/hadoop-ozone/ozone-manager-plugins/src/test/java/org/apache/hadoop/ozone/om/eventlistener/TestOMEventListenerLedgerPoller.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.BackgroundTask;
+import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
+import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OMEventListenerLedgerPoller}.
+ */
+public class TestOMEventListenerLedgerPoller {
+
+  @Test
+  public void testPollerPrunesCompletedRequestsCorrectly() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    // Configure soft retention to keep at most 5 records, hard retention 10 records
+    conf.setLong("ozone.om.plugin.kafka.ledger.retention.soft.limit", 5L);
+    conf.setLong("ozone.om.plugin.kafka.ledger.retention.hard.limit", 10L);
+
+    OMEventListenerPluginContext pluginContext = mock(OMEventListenerPluginContext.class);
+    when(pluginContext.isLeaderReady()).thenReturn(true);
+    when(pluginContext.getThreadNamePrefix()).thenReturn("test-poller-");
+
+    OMEventListenerLedgerPollerSeekPosition seekPosition = mock(OMEventListenerLedgerPollerSeekPosition.class);
+    // Seek position is 10
+    when(seekPosition.get()).thenReturn("10");
+
+    @SuppressWarnings("unchecked")
+    Consumer<OmCompletedRequestInfo> callback = mock(Consumer.class);
+
+    // List completes returns empty list for simplicity
+    when(pluginContext.listCompletedRequestInfo(eq(10L), anyInt()))
+        .thenReturn(Collections.emptyList());
+
+    OMEventListenerLedgerPoller poller = new OMEventListenerLedgerPoller(
+        1000, TimeUnit.MILLISECONDS, 1, 1000,
+        pluginContext, conf, seekPosition, callback);
+
+    BackgroundTaskQueue queue = poller.getTasks();
+    BackgroundTask task = queue.poll();
+
+    task.call();
+
+    // Verify task runs and calls listCompletedRequestInfo with current seek position (10)
+    verify(pluginContext, times(1)).listCompletedRequestInfo(eq(10L), anyInt());
+
+    // Verify pruning is triggered for startKey = 10, softLimit = 5, hardLimit = 10
+    verify(pluginContext, times(1)).pruneCompletedRequestInfo(eq(10L), eq(5L), eq(10L));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -95,6 +95,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeletedBlock;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
+import org.apache.hadoop.ozone.om.exceptions.OMCompletedRequestPrunedException;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -1380,7 +1381,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
             // TODO: we should throw a custom exception here (instead of
             // IOException) that needs to be handled appropriately by
             // callers
-            throw new IOException(
+            throw new OMCompletedRequestPrunedException(
                 "Missing rows - start key not found (startKey=" + startKey
                 + ", foundKey=" + completedRequestInfoRow.getKey() + ")");
           }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -971,8 +971,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     prefixManager = new PrefixManagerImpl(this, metadataManager, true);
     keyManager = new KeyManagerImpl(this, scmClient, configuration,
         perfMetrics);
-    eventListenerPluginManager = new OMEventListenerPluginManager(this,
-        configuration);
     // If authorizer is not initialized or the authorizer is Native
     // re-initialize the authorizer, else for non-native authorizer
     // like ranger we can reuse previous value if it is initialized
@@ -995,6 +993,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
       }
     };
+
+    eventListenerPluginManager = new OMEventListenerPluginManager(this,
+        configuration);
 
     // Reload snapshot feature config flag
     fsSnapshotEnabled = configuration.getBoolean(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContextImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContextImpl.java
@@ -19,14 +19,20 @@ package org.apache.hadoop.ozone.om.eventlistener;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A narrow set of functionality we are ok with exposing to plugin
  * implementations.
  */
 public final class OMEventListenerPluginContextImpl implements OMEventListenerPluginContext {
+  private static final Logger LOG = LoggerFactory.getLogger(OMEventListenerPluginContextImpl.class);
+
   private final OzoneManager ozoneManager;
   private final NotificationCheckpointStrategy checkpointStrategy;
 
@@ -57,5 +63,36 @@ public final class OMEventListenerPluginContextImpl implements OMEventListenerPl
   @Override
   public NotificationCheckpointStrategy getNotificationCheckpointStrategy() {
     return checkpointStrategy;
+  }
+
+  @Override
+  public void pruneCompletedRequestInfo(long checkpointKey, long softLimit, long hardLimit) throws IOException {
+    Table<Long, OmCompletedRequestInfo> table = ozoneManager.getMetadataManager().getCompletedRequestInfoTable();
+    try {
+      long softPruneBeforeKey = checkpointKey - softLimit;
+
+      long latestKey = -1;
+      try (TableIterator<Long, ? extends Table.KeyValue<Long, OmCompletedRequestInfo>>
+              iterator = table.iterator()) {
+        iterator.seekToLast();
+        if (iterator.hasNext()) {
+          latestKey = iterator.next().getKey();
+        }
+      }
+
+      long hardPruneBeforeKey = latestKey - hardLimit;
+
+      long beforeKey = Math.max(softPruneBeforeKey, hardPruneBeforeKey);
+      if (beforeKey > 0) {
+        table.deleteRange(0L, beforeKey);
+        LOG.info("Pruned records from completedRequestInfoTable older than trxLogIndex {} " +
+            "(checkpointKey={}, softLimit={}, latestKey={}, hardLimit={})",
+            beforeKey, checkpointKey, softLimit, latestKey, hardLimit);
+      }
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException("Failed to prune completedRequestInfoTable range", e);
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContextImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginContextImpl.java
@@ -28,9 +28,12 @@ import org.apache.hadoop.ozone.om.helpers.OmCompletedRequestInfo;
  */
 public final class OMEventListenerPluginContextImpl implements OMEventListenerPluginContext {
   private final OzoneManager ozoneManager;
+  private final NotificationCheckpointStrategy checkpointStrategy;
 
-  public OMEventListenerPluginContextImpl(OzoneManager ozoneManager) {
+  public OMEventListenerPluginContextImpl(OzoneManager ozoneManager,
+      NotificationCheckpointStrategy checkpointStrategy) {
     this.ozoneManager = ozoneManager;
+    this.checkpointStrategy = checkpointStrategy;
   }
 
   @Override
@@ -49,5 +52,10 @@ public final class OMEventListenerPluginContextImpl implements OMEventListenerPl
   @Override
   public String getThreadNamePrefix() {
     return ozoneManager.getThreadNamePrefix();
+  }
+
+  @Override
+  public NotificationCheckpointStrategy getNotificationCheckpointStrategy() {
+    return checkpointStrategy;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OMEventListenerPluginManager.java
@@ -92,7 +92,12 @@ public class OMEventListenerPluginManager {
       }
     }
 
-    OMEventListenerPluginContext pluginContext = new OMEventListenerPluginContextImpl(ozoneManager);
+    NotificationCheckpointStrategy checkpointStrategy = null;
+    if (ozoneManager != null && ozoneManager.getOmMetadataReader() != null) {
+      checkpointStrategy = new OzoneFileCheckpointStrategy(ozoneManager,
+          ozoneManager.getOmMetadataReader().get(), conf);
+    }
+    OMEventListenerPluginContext pluginContext = new OMEventListenerPluginContextImpl(ozoneManager, checkpointStrategy);
 
     for (String destName : destNameList) {
       try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OzoneFileCheckpointStrategy.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/eventlistener/OzoneFileCheckpointStrategy.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.IOmMetadataReader;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetBucketPropertyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserInfo;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ratis.protocol.ClientId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of NotificationCheckpointStrategy which loads/saves
+ * the the last known notification sent by an event notification plugin
+ * directly as metadata on the checkpoint bucket itself.
+ *
+ * This allows another OM to pick up from the appropriate place in the
+ * event of a leadership change.
+ *
+ * NOTE: The current approach is to store the current checkpoint as a
+ * bucket metadata property. This has the virtue of requiring only a
+ * single request (the first implementation of this used a two-phase
+ * CreateKeyRequest / CommitKeyRequest approach with the checkpoint
+ * value being stored as a KeyArgs metadata property, but the two-phase
+ * nature increased complexity).
+ */
+public class OzoneFileCheckpointStrategy implements NotificationCheckpointStrategy {
+
+  public static final Logger LOG = LoggerFactory.getLogger(OzoneFileCheckpointStrategy.class);
+
+  public static final String OZONE_OM_PLUGIN_CHECKPOINT_VOLUME = "ozone.om.plugin.kafka.checkpoint.volume";
+  public static final String OZONE_OM_PLUGIN_CHECKPOINT_VOLUME_DEFAULT = "notifications";
+
+  public static final String OZONE_OM_PLUGIN_CHECKPOINT_BUCKET = "ozone.om.plugin.kafka.checkpoint.bucket";
+  public static final String OZONE_OM_PLUGIN_CHECKPOINT_BUCKET_DEFAULT = "checkpoint";
+
+  public static final String OZONE_OM_PLUGIN_CHECKPOINT_SAVE_INTERVAL =
+      "ozone.om.plugin.kafka.checkpoint.save.interval";
+  public static final int OZONE_OM_PLUGIN_CHECKPOINT_SAVE_INTERVAL_DEFAULT = 100;
+
+  private static final String METDATA_KEY = "notification-checkpoint";
+
+  private final AtomicLong callId = new AtomicLong(0);
+  private final ClientId clientId = ClientId.randomId();
+  private final OzoneManager ozoneManager;
+  private final AtomicLong saveCount = new AtomicLong(0);
+
+  private final String volume;
+  private final String bucket;
+  private final int saveInterval;
+
+  public OzoneFileCheckpointStrategy(OzoneManager ozoneManager, final IOmMetadataReader omMetadataReader,
+      OzoneConfiguration conf) {
+    this.ozoneManager = ozoneManager;
+    this.volume = conf.get(OZONE_OM_PLUGIN_CHECKPOINT_VOLUME, OZONE_OM_PLUGIN_CHECKPOINT_VOLUME_DEFAULT);
+    this.bucket = conf.get(OZONE_OM_PLUGIN_CHECKPOINT_BUCKET, OZONE_OM_PLUGIN_CHECKPOINT_BUCKET_DEFAULT);
+
+    int interval = conf.getInt(OZONE_OM_PLUGIN_CHECKPOINT_SAVE_INTERVAL,
+        OZONE_OM_PLUGIN_CHECKPOINT_SAVE_INTERVAL_DEFAULT);
+    if (interval < 1) {
+      LOG.warn("Configured save interval {} is invalid. Defaulting to 100.", interval);
+      interval = OZONE_OM_PLUGIN_CHECKPOINT_SAVE_INTERVAL_DEFAULT;
+    }
+    this.saveInterval = interval;
+  }
+
+  @Override
+  public String load() throws IOException {
+    try {
+      OmBucketInfo bucketInfo = ozoneManager.getBucketInfo(volume, bucket);
+      if (bucketInfo != null && bucketInfo.getMetadata() != null) {
+        return bucketInfo.getMetadata().get(METDATA_KEY);
+      }
+    } catch (IOException ex) {
+      LOG.info("Error loading notification checkpoint from bucket /{}/{} - {}", volume, bucket, ex.getMessage());
+    }
+    return null;
+  }
+
+  @Override
+  public void save(String val) throws IOException {
+    if (StringUtils.isBlank(val)) {
+      return;
+    }
+    long previousSaveCount = saveCount.getAndIncrement();
+    // Throttle database commits: persist checkpoint based on configured interval to avoid write storms
+    if (previousSaveCount == 0 || previousSaveCount % saveInterval == 0) {
+      saveImpl(val);
+    }
+  }
+
+  private void saveImpl(String val) {
+    BucketArgs bucketArgs = BucketArgs.newBuilder()
+        .setVolumeName(volume)
+        .setBucketName(bucket)
+        .addMetadata(HddsProtos.KeyValue.newBuilder()
+            .setKey(METDATA_KEY)
+            .setValue(val)
+            .build())
+        .build();
+
+    SetBucketPropertyRequest setBucketPropertyRequest = SetBucketPropertyRequest.newBuilder()
+        .setBucketArgs(bucketArgs)
+        .build();
+
+    OMRequest omRequest = OMRequest.newBuilder()
+        .setCmdType(Type.SetBucketProperty)
+        .setClientId(clientId.toString())
+        .setSetBucketPropertyRequest(setBucketPropertyRequest)
+        .setUserInfo(getUserInfo())
+        .build();
+
+    submitRequest(omRequest);
+    LOG.info("Persisted {} = {} directly as metadata on bucket /{}/{}", METDATA_KEY, val, volume, bucket);
+  }
+
+  private UserInfo getUserInfo() {
+    UserInfo.Builder userInfo = UserInfo.newBuilder();
+    try {
+      userInfo.setUserName(UserGroupInformation.getCurrentUser().getShortUserName());
+    } catch (IOException e) {
+      LOG.warn("Failed to get current login user name", e);
+      userInfo.setUserName("om");
+    }
+
+    if (ozoneManager.getOmRpcServerAddr() != null) {
+      InetAddress remoteAddress = ozoneManager.getOmRpcServerAddr().getAddress();
+      if (remoteAddress != null) {
+        userInfo.setHostName(remoteAddress.getHostName());
+        userInfo.setRemoteAddress(remoteAddress.getHostAddress());
+      }
+    }
+    return userInfo.build();
+  }
+
+  private OMResponse submitRequest(OMRequest omRequest) {
+    try {
+      return OzoneManagerRatisUtils.submitRequest(ozoneManager, omRequest, clientId, callId.incrementAndGet());
+    } catch (ServiceException e) {
+      LOG.error("Set bucket metadata " + omRequest.getCmdType() + " request failed. Will retry at next run.", e);
+    }
+    return null;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/eventlistener/TestOzoneFileCheckpointStrategy.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/eventlistener/TestOzoneFileCheckpointStrategy.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.eventlistener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import org.apache.hadoop.ozone.om.IOmMetadataReader;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.ratis.protocol.ClientId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests {@link OzoneFileCheckpointStrategy}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestOzoneFileCheckpointStrategy {
+
+  @Mock
+  private OzoneManager mockOzoneManager;
+  @Mock
+  private IOmMetadataReader mockOmMetadataReader;
+  @Mock
+  private OzoneManagerProtocolProtos.OMResponse mockOmResponse;
+  @Mock
+  private OmBucketInfo mockBucketInfo;
+
+  private OzoneFileCheckpointStrategy ozoneFileCheckpointStrategy;
+
+  @BeforeEach
+  public void setup() {
+    ozoneFileCheckpointStrategy = new OzoneFileCheckpointStrategy(mockOzoneManager, mockOmMetadataReader,
+        new org.apache.hadoop.hdds.conf.OzoneConfiguration());
+  }
+
+  @Test
+  public void testSaveStrategy() throws IOException, ServiceException {
+    try (MockedStatic<OzoneManagerRatisUtils> utils = mockStatic(OzoneManagerRatisUtils.class)) {
+      utils.when(() -> OzoneManagerRatisUtils.submitRequest(any(OzoneManager.class),
+          any(OzoneManagerProtocolProtos.OMRequest.class),
+          any(ClientId.class), any(Long.class))).thenReturn(mockOmResponse);
+
+      // Check its saved on first iteration
+      ozoneFileCheckpointStrategy.save("00000000000000000001");
+      utils.verify(() -> OzoneManagerRatisUtils.submitRequest(any(OzoneManager.class),
+          any(OzoneManagerProtocolProtos.OMRequest.class),
+          any(ClientId.class), any(Long.class)), Mockito.times(1));
+
+      // But not on second
+      ozoneFileCheckpointStrategy.save("0000000000000000002");
+      utils.verify(() -> OzoneManagerRatisUtils.submitRequest(any(OzoneManager.class),
+          any(OzoneManagerProtocolProtos.OMRequest.class),
+          any(ClientId.class), any(Long.class)), Mockito.times(1));
+
+      for (int i = 0; i <= 100; i++) {
+        String val = String.format("%020d", i);
+        ozoneFileCheckpointStrategy.save(val);
+      }
+
+      // Check submit has only ran twice in total (first save + save at 100th iteration)
+      utils.verify(() -> OzoneManagerRatisUtils.submitRequest(any(OzoneManager.class),
+          any(OzoneManagerProtocolProtos.OMRequest.class),
+          any(ClientId.class), any(Long.class)), Mockito.times(2));
+    }
+  }
+
+  @Test
+  public void testLoadStrategyWhenMetadataNotSet() throws IOException {
+    when(mockOzoneManager.getBucketInfo(any(), any())).thenReturn(mockBucketInfo);
+    when(mockBucketInfo.getMetadata()).thenReturn(com.google.common.collect.ImmutableMap.of());
+    Assertions.assertNull(ozoneFileCheckpointStrategy.load());
+  }
+
+  @Test
+  public void testLoadStrategyWhenBucketDoesNotExist() throws IOException {
+    when(mockOzoneManager.getBucketInfo(any(), any())).thenThrow(IOException.class);
+    Assertions.assertNull(ozoneFileCheckpointStrategy.load());
+  }
+
+  @Test
+  public void testLoadStrategyWithValidMetaData() throws IOException {
+    when(mockOzoneManager.getBucketInfo(any(), any())).thenReturn(mockBucketInfo);
+    when(mockBucketInfo.getMetadata()).thenReturn(
+        com.google.common.collect.ImmutableMap.of("notification-checkpoint", "00000000000000000017"));
+    Assertions.assertEquals("00000000000000000017", ozoneFileCheckpointStrategy.load());
+  }
+}


### PR DESCRIPTION
Please describe your PR in detail:
* Replaced the initial blocking Kafka send/checkpoint update implementation in `OMEventListenerKafkaPublisher` with an async send which updates the checkpointing position when the sends are acknowledged.
* In-flight transaction acknowledgements are tracked in-memory using a sliding-window companion, and the checkpointing position is only advanced to the highest contiguous acknowledged transaction index (preserving "at-least-once" delivery guarantees).
* Added a flow-control backpressure limit (default: 1,000) for the in-flight transaction tracking. If the limit is reached, the poller thread will block until the window drains.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15564

## How was this patch tested?

Unit tests:
* `TestOMEventListenerKafkaPublisher.testAsyncSlidingWindowWatermark` (validated out-of-order ack progress)
* `TestOMEventListenerKafkaPublisher.testAsyncSendFailureHaltsWatermark` (validated broker failure-halting and idempotent poller retries)

