### PR TITLE
HDDS-15091. CapacityVolumeChoosingPolicy should compare utilization, not available bytes

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
@@ -122,7 +122,9 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
     if (capacity <= 0) {
       return 0;
     }
-    long free = usage.getAvailable() - volume.getCommittedBytes();
+    // Clamp at 0: committed can exceed available, and a negative ratio would skew the
+    // comparison (matches the guard in HddsVolume.checkVolumeUsages).
+    long free = Math.max(0, usage.getAvailable() - volume.getCommittedBytes());
     return (double) free / capacity;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
@@ -115,7 +115,8 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
   // Fraction of capacity still free for hdds, excluding space committed to open containers.
   // Comparing the ratio (not absolute bytes) keeps utilization balanced across volumes of
   // different capacity.
-  private static double freeSpaceRatio(HddsVolume volume) {
+  @VisibleForTesting
+  static double freeSpaceRatio(HddsVolume volume) {
     SpaceUsageSource usage = volume.getCurrentUsage();
     long capacity = usage.getCapacity();
     if (capacity <= 0) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/CapacityVolumeChoosingPolicy.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 import org.slf4j.Logger;
@@ -84,9 +85,9 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
       HddsVolume selectedVolume = volumesWithEnoughSpace.get(0);
       if (count > 1) {
         // Even if we don't have too many volumes in volumesWithEnoughSpace, this
-        // algorithm will still help us choose the volume with larger
-        // available space than other volumes.
-        // Say we have vol1 with more available space than vol2, for two choices,
+        // algorithm will still help us choose the volume with lower
+        // utilization than other volumes.
+        // Say we have vol1 with lower utilization than vol2, for two choices,
         // the distribution of possibility is as follows:
         // 1. vol1 + vol2: 25%, result is vol1
         // 2. vol1 + vol1: 25%, result is vol1
@@ -100,16 +101,27 @@ public class CapacityVolumeChoosingPolicy implements VolumeChoosingPolicy {
         HddsVolume firstVolume = volumesWithEnoughSpace.get(firstIndex);
         HddsVolume secondVolume = volumesWithEnoughSpace.get(secondIndex);
 
-        long firstAvailable = firstVolume.getCurrentUsage().getAvailable()
-            - firstVolume.getCommittedBytes();
-        long secondAvailable = secondVolume.getCurrentUsage().getAvailable()
-            - secondVolume.getCommittedBytes();
-        selectedVolume = firstAvailable < secondAvailable ? secondVolume : firstVolume;
+        double firstRatio = freeSpaceRatio(firstVolume);
+        double secondRatio = freeSpaceRatio(secondVolume);
+        selectedVolume = firstRatio < secondRatio ? secondVolume : firstVolume;
       }
       selectedVolume.incCommittedBytes(maxContainerSize);
       return selectedVolume;
     } finally {
       lock.unlock();
     }
+  }
+
+  // Fraction of capacity still free for hdds, excluding space committed to open containers.
+  // Comparing the ratio (not absolute bytes) keeps utilization balanced across volumes of
+  // different capacity.
+  private static double freeSpaceRatio(HddsVolume volume) {
+    SpaceUsageSource usage = volume.getCurrentUsage();
+    long capacity = usage.getCapacity();
+    if (capacity <= 0) {
+      return 0;
+    }
+    long free = usage.getAvailable() - volume.getCommittedBytes();
+    return (double) free / capacity;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -122,7 +122,7 @@ public class TestCapacityVolumeChoosingPolicy {
   }
 
   @Test
-  public void choosesLowerUtilizationAcrossDifferentCapacities() throws Exception {
+  public void testChoosesLowerUtilizationAcrossDifferentCapacities() throws Exception {
     // big has more free bytes but is 90% full; small is only 60% full.
     // The policy must prefer the less-utilized volume, not the one with more free bytes.
     SpaceUsageSource bigSource = MockSpaceUsageSource.fixed(1000, 100);
@@ -156,6 +156,23 @@ public class TestCapacityVolumeChoosingPolicy {
     } finally {
       bigVolume.shutdown();
       smallVolume.shutdown();
+    }
+  }
+
+  @Test
+  public void testFreeSpaceRatioIsZeroWhenCapacityUnknown() throws Exception {
+    // A volume with unknown capacity (<= 0) yields ratio 0 instead of dividing by zero,
+    // so it is never preferred over a volume with known capacity.
+    SpaceUsageSource unknown = MockSpaceUsageSource.fixed(0, 0);
+    HddsVolume volume = new HddsVolume.Builder(baseDir + "unknown")
+        .conf(CONF)
+        .usageCheckFactory(MockSpaceUsageCheckFactory.of(
+            unknown, Duration.ZERO, SpaceUsagePersistence.None.INSTANCE))
+        .build();
+    try {
+      assertEquals(0.0, CapacityVolumeChoosingPolicy.freeSpaceRatio(volume));
+    } finally {
+      volume.shutdown();
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -122,6 +122,44 @@ public class TestCapacityVolumeChoosingPolicy {
   }
 
   @Test
+  public void choosesLowerUtilizationAcrossDifferentCapacities() throws Exception {
+    // big has more free bytes but is 90% full; small is only 60% full.
+    // The policy must prefer the less-utilized volume, not the one with more free bytes.
+    SpaceUsageSource bigSource = MockSpaceUsageSource.fixed(1000, 100);
+    HddsVolume bigVolume = new HddsVolume.Builder(baseDir + "big")
+        .conf(CONF)
+        .usageCheckFactory(MockSpaceUsageCheckFactory.of(
+            bigSource, Duration.ZERO, SpaceUsagePersistence.None.INSTANCE))
+        .build();
+    SpaceUsageSource smallSource = MockSpaceUsageSource.fixed(200, 80);
+    HddsVolume smallVolume = new HddsVolume.Builder(baseDir + "small")
+        .conf(CONF)
+        .usageCheckFactory(MockSpaceUsageCheckFactory.of(
+            smallSource, Duration.ZERO, SpaceUsagePersistence.None.INSTANCE))
+        .build();
+
+    List<HddsVolume> mixedVolumes = new ArrayList<>();
+    mixedVolumes.add(bigVolume);
+    mixedVolumes.add(smallVolume);
+
+    Map<HddsVolume, Integer> chooseCount = new HashMap<>();
+    chooseCount.put(bigVolume, 0);
+    chooseCount.put(smallVolume, 0);
+
+    try {
+      for (int i = 0; i < 1000; i++) {
+        HddsVolume volume = policy.chooseVolume(mixedVolumes, 0);
+        chooseCount.put(volume, chooseCount.get(volume) + 1);
+      }
+      assertThat(chooseCount.get(smallVolume))
+          .isGreaterThan(chooseCount.get(bigVolume));
+    } finally {
+      bigVolume.shutdown();
+      smallVolume.shutdown();
+    }
+  }
+
+  @Test
   public void throwsDiskOutOfSpaceIfRequestMoreThanAvailable() {
     Exception e = assertThrows(DiskOutOfSpaceException.class,
         () -> policy.chooseVolume(volumes, 500));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -177,6 +177,24 @@ public class TestCapacityVolumeChoosingPolicy {
   }
 
   @Test
+  public void testFreeSpaceRatioIsClampedToZeroWhenOverCommitted() throws Exception {
+    // committed exceeds available, so the raw free space is negative.
+    // The ratio must clamp to 0 rather than return a negative value.
+    SpaceUsageSource source = MockSpaceUsageSource.fixed(1000, 50);
+    HddsVolume volume = new HddsVolume.Builder(baseDir + "overcommitted")
+        .conf(CONF)
+        .usageCheckFactory(MockSpaceUsageCheckFactory.of(
+            source, Duration.ZERO, SpaceUsagePersistence.None.INSTANCE))
+        .build();
+    try {
+      volume.incCommittedBytes(100);
+      assertEquals(0.0, CapacityVolumeChoosingPolicy.freeSpaceRatio(volume));
+    } finally {
+      volume.shutdown();
+    }
+  }
+
+  @Test
   public void throwsDiskOutOfSpaceIfRequestMoreThanAvailable() {
     Exception e = assertThrows(DiskOutOfSpaceException.class,
         () -> policy.chooseVolume(volumes, 500));


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CapacityVolumeChoosingPolicy` is documented to pick the volume with **lower utilization**, but it actually compared **absolute available bytes** and picked the one with more free bytes. On datanodes with different-capacity volumes (e.g. 24TB HDD vs 2TB SSD), the large volume always has more free bytes and fills up first, causing imbalance.

This change compares the free-space ratio `(available - committed) / capacity` instead, preferring the lower-utilization volume. The pick-two-random algorithm is unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15091

## How was this patch tested?

Added unit tests in `TestCapacityVolumeChoosingPolicy`:
- `testChoosesLowerUtilizationAcrossDifferentCapacities`: a big volume (90% full) with more free bytes vs a small volume (60% full); asserts the less-utilized volume is chosen more often.
- `testFreeSpaceRatioIsZeroWhenCapacityUnknown`: a volume with unknown capacity yields ratio 0 instead of dividing by zero, so it is never preferred.

Full class passes (6 tests), checkstyle clean.
