### PR TITLE
HDDS-15578. Prevent throwing InvalidStateTransitionException from updateContainerStateWithSequenceId

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -107,7 +107,7 @@ abstract class AbstractContainerReportHandler {
   protected void processContainerReplica(final DatanodeDetails datanodeDetails,
       final ContainerInfo containerInfo,
       final ContainerReplicaProto replicaProto, final EventPublisher publisher, Object detailsForLogging)
-      throws IOException, InvalidStateTransitionException {
+      throws IOException {
     getLogger().debug("Processing replica {}", detailsForLogging);
     // Synchronized block should be replaced by container lock,
     // once we have introduced lock inside ContainerInfo.
@@ -242,7 +242,7 @@ abstract class AbstractContainerReportHandler {
                                     final ContainerInfo container,
                                     final ContainerReplicaProto replica,
                                     final EventPublisher publisher,
-      Object detailsForLogging) throws IOException, InvalidStateTransitionException {
+      Object detailsForLogging) throws IOException {
 
     final ContainerID containerId = container.containerID();
     boolean replicaIsEmpty = replica.hasIsEmpty() && replica.getIsEmpty();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.lease.LeaseAlreadyExistException;
 import org.apache.hadoop.ozone.lease.LeaseManager;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
@@ -135,7 +134,7 @@ public class CloseContainerEventHandler implements EventHandler<ContainerID> {
     } catch (NotLeaderException nle) {
       LOG.warn("Skip sending close container command,"
           + " since current SCM is not leader.", nle);
-    } catch (IOException | InvalidStateTransitionException ex) {
+    } catch (IOException ex) {
       LOG.error("Failed to close the container {}.", containerID, ex);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 
 /**
  * ContainerManager is responsible for keeping track of all Containers and
@@ -163,11 +162,10 @@ public interface ContainerManager {
    * @param containerID - Container ID
    * @param event - container life cycle event
    * @throws IOException
-   * @throws InvalidStateTransitionException
    */
   void updateContainerState(ContainerID containerID,
                             LifeCycleEvent event)
-      throws IOException, InvalidStateTransitionException;
+      throws IOException;
 
   /**
    * Bypasses the container state machine to change a container's state from DELETING/DELETED to CLOSED/QUASI_CLOSED.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.hdds.scm.ha.SequenceIdType;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -275,8 +274,7 @@ public class ContainerManagerImpl implements ContainerManager {
 
   @Override
   public void updateContainerState(final ContainerID cid,
-                                   final LifeCycleEvent event)
-      throws IOException, InvalidStateTransitionException {
+                                   final LifeCycleEvent event) throws IOException {
     HddsProtos.ContainerID protoId = cid.getProtobuf();
     lock.lock();
     try {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
@@ -234,7 +234,7 @@ public class ContainerReportHandler extends AbstractContainerReportHandler
     }
     try {
       processContainerReplica(datanodeDetails, container, replicaProto, publisher, detailsForLogging);
-    } catch (IOException | InvalidStateTransitionException e) {
+    } catch (IOException e) {
       getLogger().error("Failed to process {}", detailsForLogging, e);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.Containe
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -179,7 +179,7 @@ public interface ContainerStateManager extends SCMHandler {
   void updateContainerStateWithSequenceId(HddsProtos.ContainerID id,
                                           HddsProtos.LifeCycleEvent event,
                                           Long sequenceId)
-      throws IOException, InvalidStateTransitionException;
+      throws IOException;
 
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.scm.ha.SCMHandler;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 
 /**
  * A ContainerStateManager is responsible for keeping track of all the

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -405,31 +405,28 @@ public final class ContainerStateManagerImpl
               containerInfo.getSequenceId(), sequenceId);
         }
 
-        try {
-          final LifeCycleState oldState = containerInfo.getState();
-          final LifeCycleState newState = stateMachine.getNextState(
-              oldState, event);
+        final LifeCycleState oldState = containerInfo.getState();
+        final LifeCycleState newState = stateMachine.getNextState(
+            oldState, event);
 
-          if (newState.getNumber() > oldState.getNumber()) {
-            ExecutionUtil.create(() -> {
-              containers.updateState(id, oldState, newState);
-              transactionBuffer.addToBuffer(containerStore, id,
-                  containers.getContainerInfo(id));
-            }).onException(() -> {
-              containers.updateState(id, newState, oldState);
-              ContainerInfo currentInfo = containers.getContainerInfo(id);
-              transactionBuffer.addToBuffer(containerStore, id, currentInfo);
+        if (newState.getNumber() > oldState.getNumber()) {
+          ExecutionUtil.create(() -> {
+            containers.updateState(id, oldState, newState);
+            transactionBuffer.addToBuffer(containerStore, id,
+                containers.getContainerInfo(id));
+          }).onException(() -> {
+            containers.updateState(id, newState, oldState);
+            ContainerInfo currentInfo = containers.getContainerInfo(id);
+            transactionBuffer.addToBuffer(containerStore, id, currentInfo);
 
-            }).execute();
-            containerStateChangeActions.getOrDefault(event, info -> { })
-                .accept(containerInfo);
-          }
-        } catch (InvalidStateTransitionException ex) {
-          LOG.warn("Ignoring invalid container state transition for container {} " +
-                  "for event {} at state {}",
-              id, event, containerInfo.getState(), ex);
+          }).execute();
+          containerStateChangeActions.getOrDefault(event, info -> { })
+              .accept(containerInfo);
         }
       }
+    } catch (InvalidStateTransitionException e) {
+      LOG.warn("Failed to updateContainerStateWithSequenceId for container {} at sequenceId {}, ignoring it.",
+          id, sequenceId, e);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -389,7 +389,7 @@ public final class ContainerStateManagerImpl
   public void updateContainerStateWithSequenceId(final HddsProtos.ContainerID containerID,
                                                   final LifeCycleEvent event,
                                                   final Long sequenceId)
-      throws IOException, InvalidStateTransitionException {
+      throws IOException {
     // TODO: Remove the protobuf conversion after fixing ContainerStateMap.
     final ContainerID id = ContainerID.getFromProtobuf(containerID);
 
@@ -404,23 +404,30 @@ public final class ContainerStateManagerImpl
           LOG.warn("Container sequenceId is {} greater than the leader container sequenceId {}",
               containerInfo.getSequenceId(), sequenceId);
         }
-        
-        final LifeCycleState oldState = containerInfo.getState();
-        final LifeCycleState newState = stateMachine.getNextState(
-            oldState, event);
-        if (newState.getNumber() > oldState.getNumber()) {
-          ExecutionUtil.create(() -> {
-            containers.updateState(id, oldState, newState);
-            transactionBuffer.addToBuffer(containerStore, id,
-                containers.getContainerInfo(id));
-          }).onException(() -> {
-            containers.updateState(id, newState, oldState);
-            ContainerInfo currentInfo = containers.getContainerInfo(id);
-            transactionBuffer.addToBuffer(containerStore, id, currentInfo);
 
-          }).execute();
-          containerStateChangeActions.getOrDefault(event, info -> { })
-              .accept(containerInfo);
+        try {
+          final LifeCycleState oldState = containerInfo.getState();
+          final LifeCycleState newState = stateMachine.getNextState(
+              oldState, event);
+
+          if (newState.getNumber() > oldState.getNumber()) {
+            ExecutionUtil.create(() -> {
+              containers.updateState(id, oldState, newState);
+              transactionBuffer.addToBuffer(containerStore, id,
+                  containers.getContainerInfo(id));
+            }).onException(() -> {
+              containers.updateState(id, newState, oldState);
+              ContainerInfo currentInfo = containers.getContainerInfo(id);
+              transactionBuffer.addToBuffer(containerStore, id, currentInfo);
+
+            }).execute();
+            containerStateChangeActions.getOrDefault(event, info -> { })
+                .accept(containerInfo);
+          }
+        } catch (InvalidStateTransitionException ex) {
+          LOG.warn("Ignoring invalid container state transition for container {} " +
+                  "for event {} at state {}",
+              id, event, containerInfo.getState(), ex);
         }
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.IncrementalContainerReportFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +121,7 @@ public class IncrementalContainerReportHandler
           } else {
             getLogger().info("Failed to process {}", detailsForLogging, ex);
           }
-        } catch (IOException | InvalidStateTransitionException e) {
+        } catch (IOException e) {
           getLogger().info("Failed to process {}", detailsForLogging, e);
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -737,7 +737,7 @@ public class ReplicationManager implements SCMService, ContainerReplicaPendingOp
                                    HddsProtos.LifeCycleEvent event) {
     try {
       containerManager.updateContainerState(containerID, event);
-    } catch (IOException | InvalidStateTransitionException e) {
+    } catch (IOException e) {
       LOG.error("Failed to update the state of container {}, update Event {}",
           containerID, event, e);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -85,7 +85,6 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.ratis.protocol.Message;
 
 /** Code generated for {@link ContainerStateManager}.  Do not modify. */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
@@ -181,7 +181,7 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
 
       @Override
       public void updateContainerStateWithSequenceId(HddsProtos.ContainerID arg0, LifeCycleEvent arg1, Long arg2) throws
-          IOException, InvalidStateTransitionException {
+          IOException {
         final Object[] args = {arg0, arg1, arg2};
         invoker.invokeReplicateDirect(ReplicateMethod.updateContainerStateWithSequenceId, args);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -478,12 +478,8 @@ public class PipelineManagerImpl implements PipelineManager {
     for (ContainerID containerID : containerIDs) {
       if (containerManager.getContainer(containerID).getState()
             == HddsProtos.LifeCycleState.OPEN) {
-        try {
-          containerManager.updateContainerState(containerID,
-              HddsProtos.LifeCycleEvent.FINALIZE);
-        } catch (InvalidStateTransitionException ex) {
-          throw new IOException(ex);
-        }
+        containerManager.updateContainerState(containerID,
+            HddsProtos.LifeCycleEvent.FINALIZE);
       }
       eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, containerID);
       LOG.info("Container {} closed for pipeline={}", containerID, pipelineId);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -483,8 +483,8 @@ public class PipelineManagerImpl implements PipelineManager {
       if (containerManager.getContainer(containerID).getState() ==
           HddsProtos.LifeCycleState.CLOSING) {
         eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, containerID);
-        LOG.info("Container {} closed for pipeline={}", containerID, pipelineId);
       }
+      LOG.info("Container {} closed for pipeline={}", containerID, pipelineId);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -63,7 +63,6 @@ import org.apache.hadoop.hdds.utils.db.RocksDatabaseException;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.ozone.ClientVersion;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.slf4j.Logger;
@@ -481,8 +480,11 @@ public class PipelineManagerImpl implements PipelineManager {
         containerManager.updateContainerState(containerID,
             HddsProtos.LifeCycleEvent.FINALIZE);
       }
-      eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, containerID);
-      LOG.info("Container {} closed for pipeline={}", containerID, pipelineId);
+      if (containerManager.getContainer(containerID).getState() ==
+          HddsProtos.LifeCycleState.CLOSING) {
+        eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, containerID);
+        LOG.info("Container {} closed for pipeline={}", containerID, pipelineId);
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -546,8 +546,7 @@ public final class HddsTestUtils {
    * @throws IOException
    */
   public static void quasiCloseContainer(ContainerManager containerManager,
-       ContainerID id) throws IOException,
-      InvalidStateTransitionException, TimeoutException {
+       ContainerID id) throws IOException {
     containerManager.updateContainerState(
         id, HddsProtos.LifeCycleEvent.FINALIZE);
     containerManager.updateContainerState(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -180,7 +180,7 @@ public class TestCloseContainerEventHandler {
 
   private void closeContainerForValidContainer(ReplicationConfig repConfig,
       int nodeCount, boolean forceClose)
-      throws IOException, InvalidStateTransitionException, TimeoutException {
+      throws IOException {
     final Pipeline pipeline = createPipeline(repConfig, nodeCount);
     final ContainerInfo container =
         createContainer(repConfig, pipeline.getId());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -213,7 +212,7 @@ public class TestContainerManagerImpl {
   @EnumSource(value = HddsProtos.LifeCycleState.class,
       names = {"DELETING", "DELETED"})
   void testTransitionDeletingOrDeletedToTargetState(HddsProtos.LifeCycleState desiredState)
-      throws IOException, InvalidStateTransitionException {
+      throws IOException {
     // Allocate OPEN Ratis and Ec containers, and do a series of state changes to transition them to DELETING / DELETED
     final ContainerInfo container = containerManager.allocateContainer(
         RatisReplicationConfig.getInstance(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -73,7 +73,6 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.Containe
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.junit.jupiter.api.AfterEach;
@@ -100,7 +99,7 @@ public class TestContainerReportHandler {
   private PipelineManager pipelineManager;
 
   @BeforeEach
-  void setup() throws IOException, InvalidStateTransitionException {
+  void setup() throws IOException {
     final OzoneConfiguration conf = SCMTestUtils.getConf(testDir);
     nodeManager = new MockNodeManager(true, 10);
     containerManager = mock(ContainerManager.class);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -66,7 +66,6 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.junit.jupiter.api.AfterEach;
@@ -94,7 +93,7 @@ public class TestContainerStateManager {
   private EventPublisher publisher;
 
   @BeforeEach
-  public void init() throws IOException, TimeoutException, InvalidStateTransitionException {
+  public void init() throws IOException, TimeoutException {
     OzoneConfiguration conf = new OzoneConfiguration();
     SCMHAManager scmhaManager = SCMHAManagerStub.getInstance(true);
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testDir.getAbsolutePath());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -86,7 +86,6 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -110,7 +109,7 @@ public class TestIncrementalContainerReportHandler {
   private DBStore dbStore;
 
   @BeforeEach
-  public void setup() throws IOException, InvalidStateTransitionException,
+  public void setup() throws IOException,
       TimeoutException {
     final OzoneConfiguration conf = new OzoneConfiguration();
     Path scmPath = Paths.get(testDir.getPath(), "scm-meta");

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +62,7 @@ public class TestEmptyContainerHandler {
 
   @BeforeEach
   public void setup()
-      throws IOException, InvalidStateTransitionException, TimeoutException {
+      throws IOException, TimeoutException {
     ecReplicationConfig = new ECReplicationConfig(3, 2);
     ratisReplicationConfig = RatisReplicationConfig.getInstance(
         HddsProtos.ReplicationFactor.THREE);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.tag.Flaky;
@@ -145,8 +144,7 @@ public class TestContainerStateManagerIntegration {
 
   @Test
   public void testContainerStateManagerRestart() throws IOException,
-      TimeoutException, InterruptedException, AuthenticationException,
-      InvalidStateTransitionException {
+      TimeoutException, InterruptedException, AuthenticationException {
     // Allocate 5 containers in ALLOCATED state and 5 in CREATING state
 
     for (int i = 0; i < 10; i++) {
@@ -271,8 +269,7 @@ public class TestContainerStateManagerIntegration {
   }
 
   @Test
-  public void testUpdateContainerState() throws IOException,
-      InvalidStateTransitionException {
+  public void testUpdateContainerState() throws IOException {
     assertContainerCount(LifeCycleState.OPEN, 0);
 
     // Allocate container1 and update its state from

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,8 +61,7 @@ public abstract class TestNode2PipelineMap implements NonHATests.TestCase {
   }
 
   @Test
-  public void testPipelineMap() throws IOException,
-      InvalidStateTransitionException, TimeoutException {
+  public void testPipelineMap() throws IOException {
 
     Set<ContainerID> set = pipelineManager
         .getContainersInPipeline(ratisContainer.getPipeline().getId());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.ClosePipelineCommandHandler;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
@@ -123,8 +122,7 @@ public class TestPipelineClose {
   }
 
   @Test
-  public void testPipelineCloseWithClosedContainer() throws IOException,
-      InvalidStateTransitionException, TimeoutException {
+  public void testPipelineCloseWithClosedContainer() throws IOException {
     Set<ContainerID> set = pipelineManager
         .getContainersInPipeline(ratisContainer.getPipeline().getId());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -99,7 +99,6 @@ import org.apache.hadoop.ozone.client.io.InsufficientLocationsException;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
@@ -934,7 +933,7 @@ public class TestContainerCommandsEC {
   }
 
   private void closeContainer(long conID)
-      throws IOException, InvalidStateTransitionException {
+      throws IOException {
     //Close the container first.
     scm.getContainerManager().getContainerStateManager().updateContainerStateWithSequenceId(
         HddsProtos.ContainerID.newBuilder().setId(conID).build(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -67,7 +67,6 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ozone.test.tag.Unhealthy;
@@ -252,7 +251,7 @@ public class TestScmSafeMode {
             HddsProtos.LifeCycleEvent.FINALIZE);
         mapping.updateContainerState(c.containerID(),
             LifeCycleEvent.CLOSE);
-      } catch (IOException | InvalidStateTransitionException e) {
+      } catch (IOException e) {
         LOG.info("Failed to change state of open containers.", e);
       }
     });

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -75,7 +75,6 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -1331,7 +1330,7 @@ public class TestContainerEndpoint {
   }
 
   private void updateContainerStateToDeleted(long containerId)
-      throws IOException, InvalidStateTransitionException, TimeoutException {
+      throws IOException {
     reconContainerManager.updateContainerState(ContainerID.valueOf(containerId),
         HddsProtos.LifeCycleEvent.FINALIZE);
     reconContainerManager.updateContainerState(ContainerID.valueOf(containerId),


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are methods annotated with `@Replicate` that can throw InvalidStateTransitionException like ContainerStateManager#updateContainerStateWithSequenceId.

When the method is applied by SCM Ratis, an exception from the StateMachineUpdater path can terminate SCM although it is not really a critical error (e.g. if there are duplicate events, we can simply ignore one).

Example risk (Edit: Due to the makeStateTransitionIdempotent, this is not really valid):

- Leader submits FINALIZE for OPEN.
- Before/apply ordering or duplicate report causes the current state to already be CLOSING.
- Applying FINALIZE at CLOSING is invalid.
- Exception escapes from replicated apply path.

The chance is very low since most of there is a check of the container state before in updateContainerStateWithSequenceId the caller will check that the current container state is expected, but it's there. 

Note that the `makeStateTransitionIdempotent` also adds a guard to make sure that transition is idempotent.

We can try to fix it by

- Inside the replicated implementation, catch InvalidStateTransitionException.
- Log and return without mutation.
- Treat it as a stale/duplicate lifecycle event, not a fatal replicated-state-machine error.

Or we can simply catch InvalidStateTransitionException  SCMStateMachine#applyTransaction, but this means that all future InvalidStateTransitionException are non-fatal.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15578

## How was this patch tested?

CI (https://github.com/ivandika3/ozone/actions/runs/27731733234)
