### PR TITLE
HDDS-15574. Update copyright year in NOTICE to 2026

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Ozone
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Ozone
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request updates the copyright year in the Apache Ozone `NOTICE.txt` file from 2025 to 2026.

The Jira issue HDDS-15574 tracks the release task to update the copyright year in `NOTICE.txt` for the Apache Ozone 2.1.2 target version. This change updates the project notice metadata so that it reflects the current copyright year.

No functional code changes are included in this pull request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15574

## How was this patch tested?

This patch was tested by reviewing the local git diff to confirm that only `NOTICE.txt` was changed.

The change is limited to updating the copyright year from 2025 to 2026, so no unit tests were run.