### PR TITLE
HDDS-15588. Log DEBUG message when there is no command count information for datanode

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -905,7 +905,7 @@ public class SCMNodeManager implements NodeManager {
     try {
       int dnCount = getNodeQueuedCommandCount(datanodeDetails, cmdType);
       if (dnCount == -1) {
-        LOG.warn("No command count information for datanode {} and command {}" +
+        LOG.debug("No command count information for datanode {} and command {}" +
             ". Assuming zero", datanodeDetails, cmdType);
         dnCount = 0;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Log DEBUG message when there is no command count information for datanode, avoid flood the SCM log file with WARN messages. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15588

## How was this patch tested?


