### PR TITLE
HDDS-15589. Let build-ratis workflow output all property override

### DIFF
--- a/.github/workflows/build-ratis.yml
+++ b/.github/workflows/build-ratis.yml
@@ -54,6 +54,9 @@ on:
       protobuf-version:
         description: "Protobuf Version"
         value: ${{ jobs.ratis-thirdparty.outputs.protobuf-version }}
+      build-args:
+        description: "Arguments for building with Ratis"
+        value: ${{ jobs.summary.outputs.build-args }}
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 permissions: { }
@@ -126,19 +129,30 @@ jobs:
           echo "grpc=$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=shaded.grpc.version)" >> $GITHUB_OUTPUT
           echo "netty=$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=shaded.netty.version)" >> $GITHUB_OUTPUT
           echo "protobuf=$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=shaded.protobuf.version)" >> $GITHUB_OUTPUT
-  debug:
+  summary:
     runs-on: ubuntu-slim
     needs:
       - ratis
       - ratis-thirdparty
+    outputs:
+      build-args: ${{ steps.versions.outputs.build-args }}
     steps:
       - name: Print versions
+        id: versions
         run: |
+          build_args="-Dratis.version=$ratis_version"
+          build_args="$build_args -Dratis.thirdparty.version=$ratis_thirdparty_version"
+          build_args="$build_args -Dratis-thirdparty.grpc.version=$grpc_version"
+          build_args="$build_args -Dratis-thirdparty.netty.version=$netty_version"
+          build_args="$build_args -Dratis-thirdparty.protobuf.version=$protobuf_version"
+          echo "build-args=$build_args" >> "$GITHUB_OUTPUT"
+
           echo "Ratis: $ratis_version"
           echo "Thirdparty: $ratis_thirdparty_version"
           echo "Grpc: $grpc_version"
           echo "Netty: $netty_version"
           echo "Protobuf: $protobuf_version"
+          echo "Build args for Ozone: $build_args"
         env:
           ratis_version: ${{ needs.ratis.outputs.ratis-version }}
           ratis_thirdparty_version: ${{ needs.ratis.outputs.thirdparty-version }}

--- a/.github/workflows/ci-with-ratis.yml
+++ b/.github/workflows/ci-with-ratis.yml
@@ -54,5 +54,5 @@ jobs:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
     with:
-      ratis_args: "-Dratis.version=${{ needs.ratis.outputs.ratis-version }} -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }} -Dratis-thirdparty.grpc.version=${{ needs.ratis.outputs.grpc-version }} -Dratis-thirdparty.netty.version=${{ needs.ratis.outputs.netty-version }} -Dratis-thirdparty.protobuf.version=${{ needs.ratis.outputs.protobuf-version }}"
+      ratis_args: ${{ needs.ratis.outputs.build-args }}
       ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -135,23 +135,12 @@ jobs:
       - name: Build (most) of Ozone
         run: |
           args="-DskipRecon -DskipShade -Dmaven.javadoc.skip=true -Drocks_tools_native"
-          if [[ "$RATIS_VERSION" != "" ]]; then
-            args="$args -Dratis.version=$ratis_version"
-            args="$args -Dratis.thirdparty.version=$ratis_thirdparty_version"
-            args="$args -Dratis-thirdparty.grpc.version=$grpc_version"
-            args="$args -Dratis-thirdparty.netty.version=$netty_version"
-            args="$args -Dratis-thirdparty.protobuf.version=$protobuf_version"
-          fi
-
+          args="$args $ratis_args"
           args="$args -am -pl :$SUBMODULE"
 
           hadoop-ozone/dev-support/checks/build.sh $args
         env:
-          ratis_version: ${{ needs.ratis.outputs.ratis-version }}
-          ratis_thirdparty_version: ${{ needs.ratis.outputs.thirdparty-version }}
-          grpc_version: ${{ needs.ratis.outputs.grpc-version }}
-          netty_version: ${{ needs.ratis.outputs.netty-version }}
-          protobuf_version: ${{ needs.ratis.outputs.protobuf-version }}
+          ratis_args: ${{ needs.ratis.outputs.build-args }}
       - name: Store Maven repo for tests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -212,14 +201,7 @@ jobs:
           fi
 
           args="-DexcludedGroups=slow|unhealthy -DskipShade -Drocks_tools_native"
-          if [[ "$RATIS_VERSION" != "" ]]; then
-            args="$args -Dratis.version=$ratis_version"
-            args="$args -Dratis.thirdparty.version=$ratis_thirdparty_version"
-            args="$args -Dratis-thirdparty.grpc.version=$grpc_version"
-            args="$args -Dratis-thirdparty.netty.version=$netty_version"
-            args="$args -Dratis-thirdparty.protobuf.version=$protobuf_version"
-          fi
-
+          args="$args $ratis_args"
           args="$args -pl :$SUBMODULE"
 
           if [ "$TEST_METHOD" = "ALL" ]; then
@@ -235,14 +217,10 @@ jobs:
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           repo_path: ${{ steps.download-ozone-repo.outputs.download-path }}
-          ratis_version: ${{ needs.ratis.outputs.ratis-version }}
-          ratis_thirdparty_version: ${{ needs.ratis.outputs.thirdparty-version }}
-          grpc_version: ${{ needs.ratis.outputs.grpc-version }}
-          netty_version: ${{ needs.ratis.outputs.netty-version }}
-          protobuf_version: ${{ needs.ratis.outputs.protobuf-version }}
+          ratis_args: ${{ needs.ratis.outputs.build-args }}
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/unit/summary.txt
-        if: ${{ !cancelled() }}
+        if: ${{ failure() }}
       - name: Archive build results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`build-ratis` workflow has several outputs, assembled for Ozone mvn commands in multiple places.  To reduce duplication, `build-ratis` could also output the argument list assembled.

https://issues.apache.org/jira/browse/HDDS-15589

## How was this patch tested?

`flaky-test-check`:
https://github.com/adoroszlai/ozone/actions/runs/27680931922/job/81868109631#step:7:39

`flaky-test-check` with Ratis:
https://github.com/adoroszlai/ozone/actions/runs/27680832023/job/81868139024#step:7:39

`build-with-ratis`:
https://github.com/adoroszlai/ozone/actions/runs/27681321012/job/81869755651#step:13:14