### PR TITLE
HDDS-15511. Implement Ozone client API's for bucket tagging

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -161,11 +160,6 @@ public class OzoneBucket extends WithMetadata {
    */
   private long pendingDeleteNamespace;
 
-  /**
-   * S3-style bucketTags on the bucket.
-   */
-  private final Map<String, String> bucketTags = new HashMap<>();
-
   protected OzoneBucket(Builder builder) {
     super(builder);
     this.proxy = builder.proxy;
@@ -207,9 +201,6 @@ public class OzoneBucket extends WithMetadata {
       this.bucketLayout = builder.bucketLayout;
     }
     this.owner = builder.owner;
-    if (builder.tags != null) {
-      this.bucketTags.putAll(builder.tags);
-    }
   }
 
   /**
@@ -274,15 +265,6 @@ public class OzoneBucket extends WithMetadata {
    */
   public Instant getModificationTime() {
     return modificationTime;
-  }
-
-  /**
-   * Returns the bucketTags of the bucket.
-   *
-   * @return bucket bucketTags.
-   */
-  public Map<String, String> getBucketTags() {
-    return Collections.unmodifiableMap(bucketTags);
   }
 
   /**
@@ -1249,7 +1231,6 @@ public class OzoneBucket extends WithMetadata {
    */
   public void putBucketTagging(Map<String, String> tags) throws IOException {
     proxy.putBucketTagging(volumeName, name, tags);
-    applyBucketTaggingUpdate(tags);
   }
 
   /**
@@ -1258,24 +1239,6 @@ public class OzoneBucket extends WithMetadata {
    */
   public void deleteBucketTagging() throws IOException {
     proxy.deleteBucketTagging(volumeName, name);
-    applyBucketTaggingDelete();
-  }
-
-  /**
-   * Updates cached bucket tags after a successful put.
-   */
-  protected void applyBucketTaggingUpdate(Map<String, String> tags) {
-    bucketTags.clear();
-    if (tags != null) {
-      bucketTags.putAll(tags);
-    }
-  }
-
-  /**
-   * Updates cached bucket tags after a successful delete tagging call.
-   */
-  protected void applyBucketTaggingDelete() {
-    bucketTags.clear();
   }
 
   public void setSourcePathExist(boolean b) {
@@ -1316,7 +1279,6 @@ public class OzoneBucket extends WithMetadata {
     private String owner;
     private long pendingDeleteBytes;
     private long pendingDeleteNamespace;
-    private Map<String, String> tags;
 
     protected Builder() {
     }
@@ -1420,11 +1382,6 @@ public class OzoneBucket extends WithMetadata {
 
     public Builder setPendingDeleteNamespace(long pendingDeleteNamespace) {
       this.pendingDeleteNamespace = pendingDeleteNamespace;
-      return this;
-    }
-
-    public Builder setTags(Map<String, String> tags) {
-      this.tags = tags;
       return this;
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -160,6 +161,11 @@ public class OzoneBucket extends WithMetadata {
    */
   private long pendingDeleteNamespace;
 
+  /**
+   * S3-style bucketTags on the bucket.
+   */
+  private final Map<String, String> bucketTags = new HashMap<>();
+
   protected OzoneBucket(Builder builder) {
     super(builder);
     this.proxy = builder.proxy;
@@ -201,6 +207,9 @@ public class OzoneBucket extends WithMetadata {
       this.bucketLayout = builder.bucketLayout;
     }
     this.owner = builder.owner;
+    if (builder.tags != null) {
+      this.bucketTags.putAll(builder.tags);
+    }
   }
 
   /**
@@ -265,6 +274,15 @@ public class OzoneBucket extends WithMetadata {
    */
   public Instant getModificationTime() {
     return modificationTime;
+  }
+
+  /**
+   * Returns the bucketTags of the bucket.
+   *
+   * @return bucket bucketTags.
+   */
+  public Map<String, String> getBucketTags() {
+    return Collections.unmodifiableMap(bucketTags);
   }
 
   /**
@@ -1214,6 +1232,52 @@ public class OzoneBucket extends WithMetadata {
     proxy.deleteObjectTagging(volumeName, name, keyName);
   }
 
+  /**
+   * Gets the bucketTags for this bucket.
+   * @return Tags for this bucket.
+   * @throws IOException
+   */
+  @JsonIgnore
+  public Map<String, String> getBucketTagging() throws IOException {
+    return proxy.getBucketTagging(volumeName, name);
+  }
+
+  /**
+   * Sets bucketTags on this bucket (replaces existing tag set).
+   * @param tags Tags to set on the bucket.
+   * @throws IOException
+   */
+  public void putBucketTagging(Map<String, String> tags) throws IOException {
+    proxy.putBucketTagging(volumeName, name, tags);
+    applyBucketTaggingUpdate(tags);
+  }
+
+  /**
+   * Removes all bucketTags from this bucket.
+   * @throws IOException
+   */
+  public void deleteBucketTagging() throws IOException {
+    proxy.deleteBucketTagging(volumeName, name);
+    applyBucketTaggingDelete();
+  }
+
+  /**
+   * Updates cached bucket tags after a successful put.
+   */
+  protected void applyBucketTaggingUpdate(Map<String, String> tags) {
+    bucketTags.clear();
+    if (tags != null) {
+      bucketTags.putAll(tags);
+    }
+  }
+
+  /**
+   * Updates cached bucket tags after a successful delete tagging call.
+   */
+  protected void applyBucketTaggingDelete() {
+    bucketTags.clear();
+  }
+
   public void setSourcePathExist(boolean b) {
     this.sourcePathExist = b;
   }
@@ -1252,6 +1316,7 @@ public class OzoneBucket extends WithMetadata {
     private String owner;
     private long pendingDeleteBytes;
     private long pendingDeleteNamespace;
+    private Map<String, String> tags;
 
     protected Builder() {
     }
@@ -1355,6 +1420,11 @@ public class OzoneBucket extends WithMetadata {
 
     public Builder setPendingDeleteNamespace(long pendingDeleteNamespace) {
       this.pendingDeleteNamespace = pendingDeleteNamespace;
+      return this;
+    }
+
+    public Builder setTags(Map<String, String> tags) {
+      this.tags = tags;
       return this;
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -1493,4 +1493,31 @@ public interface ClientProtocol {
   void deleteObjectTagging(String volumeName, String bucketName, String keyName)
       throws IOException;
 
+  /**
+   * Gets the tags for an existing bucket.
+   * @param volumeName Volume name.
+   * @param bucketName Bucket name.
+   * @return Tags for the specified bucket.
+   * @throws IOException
+   */
+  Map<String, String> getBucketTagging(String volumeName, String bucketName)
+      throws IOException;
+
+  /**
+   * Sets tags on an existing bucket (replaces existing tag set).
+   * @param volumeName Volume name.
+   * @param bucketName Bucket name.
+   * @param tags Tags to set on the bucket.
+   * @throws IOException
+   */
+  void putBucketTagging(String volumeName, String bucketName,
+      Map<String, String> tags) throws IOException;
+
+  /**
+   * Removes all tags from the specified bucket.
+   * @param volumeName Volume name.
+   * @param bucketName Bucket name.
+   * @throws IOException
+   */
+  void deleteBucketTagging(String volumeName, String bucketName) throws IOException;
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1340,7 +1340,6 @@ public class RpcClient implements ClientProtocol {
         .setBucketLayout(bucketInfo.getBucketLayout())
         .setOwner(bucketInfo.getOwner())
         .setDefaultReplicationConfig(bucketInfo.getDefaultReplicationConfig())
-        .setTags(bucketInfo.getTags())
         .build();
   }
 
@@ -1375,7 +1374,6 @@ public class RpcClient implements ClientProtocol {
                 .setOwner(bucket.getOwner())
                 .setDefaultReplicationConfig(
                     bucket.getDefaultReplicationConfig())
-                .setTags(bucket.getTags())
                 .build())
         .collect(Collectors.toList());
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1340,6 +1340,7 @@ public class RpcClient implements ClientProtocol {
         .setBucketLayout(bucketInfo.getBucketLayout())
         .setOwner(bucketInfo.getOwner())
         .setDefaultReplicationConfig(bucketInfo.getDefaultReplicationConfig())
+        .setTags(bucketInfo.getTags())
         .build();
   }
 
@@ -1374,6 +1375,7 @@ public class RpcClient implements ClientProtocol {
                 .setOwner(bucket.getOwner())
                 .setDefaultReplicationConfig(
                     bucket.getDefaultReplicationConfig())
+                .setTags(bucket.getTags())
                 .build())
         .collect(Collectors.toList());
   }
@@ -2883,6 +2885,55 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .build();
     ozoneManagerClient.deleteObjectTagging(keyArgs);
+  }
+
+  @Override
+  public Map<String, String> getBucketTagging(String volumeName, String bucketName)
+      throws IOException {
+    if (omVersion.compareTo(OzoneManagerVersion.S3_BUCKET_TAGGING_API) < 0) {
+      throw new IOException("OzoneManager does not support S3 bucket tagging API");
+    }
+
+    verifyVolumeName(volumeName);
+    verifyBucketName(bucketName);
+    OmBucketArgs bucketArgs = new OmBucketArgs.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .build();
+    return ozoneManagerClient.getBucketTagging(bucketArgs);
+  }
+
+  @Override
+  public void putBucketTagging(String volumeName, String bucketName,
+      Map<String, String> tags) throws IOException {
+    if (omVersion.compareTo(OzoneManagerVersion.S3_BUCKET_TAGGING_API) < 0) {
+      throw new IOException("OzoneManager does not support S3 bucket tagging API");
+    }
+
+    verifyVolumeName(volumeName);
+    verifyBucketName(bucketName);
+    OmBucketArgs bucketArgs = new OmBucketArgs.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .addAllTags(tags)
+        .build();
+    ozoneManagerClient.putBucketTagging(bucketArgs);
+  }
+
+  @Override
+  public void deleteBucketTagging(String volumeName, String bucketName)
+      throws IOException {
+    if (omVersion.compareTo(OzoneManagerVersion.S3_BUCKET_TAGGING_API) < 0) {
+      throw new IOException("OzoneManager does not support S3 bucket tagging API");
+    }
+
+    verifyVolumeName(volumeName);
+    verifyBucketName(bucketName);
+    OmBucketArgs bucketArgs = new OmBucketArgs.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .build();
+    ozoneManagerClient.deleteBucketTagging(bucketArgs);
   }
 
   private static ExecutorService createThreadPoolExecutor(

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -1219,10 +1219,24 @@ public interface OzoneManagerProtocol
    * @return Tags associated with the bucket.
    */
   @Override
-  default Map<String, String> getBucketTagging(OmBucketArgs args) throws IOException {
-    // This will be removed in the follow-up ticket HDDS-15511.
+  Map<String, String> getBucketTagging(OmBucketArgs args) throws IOException;
+
+  /**
+   * Sets tags on an existing bucket (replaces existing tag set).
+   * @param args Bucket args
+   */
+  default void putBucketTagging(OmBucketArgs args) throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
-        "this to be implemented, as bucket tagging client support is pending.");
+        "this to be implemented, as write requests use a new approach.");
+  }
+
+  /**
+   * Removes all tags from the specified bucket.
+   * @param args Bucket args
+   */
+  default void deleteBucketTagging(OmBucketArgs args) throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented, as write requests use a new approach.");
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -120,6 +120,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateV
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteBucketRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteBucketTaggingRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysRequest;
@@ -136,6 +137,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Finaliz
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.FinalizeUpgradeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetAclResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetBucketTaggingRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetBucketTaggingResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetDelegationTokenResponseProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetFileStatusRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetFileStatusResponse;
@@ -191,6 +194,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Prepare
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PutBucketTaggingRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PutObjectTaggingRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RangerBGSyncRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RangerBGSyncResponse;
@@ -2750,6 +2754,67 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     OMResponse omResponse = submitRequest(omRequest);
     handleError(omResponse);
+  }
+
+  @Override
+  public Map<String, String> getBucketTagging(OmBucketArgs args) throws IOException {
+    BucketArgs bucketArgs = BucketArgs.newBuilder()
+        .setVolumeName(args.getVolumeName())
+        .setBucketName(args.getBucketName())
+        .build();
+
+    GetBucketTaggingRequest req =
+        GetBucketTaggingRequest.newBuilder()
+            .setBucketArgs(bucketArgs)
+            .build();
+
+    OMRequest omRequest = createOMRequest(Type.GetBucketTagging)
+        .setGetBucketTaggingRequest(req)
+        .build();
+
+    GetBucketTaggingResponse resp =
+        handleError(submitRequest(omRequest)).getGetBucketTaggingResponse();
+
+    return KeyValueUtil.getFromProtobuf(resp.getTagsList());
+  }
+
+  @Override
+  public void putBucketTagging(OmBucketArgs args) throws IOException {
+    BucketArgs bucketArgs = BucketArgs.newBuilder()
+        .setVolumeName(args.getVolumeName())
+        .setBucketName(args.getBucketName())
+        .addAllTags(KeyValueUtil.toProtobuf(args.getTags()))
+        .build();
+
+    PutBucketTaggingRequest req =
+        PutBucketTaggingRequest.newBuilder()
+            .setBucketArgs(bucketArgs)
+            .build();
+
+    OMRequest omRequest = createOMRequest(Type.PutBucketTagging)
+        .setPutBucketTaggingRequest(req)
+        .build();
+
+    handleError(submitRequest(omRequest));
+  }
+
+  @Override
+  public void deleteBucketTagging(OmBucketArgs args) throws IOException {
+    BucketArgs bucketArgs = BucketArgs.newBuilder()
+        .setVolumeName(args.getVolumeName())
+        .setBucketName(args.getBucketName())
+        .build();
+
+    DeleteBucketTaggingRequest req =
+        DeleteBucketTaggingRequest.newBuilder()
+            .setBucketArgs(bucketArgs)
+            .build();
+
+    OMRequest omRequest = createOMRequest(Type.DeleteBucketTagging)
+        .setDeleteBucketTaggingRequest(req)
+        .build();
+
+    handleError(submitRequest(omRequest));
   }
 
   private SafeMode toProtoBuf(SafeModeAction action) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -5735,8 +5735,8 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     bucket.putBucketTagging(tags);
 
     OzoneBucket updatedBucket = volume.getBucket(bucketName);
-    assertEquals(tags.size(), updatedBucket.getBucketTags().size());
-    assertThat(updatedBucket.getBucketTags()).containsAllEntriesOf(tags);
+    assertEquals(tags.size(), updatedBucket.getBucketTagging().size());
+    assertThat(updatedBucket.getBucketTagging()).containsAllEntriesOf(tags);
     assertThat(updatedBucket.getModificationTime())
         .isAfterOrEqualTo(modificationTimeBeforePut);
 
@@ -5747,9 +5747,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     bucket.putBucketTagging(secondTags);
 
     OzoneBucket updatedBucket2 = volume.getBucket(bucketName);
-    assertEquals(secondTags.size(), updatedBucket2.getBucketTags().size());
-    assertThat(updatedBucket2.getBucketTags()).containsAllEntriesOf(secondTags);
-    assertThat(updatedBucket2.getBucketTags()).doesNotContainKeys("tag-key-1", "tag-key-2");
+    assertEquals(secondTags.size(), updatedBucket2.getBucketTagging().size());
+    assertThat(updatedBucket2.getBucketTagging()).containsAllEntriesOf(secondTags);
+    assertThat(updatedBucket2.getBucketTagging()).doesNotContainKeys("tag-key-1", "tag-key-2");
     assertThat(updatedBucket2.getModificationTime())
         .isAfterOrEqualTo(updatedBucket.getModificationTime());
   }
@@ -5773,14 +5773,14 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
 
     bucket.putBucketTagging(tags);
     OzoneBucket bucketAfterPut = volume.getBucket(bucketName);
-    assertFalse(bucketAfterPut.getBucketTags().isEmpty());
+    assertFalse(bucketAfterPut.getBucketTagging().isEmpty());
 
     bucket.deleteBucketTagging();
     OzoneBucket updatedBucket = volume.getBucket(bucketName);
-    assertTrue(updatedBucket.getBucketTags().isEmpty());
+    assertTrue(updatedBucket.getBucketTagging().isEmpty());
     assertThat(updatedBucket.getModificationTime())
         .isAfterOrEqualTo(bucketAfterPut.getModificationTime());
-    assertThat(updatedBucket.getBucketTags()).doesNotContainKeys("tag-key-1", "tag-key-2");
+    assertThat(updatedBucket.getBucketTagging()).doesNotContainKeys("tag-key-1", "tag-key-2");
   }
 
   @ParameterizedTest
@@ -5803,7 +5803,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     bucket.putBucketTagging(tags);
 
     OzoneBucket updatedBucket = volume.getBucket(bucketName);
-    assertEquals(tags.size(), updatedBucket.getBucketTags().size());
-    assertThat(updatedBucket.getBucketTags()).containsAllEntriesOf(tags);
+    assertEquals(tags.size(), updatedBucket.getBucketTagging().size());
+    assertThat(updatedBucket.getBucketTagging()).containsAllEntriesOf(tags);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -5710,4 +5710,100 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
         getCluster().getStorageContainerManager().getPipelineManager().getMetrics().getTotalNumBlocksAllocated();
     assertEquals(initialAllocatedBlocks + 1, currentAllocatedBlocks);
   }
+
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testPutBucketTagging(BucketLayout bucketLayout) throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    BucketArgs bucketArgs =
+        BucketArgs.newBuilder().setBucketLayout(bucketLayout).build();
+    volume.createBucket(bucketName, bucketArgs);
+
+    // initially bucket has no tags
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    assertTrue(bucket.getBucketTagging().isEmpty());
+    Instant modificationTimeBeforePut = bucket.getModificationTime();
+
+    Map<String, String> tags = new HashMap<>();
+    tags.put("tag-key-1", "tag-value-1");
+    tags.put("tag-key-2", "tag-value-2");
+
+    bucket.putBucketTagging(tags);
+
+    OzoneBucket updatedBucket = volume.getBucket(bucketName);
+    assertEquals(tags.size(), updatedBucket.getBucketTags().size());
+    assertThat(updatedBucket.getBucketTags()).containsAllEntriesOf(tags);
+    assertThat(updatedBucket.getModificationTime())
+        .isAfterOrEqualTo(modificationTimeBeforePut);
+
+    // 2nd put should replace the previous tags
+    Map<String, String> secondTags = new HashMap<>();
+    secondTags.put("tag-key-3", "tag-value-3");
+
+    bucket.putBucketTagging(secondTags);
+
+    OzoneBucket updatedBucket2 = volume.getBucket(bucketName);
+    assertEquals(secondTags.size(), updatedBucket2.getBucketTags().size());
+    assertThat(updatedBucket2.getBucketTags()).containsAllEntriesOf(secondTags);
+    assertThat(updatedBucket2.getBucketTags()).doesNotContainKeys("tag-key-1", "tag-key-2");
+    assertThat(updatedBucket2.getModificationTime())
+        .isAfterOrEqualTo(updatedBucket.getModificationTime());
+  }
+
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testDeleteBucketTagging(BucketLayout bucketLayout) throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    BucketArgs bucketArgs =
+        BucketArgs.newBuilder().setBucketLayout(bucketLayout).build();
+    volume.createBucket(bucketName, bucketArgs);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    Map<String, String> tags = new HashMap<>();
+    tags.put("tag-key-1", "tag-value-1");
+    tags.put("tag-key-2", "tag-value-2");
+
+    bucket.putBucketTagging(tags);
+    OzoneBucket bucketAfterPut = volume.getBucket(bucketName);
+    assertFalse(bucketAfterPut.getBucketTags().isEmpty());
+
+    bucket.deleteBucketTagging();
+    OzoneBucket updatedBucket = volume.getBucket(bucketName);
+    assertTrue(updatedBucket.getBucketTags().isEmpty());
+    assertThat(updatedBucket.getModificationTime())
+        .isAfterOrEqualTo(bucketAfterPut.getModificationTime());
+    assertThat(updatedBucket.getBucketTags()).doesNotContainKeys("tag-key-1", "tag-key-2");
+  }
+
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testGetBucketTagging(BucketLayout bucketLayout) throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    BucketArgs bucketArgs =
+        BucketArgs.newBuilder().setBucketLayout(bucketLayout).build();
+    volume.createBucket(bucketName, bucketArgs);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    Map<String, String> tags = new HashMap<>();
+    tags.put("tag-key-1", "tag-value-1");
+    tags.put("tag-key-2", "tag-value-2");
+
+    bucket.putBucketTagging(tags);
+
+    OzoneBucket updatedBucket = volume.getBucket(bucketName);
+    assertEquals(tags.size(), updatedBucket.getBucketTags().size());
+    assertThat(updatedBucket.getBucketTags()).containsAllEntriesOf(tags);
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3BucketTaggingRequestBase.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3BucketTaggingRequestBase.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.s3.tagging;
+
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.BUCKET_LOCK;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.OzoneManagerUtils;
+import org.apache.hadoop.ozone.om.ResolvedBucket;
+import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
+import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.bucket.OMBucketSetPropertyResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for S3 bucket tagging write requests (put / delete).
+ */
+public abstract class S3BucketTaggingRequestBase extends OMClientRequest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(S3BucketTaggingRequestBase.class);
+
+  protected S3BucketTaggingRequestBase(OMRequest omRequest) {
+    super(omRequest);
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    OMRequest baseRequest = super.preExecute(ozoneManager);
+    BucketArgs bucketArgs = getRequestBucketArgs(baseRequest);
+
+    OmBucketArgs omBucketArgs = OmBucketArgs.getFromProtobuf(bucketArgs);
+    String volumeName = bucketArgs.getVolumeName();
+    String bucketName = bucketArgs.getBucketName();
+
+    ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
+        Pair.of(volumeName, bucketName), this);
+
+    if (ozoneManager.getAclsEnabled()) {
+      try {
+        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
+            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE,
+            resolvedBucket.realVolume(), resolvedBucket.realBucket(), null);
+      } catch (IOException ex) {
+        markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
+            getAuditAction(),
+            resolvedBucket.audit(omBucketArgs.toAuditMap()), ex,
+            getOmRequest().getUserInfo()));
+        throw ex;
+      }
+    }
+    return buildUpdatedOMRequest(baseRequest,
+        resolvedBucket.update(bucketArgs), Time.now());
+  }
+
+  @Override
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
+      ExecutionContext context) {
+    final long transactionLogIndex = context.getIndex();
+
+    OMRequest omRequest = getOmRequest();
+    BucketArgs bucketArgs = getRequestBucketArgs(omRequest);
+
+    OmBucketArgs omBucketArgs = OmBucketArgs.getFromProtobuf(bucketArgs);
+    String volumeName = bucketArgs.getVolumeName();
+    String bucketName = bucketArgs.getBucketName();
+    long modificationTime = getModificationTime(omRequest);
+
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    OMMetrics omMetrics = ozoneManager.getMetrics();
+    incRequestMetric(omMetrics);
+
+    OMResponse.Builder omResponse =
+        OmResponseUtil.getOMResponseBuilder(omRequest);
+    Exception exception = null;
+    boolean acquiredBucketLock = false;
+    boolean success = true;
+    OMClientResponse omClientResponse = null;
+    try {
+      mergeOmLockDetails(omMetadataManager.getLock().acquireWriteLock(
+          BUCKET_LOCK, volumeName, bucketName));
+
+      acquiredBucketLock = getOmLockDetails().isLockAcquired();
+      String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+      OmBucketInfo dbBucketInfo = OzoneManagerUtils.getBucketInfo(
+          omMetadataManager, volumeName, bucketName);
+
+      Map<String, String> tags = getTagsToApply(bucketArgs);
+      OmBucketInfo omBucketInfo = dbBucketInfo.toBuilder()
+          .setTags(tags)
+          .setUpdateID(transactionLogIndex)
+          .setModificationTime(modificationTime)
+          .build();
+
+      omMetadataManager.getBucketTable().addCacheEntry(
+          new CacheKey<>(bucketKey),
+          CacheValue.get(transactionLogIndex, omBucketInfo));
+      setSuccessResponse(omResponse);
+      omClientResponse = new OMBucketSetPropertyResponse(
+          omResponse.build(), omBucketInfo);
+    } catch (IOException ex) {
+      success = false;
+      exception = ex;
+      omClientResponse = new OMBucketSetPropertyResponse(
+          createErrorOMResponse(omResponse, exception));
+    } finally {
+      if (acquiredBucketLock) {
+        mergeOmLockDetails(omMetadataManager.getLock()
+            .releaseWriteLock(BUCKET_LOCK, volumeName, bucketName));
+      }
+      if (omClientResponse != null) {
+        omClientResponse.setOmLockDetails(getOmLockDetails());
+      }
+    }
+    Map<String, String> auditMap = omBucketArgs.toAuditMap();
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
+        getAuditAction(), auditMap, exception, getOmRequest().getUserInfo()));
+
+    if (success) {
+      LOG.debug("{} bucket tagging succeeded for bucket:{} in volume:{}",
+          getOperationName(), bucketName, volumeName);
+      return omClientResponse;
+    }
+
+    incRequestFailMetric(omMetrics);
+    LOG.error("{} bucket tagging failed for bucket:{} in volume:{}",
+        getOperationName(), bucketName, volumeName, exception);
+    return omClientResponse;
+  }
+
+  protected abstract BucketArgs getRequestBucketArgs(OMRequest omRequest);
+
+  protected abstract long getModificationTime(OMRequest omRequest);
+
+  protected abstract OMRequest buildUpdatedOMRequest(OMRequest baseRequest,
+      BucketArgs bucketArgs, long modificationTime) throws IOException;
+
+  protected abstract Map<String, String> getTagsToApply(BucketArgs bucketArgs);
+
+  protected abstract void setSuccessResponse(OMResponse.Builder omResponse);
+
+  protected abstract OMAction getAuditAction();
+
+  protected abstract void incRequestMetric(OMMetrics omMetrics);
+
+  protected abstract void incRequestFailMetric(OMMetrics omMetrics);
+
+  protected abstract String getOperationName();
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3DeleteBucketTaggingRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3DeleteBucketTaggingRequest.java
@@ -17,171 +17,116 @@
 
 package org.apache.hadoop.ozone.om.request.s3.tagging;
 
-import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.BUCKET_LOCK;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.OMAction;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
-import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.OzoneManagerUtils;
-import org.apache.hadoop.ozone.om.ResolvedBucket;
-import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
-import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.request.OMClientRequest;
-import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
-import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.om.response.bucket.OMBucketSetPropertyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteBucketTaggingRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteBucketTaggingResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.apache.hadoop.ozone.security.acl.OzoneObj;
-import org.apache.hadoop.util.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handles DeleteBucketTagging (S3 bucket tagging).
  */
-public class S3DeleteBucketTaggingRequest extends OMClientRequest {
+public class S3DeleteBucketTaggingRequest extends S3BucketTaggingRequestBase {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(S3DeleteBucketTaggingRequest.class);
-
+  /**
+   * Creates a delete-bucket-tagging request from the incoming OM RPC payload.
+   */
   public S3DeleteBucketTaggingRequest(OMRequest omRequest) {
     super(omRequest);
   }
 
+  /**
+   * Returns bucket args from the delete-bucket-tagging sub-request.
+   */
   @Override
-  public OMRequest preExecute(OzoneManager ozoneManager)
-      throws IOException {
+  protected BucketArgs getRequestBucketArgs(OMRequest omRequest) {
     DeleteBucketTaggingRequest deleteBucketTaggingRequest =
-        getOmRequest().getDeleteBucketTaggingRequest();
+        omRequest.getDeleteBucketTaggingRequest();
     Objects.requireNonNull(deleteBucketTaggingRequest,
         "deleteBucketTaggingRequest == null");
+    return deleteBucketTaggingRequest.getBucketArgs();
+  }
 
-    BucketArgs bucketArgs = deleteBucketTaggingRequest.getBucketArgs();
-    OmBucketArgs omBucketArgs = OmBucketArgs.getFromProtobuf(bucketArgs);
-    String volumeName = bucketArgs.getVolumeName();
-    String bucketName = bucketArgs.getBucketName();
+  /**
+   *  Returns the modification time stamped during preExecute.
+   */
+  @Override
+  protected long getModificationTime(OMRequest omRequest) {
+    return omRequest.getDeleteBucketTaggingRequest().getModificationTime();
+  }
 
-    ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
-        Pair.of(volumeName, bucketName), this);
-
-    if (ozoneManager.getAclsEnabled()) {
-      try {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
-            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE,
-            resolvedBucket.realVolume(), resolvedBucket.realBucket(), null);
-      } catch (IOException ex) {
-        markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
-            OMAction.DELETE_BUCKET_TAGGING,
-            resolvedBucket.audit(omBucketArgs.toAuditMap()), ex,
-            getOmRequest().getUserInfo()));
-        throw ex;
-      }
-    }
+  /**
+   * Rebuilds the OM request with resolved bucket args and modification time.
+   */
+  @Override
+  protected OMRequest buildUpdatedOMRequest(OMRequest baseRequest,
+      BucketArgs bucketArgs, long modificationTime) throws IOException {
+    DeleteBucketTaggingRequest deleteBucketTaggingRequest =
+        baseRequest.getDeleteBucketTaggingRequest();
 
     DeleteBucketTaggingRequest.Builder req =
         deleteBucketTaggingRequest.toBuilder();
-    req.setModificationTime(Time.now());
-    req.setBucketArgs(resolvedBucket.update(bucketArgs));
+    req.setModificationTime(modificationTime);
+    req.setBucketArgs(bucketArgs);
 
-    return getOmRequest().toBuilder()
+    return baseRequest.toBuilder()
         .setDeleteBucketTaggingRequest(req.build())
         .setUserInfo(getUserInfo())
         .build();
   }
 
+  /**
+   * Clears all tags when deleting bucket tagging.
+   */
   @Override
-  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
-      ExecutionContext context) {
-    final long transactionLogIndex = context.getIndex();
+  protected Map<String, String> getTagsToApply(BucketArgs bucketArgs) {
+    return Collections.emptyMap();
+  }
 
-    DeleteBucketTaggingRequest deleteBucketTaggingRequest =
-        getOmRequest().getDeleteBucketTaggingRequest();
-    Objects.requireNonNull(deleteBucketTaggingRequest,
-        "deleteBucketTaggingRequest == null");
+  /**
+   * Sets the successful delete-bucket-tagging response on the OM response.
+   */
+  @Override
+  protected void setSuccessResponse(OMResponse.Builder omResponse) {
+    omResponse.setDeleteBucketTaggingResponse(
+        DeleteBucketTaggingResponse.newBuilder().build());
+  }
 
-    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
-    OMMetrics omMetrics = ozoneManager.getMetrics();
+  /**
+   * Returns the audit action for delete bucket tagging.
+   */
+  @Override
+  protected OMAction getAuditAction() {
+    return OMAction.DELETE_BUCKET_TAGGING;
+  }
+
+  /**
+   * Increments the delete-bucket-tagging request metric.
+   */
+  @Override
+  protected void incRequestMetric(OMMetrics omMetrics) {
     omMetrics.incNumDeleteBucketTagging();
+  }
 
-    BucketArgs bucketArgs = deleteBucketTaggingRequest.getBucketArgs();
-    OmBucketArgs omBucketArgs = OmBucketArgs.getFromProtobuf(bucketArgs);
-
-    String volumeName = bucketArgs.getVolumeName();
-    String bucketName = bucketArgs.getBucketName();
-
-    OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
-        getOmRequest());
-    OmBucketInfo omBucketInfo = null;
-
-    Exception exception = null;
-    boolean acquiredBucketLock = false;
-    boolean success = true;
-    OMClientResponse omClientResponse = null;
-    try {
-      mergeOmLockDetails(omMetadataManager.getLock().acquireWriteLock(
-          BUCKET_LOCK, volumeName, bucketName));
-      acquiredBucketLock = getOmLockDetails().isLockAcquired();
-
-      String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
-      OmBucketInfo dbBucketInfo = OzoneManagerUtils.getBucketInfo(
-          omMetadataManager, volumeName, bucketName);
-
-      omBucketInfo = dbBucketInfo.toBuilder()
-          .setTags(Collections.emptyMap())
-          .setUpdateID(transactionLogIndex)
-          .setModificationTime(deleteBucketTaggingRequest.getModificationTime())
-          .build();
-
-      omMetadataManager.getBucketTable().addCacheEntry(
-          new CacheKey<>(bucketKey),
-          CacheValue.get(transactionLogIndex, omBucketInfo));
-
-      omResponse.setDeleteBucketTaggingResponse(
-          DeleteBucketTaggingResponse.newBuilder().build());
-      omClientResponse = new OMBucketSetPropertyResponse(
-          omResponse.build(), omBucketInfo);
-    } catch (IOException ex) {
-      success = false;
-      exception = ex;
-      omClientResponse = new OMBucketSetPropertyResponse(
-          createErrorOMResponse(omResponse, exception));
-    } finally {
-      if (acquiredBucketLock) {
-        mergeOmLockDetails(omMetadataManager.getLock()
-            .releaseWriteLock(BUCKET_LOCK, volumeName, bucketName));
-      }
-      if (omClientResponse != null) {
-        omClientResponse.setOmLockDetails(getOmLockDetails());
-      }
-    }
-
-    Map<String, String> auditMap = omBucketArgs.toAuditMap();
-    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
-        OMAction.DELETE_BUCKET_TAGGING, auditMap, exception,
-        getOmRequest().getUserInfo()));
-
-    if (success) {
-      LOG.debug("Delete bucket tagging for bucket:{} in volume:{}",
-          bucketName, volumeName);
-      return omClientResponse;
-    }
+  /**
+   * Increments the delete-bucket-tagging failure metric.
+   */
+  @Override
+  protected void incRequestFailMetric(OMMetrics omMetrics) {
     omMetrics.incNumDeleteBucketTaggingFails();
-    LOG.error("Delete bucket tagging failed for bucket:{} in volume:{}",
-        bucketName, volumeName, exception);
-    return omClientResponse;
+  }
+
+  /**
+   * Returns the operation label used in debug and error logs.
+   */
+  @Override
+  protected String getOperationName() {
+    return "Delete";
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3PutBucketTaggingRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tagging/S3PutBucketTaggingRequest.java
@@ -17,169 +17,113 @@
 
 package org.apache.hadoop.ozone.om.request.s3.tagging;
 
-import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.BUCKET_LOCK;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.OMAction;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
-import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.OzoneManagerUtils;
-import org.apache.hadoop.ozone.om.ResolvedBucket;
-import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
-import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.request.OMClientRequest;
-import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
-import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.om.response.bucket.OMBucketSetPropertyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PutBucketTaggingRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PutBucketTaggingResponse;
-import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.apache.hadoop.ozone.security.acl.OzoneObj;
-import org.apache.hadoop.util.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handles PutBucketTagging (S3 bucket tagging).
  */
-public class S3PutBucketTaggingRequest extends OMClientRequest {
+public class S3PutBucketTaggingRequest extends S3BucketTaggingRequestBase {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(S3PutBucketTaggingRequest.class);
-
+  /**
+   * Creates a put-bucket-tagging request from the incoming OM RPC payload.
+   */
   public S3PutBucketTaggingRequest(OMRequest omRequest) {
     super(omRequest);
   }
 
+  /**
+   * Returns bucket args from the put-bucket-tagging sub-request.
+   */
   @Override
-  public OMRequest preExecute(OzoneManager ozoneManager)
-      throws IOException {
+  protected BucketArgs getRequestBucketArgs(OMRequest omRequest) {
     PutBucketTaggingRequest putBucketTaggingRequest =
-        getOmRequest().getPutBucketTaggingRequest();
-    Objects.requireNonNull(putBucketTaggingRequest, "putBucketTaggingRequest == null");
+        omRequest.getPutBucketTaggingRequest();
+    Objects.requireNonNull(putBucketTaggingRequest,
+        "putBucketTaggingRequest == null");
+    return putBucketTaggingRequest.getBucketArgs();
+  }
 
-    BucketArgs bucketArgs = putBucketTaggingRequest.getBucketArgs();
-    OmBucketArgs omBucketArgs = OmBucketArgs.getFromProtobuf(bucketArgs);
-    String volumeName = bucketArgs.getVolumeName();
-    String bucketName = bucketArgs.getBucketName();
+  /**
+   * Returns the modification time stamped during preExecute.
+   */
+  @Override
+  protected long getModificationTime(OMRequest omRequest) {
+    return omRequest.getPutBucketTaggingRequest().getModificationTime();
+  }
 
-    ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
-        Pair.of(volumeName, bucketName), this);
-
-    if (ozoneManager.getAclsEnabled()) {
-      try {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
-            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE,
-            resolvedBucket.realVolume(), resolvedBucket.realBucket(), null);
-      } catch (IOException ex) {
-        markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
-            OMAction.PUT_BUCKET_TAGGING,
-            resolvedBucket.audit(omBucketArgs.toAuditMap()), ex,
-            getOmRequest().getUserInfo()));
-        throw ex;
-      }
-    }
-
+  /**
+   * Rebuilds the OM request with resolved bucket args and modification time.
+   */
+  @Override
+  protected OMRequest buildUpdatedOMRequest(OMRequest baseRequest,
+      BucketArgs bucketArgs, long modificationTime) throws IOException {
+    PutBucketTaggingRequest putBucketTaggingRequest =
+        baseRequest.getPutBucketTaggingRequest();
     PutBucketTaggingRequest.Builder req = putBucketTaggingRequest.toBuilder();
-    req.setModificationTime(Time.now());
-    req.setBucketArgs(resolvedBucket.update(bucketArgs));
-    return getOmRequest().toBuilder()
+    req.setModificationTime(modificationTime);
+    req.setBucketArgs(bucketArgs);
+    return baseRequest.toBuilder()
         .setPutBucketTaggingRequest(req.build())
         .setUserInfo(getUserInfo())
         .build();
   }
 
+  /**
+   * Converts request tag list into the map persisted on bucket metadata.
+   */
   @Override
-  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
-      ExecutionContext context) {
-    final long transactionLogIndex = context.getIndex();
+  protected Map<String, String> getTagsToApply(BucketArgs bucketArgs) {
+    return KeyValueUtil.getFromProtobuf(bucketArgs.getTagsList());
+  }
 
-    PutBucketTaggingRequest putBucketTaggingRequest =
-        getOmRequest().getPutBucketTaggingRequest();
-    Objects.requireNonNull(putBucketTaggingRequest, "putBucketTaggingRequest == null");
+  /**
+   * Sets the successful put-bucket-tagging response on the OM response.
+   */
+  @Override
+  protected void setSuccessResponse(OMResponse.Builder omResponse) {
+    omResponse.setPutBucketTaggingResponse(
+        PutBucketTaggingResponse.newBuilder().build());
+  }
 
-    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
-    OMMetrics omMetrics = ozoneManager.getMetrics();
+  /**
+   * Returns the audit action for put bucket tagging.
+   */
+  @Override
+  protected OMAction getAuditAction() {
+    return OMAction.PUT_BUCKET_TAGGING;
+  }
+
+  /**
+   * Increments the put-bucket-tagging request metric.
+   */
+  @Override
+  protected void incRequestMetric(OMMetrics omMetrics) {
     omMetrics.incNumPutBucketTagging();
+  }
 
-    BucketArgs bucketArgs = putBucketTaggingRequest.getBucketArgs();
-    OmBucketArgs omBucketArgs = OmBucketArgs.getFromProtobuf(bucketArgs);
-
-    String volumeName = bucketArgs.getVolumeName();
-    String bucketName = bucketArgs.getBucketName();
-
-    OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
-        getOmRequest());
-    OmBucketInfo omBucketInfo = null;
-
-    Exception exception = null;
-    boolean acquiredBucketLock = false;
-    boolean success = true;
-    OMClientResponse omClientResponse = null;
-    try {
-      mergeOmLockDetails(omMetadataManager.getLock().acquireWriteLock(
-          BUCKET_LOCK, volumeName, bucketName));
-      acquiredBucketLock = getOmLockDetails().isLockAcquired();
-
-      String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
-      OmBucketInfo dbBucketInfo = OzoneManagerUtils.getBucketInfo(
-          omMetadataManager, volumeName, bucketName);
-
-      Map<String, String> tags =
-          KeyValueUtil.getFromProtobuf(bucketArgs.getTagsList());
-
-      omBucketInfo = dbBucketInfo.toBuilder()
-          .setTags(tags)
-          .setUpdateID(transactionLogIndex)
-          .setModificationTime(putBucketTaggingRequest.getModificationTime())
-          .build();
-
-      omMetadataManager.getBucketTable().addCacheEntry(
-          new CacheKey<>(bucketKey),
-          CacheValue.get(transactionLogIndex, omBucketInfo));
-
-      omResponse.setPutBucketTaggingResponse(
-          PutBucketTaggingResponse.newBuilder().build());
-      omClientResponse = new OMBucketSetPropertyResponse(
-          omResponse.build(), omBucketInfo);
-    } catch (IOException ex) {
-      success = false;
-      exception = ex;
-      omClientResponse = new OMBucketSetPropertyResponse(
-          createErrorOMResponse(omResponse, exception));
-    } finally {
-      if (acquiredBucketLock) {
-        mergeOmLockDetails(omMetadataManager.getLock()
-            .releaseWriteLock(BUCKET_LOCK, volumeName, bucketName));
-      }
-      if (omClientResponse != null) {
-        omClientResponse.setOmLockDetails(getOmLockDetails());
-      }
-    }
-    Map<String, String> auditMap = omBucketArgs.toAuditMap();
-    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
-        OMAction.PUT_BUCKET_TAGGING, auditMap, exception,
-        getOmRequest().getUserInfo()));
-
-    if (success) {
-      LOG.debug("Put bucket tagging for bucket:{} in volume:{}",
-          bucketName, volumeName);
-      return omClientResponse;
-    }
+  /**
+   * Increments the put-bucket-tagging failure metric.
+   */
+  @Override
+  protected void incRequestFailMetric(OMMetrics omMetrics) {
     omMetrics.incNumPutBucketTaggingFails();
-    LOG.error("Put bucket tagging failed for bucket:{} in volume:{}",
-        bucketName, volumeName, exception);
-    return omClientResponse;
+  }
+
+  /**
+   * Returns the operation label used in debug and error logs.
+   */
+  @Override
+  protected String getOperationName() {
+    return "Put";
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -871,4 +871,19 @@ public class ClientProtocolStub implements ClientProtocol {
     getBucket(volumeName, bucketName).deleteObjectTagging(keyName);
   }
 
+  @Override
+  public Map<String, String> getBucketTagging(String volumeName, String bucketName) throws IOException {
+    return getBucket(volumeName, bucketName).getBucketTagging();
+  }
+
+  @Override
+  public void putBucketTagging(String volumeName, String bucketName, Map<String, String> tags)
+      throws IOException {
+    getBucket(volumeName, bucketName).putBucketTagging(tags);
+  }
+
+  @Override
+  public void deleteBucketTagging(String volumeName, String bucketName) throws IOException {
+    getBucket(volumeName, bucketName).deleteBucketTagging();
+  }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -78,6 +78,8 @@ public final class OzoneBucketStub extends OzoneBucket {
 
   private Map<String, MultipartInfoStub> keyToMultipartUpload = new HashMap<>();
 
+  private final Map<String, String> bucketTags = new HashMap<>();
+
   private Map<String, Map<Integer, Part>> partList = new HashMap<>();
 
   private ArrayList<OzoneAcl> aclList = new ArrayList<>();
@@ -744,17 +746,20 @@ public final class OzoneBucketStub extends OzoneBucket {
 
   @Override
   public Map<String, String> getBucketTagging() throws IOException {
-    return getBucketTags();
+    return Collections.unmodifiableMap(bucketTags);
   }
 
   @Override
   public void putBucketTagging(Map<String, String> tags) throws IOException {
-    applyBucketTaggingUpdate(tags);
+    bucketTags.clear();
+    if (tags != null) {
+      bucketTags.putAll(tags);
+    }
   }
 
   @Override
   public void deleteBucketTagging() throws IOException {
-    applyBucketTaggingDelete();
+    bucketTags.clear();
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -742,6 +742,21 @@ public final class OzoneBucketStub extends OzoneBucket {
     }
   }
 
+  @Override
+  public Map<String, String> getBucketTagging() throws IOException {
+    return getBucketTags();
+  }
+
+  @Override
+  public void putBucketTagging(Map<String, String> tags) throws IOException {
+    applyBucketTaggingUpdate(tags);
+  }
+
+  @Override
+  public void deleteBucketTagging() throws IOException {
+    applyBucketTaggingDelete();
+  }
+
   /**
    * Class used to hold part information in a upload part request.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Expose `getBucketTagging` / `putBucketTagging` / `deleteBucketTagging` on Ozone client with version gating.

- `ClientProtocol.java / OzoneManagerProtocol.java `— interface methods
- `OzoneManagerProtocolClientSideTranslatorPB.java` — PB translation
- `RpcClient.java `— getBucketTagging, putBucketTagging, deleteBucketTagging with S3_BUCKET_TAGGING_API version gate
- `OzoneBucket.java` — public client API
- `OzoneRpcClientTests.java` integration tests:
      - testPutBucketTagging (overwrite semantics)
      - testGetBucketTagging
      - testDeleteBucketTagging
      - Parameterized across bucket layouts (LEGACY, FILE_SYSTEM_OPTIMIZED, OBJECT_STORE)
2. **nit:**
If we could introduce a base class for bucket tagging, or make delete request to derive put request.
the duplication between ‎`S3PutBucketTaggingRequest` and ‎`S3DeleteBucketTaggingRequest`
[Discussion link](https://github.com/apache/ozone/pull/10498#discussion_r3418734551)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15511

## How was this patch tested?

Added unit tests for 'OzoneRpcClientTests`.
