### PR TITLE
HDDS-15298. Fix intermittent failure in testDelegationTokenRenewal

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -650,9 +650,9 @@ final class TestSecureOzoneCluster {
       // Start SCM
       scm.start();
 
-      // Setup secure OM for start.
-      int tokenMaxLifetime = 1000;
-      conf.setLong(DELEGATION_TOKEN_MAX_LIFETIME_KEY, tokenMaxLifetime);
+      // Setup secure OM for start.  Generous token lifetime so the renewer and
+      // tampered-token cases below do not race token expiry.
+      conf.setLong(DELEGATION_TOKEN_MAX_LIFETIME_KEY, 60 * 1000L);
       setupOm(conf);
       OzoneManager.setTestSecureOmFlag(true);
       om.setCertClient(new CertificateClientTestImpl(conf));
@@ -683,10 +683,15 @@ final class TestSecureOzoneCluster {
       omLogs.clearOutput();
 
       // Test failure of delegation renewal
-      // 1. When token maxExpiryTime exceeds
-      Thread.sleep(tokenMaxLifetime);
+      // 1. When token maxExpiryTime exceeds (maxDate in the past)
+      OzoneTokenIdentifier expiredId = OzoneTokenIdentifier.readProtoBuf(
+          token.getIdentifier());
+      expiredId.setMaxDate(System.currentTimeMillis() - 1000);
+      Token<OzoneTokenIdentifier> expiredToken = new Token<>(
+          expiredId.getBytes(), token.getPassword(), token.getKind(),
+          token.getService());
       OMException ex = assertThrows(OMException.class,
-          () -> omClient.renewDelegationToken(token));
+          () -> omClient.renewDelegationToken(expiredToken));
       assertEquals(TOKEN_EXPIRED, ex.getResult());
       omLogs.clearOutput();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestSecureOzoneCluster#testDelegationTokenRenewal` is time-dependent and fails intermittently. On the server, `OzoneDelegationTokenSecretManager#renewToken` checks token expiry (`maxDate < now`, throwing `TOKEN_EXPIRED`) **before** it checks the renewer. The test set the token max lifetime to only 1 second, so on a slow or loaded host the renewer-mismatch token could expire before its renewal reached the server. The renewal then failed with `TOKEN_EXPIRED` instead of the expected renewer-mismatch error, breaking the assertion.

The fix removes the timing dependence:

- Use a generous 60s token max lifetime so the renewer-mismatch and tampered-token cases cannot race expiry.
- Trigger the expiry case deterministically with an already-past `maxDate` (reusing the existing tampered-token pattern) instead of `Thread.sleep`, which also drops a 1s sleep.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15298

## How was this patch tested?

- Reproduced the original failure on the unmodified test by forcing a stall before the renewer-mismatch renewal, giving the exact reported `TOKEN_EXPIRED` assertion failure.
- Confirmed the fix by injecting a 3s stall (3x the old lifetime) at the same point: the test passes, so the race window is closed.
- Ran the test 10 times locally with the fix; the timing failure did not recur.
