### PR TITLE
HDDS-14774. Fix intermittent timeout in TestContainerReportHandling

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -92,9 +92,6 @@ public class TestContainerReportHandling {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
-    // Without a short container report interval, the replica deletion is only triggered by the one-shot full
-    // container report a datanode sends on restart. If that report is disrupted, the next periodic report is 60
-    // minutes away (default), so deletion cannot recover within the wait below (HDDS-14774).
     conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 1, TimeUnit.SECONDS);
 
     Path clusterPath = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
@@ -91,6 +92,10 @@ public class TestContainerReportHandling {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
+    // Without a short container report interval, the replica deletion is only triggered by the one-shot full
+    // container report a datanode sends on restart. If that report is disrupted, the next periodic report is 60
+    // minutes away (default), so deletion cannot recover within the wait below (HDDS-14774).
+    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 1, TimeUnit.SECONDS);
 
     Path clusterPath = null;
     try (MiniOzoneCluster cluster = newCluster(conf, replicationInput.getNumDatanodes())) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
@@ -94,6 +95,10 @@ public class TestContainerReportHandlingWithHA {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
+    // Without a short container report interval, the replica deletion is only triggered by the one-shot full
+    // container report a datanode sends on restart. If that report is disrupted, the next periodic report is 60
+    // minutes away (default), so deletion cannot recover within the wait below (HDDS-14774).
+    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 1, TimeUnit.SECONDS);
 
     int numSCM = 3;
     Path clusterPath = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -95,9 +95,6 @@ public class TestContainerReportHandlingWithHA {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
-    // Without a short container report interval, the replica deletion is only triggered by the one-shot full
-    // container report a datanode sends on restart. If that report is disrupted, the next periodic report is 60
-    // minutes away (default), so deletion cannot recover within the wait below (HDDS-14774).
     conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 1, TimeUnit.SECONDS);
 
     int numSCM = 3;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestContainerReportHandling#testDeletingOrDeletedContainerWhenNonEmptyReplicaIsReported` intermittently times out on CI while waiting for replicas to be deleted.

In this test, SCM only deletes a DELETING/DELETED container's replicas when it processes a container report. The test triggers that report once, by restarting the datanodes. Because `hdds.container.report.interval` is left at its 60-minute default, if that single report is disrupted (e.g. command expiry, missed heartbeat, or a datanode briefly marked stale/dead under CI load), the next report is 60 minutes away, far beyond the 180s wait, so the test times out.

The fix sets `hdds.container.report.interval` to 1s, matching sibling tests (`TestECContainerRecovery`, `TestBlockDeletion`). A periodic report then re-triggers the deletion within seconds, so a single disrupted report can recover well within the wait.

`TestContainerReportHandlingWithHA` shares the identical pattern and root cause, so it is fixed the same way in this PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14774

## How was this patch tested?

- Reproduced the timeout deterministically: with the datanode restart removed (simulating a disrupted report) and the default report interval, all parameters fail with the same `TimeoutException`; with the 1s interval added, they pass.
- Ran both `TestContainerReportHandling` and `TestContainerReportHandlingWithHA` locally; all parameters pass.
- `checkstyle` passes.

Generated-by: Claude Code (Opus 4.8)
