### PR TITLE
HDDS-15593. Fix recursive Ratis protobuf import rewriting

### DIFF
--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -113,9 +113,21 @@
             <configuration>
               <target>
                 <!-- use grpc, guava, protobuf from ratis-thirdparty -->
-                <replace dir="target/generated-sources/proto-java-for-ratis" token="com.google.common" value="org.apache.ratis.thirdparty.com.google.common" />
-                <replace dir="target/generated-sources/proto-java-for-ratis" token="com.google.protobuf" value="org.apache.ratis.thirdparty.com.google.protobuf" />
-                <replace dir="target/generated-sources/proto-java-for-ratis" token="io.grpc" value="org.apache.ratis.thirdparty.io.grpc" />
+                <replace token="com.google.common" value="org.apache.ratis.thirdparty.com.google.common">
+                  <fileset dir="${project.build.directory}/generated-sources/proto-java-for-ratis">
+                    <include name="**/*.java" />
+                  </fileset>
+                </replace>
+                <replace token="com.google.protobuf" value="org.apache.ratis.thirdparty.com.google.protobuf">
+                  <fileset dir="${project.build.directory}/generated-sources/proto-java-for-ratis">
+                    <include name="**/*.java" />
+                  </fileset>
+                </replace>
+                <replace token="io.grpc" value="org.apache.ratis.thirdparty.io.grpc">
+                  <fileset dir="${project.build.directory}/generated-sources/proto-java-for-ratis">
+                    <include name="**/*.java" />
+                  </fileset>
+                </replace>
               </target>
             </configuration>
           </execution>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -122,9 +122,21 @@
             <configuration>
               <target>
                 <!-- use grpc, guava, protobuf from ratis-thirdparty -->
-                <replace dir="target/generated-sources/proto-java-for-ratis" token="com.google.common" value="org.apache.ratis.thirdparty.com.google.common" />
-                <replace dir="target/generated-sources/proto-java-for-ratis" token="com.google.protobuf" value="org.apache.ratis.thirdparty.com.google.protobuf" />
-                <replace dir="target/generated-sources/proto-java-for-ratis" token="io.grpc" value="org.apache.ratis.thirdparty.io.grpc" />
+                <replace token="com.google.common" value="org.apache.ratis.thirdparty.com.google.common">
+                  <fileset dir="${project.build.directory}/generated-sources/proto-java-for-ratis">
+                    <include name="**/*.java" />
+                  </fileset>
+                </replace>
+                <replace token="com.google.protobuf" value="org.apache.ratis.thirdparty.com.google.protobuf">
+                  <fileset dir="${project.build.directory}/generated-sources/proto-java-for-ratis">
+                    <include name="**/*.java" />
+                  </fileset>
+                </replace>
+                <replace token="io.grpc" value="org.apache.ratis.thirdparty.io.grpc">
+                  <fileset dir="${project.build.directory}/generated-sources/proto-java-for-ratis">
+                    <include name="**/*.java" />
+                  </fileset>
+                </replace>
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix protobuf/gRPC generated-source rewriting in `hdds-interface-client` and `hdds-interface-server`.

These modules generate Ratis protocol classes that must use Ratis-shaded packages, for example:

```java
org.apache.ratis.thirdparty.io.grpc
org.apache.ratis.thirdparty.com.google.protobuf
org.apache.ratis.thirdparty.com.google.common
```

The previous Ant `<replace dir="...">` configuration did not reliably rewrite nested generated Java files under:

```text
target/generated-sources/proto-java-for-ratis/org/apache/hadoop/...
```

This patch changes the replacement rules to use explicit recursive `<fileset>` entries over `**/*.java`.

### Reproduction

A targeted clean build can fail before this patch:

```bash
mvn clean
mvn clean test-compile -pl hadoop-ozone/s3gateway -am
```

Example error:

```text
XceiverClientProtocolServiceGrpc.java:[3,22] package io.grpc does not exist
IntraDatanodeProtocolServiceGrpc.java:[7,26] package io.grpc.stub.annotations does not exist
```

This may be hidden by a prior full build or local cache, because downstream module-only tests can resolve already-installed snapshot artifacts from `~/.m2`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15593

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
