### PR TITLE
HDDS-15599. Follow up clean up from HDDS-15531 PR 10486

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ConnectionFailureUtils.java
@@ -82,9 +82,11 @@ public final class ConnectionFailureUtils {
   public static boolean isConnectionFailure(Throwable t) {
     Throwable cause = t;
     for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; depth++) {
-      if (cause instanceof ConnectException
-          || cause instanceof SocketTimeoutException
-          || cause instanceof NoRouteToHostException
+      // ConnectException and NoRouteToHostException both extend
+      // SocketException, so the SocketException check below already matches
+      // them. They remain listed in this class's Javadoc as connection-
+      // failure shapes for documentation.
+      if (cause instanceof SocketTimeoutException
           || cause instanceof UnknownHostException
           || cause instanceof EOFException
           || cause instanceof SocketException) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -491,6 +491,18 @@ public final class OzoneConfigKeys {
       "ozone.client.failover.max.attempts";
   public static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT =
       500;
+  /**
+   * When true, RPC clients (DN heartbeat, OM client, SCM client) re-resolve
+   * cached hostnames on connection failure and rebuild the proxy if the
+   * resolved IP has changed. Set to true in environments where server pod
+   * IPs may change while DNS names remain stable, such as Kubernetes.
+   * Default false preserves pre-fix behavior. Mirrors the design intent of
+   * HADOOP-17068 / HDFS-14118.
+   */
+  public static final String OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY =
+          "ozone.client.failover.resolve-needed";
+  public static final boolean OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT =
+          false;
   public static final String OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY =
       "ozone.client.wait.between.retries.millis";
   public static final long OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT =
@@ -603,19 +615,6 @@ public final class OzoneConfigKeys {
           "ozone.network.jvm.address.cache.enabled";
   public static final boolean OZONE_JVM_NETWORK_ADDRESS_CACHE_ENABLED_DEFAULT =
           true;
-
-  /**
-   * When true, RPC clients (DN heartbeat, OM client, SCM client) re-resolve
-   * cached hostnames on connection failure and rebuild the proxy if the
-   * resolved IP has changed. Set to true in environments where server pod
-   * IPs may change while DNS names remain stable, such as Kubernetes.
-   * Default false preserves pre-fix behavior. Mirrors the design intent of
-   * HADOOP-17068 / HDFS-14118.
-   */
-  public static final String OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY =
-          "ozone.client.failover.resolve-needed";
-  public static final boolean OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT =
-          false;
 
   public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY =
       "ozone.client.required.om.version.min";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsUtils;
@@ -533,18 +534,13 @@ public abstract class OMFailoverProxyProviderBase<T> implements
    */
   @VisibleForTesting
   boolean maybeRefreshCurrentOmAddress() {
-    final String nodeId;
-    final OMProxyInfo<T> info;
-    synchronized (this) {
-      nodeId = getCurrentProxyOMNodeId();
-      if (nodeId == null) {
-        return false;
-      }
-      info = omProxies.get(nodeId);
-      if (info == null) {
-        return false;
-      }
-    }
+    // getCurrentProxyOMNodeId() is synchronized and omProxies is an
+    // unmodifiable map populated once at construction, so neither read
+    // needs the provider monitor; both values are always present.
+    final String nodeId = Objects.requireNonNull(getCurrentProxyOMNodeId(),
+        "Current proxy node id is null");
+    final OMProxyInfo<T> info = Objects.requireNonNull(omProxies.get(nodeId),
+        "Current proxy info is null");
     // refreshAddressIfChanged handles its own locking and performs the
     // DNS lookup outside its entry monitor.
     boolean swapped = info.refreshAddressIfChanged();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Post-merge cleanup addressing @szetszwo's review comments on #10486
(HDDS-15531). He left three minor comments after the merge and asked that
they be handled in a follow-up PR. All three are behavior-preserving.

1. **`ConnectionFailureUtils`** — `ConnectException` and
   `NoRouteToHostException` both extend `SocketException`, so their explicit
   `instanceof` checks were redundant. Removed them (the `SocketException`
   branch still matches both) and added a comment. They remain listed in the
   class Javadoc as connection-failure shapes.
   ([comment](https://github.com/apache/ozone/pull/10486#discussion_r3430314845))

2. **`OzoneConfigKeys`** — moved `ozone.client.failover.resolve-needed`
   (key, default, and Javadoc) next to `ozone.client.failover.max.attempts`.
   ([comment](https://github.com/apache/ozone/pull/10486#discussion_r3430323286))

3. **`OMFailoverProxyProviderBase.maybeRefreshCurrentOmAddress`** — replaced
   the `synchronized` null-guard with `Objects.requireNonNull` for `nodeId`
   and `info`. `getCurrentProxyOMNodeId()` is already `synchronized` and
   `omProxies` is an unmodifiable map built once at construction, so neither
   read needs the provider monitor and both values are always present.
   ([comment](https://github.com/apache/ozone/pull/10486#discussion_r3430408425))

No functional changes: the connection-failure classification is identical
(the removed types still match via `SocketException`), the config constant is
unchanged, and `requireNonNull` only fast-fails on inputs that cannot occur
rather than silently returning `false`.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15599

## How was this patch tested?

No new tests — these are refactors covered by the existing suites:

- `TestConnectionFailureUtils`: `ConnectException` / `NoRouteToHostException`
  (bare and cause-nested) remain classified as connection failures via the
  `SocketException` branch.
- `TestOMFailoverProxyProviderRefreshWired` and `TestOMProxyInfoDnsRefresh`:
  the refresh wiring is exercised through method overrides, so the internal
  refactor of `maybeRefreshCurrentOmAddress` does not change their behavior.

`mvn checkstyle:check` reports 0 violations on both `hadoop-hdds/common` and
`hadoop-ozone/common`.
