### PR TITLE
HDDS-15596. Hide deprecated CLI options

### DIFF
--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/DeprecatedCliOption.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/DeprecatedCliOption.java
@@ -69,15 +69,9 @@ public final class DeprecatedCliOption {
       return;
     }
 
-    for (CommandLine cli : parseResult.asCommandLineList()) {
-      CommandLine.ParseResult subcommandResult = cli.getParseResult();
-      if (subcommandResult.matchedOptions().isEmpty()) {
-        continue;
-      }
-      for (Map.Entry<String, String> entry : DEPRECATED_OPTIONS.entrySet()) {
-        if (subcommandResult.hasMatchedOption(entry.getKey())) {
-          warn(cli.getErr(), entry.getKey(), entry.getValue());
-        }
+    for (Map.Entry<String, String> entry : DEPRECATED_OPTIONS.entrySet()) {
+      if (parseResult.expandedArgs().contains(entry.getKey())) {
+        warn(parseResult.commandSpec().commandLine().getErr(), entry.getKey(), entry.getValue());
       }
     }
   }

--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/DeprecatedCliOption.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/DeprecatedCliOption.java
@@ -18,10 +18,9 @@
 package org.apache.hadoop.hdds.cli;
 
 import java.io.PrintWriter;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import picocli.CommandLine;
+import java.util.Objects;
 
 /**
  * Emits warnings when deprecated multi-character short CLI options are used.
@@ -51,29 +50,28 @@ public final class DeprecatedCliOption {
     return options;
   }
 
-  public static boolean isDeprecated(String name) {
-    return DEPRECATED_OPTIONS.containsKey(name);
-  }
-
-  public static String[] withoutDeprecated(String[] names) {
-    return Arrays.stream(names)
-        .filter(name -> !isDeprecated(name))
-        .toArray(String[]::new);
-  }
-
   /**
-   * Print a warning to stderr for each deprecated option present on the command line.
+   * If {@code arg} is a deprecated option (with or without {@code =value} part),
+   * print a warning to stderr and return with the recommended replacement option.
    */
-  public static void warnIfMatched(CommandLine.ParseResult parseResult) {
-    if (parseResult == null) {
-      return;
+  public static String toNonDeprecated(String arg, PrintWriter err) {
+    if (arg == null || arg.isEmpty()) {
+      return arg;
     }
 
-    for (Map.Entry<String, String> entry : DEPRECATED_OPTIONS.entrySet()) {
-      if (parseResult.expandedArgs().contains(entry.getKey())) {
-        warn(parseResult.commandSpec().commandLine().getErr(), entry.getKey(), entry.getValue());
-      }
+    String result = arg;
+    String[] parts = arg.split("=", 2);
+    String opt = parts[0];
+    String optToUse = DEPRECATED_OPTIONS.getOrDefault(opt, opt);
+
+    if (!Objects.equals(opt, optToUse)) {
+      warn(err, opt, optToUse);
+      result = parts.length == 2
+          ? optToUse + '=' + parts[1]
+          : optToUse;
     }
+
+    return result;
   }
 
   private static void warn(PrintWriter err, String deprecated, String replacement) {

--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/DeprecatedCliOption.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/DeprecatedCliOption.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.cli;
 
 import java.io.PrintWriter;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import picocli.CommandLine;
@@ -48,6 +49,16 @@ public final class DeprecatedCliOption {
     options.put("-pct", "--prepare-check-interval");
     options.put("-pt", "--prepare-timeout");
     return options;
+  }
+
+  public static boolean isDeprecated(String name) {
+    return DEPRECATED_OPTIONS.containsKey(name);
+  }
+
+  public static String[] withoutDeprecated(String[] names) {
+    return Arrays.stream(names)
+        .filter(name -> !isDeprecated(name))
+        .toArray(String[]::new);
   }
 
   /**

--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -23,7 +23,11 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystemException;
 import java.nio.file.NoSuchFileException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -87,6 +91,7 @@ public abstract class GenericCli implements GenericParentCommand {
 
   public GenericCli(CommandLine.IFactory factory) {
     cmd = new CommandLine(this, factory);
+    ExtensibleParentCommand.addSubcommands(cmd);
     cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
       printError(ex);
       return EXECUTION_ERROR_EXIT_CODE;
@@ -95,8 +100,33 @@ public abstract class GenericCli implements GenericParentCommand {
       DeprecatedCliOption.warnIfMatched(parseResult);
       return new CommandLine.RunLast().execute(parseResult);
     });
+    cmd.setHelpFactory((commandSpec, colorScheme) -> new CommandLine.Help(commandSpec, colorScheme) {
+      @Override
+      public IOptionRenderer createDefaultOptionRenderer() {
+        IOptionRenderer delegate = super.createDefaultOptionRenderer();
+        return (option, parameterLabelRenderer, scheme) -> {
+          return delegate.render(withoutDeprecated(option), parameterLabelRenderer, scheme);
+        };
+      }
 
-    ExtensibleParentCommand.addSubcommands(cmd);
+      @Override
+      protected Ansi.Text createDetailedSynopsisOptionsText(Collection<CommandLine.Model.ArgSpec> done,
+          List<CommandLine.Model.OptionSpec> optionList, Comparator<CommandLine.Model.OptionSpec> optionSort,
+          boolean clusterBooleanOptions) {
+        List<CommandLine.Model.OptionSpec> withoutDeprecated = optionList.stream()
+            .map(this::withoutDeprecated)
+            .collect(Collectors.toList());
+        return super.createDetailedSynopsisOptionsText(done, withoutDeprecated, optionSort, clusterBooleanOptions);
+      }
+
+      private CommandLine.Model.OptionSpec withoutDeprecated(CommandLine.Model.OptionSpec option) {
+        String[] names = option.names();
+        String[] nonDeprecated = DeprecatedCliOption.withoutDeprecated(names);
+        return nonDeprecated.length < names.length
+            ? option.toBuilder().names(nonDeprecated).build()
+            : option;
+      }
+    });
   }
 
   public void run(String[] argv) {

--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -23,11 +23,7 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystemException;
 import java.nio.file.NoSuchFileException;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -60,7 +56,7 @@ public abstract class GenericCli implements GenericParentCommand {
     configOverrides.forEach(config::set);
   }
 
-  @Option(names = {"-conf", "--conf"},
+  @Option(names = {"--conf"},
       description = "Path to custom configuration file.")
   public void setConfigurationPath(String configPath) {
     config.addResource(new Path(configPath));
@@ -73,40 +69,14 @@ public abstract class GenericCli implements GenericParentCommand {
   public GenericCli(CommandLine.IFactory factory) {
     cmd = new CommandLine(this, factory);
     ExtensibleParentCommand.addSubcommands(cmd);
+    cmd.getCommandSpec().preprocessor((args, commandSpec, argSpec, info) -> {
+      args.replaceAll(arg -> DeprecatedCliOption.toNonDeprecated(arg, cmd.getErr()));
+      return false;
+    });
+
     cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
       printError(ex);
       return EXECUTION_ERROR_EXIT_CODE;
-    });
-    cmd.setExecutionStrategy(parseResult -> {
-      DeprecatedCliOption.warnIfMatched(parseResult);
-      return new CommandLine.RunLast().execute(parseResult);
-    });
-    cmd.setHelpFactory((commandSpec, colorScheme) -> new CommandLine.Help(commandSpec, colorScheme) {
-      @Override
-      public IOptionRenderer createDefaultOptionRenderer() {
-        IOptionRenderer delegate = super.createDefaultOptionRenderer();
-        return (option, parameterLabelRenderer, scheme) -> {
-          return delegate.render(withoutDeprecated(option), parameterLabelRenderer, scheme);
-        };
-      }
-
-      @Override
-      protected Ansi.Text createDetailedSynopsisOptionsText(Collection<CommandLine.Model.ArgSpec> done,
-          List<CommandLine.Model.OptionSpec> optionList, Comparator<CommandLine.Model.OptionSpec> optionSort,
-          boolean clusterBooleanOptions) {
-        List<CommandLine.Model.OptionSpec> withoutDeprecated = optionList.stream()
-            .map(this::withoutDeprecated)
-            .collect(Collectors.toList());
-        return super.createDetailedSynopsisOptionsText(done, withoutDeprecated, optionSort, clusterBooleanOptions);
-      }
-
-      private CommandLine.Model.OptionSpec withoutDeprecated(CommandLine.Model.OptionSpec option) {
-        String[] names = option.names();
-        String[] nonDeprecated = DeprecatedCliOption.withoutDeprecated(names);
-        return nonDeprecated.length < names.length
-            ? option.toBuilder().names(nonDeprecated).build()
-            : option;
-      }
     });
   }
 

--- a/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -50,10 +50,6 @@ public abstract class GenericCli implements GenericParentCommand {
 
   private UserGroupInformation user;
 
-  private String configurationPath;
-  private String deprecatedConfigurationPath;
-  private boolean isConfigurationPathAdded = false;
-
   @Option(names = {"--verbose"},
       scope = CommandLine.ScopeType.INHERIT,
       description = "More verbose output. Show the stack trace of the errors.")
@@ -64,25 +60,10 @@ public abstract class GenericCli implements GenericParentCommand {
     configOverrides.forEach(config::set);
   }
 
-  @Option(names = {"--conf"},
+  @Option(names = {"-conf", "--conf"},
       description = "Path to custom configuration file.")
   public void setConfigurationPath(String configPath) {
-    configurationPath = configPath;
-  }
-
-  /** For backward compatibility. */
-  @Option(names = {"-conf"}, hidden = true)
-  @Deprecated
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  public void setDeprecatedConfigurationPath(String configPath) {
-    deprecatedConfigurationPath = configPath;
-  }
-
-  private String getConfigurationPath() {
-    if (configurationPath != null) {
-      return configurationPath;
-    }
-    return deprecatedConfigurationPath;
+    config.addResource(new Path(configPath));
   }
 
   public GenericCli() {
@@ -165,11 +146,6 @@ public abstract class GenericCli implements GenericParentCommand {
 
   @Override
   public OzoneConfiguration getOzoneConf() {
-    String path = getConfigurationPath();
-    if (path != null && !isConfigurationPathAdded) {
-      config.addResource(new Path(path));
-      isConfigurationPathAdded = true;
-    }
     return config;
   }
 

--- a/hadoop-hdds/cli-common/src/test/java/org/apache/hadoop/hdds/cli/TestGenericCliConfiguration.java
+++ b/hadoop-hdds/cli-common/src/test/java/org/apache/hadoop/hdds/cli/TestGenericCliConfiguration.java
@@ -18,49 +18,44 @@
 package org.apache.hadoop.hdds.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 /**
  * Tests for {@link GenericCli} configuration option handling.
  */
 public class TestGenericCliConfiguration {
 
+  private static Path deprecatedConf;
+  private static Path preferredConf;
+
   private static final class TestGenericCli extends GenericCli {
   }
 
-  @Test
-  public void nonDeprecatedConfWinsWhenBothAreProvided() throws IOException {
-    Path deprecatedConf = writeConf("deprecated");
-    Path preferredConf = writeConf("preferred");
-
-    TestGenericCli cli = new TestGenericCli();
-    cli.getCmd().parseArgs("-conf", deprecatedConf.toString(), "--conf",
-        preferredConf.toString());
-
-    assertThat(cli.getOzoneConf().get("test.key")).isEqualTo("preferred");
+  @BeforeAll
+  static void setup() throws IOException {
+    deprecatedConf = writeConf("deprecated");
+    preferredConf = writeConf("preferred");
   }
 
   @Test
-  public void nonDeprecatedConfWinsRegardlessOfOrder() throws IOException {
-    Path deprecatedConf = writeConf("deprecated");
-    Path preferredConf = writeConf("preferred");
-
-    TestGenericCli cli = new TestGenericCli();
-    cli.getCmd().parseArgs("--conf", preferredConf.toString(), "-conf",
-        deprecatedConf.toString());
-
-    assertThat(cli.getOzoneConf().get("test.key")).isEqualTo("preferred");
+  void confOptionsAreExclusive() {
+    CommandLine cmd = new TestGenericCli().getCmd();
+    assertThrows(CommandLine.OverwrittenOptionException.class,
+        () -> cmd.parseArgs("-conf", deprecatedConf.toString(), "--conf", preferredConf.toString()));
+    assertThrows(CommandLine.OverwrittenOptionException.class,
+        () -> cmd.parseArgs("--conf", deprecatedConf.toString(), "-conf", preferredConf.toString()));
   }
 
   @Test
-  public void deprecatedConfIsUsedWhenNonDeprecatedIsAbsent() throws IOException {
-    Path deprecatedConf = writeConf("deprecated");
-
+  void deprecatedConfIsUsedWhenNonDeprecatedIsAbsent() {
     TestGenericCli cli = new TestGenericCli();
     cli.getCmd().parseArgs("-conf", deprecatedConf.toString());
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
@@ -42,7 +42,7 @@ public class ScmOption extends AbstractMixin {
       description = "The destination scm (host:port)")
   private String scm;
 
-  @CommandLine.Option(names = {"--service-id", "-id"}, description =
+  @CommandLine.Option(names = {"--service-id"}, description =
       "ServiceId of SCM HA Cluster")
   private String scmServiceId;
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
@@ -42,15 +42,9 @@ public class ScmOption extends AbstractMixin {
       description = "The destination scm (host:port)")
   private String scm;
 
-  @CommandLine.Option(names = {"--service-id"}, description =
+  @CommandLine.Option(names = {"--service-id", "-id"}, description =
       "ServiceId of SCM HA Cluster")
   private String scmServiceId;
-
-  /** For backward compatibility. */
-  @CommandLine.Option(names = {"-id"}, hidden = true)
-  @Deprecated
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  private String deprecatedScmServiceId;
 
   public ScmClient createScmClient() throws IOException {
     OzoneConfiguration conf = getOzoneConf();
@@ -76,9 +70,8 @@ public class ScmOption extends AbstractMixin {
 
     // Use the scm service Id passed from the client.
 
-    String serviceId = getScmServiceId();
-    if (StringUtils.isNotEmpty(serviceId)) {
-      conf.set(ScmConfigKeys.OZONE_SCM_DEFAULT_SERVICE_ID, serviceId);
+    if (StringUtils.isNotEmpty(scmServiceId)) {
+      conf.set(ScmConfigKeys.OZONE_SCM_DEFAULT_SERVICE_ID, scmServiceId);
     } else if (StringUtils.isBlank(HddsUtils.getScmServiceId(conf))) {
       // Scm service id is not passed, and scm service id is not defined in
       // the config, assuming it should be non-HA cluster.
@@ -104,12 +97,5 @@ public class ScmOption extends AbstractMixin {
 
   public String getScm() {
     return scm;
-  }
-
-  public String getScmServiceId() {
-    if (StringUtils.isNotEmpty(scmServiceId)) {
-      return scmServiceId;
-    }
-    return deprecatedScmServiceId;
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/FilterPipelineOptions.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/FilterPipelineOptions.java
@@ -45,7 +45,7 @@ public class FilterPipelineOptions {
   private String replication;
 
   @CommandLine.Option(
-      names = {"-ffc", "--filterByFactor", "--filter-by-factor"},
+      names = {"--filterByFactor", "--filter-by-factor"},
       description = "[deprecated] Filter pipelines by factor (e.g. ONE, THREE) (implies RATIS replication type)")
   private ReplicationFactor factor;
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/FilterPipelineOptions.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/FilterPipelineOptions.java
@@ -45,30 +45,20 @@ public class FilterPipelineOptions {
   private String replication;
 
   @CommandLine.Option(
-      names = {"--filterByFactor", "--filter-by-factor"},
+      names = {"-ffc", "--filterByFactor", "--filter-by-factor"},
       description = "[deprecated] Filter pipelines by factor (e.g. ONE, THREE) (implies RATIS replication type)")
   private ReplicationFactor factor;
 
-  /** For backward compatibility. */
-  @CommandLine.Option(
-      names = {"-ffc"},
-      hidden = true
-  )
-  @Deprecated
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  private ReplicationFactor deprecatedFactor;
-
   Optional<Predicate<? super Pipeline>> getReplicationFilter() {
-    ReplicationFactor effectiveFactor = getFactor();
     boolean hasReplication = !Strings.isNullOrEmpty(replication);
-    boolean hasFactor = effectiveFactor != null;
+    boolean hasFactor = factor != null;
     boolean hasReplicationType = !Strings.isNullOrEmpty(replicationType);
 
     if (hasFactor) {
       if (hasReplication) {
         throw new IllegalArgumentException("Factor and replication are mutually exclusive");
       }
-      ReplicationConfig replicationConfig = RatisReplicationConfig.getInstance(effectiveFactor.toProto());
+      ReplicationConfig replicationConfig = RatisReplicationConfig.getInstance(factor.toProto());
       return Optional.of(p -> replicationConfig.equals(p.getReplicationConfig()));
     }
 
@@ -90,9 +80,5 @@ public class FilterPipelineOptions {
     }
 
     return Optional.empty();
-  }
-
-  private ReplicationFactor getFactor() {
-    return factor != null ? factor : deprecatedFactor;
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
@@ -44,7 +44,7 @@ public class ListPipelinesSubcommand extends ScmSubcommand {
   private final FilterPipelineOptions filterOptions = new FilterPipelineOptions();
 
   @CommandLine.Option(
-      names = {"-s", "--state", "-fst", "--filterByState", "--filter-by-state"},
+      names = {"-s", "--state", "--filterByState", "--filter-by-state"},
       description = "Filter listed pipelines by State, eg OPEN, CLOSED",
       defaultValue = "")
   private String state;

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
@@ -44,20 +44,10 @@ public class ListPipelinesSubcommand extends ScmSubcommand {
   private final FilterPipelineOptions filterOptions = new FilterPipelineOptions();
 
   @CommandLine.Option(
-      names = {"-s", "--state", "--filterByState", "--filter-by-state"},
+      names = {"-s", "--state", "-fst", "--filterByState", "--filter-by-state"},
       description = "Filter listed pipelines by State, eg OPEN, CLOSED",
       defaultValue = "")
   private String state;
-
-  /** For backward compatibility. */
-  @CommandLine.Option(
-      names = {"-fst"},
-      hidden = true,
-      defaultValue = ""
-  )
-  @Deprecated
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  private String deprecatedState;
 
   @CommandLine.Option(
       names = {"--json"},
@@ -73,10 +63,9 @@ public class ListPipelinesSubcommand extends ScmSubcommand {
     if (replicationFilter.isPresent()) {
       stream = stream.filter(replicationFilter.get());
     }
-    String effectiveState = getState();
-    if (!Strings.isNullOrEmpty(effectiveState)) {
+    if (!Strings.isNullOrEmpty(state)) {
       stream = stream.filter(p -> p.getPipelineState().toString()
-          .compareToIgnoreCase(effectiveState) == 0);
+          .compareToIgnoreCase(state) == 0);
     }
 
     if (json) {
@@ -86,12 +75,5 @@ public class ListPipelinesSubcommand extends ScmSubcommand {
     } else {
       stream.forEach(System.out::println);
     }
-  }
-
-  private String getState() {
-    if (!Strings.isNullOrEmpty(state)) {
-      return state;
-    }
-    return deprecatedState;
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -67,12 +67,12 @@ public class DecommissionOMSubcommand implements Callable<Void> {
   @CommandLine.Mixin
   private OmAddressOptions.MandatoryServiceIdMixin omServiceOption;
 
-  @CommandLine.Option(names = {"-nodeid", "--nodeid"},
+  @CommandLine.Option(names = {"--nodeid"},
       description = "NodeID of the OM to be decommissioned.",
       required = true)
   private String decommNodeId;
 
-  @CommandLine.Option(names = {"-hostname", "--node-host-address"},
+  @CommandLine.Option(names = {"--node-host-address"},
       description = "Host name/address of the OM to be decommissioned.",
       required = true)
   private String hostname;

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -43,8 +43,8 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "decommission",
     customSynopsis = "ozone admin om decommission --service-id=<om-service-id> " +
-        "--nodeid=<decommission-om-node-id> " +
-        "--node-host-address=<decommission-om-node-address> [options]",
+        "-nodeid=<decommission-om-node-id> " +
+        "-hostname=<decommission-om-node-address> [options]",
     description = "Decommission an OzoneManager. Ensure that the node being " +
         "decommissioned is shutdown first." +
         "%nNote - Add the node to be decommissioned to " +
@@ -67,11 +67,15 @@ public class DecommissionOMSubcommand implements Callable<Void> {
   @CommandLine.Mixin
   private OmAddressOptions.MandatoryServiceIdMixin omServiceOption;
 
-  @CommandLine.ArgGroup(multiplicity = "1")
-  private NodeIdOptions nodeIdOptions;
+  @CommandLine.Option(names = {"-nodeid", "--nodeid"},
+      description = "NodeID of the OM to be decommissioned.",
+      required = true)
+  private String decommNodeId;
 
-  @CommandLine.ArgGroup(multiplicity = "1")
-  private HostnameOptions hostnameOptions;
+  @CommandLine.Option(names = {"-hostname", "--node-host-address"},
+      description = "Host name/address of the OM to be decommissioned.",
+      required = true)
+  private String hostname;
 
   private InetAddress hostInetAddress;
 
@@ -102,14 +106,14 @@ public class DecommissionOMSubcommand implements Callable<Void> {
              OMAdminProtocolClientSideImpl.createProxyForOMHA(ozoneConf, user,
                  omServiceOption.getServiceID())) {
       OMNodeDetails decommNodeDetails = new OMNodeDetails.Builder()
-          .setOMNodeId(nodeIdOptions.getNodeId())
+          .setOMNodeId(decommNodeId)
           .setHostAddress(hostInetAddress.getHostAddress())
           .build();
       omAdminProtocolClient.decommission(decommNodeDetails);
 
-      System.out.println("Successfully decommissioned OM " + nodeIdOptions.getNodeId());
+      System.out.println("Successfully decommissioned OM " + decommNodeId);
     } catch (IOException e) {
-      System.out.println("Failed to decommission OM " + nodeIdOptions.getNodeId());
+      System.out.println("Failed to decommission OM " + decommNodeId);
       throw e;
     }
     return null;
@@ -121,19 +125,19 @@ public class DecommissionOMSubcommand implements Callable<Void> {
    */
   private void verifyNodeIdAndHostAddress() throws IOException {
     String rpcAddrKey = ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY,
-        omServiceOption.getServiceID(), nodeIdOptions.getNodeId());
+        omServiceOption.getServiceID(), decommNodeId);
     String rpcAddrStr = OmUtils.getOmRpcAddress(ozoneConf, rpcAddrKey);
     if (rpcAddrStr == null || rpcAddrStr.isEmpty()) {
-      throw new IOException("There is no OM corresponding to " + nodeIdOptions.getNodeId()
+      throw new IOException("There is no OM corresponding to " + decommNodeId
           + "in the configuration.");
     }
 
-    hostInetAddress = InetAddress.getByName(hostnameOptions.getHostname());
+    hostInetAddress = InetAddress.getByName(hostname);
     InetAddress rpcAddressFromConfig = InetAddress.getByName(
         rpcAddrStr.split(":")[0]);
 
     if (!hostInetAddress.equals(rpcAddressFromConfig)) {
-      throw new IOException("OM " + nodeIdOptions.getNodeId() + "'s host address in " +
+      throw new IOException("OM " + decommNodeId + "'s host address in " +
           "config - " + rpcAddressFromConfig.getHostAddress() + " does not " +
           "match the provided host address " + hostInetAddress);
     }
@@ -149,9 +153,9 @@ public class DecommissionOMSubcommand implements Callable<Void> {
         OZONE_OM_DECOMMISSIONED_NODES_KEY, omServiceOption.getServiceID());
     Collection<String> decommNodes =
         OmUtils.getDecommissionedNodeIds(ozoneConf, decommNodesKey);
-    if (!decommNodes.contains(nodeIdOptions.getNodeId())) {
+    if (!decommNodes.contains(decommNodeId)) {
       throw new IOException("Please add the to be decommissioned OM "
-          + nodeIdOptions.getNodeId() + " to the " + decommNodesKey + " config in " +
+          + decommNodeId + " to the " + decommNodesKey + " config in " +
           "ozone-site.xml of all nodes.");
     }
 
@@ -161,7 +165,7 @@ public class DecommissionOMSubcommand implements Callable<Void> {
     List<OMNodeDetails> activeOMNodeDetails = OmUtils.getAllOMHAAddresses(
         ozoneConf, omServiceOption.getServiceID(), false);
     if (activeOMNodeDetails.isEmpty()) {
-      throw new IOException("Cannot decommission OM " + nodeIdOptions.getNodeId() + " as " +
+      throw new IOException("Cannot decommission OM " + decommNodeId + " as " +
           "it is the only node in the ring.");
     }
 
@@ -190,7 +194,7 @@ public class DecommissionOMSubcommand implements Callable<Void> {
                  user, omNodeDetails)) {
       OMConfiguration omConfig = omAdminProtocolClient.getOMConfiguration();
       OMNodeDetails decommNodeDetails = omConfig
-          .getDecommissionedNodesInNewConf().get(nodeIdOptions.getNodeId());
+          .getDecommissionedNodesInNewConf().get(decommNodeId);
       if (decommNodeDetails == null) {
         return false;
       }
@@ -200,45 +204,5 @@ public class DecommissionOMSubcommand implements Callable<Void> {
       }
     }
     return true;
-  }
-
-  /** Options for OM node ID. */
-  static class NodeIdOptions {
-    @CommandLine.Option(names = {"--nodeid"},
-        description = "NodeID of the OM to be decommissioned.",
-        required = true)
-    private String nodeId;
-
-    /** For backward compatibility. */
-    @CommandLine.Option(names = {"-nodeid"},
-        hidden = true,
-        required = true)
-    @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    private String deprecatedNodeId;
-
-    String getNodeId() {
-      return nodeId != null ? nodeId : deprecatedNodeId;
-    }
-  }
-
-  /** Options for OM host name/address. */
-  static class HostnameOptions {
-    @CommandLine.Option(names = {"--node-host-address"},
-        description = "Host name/address of the OM to be decommissioned.",
-        required = true)
-    private String hostname;
-
-    /** For backward compatibility. */
-    @CommandLine.Option(names = {"-hostname"},
-        hidden = true,
-        required = true)
-    @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    private String deprecatedHostname;
-
-    String getHostname() {
-      return hostname != null ? hostname : deprecatedHostname;
-    }
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -43,8 +43,8 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "decommission",
     customSynopsis = "ozone admin om decommission --service-id=<om-service-id> " +
-        "-nodeid=<decommission-om-node-id> " +
-        "-hostname=<decommission-om-node-address> [options]",
+        "--nodeid=<decommission-om-node-id> " +
+        "--node-host-address=<decommission-om-node-address> [options]",
     description = "Decommission an OzoneManager. Ensure that the node being " +
         "decommissioned is shutdown first." +
         "%nNote - Add the node to be decommissioned to " +

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/OmAddressOptions.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/OmAddressOptions.java
@@ -126,21 +126,8 @@ public final class OmAddressOptions {
     )
     private String serviceID;
 
-    /** For backward compatibility. */
-    @CommandLine.Option(
-        names = {"-id"},
-        hidden = true,
-        required = true
-    )
-    @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    private String deprecatedID;
-
     public String getServiceID() {
-      if (serviceID != null) {
-        return serviceID;
-      }
-      return deprecatedID;
+      return serviceID;
     }
 
     @Override
@@ -159,18 +146,8 @@ public final class OmAddressOptions {
     )
     private String host;
 
-    /** For backward compatibility. */
-    @CommandLine.Option(
-        names = {"-host"},
-        hidden = true,
-        required = true
-    )
-    @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    private String deprecatedHost;
-
     public String getHost() {
-      return host != null ? host : deprecatedHost;
+      return host;
     }
 
     @Override

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
@@ -57,7 +57,7 @@ public class PrepareSubCommand implements Callable<Void> {
   private OmAddressOptions.MandatoryServiceIdMixin omServiceOption;
 
   @CommandLine.Option(
-      names = {"-tawt", "--transaction-apply-wait-timeout"},
+      names = {"--transaction-apply-wait-timeout"},
       description = "Max time in SECONDS to wait for all transactions before" +
           "the prepare request to be applied to the OM DB.",
       defaultValue = "120",
@@ -66,7 +66,7 @@ public class PrepareSubCommand implements Callable<Void> {
   private long txnApplyWaitTimeSeconds;
 
   @CommandLine.Option(
-      names = {"-tact", "--transaction-apply-check-interval"},
+      names = {"--transaction-apply-check-interval"},
       description = "Time in SECONDS to wait between successive checks for " +
           "all transactions to be applied to the OM DB.",
       defaultValue = "5",
@@ -75,7 +75,7 @@ public class PrepareSubCommand implements Callable<Void> {
   private long txnApplyCheckIntervalSeconds;
 
   @CommandLine.Option(
-      names = {"-pct", "--prepare-check-interval"},
+      names = {"--prepare-check-interval"},
       description = "Time in SECONDS to wait between successive checks for OM" +
           " preparation.",
       defaultValue = "10",
@@ -84,7 +84,7 @@ public class PrepareSubCommand implements Callable<Void> {
   private long prepareCheckInterval;
 
   @CommandLine.Option(
-      names = {"-pt", "--prepare-timeout"},
+      names = {"--prepare-timeout"},
       description = "Max time in SECONDS to wait for all OMs to be prepared",
       defaultValue = "300",
       hidden = true

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
@@ -57,71 +57,39 @@ public class PrepareSubCommand implements Callable<Void> {
   private OmAddressOptions.MandatoryServiceIdMixin omServiceOption;
 
   @CommandLine.Option(
-      names = {"--transaction-apply-wait-timeout"},
+      names = {"-tawt", "--transaction-apply-wait-timeout"},
       description = "Max time in SECONDS to wait for all transactions before" +
           "the prepare request to be applied to the OM DB.",
+      defaultValue = "120",
       hidden = true
   )
-  private Long txnApplyWaitTimeSeconds;
-
-  /** For backward compatibility. */
-  @CommandLine.Option(
-      names = {"-tawt"},
-      hidden = true
-  )
-  @Deprecated
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  private Long deprecatedTxnApplyWaitTimeSeconds;
+  private long txnApplyWaitTimeSeconds;
 
   @CommandLine.Option(
-      names = {"--transaction-apply-check-interval"},
+      names = {"-tact", "--transaction-apply-check-interval"},
       description = "Time in SECONDS to wait between successive checks for " +
           "all transactions to be applied to the OM DB.",
+      defaultValue = "5",
       hidden = true
   )
-  private Long txnApplyCheckIntervalSeconds;
-
-  /** For backward compatibility. */
-  @CommandLine.Option(
-      names = {"-tact"},
-      hidden = true
-  )
-  @Deprecated
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  private Long deprecatedTxnApplyCheckIntervalSeconds;
+  private long txnApplyCheckIntervalSeconds;
 
   @CommandLine.Option(
-      names = {"--prepare-check-interval"},
+      names = {"-pct", "--prepare-check-interval"},
       description = "Time in SECONDS to wait between successive checks for OM" +
           " preparation.",
+      defaultValue = "10",
       hidden = true
   )
-  private Long prepareCheckInterval;
-
-  /** For backward compatibility. */
-  @CommandLine.Option(
-      names = {"-pct"},
-      hidden = true
-  )
-  @Deprecated
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  private Long deprecatedPrepareCheckInterval;
+  private long prepareCheckInterval;
 
   @CommandLine.Option(
-      names = {"--prepare-timeout"},
+      names = {"-pt", "--prepare-timeout"},
       description = "Max time in SECONDS to wait for all OMs to be prepared",
+      defaultValue = "300",
       hidden = true
   )
-  private Long prepareTimeOut;
-
-  /** For backward compatibility. */
-  @CommandLine.Option(
-      names = {"-pt"},
-      hidden = true
-  )
-  @Deprecated
-  @SuppressWarnings("DeprecatedIsStillUsed")
-  private Long deprecatedPrepareTimeOut;
+  private long prepareTimeOut;
 
   @Override
   public Void call() throws Exception {
@@ -132,8 +100,8 @@ public class PrepareSubCommand implements Callable<Void> {
   }
 
   private void execute(OzoneManagerProtocol client) throws Exception {
-    long prepareTxnId = client.prepareOzoneManager(getTxnApplyWaitTimeSeconds(),
-        getTxnApplyCheckIntervalSeconds());
+    long prepareTxnId = client.prepareOzoneManager(txnApplyWaitTimeSeconds,
+        txnApplyCheckIntervalSeconds);
     System.out.println("Ozone Manager Prepare Request successfully returned " +
         "with Transaction Id : [" + prepareTxnId + "].");
 
@@ -141,8 +109,8 @@ public class PrepareSubCommand implements Callable<Void> {
     Set<String> omHosts = getOmHostsFromConfig(
         parent.getParent().getOzoneConf(), omServiceOption.getServiceID());
     omHosts.forEach(h -> omPreparedStatusMap.put(h, false));
-    Duration pTimeout = Duration.of(getPrepareTimeOut(), ChronoUnit.SECONDS);
-    Duration pInterval = Duration.of(getPrepareCheckInterval(), ChronoUnit.SECONDS);
+    Duration pTimeout = Duration.of(prepareTimeOut, ChronoUnit.SECONDS);
+    Duration pInterval = Duration.of(prepareCheckInterval, ChronoUnit.SECONDS);
 
     System.out.println();
     System.out.println("Checking individual OM instances for prepare request " +
@@ -175,7 +143,7 @@ public class PrepareSubCommand implements Callable<Void> {
         }
       }
       if (currentNumPreparedOms < expectedNumPreparedOms) {
-        System.out.println("Waiting for " + getPrepareCheckInterval() +
+        System.out.println("Waiting for " + prepareCheckInterval +
             " seconds before retrying...");
         Thread.sleep(pInterval.toMillis());
       }
@@ -199,32 +167,6 @@ public class PrepareSubCommand implements Callable<Void> {
       System.out.println("No new write requests will be allowed until " +
           "preparation is cancelled or upgrade/downgrade is done.");
     }
-  }
-
-  private long getTxnApplyWaitTimeSeconds() {
-    return resolveOption(txnApplyWaitTimeSeconds, deprecatedTxnApplyWaitTimeSeconds, 120L);
-  }
-
-  private long getTxnApplyCheckIntervalSeconds() {
-    return resolveOption(txnApplyCheckIntervalSeconds, deprecatedTxnApplyCheckIntervalSeconds, 5L);
-  }
-
-  private long getPrepareCheckInterval() {
-    return resolveOption(prepareCheckInterval, deprecatedPrepareCheckInterval, 10L);
-  }
-
-  private long getPrepareTimeOut() {
-    return resolveOption(prepareTimeOut, deprecatedPrepareTimeOut, 300L);
-  }
-
-  private static long resolveOption(Long value, Long deprecatedValue, long defaultValue) {
-    if (value != null) {
-      return value;
-    }
-    if (deprecatedValue != null) {
-      return deprecatedValue;
-    }
-    return defaultValue;
   }
 
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/scm/DecommissionScmSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/scm/DecommissionScmSubcommand.java
@@ -39,7 +39,7 @@ public class DecommissionScmSubcommand extends ScmSubcommand {
   @CommandLine.ParentCommand
   private ScmAdmin parent;
 
-  @CommandLine.Option(names = {"-nodeid", "--nodeid"},
+  @CommandLine.Option(names = {"--nodeid"},
       description = "NodeID of the SCM to be decommissioned.",
       required = true)
   private String nodeId;

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/scm/DecommissionScmSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/scm/DecommissionScmSubcommand.java
@@ -39,42 +39,23 @@ public class DecommissionScmSubcommand extends ScmSubcommand {
   @CommandLine.ParentCommand
   private ScmAdmin parent;
 
-  @CommandLine.ArgGroup(multiplicity = "1")
-  private NodeIdOptions nodeIdOptions;
+  @CommandLine.Option(names = {"-nodeid", "--nodeid"},
+      description = "NodeID of the SCM to be decommissioned.",
+      required = true)
+  private String nodeId;
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    DecommissionScmResponseProto response = scmClient.decommissionScm(
-        nodeIdOptions.getNodeId());
+    DecommissionScmResponseProto response = scmClient.decommissionScm(nodeId);
     if (!response.getSuccess()) {
-      String errorMsg = "Error decommissioning Scm " + nodeIdOptions.getNodeId();
+      String errorMsg = "Error decommissioning Scm " + nodeId;
       if (response.hasErrorMsg()) {
         errorMsg = errorMsg + ", " + response.getErrorMsg();
       }
       // Throwing exception to create non-zero exit code in case of failure.
       throw new IOException(errorMsg);
     } else {
-      System.out.println("Decommissioned Scm " + nodeIdOptions.getNodeId());
-    }
-  }
-
-  /** Options for SCM node ID. */
-  static class NodeIdOptions {
-    @CommandLine.Option(names = {"--nodeid"},
-        description = "NodeID of the SCM to be decommissioned.",
-        required = true)
-    private String nodeId;
-
-    /** For backward compatibility. */
-    @CommandLine.Option(names = {"-nodeid"},
-        hidden = true,
-        required = true)
-    @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    private String deprecatedNodeId;
-
-    String getNodeId() {
-      return nodeId != null ? nodeId : deprecatedNodeId;
+      System.out.println("Decommissioned Scm " + nodeId);
     }
   }
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/cli/TestOzoneAdminDeprecatedOptions.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/cli/TestOzoneAdminDeprecatedOptions.java
@@ -21,36 +21,39 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import org.apache.hadoop.hdds.scm.cli.pipeline.ListPipelinesSubcommand;
+import org.apache.hadoop.ozone.admin.OzoneAdmin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 /**
- * Tests for deprecated CLI option warnings.
+ * Tests for deprecated CLI option warnings of @{code ozone admin}.
  */
-public class TestDeprecatedCliOption {
+class TestOzoneAdminDeprecatedOptions {
+
+  private CommandLine cli;
   private StringWriter err;
 
   @BeforeEach
   public void setup() {
     err = new StringWriter();
+    cli = createCommandLine();
   }
 
-  private CommandLine createCommandLine(Object command) {
-    CommandLine cli = new CommandLine(command);
-    cli.setErr(new PrintWriter(err, true));
-    cli.setExecutionStrategy(parseResult -> {
-      DeprecatedCliOption.warnIfMatched(parseResult);
-      return CommandLine.ExitCode.OK;
-    });
-    return cli;
+  private CommandLine createCommandLine() {
+    OzoneAdmin command = new OzoneAdmin();
+    CommandLine cmd = command.getCmd();
+    cmd.setErr(new PrintWriter(err, true));
+    cmd.setExecutionStrategy(parseResult -> CommandLine.ExitCode.OK);
+    return cmd;
   }
 
-  @Test
-  public void warnsForDeprecatedOption() {
-    createCommandLine(new ListPipelinesSubcommand())
-        .execute("-ffc", "THREE");
+  @ParameterizedTest
+  @ValueSource(strings = {"-ffc THREE", "-ffc=ONE"})
+  public void warnsForDeprecatedOption(String arg) {
+    execute("pipeline list " + arg);
 
     assertThat(err.toString())
         .contains("WARNING: Option '-ffc' is deprecated")
@@ -59,19 +62,22 @@ public class TestDeprecatedCliOption {
 
   @Test
   public void warnsForMultipleDeprecatedOptions() {
-    createCommandLine(new ListPipelinesSubcommand())
-        .execute("-ffc", "THREE", "-fst", "OPEN");
+    execute("pipeline list -ffc THREE -fst OPEN");
 
     assertThat(err.toString())
         .contains("WARNING: Option '-ffc' is deprecated")
         .contains("WARNING: Option '-fst' is deprecated");
   }
 
-  @Test
-  public void doesNotWarnForLongOption() {
-    createCommandLine(new ListPipelinesSubcommand())
-        .execute("--filter-by-factor", "THREE");
+  @ParameterizedTest
+  @ValueSource(strings = {"--filter-by-factor=THREE", "--filter-by-factor ONE"})
+  public void doesNotWarnForLongOption(String arg) {
+    execute("pipeline list " + arg);
 
     assertThat(err.toString()).isEmpty();
+  }
+
+  private void execute(String cmd) {
+    cli.execute(cmd.split(" "));
   }
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestClosePipelinesSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestClosePipelinesSubCommand.java
@@ -69,12 +69,12 @@ class TestClosePipelinesSubCommand {
             "with empty parameters"
         ),
         arguments(
-            new String[]{"--all", "-ffc", "THREE"},
+            new String[]{"--all", "--filter-by-factor", "THREE"},
             "Sending close command for 1 pipelines...\n",
             "by filter factor, opened"
         ),
         arguments(
-            new String[]{"--all", "-ffc", "ONE"},
+            new String[]{"--all", "--filter-by-factor", "ONE"},
             "Sending close command for 0 pipelines...\n",
             "by filter factor, closed"
         ),

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
@@ -124,7 +124,7 @@ public class TestListPipelinesSubCommand {
   @Test
   public void testLegacyFactorWithoutType() throws IOException {
     CommandLine c = new CommandLine(cmd);
-    c.parseArgs("-ffc", "THREE");
+    c.parseArgs("--filter-by-factor", "THREE");
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
@@ -135,7 +135,7 @@ public class TestListPipelinesSubCommand {
   @Test
   public void factorAndReplicationAreMutuallyExclusive() {
     CommandLine c = new CommandLine(cmd);
-    c.parseArgs("-r", "THREE", "-ffc", "ONE");
+    c.parseArgs("-r", "THREE", "--filter-by-factor", "ONE");
     assertThrows(IllegalArgumentException.class, () -> cmd.execute(scmClient));
   }
 
@@ -165,7 +165,7 @@ public class TestListPipelinesSubCommand {
   @Test
   public void testLegacyFactorAndState() throws IOException {
     CommandLine c = new CommandLine(cmd);
-    c.parseArgs("-ffc", "THREE", "-fst", "OPEN");
+    c.parseArgs("--filter-by-factor", "THREE", "--state", "OPEN");
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.shell;
 
 import java.util.Collections;
 import java.util.List;
-import org.apache.hadoop.hdds.cli.DeprecatedCliOption;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -90,7 +89,6 @@ public abstract class Shell extends GenericCli {
   }
 
   private int execute(CommandLine.ParseResult parseResult) {
-    DeprecatedCliOption.warnIfMatched(parseResult);
     name = spec.name();
 
     if (parseResult.hasMatchedOption("--interactive") || parseResult.hasMatchedOption("--execute")) {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
@@ -31,7 +31,7 @@ import picocli.CommandLine;
  */
 public class AclOption implements CommandLine.ITypeConverter<OzoneAcl> {
 
-  @CommandLine.Option(names = {"--acls", "--acl", "-al", "-a"}, split = ",",
+  @CommandLine.Option(names = {"--acls", "--acl", "-a"}, split = ",",
       required = true,
       converter = AclOption.class,
       description = "Comma separated ACL list:%n" +

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/acl/AclOption.java
@@ -31,39 +31,24 @@ import picocli.CommandLine;
  */
 public class AclOption implements CommandLine.ITypeConverter<OzoneAcl> {
 
-  @CommandLine.ArgGroup(multiplicity = "1")
-  private Exclusive exclusive = new Exclusive();
-
-  private static final class Exclusive {
-    @CommandLine.Option(names = {"--acls", "--acl", "-a"}, split = ",",
-        required = true,
-        converter = AclOption.class,
-        description = "Comma separated ACL list:%n" +
-            "Example: user:user2:a OR user:user1:rw,group:hadoop:a%n" +
-            "r = READ, " +
-            "w = WRITE, " +
-            "c = CREATE, " +
-            "d = DELETE, " +
-            "l = LIST, " +
-            "a = ALL, " +
-            "n = NONE, " +
-            "x = READ_ACL, " +
-            "y = WRITE_ACL.")
-        private OzoneAcl[] values;
-
-    /** For backward compatibility. */
-    @CommandLine.Option(names = {"-al"}, split = ",", hidden = true,
-        required = true, converter = AclOption.class)
-    @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    private OzoneAcl[] deprecatedValues;
-  }
+  @CommandLine.Option(names = {"--acls", "--acl", "-al", "-a"}, split = ",",
+      required = true,
+      converter = AclOption.class,
+      description = "Comma separated ACL list:%n" +
+          "Example: user:user2:a OR user:user1:rw,group:hadoop:a%n" +
+          "r = READ, " +
+          "w = WRITE, " +
+          "c = CREATE, " +
+          "d = DELETE, " +
+          "l = LIST, " +
+          "a = ALL, " +
+          "n = NONE, " +
+          "x = READ_ACL, " +
+          "y = WRITE_ACL.")
+  private OzoneAcl[] values;
 
   private List<OzoneAcl> getAclList() {
-    OzoneAcl[] acls = exclusive.values != null
-        ? exclusive.values
-        : exclusive.deprecatedValues;
-    return ImmutableList.copyOf(acls);
+    return ImmutableList.copyOf(values);
   }
 
   public void addTo(OzoneObj obj, ObjectStore objectStore, PrintWriter out)

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
@@ -24,23 +24,39 @@ Test Timeout        5 minutes
 ${PIPELINE}
 ${SCM}       scm
 
+*** Keywords ***
+List Should Have Ratis Pipeline
+    [arguments]    ${json}    ${factor}    ${expected}=${TRUE}
+    ${actual} =    Execute     echo '${json}' | jq 'map(.replicationConfig) | contains([{"replicationFactor": "${factor}", "replicationType": "RATIS"}])'
+    Should Be Equal    '${expected}'    '${actual}'    ignore_case=True
+
 *** Test Cases ***
 List pipelines
     ${output} =         Execute          ozone admin pipeline list
                         Should contain   ${output}   RATIS/ONE
-    ${pipeline} =       Execute          ozone admin pipeline list | grep 'ReplicationConfig: RATIS/ONE' | head -n 1 | cut -d' ' -f3 | sed 's/,$//'
+    ${pipeline} =       Execute          echo '${output}' | grep 'ReplicationConfig: RATIS/ONE' | head -n 1 | cut -d' ' -f3 | sed 's/,$//'
                         Set Suite Variable    ${PIPELINE}    ${pipeline}
 
 List pipeline with json option
-    ${output} =         Execute          ozone admin pipeline list --json | jq 'map(.replicationConfig) | contains([{"replicationFactor": "ONE", "replicationType": "RATIS"}])'
-    Should be true      $output
+    ${output} =         Execute          ozone admin pipeline list --json
+    List Should Have Ratis Pipeline    ${output}    ONE
 
 List pipelines with explicit host
     ${output} =         Execute          ozone admin pipeline list --scm ${SCM}
                         Should contain   ${output}   RATIS/ONE
 
 List pipelines with explicit host and json option
-    ${output} =         Execute   ozone admin pipeline list --scm ${SCM} --json | jq 'map(.replicationConfig) | contains([{"replicationFactor": "ONE", "replicationType": "RATIS"}])'
+    ${output} =         Execute   ozone admin pipeline list --scm ${SCM} --json
+    List Should Have Ratis Pipeline    ${output}    ONE
+
+List pipeline respects deprecated option -ffc
+    ${output} =         Execute          ozone admin pipeline list --json -ffc ONE 2>/dev/null
+    List Should Have Ratis Pipeline    ${output}    ONE
+    List Should Have Ratis Pipeline    ${output}    THREE    ${FALSE}
+
+List pipeline respects deprecated option -fst
+    ${output} =         Execute          ozone admin pipeline list -fst DORMANT
+    Should Not Contain  ${output}        DORMANT
 
 Deactivate pipeline
                         Execute          ozone admin pipeline deactivate "${PIPELINE}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-7957 deprecated several command-line options.  These are still accepted, but not shown in the help.  It was achieved by splitting such options into two, the deprecated one being `hidden=true`:

https://github.com/apache/ozone/blob/c479e1e7a119dba67eece4511da2aff2caffa715/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java#L46-L60

Methods to get one of the options were needed:

https://github.com/apache/ozone/blob/c479e1e7a119dba67eece4511da2aff2caffa715/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java#L91-L95

Also, default value had to be removed from primitive type options:

https://github.com/apache/ozone/blob/c479e1e7a119dba67eece4511da2aff2caffa715/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java#L59-L65

This PR achieves the same result via a parameter preprocessor in `GenericCli`, replacing deprecated options with the real ones (e.g. `-ffc` with `--filter-by-factor`) before command execution.

https://github.com/apache/ozone/blob/6eb8bdcc10fb6c4e9939e098d95324a9e4bfa307/hadoop-hdds/cli-common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java#L72-L75

This avoids the need for boilerplate changes shown above and the default value problem.

Most of this PR is to undo the options split from 175e2934fe.

https://issues.apache.org/jira/browse/HDDS-15596

## How was this patch tested?

Verified that deprecated options are hidden in help, e.g.:

```bash
$ ozone admin pipeline list --help
Usage: ozone admin pipeline list [-hV] [--json] [--verbose]
                                 [--filterByFactor=<factor>] [-r=<replication>]
                                 [-s=<state>] [--scm=<scm>]
                                 [--service-id=<scmServiceId>]
                                 [-t=<replicationType>]
List all active pipelines
      --filterByFactor, --filter-by-factor=<factor>
                    [deprecated] Filter pipelines by factor (e.g. ONE, THREE)
                      (implies RATIS replication type)
...
  -s, --state, --filterByState, --filter-by-state=<state>
                    Filter listed pipelines by State, eg OPEN, CLOSED
...
```

but command accepts and handles them:

```bash
$ ozone admin pipeline list -ffc THREE -fst OPEN
Pipeline{ Id: 6b7a1780-a520-491b-afd3-e548538789a8, Nodes: [ {0e7511ea-3861-465f-97b4-0b4ebb900dd0(ozone-datanode-2.ozone_default/172.18.0.9), ReplicaIndex: 0}, {ee732661-3d27-498f-b807-fd9d0493ff8e(ozone-datanode-1.ozone_default/172.18.0.7), ReplicaIndex: 0}, {021b0f1e-5f0b-4311-8197-774c87160caf(ozone-datanode-3.ozone_default/172.18.0.8), ReplicaIndex: 0},], ReplicationConfig: RATIS/THREE, State:OPEN, leaderId:ee732661-3d27-498f-b807-fd9d0493ff8e, CreationTimestamp2026-06-18T11:55:50.710Z[Etc/UTC]}

$ ozone admin pipeline list -ffc ONE -fst OPEN
Pipeline{ Id: cdce37fc-36a4-4e96-85c2-85c9e414944b, Nodes: [ {0e7511ea-3861-465f-97b4-0b4ebb900dd0(ozone-datanode-2.ozone_default/172.18.0.9), ReplicaIndex: 0},], ReplicationConfig: RATIS/ONE, State:OPEN, leaderId:0e7511ea-3861-465f-97b4-0b4ebb900dd0, CreationTimestamp2026-06-18T11:55:50.656Z[Etc/UTC]}
Pipeline{ Id: e66555dd-9902-4d4d-8351-c140d7d811ab, Nodes: [ {ee732661-3d27-498f-b807-fd9d0493ff8e(ozone-datanode-1.ozone_default/172.18.0.7), ReplicaIndex: 0},], ReplicationConfig: RATIS/ONE, State:OPEN, leaderId:ee732661-3d27-498f-b807-fd9d0493ff8e, CreationTimestamp2026-06-18T11:55:50.715Z[Etc/UTC]}
Pipeline{ Id: 8e46649d-7d8f-47d2-8709-79738700c5ea, Nodes: [ {021b0f1e-5f0b-4311-8197-774c87160caf(ozone-datanode-3.ozone_default/172.18.0.8), ReplicaIndex: 0},], ReplicationConfig: RATIS/ONE, State:OPEN, leaderId:021b0f1e-5f0b-4311-8197-774c87160caf, CreationTimestamp2026-06-18T11:55:50.719Z[Etc/UTC]}
```

Same for interactive mode:

```bash
$ ozone admin --interactive
ozone admin> pipeline list -<TAB>
--filter-by-factor   --filterByFactor     --help               --replication        --service-id         --type               --version            -h                   -s
--filter-by-state    --filterByState      --json               --scm                --state              --verbose            -V                   -r                   -t

ozone admin> pipeline list -ffc THREE
WARNING: Option '-ffc' is deprecated. Use '--filter-by-factor' instead.
Pipeline{ Id: 6d989d02-f1c6-4009-a5f0-372b4135bd02, Nodes: [ {5f3ef100-5fb5-4b42-9364-c4f1149f8a9c(ozone-datanode-3.ozone_default/172.18.0.9), ReplicaIndex: 0}, {738917eb-d46f-4df2-979e-8fcff1aac502(ozone-datanode-1.ozone_default/172.18.0.8), ReplicaIndex: 0}, {6957c4f1-1bc7-47e3-92dc-c5d49cbd96ed(ozone-datanode-2.ozone_default/172.18.0.3), ReplicaIndex: 0},], ReplicationConfig: RATIS/THREE, State:OPEN, leaderId:6957c4f1-1bc7-47e3-92dc-c5d49cbd96ed, CreationTimestamp2026-06-18T12:56:51.917Z[Etc/UTC]}
```

Updated unit test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/27765382504