### PR TITLE
HDDS-15609. Legacy SCM Finalize command should become a no-op

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1159,7 +1159,7 @@ public class SCMClientProtocolServer implements
     // This command is kept only for legacy upgrade scripts which would have first finalized SCM and then
     // made a call to OM to finalize it. The new flow, is that a single call to OM triggers the finalization process.
     // The legacy OM command now calls the new one and correctly starts the flow, so this command has become a
-    // noop. Regardless of whether SCM is finalized or not, we return ALREADY_FINALIZED to allow nay scripts to move
+    // noop. Regardless of whether SCM is finalized or not, we return ALREADY_FINALIZED to allow any scripts to move
     // on and call OM to start the process.
     return new StatusAndMessages(ALREADY_FINALIZED, Collections.emptyList());
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1150,14 +1150,16 @@ public class SCMClientProtocolServer implements
     return scm.getReplicationManager().getContainerReport();
   }
 
+  /*
+   * This command is deprecated and is retained for backward compatibility. It no longer finalizes SCM
+   * as the process is driven from OM which will trigger the SCM finalize process.
+   */
   @Override
   @Deprecated
-  public StatusAndMessages finalizeScmUpgrade(String upgradeClientID) throws
-      IOException {
+  public StatusAndMessages finalizeScmUpgrade(String upgradeClientID) {
     if (!scm.getVersionManager().needsFinalization()) {
       return new StatusAndMessages(ALREADY_FINALIZED, Collections.emptyList());
     }
-    finalizeUpgrade();
     return new StatusAndMessages(STARTING_FINALIZATION, Collections.emptyList());
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -32,7 +32,6 @@ import static org.apache.hadoop.hdds.utils.HddsServerUtil.getRemoteUser;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.FINALIZATION_DONE_MSG;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.FINALIZATION_REQUIRED_MSG;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.ALREADY_FINALIZED;
-import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.STARTING_FINALIZATION;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1157,10 +1157,12 @@ public class SCMClientProtocolServer implements
   @Override
   @Deprecated
   public StatusAndMessages finalizeScmUpgrade(String upgradeClientID) {
-    if (!scm.getVersionManager().needsFinalization()) {
-      return new StatusAndMessages(ALREADY_FINALIZED, Collections.emptyList());
-    }
-    return new StatusAndMessages(STARTING_FINALIZATION, Collections.emptyList());
+    // This command is kept only for legacy upgrade scripts which would have first finalized SCM and then
+    // made a call to OM to finalize it. The new flow, is that a single call to OM triggers the finalization process.
+    // The legacy OM command now calls the new one and correctly starts the flow, so this command has become a
+    // noop. Regardless of whether SCM is finalized or not, we return ALREADY_FINALIZED to allow nay scripts to move
+    // on and call OM to start the process.
+    return new StatusAndMessages(ALREADY_FINALIZED, Collections.emptyList());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -98,8 +98,8 @@ public class TestSCMClientProtocolServer {
     when(mockSafeModeManager.getInSafeMode()).thenReturn(false);
   }
 
-  @AfterEach
-  public void tearDown() throws Exception {
+  @AfterAll
+  public static void tearDown() throws Exception {
     if (scm != null) {
       scm.stop();
       scm.join();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -19,12 +19,16 @@ package org.apache.hadoop.hdds.scm.server;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.ALREADY_FINALIZED;
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.STARTING_FINALIZATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -48,8 +52,11 @@ import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocolServerSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationManager;
+import org.apache.hadoop.hdds.scm.server.upgrade.ScmVersionManager;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterEach;
@@ -179,6 +186,47 @@ public class TestSCMClientProtocolServer {
     when(scmNodeDetails.getClientProtocolServerAddressKey()).thenReturn("test");
     when(storageContainerManager.getScmNodeDetails()).thenReturn(scmNodeDetails);
     return storageContainerManager;
+  }
+
+  @Test
+  public void testLegacyFinalizeScmUpgradeAlreadyFinalized() throws Exception {
+    FinalizationManager mockFinalizationManager = mock(FinalizationManager.class);
+    SCMClientProtocolServer testServer = serverWithMockFinalization(false, mockFinalizationManager);
+    try {
+      StatusAndMessages result = testServer.finalizeScmUpgrade("testClientID");
+      assertEquals(ALREADY_FINALIZED, result.status());
+      assertTrue(result.msgs().isEmpty());
+      verify(mockFinalizationManager, never()).finalizeUpgrade();
+    } finally {
+      testServer.stop();
+    }
+  }
+
+  @Test
+  public void testLegacyFinalizeScmUpgradeFinalizationRequired() throws Exception {
+    FinalizationManager mockFinalizationManager = mock(FinalizationManager.class);
+    SCMClientProtocolServer testServer = serverWithMockFinalization(true, mockFinalizationManager);
+    try {
+      StatusAndMessages result = testServer.finalizeScmUpgrade("testClientID");
+      assertEquals(STARTING_FINALIZATION, result.status());
+      assertTrue(result.msgs().isEmpty());
+      verify(mockFinalizationManager, never()).finalizeUpgrade();
+    } finally {
+      testServer.stop();
+    }
+  }
+
+  private SCMClientProtocolServer serverWithMockFinalization(
+      boolean needsFinalization, FinalizationManager finalizationManager) throws IOException {
+    ScmVersionManager mockVersionManager = mock(ScmVersionManager.class);
+    when(mockVersionManager.needsFinalization()).thenReturn(needsFinalization);
+
+    StorageContainerManager mockScm = mockStorageContainerManager();
+    when(mockScm.getVersionManager()).thenReturn(mockVersionManager);
+    when(mockScm.getFinalizationManager()).thenReturn(finalizationManager);
+
+    return new SCMClientProtocolServer(
+        new OzoneConfiguration(), mockScm, mock(ReconfigurationHandler.class));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.server;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.ALREADY_FINALIZED;
-import static org.apache.hadoop.ozone.upgrade.UpgradeFinalization.Status.STARTING_FINALIZATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -74,8 +73,7 @@ public class TestSCMClientProtocolServer {
   private static StorageContainerManager scm;
   private static StorageContainerLocationProtocolServerSideTranslatorPB service;
   private static SCMSafeModeManager mockSafeModeManager;
-
-
+  
   @BeforeAll
   static void setUp(@TempDir File testDir) throws Exception {
     OzoneConfiguration config = SCMTestUtils.getConf(testDir);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -69,17 +70,17 @@ import org.junit.jupiter.api.io.TempDir;
  * servicing commands from the scm client.
  */
 public class TestSCMClientProtocolServer {
-  private SCMClientProtocolServer server;
-  private StorageContainerManager scm;
-  private StorageContainerLocationProtocolServerSideTranslatorPB service;
-  private SCMSafeModeManager mockSafeModeManager;
+  private static SCMClientProtocolServer server;
+  private static StorageContainerManager scm;
+  private static StorageContainerLocationProtocolServerSideTranslatorPB service;
+  private static SCMSafeModeManager mockSafeModeManager;
 
-  @BeforeEach
-  void setUp(@TempDir File testDir) throws Exception {
+
+  @BeforeAll
+  static void setUp(@TempDir File testDir) throws Exception {
     OzoneConfiguration config = SCMTestUtils.getConf(testDir);
 
     mockSafeModeManager = mock(SCMSafeModeManager.class);
-    when(mockSafeModeManager.getInSafeMode()).thenReturn(false);
 
     SCMConfigurator configurator = new SCMConfigurator();
     configurator.setSCMHAManager(SCMHAManagerStub.getInstance(true));
@@ -92,6 +93,11 @@ public class TestSCMClientProtocolServer {
     server = scm.getClientProtocolServer();
     service = new StorageContainerLocationProtocolServerSideTranslatorPB(server,
         scm, mock(ProtocolMessageMetrics.class));
+  }
+
+  @BeforeEach
+  void setUp() {
+    when(mockSafeModeManager.getInSafeMode()).thenReturn(false);
   }
 
   @AfterEach
@@ -208,7 +214,7 @@ public class TestSCMClientProtocolServer {
     SCMClientProtocolServer testServer = serverWithMockFinalization(true, mockFinalizationManager);
     try {
       StatusAndMessages result = testServer.finalizeScmUpgrade("testClientID");
-      assertEquals(STARTING_FINALIZATION, result.status());
+      assertEquals(ALREADY_FINALIZED, result.status());
       assertTrue(result.msgs().isEmpty());
       verify(mockFinalizationManager, never()).finalizeUpgrade();
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now that finalization is driven from OM, the legacy SCM finalize command should become a no-op.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15609

## How was this patch tested?

New unit test added.
