### PR TITLE
HDDS-15077. Explain exclusiveSize and exclusiveSizeDeltaFromDirDeepCleaning

### DIFF
--- a/hadoop-hdds/docs/content/feature/Snapshot.md
+++ b/hadoop-hdds/docs/content/feature/Snapshot.md
@@ -48,9 +48,16 @@ When keys are changed or deleted in the live bucket, their data blocks are retai
 
 **Snapshot Data Storage:** Snapshot metadata resides in OM's RocksDB. Diff job data is stored in `ozone.om.snapshot.diff.db.dir` (defaults to OM metadata directory).
 
-### Snapshot Exclusive Size Tracking
+### Snapshot Space & Size Tracking
 
-When a snapshot is taken, some blocks are shared with the active bucket or other snapshots. As mutations occur, some data becomes exclusively referenced by a single snapshot. Ozone tracks this exclusive size using two separate asynchronous background services:
+When a snapshot is created, it references the state of the bucket at that point in time. Over time, as keys are deleted or overwritten in the active namespace, the data blocks are kept alive by the snapshots. Ozone tracks space usage for snapshots using the following metrics:
+
+#### Referenced Size
+* **`referencedSize`**: The total logical data size (in bytes, unreplicated) of all active keys/files in the bucket at the moment the snapshot was created.
+* **`referencedReplicatedSize`**: The total replicated data size (in bytes, replicated) referenced by the snapshot at its creation point.
+
+#### Exclusive Size
+As mutations occur in the active bucket or other snapshots, some blocks become exclusively held by a single snapshot. Ozone tracks this exclusive size using two separate asynchronous background services:
 
 1. **`KeyDeletingService` (Key Deep Cleaning)**: Processes deleted keys to find blocks exclusively held by the snapshot. It sets `exclusiveSize` (unreplicated) and `exclusiveReplicatedSize` (replicated).
 2. **`SnapshotDirectoryCleaningService` (Directory Deep Cleaning)**: Recursively processes deleted directories. To avoid write conflicts and overwriting between these two independent services, it stores its results separately in `exclusiveSizeDeltaFromDirDeepCleaning` (unreplicated) and `exclusiveReplicatedSizeDeltaFromDirDeepCleaning` (replicated).

--- a/hadoop-hdds/docs/content/feature/Snapshot.md
+++ b/hadoop-hdds/docs/content/feature/Snapshot.md
@@ -48,6 +48,17 @@ When keys are changed or deleted in the live bucket, their data blocks are retai
 
 **Snapshot Data Storage:** Snapshot metadata resides in OM's RocksDB. Diff job data is stored in `ozone.om.snapshot.diff.db.dir` (defaults to OM metadata directory).
 
+### Snapshot Exclusive Size Tracking
+
+When a snapshot is taken, some blocks are shared with the active bucket or other snapshots. As mutations occur, some data becomes exclusively referenced by a single snapshot. Ozone tracks this exclusive size using two separate asynchronous background services:
+
+1. **`KeyDeletingService` (Key Deep Cleaning)**: Processes deleted keys to find blocks exclusively held by the snapshot. It sets `exclusiveSize` (unreplicated) and `exclusiveReplicatedSize` (replicated).
+2. **`SnapshotDirectoryCleaningService` (Directory Deep Cleaning)**: Recursively processes deleted directories. To avoid write conflicts and overwriting between these two independent services, it stores its results separately in `exclusiveSizeDeltaFromDirDeepCleaning` (unreplicated) and `exclusiveReplicatedSizeDeltaFromDirDeepCleaning` (replicated).
+
+The actual total exclusive size of a snapshot is the sum of these fields:
+* **Total Exclusive Size**: `exclusiveSize` + `exclusiveSizeDeltaFromDirDeepCleaning`
+* **Total Exclusive Replicated Size**: `exclusiveReplicatedSize` + `exclusiveReplicatedSizeDeltaFromDirDeepCleaning`
+
 For more details, see Prashant Pogde’s [Introducing Apache Ozone Snapshots](https://medium.com/@prashantpogde/introducing-apache-ozone-snapshots-af82e976142f).
 
 ## User Tutorial

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -74,9 +74,24 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
   private boolean sstFiltered;
   private long referencedSize;
   private long referencedReplicatedSize;
+  /**
+   * The amount of data (in bytes, unreplicated) exclusively referenced by this snapshot,
+   * determined during key-level deep cleaning when KeyDeletingService processes deleted keys.
+   */
   private long exclusiveSize;
+  /**
+   * Same as exclusiveSize, but accounts for the replication factor.
+   */
   private long exclusiveReplicatedSize;
+  /**
+   * The additional exclusive size (in bytes, unreplicated) discovered during directory-level
+   * deep cleaning when SnapshotDirectoryCleaningService processes deleted directories.
+   * Kept separate from exclusiveSize to avoid write overwrites between asynchronous services.
+   */
   private long exclusiveSizeDeltaFromDirDeepCleaning;
+  /**
+   * Same as exclusiveSizeDeltaFromDirDeepCleaning, but accounts for the replication factor.
+   */
   private long exclusiveReplicatedSizeDeltaFromDirDeepCleaning;
   private boolean deepCleanedDeletedDir;
   private ByteString createTransactionInfo;
@@ -342,25 +357,36 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
       return this;
     }
 
-    /** @param exclusiveSize - Snapshot exclusive size. */
+    /**
+     * @param exclusiveSize - The amount of data (in bytes, unreplicated) exclusively
+     * referenced by this snapshot, determined during key-level deep cleaning.
+     */
     public Builder setExclusiveSize(long exclusiveSize) {
       this.exclusiveSize = exclusiveSize;
       return this;
     }
 
-    /** @param exclusiveReplicatedSize - Snapshot exclusive size w/ replication. */
+    /**
+     * @param exclusiveReplicatedSize - Same as exclusiveSize, but scaled by the replication factor.
+     */
     public Builder setExclusiveReplicatedSize(long exclusiveReplicatedSize) {
       this.exclusiveReplicatedSize = exclusiveReplicatedSize;
       return this;
     }
 
-    /** @param exclusiveSizeDeltaFromDirDeepCleaning - Snapshot exclusive size. */
+    /**
+     * @param exclusiveSizeDeltaFromDirDeepCleaning - The additional exclusive size (in bytes,
+     * unreplicated) discovered during directory-level deep cleaning.
+     */
     public Builder setExclusiveSizeDeltaFromDirDeepCleaning(long exclusiveSizeDeltaFromDirDeepCleaning) {
       this.exclusiveSizeDeltaFromDirDeepCleaning = exclusiveSizeDeltaFromDirDeepCleaning;
       return this;
     }
 
-    /** @param exclusiveReplicatedSizeDeltaFromDirDeepCleaning - Snapshot exclusive size w/ replication. */
+    /**
+     * @param exclusiveReplicatedSizeDeltaFromDirDeepCleaning - Same as
+     * exclusiveSizeDeltaFromDirDeepCleaning, but scaled by the replication factor.
+     */
     public Builder setExclusiveReplicatedSizeDeltaFromDirDeepCleaning(
         long exclusiveReplicatedSizeDeltaFromDirDeepCleaning) {
       this.exclusiveReplicatedSizeDeltaFromDirDeepCleaning = exclusiveReplicatedSizeDeltaFromDirDeepCleaning;
@@ -583,6 +609,10 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     this.exclusiveSize = exclusiveSize;
   }
 
+  /**
+   * Returns the unreplicated data size exclusively referenced by this snapshot,
+   * calculated during key-level deep cleaning.
+   */
   public long getExclusiveSize() {
     return exclusiveSize;
   }
@@ -591,6 +621,10 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     this.exclusiveSizeDeltaFromDirDeepCleaning = exclusiveSizeDeltaFromDirDeepCleaning;
   }
 
+  /**
+   * Returns the additional unreplicated data size discovered exclusively by this snapshot
+   * during directory-level deep cleaning.
+   */
   public long getExclusiveSizeDeltaFromDirDeepCleaning() {
     return exclusiveSizeDeltaFromDirDeepCleaning;
   }
@@ -603,10 +637,18 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     this.exclusiveReplicatedSizeDeltaFromDirDeepCleaning = exclusiveReplicatedSizeDeltaFromDirDeepCleaning;
   }
 
+  /**
+   * Returns the additional replicated data size discovered exclusively by this snapshot
+   * during directory-level deep cleaning.
+   */
   public long getExclusiveReplicatedSizeDeltaFromDirDeepCleaning() {
     return exclusiveReplicatedSizeDeltaFromDirDeepCleaning;
   }
 
+  /**
+   * Returns the replicated data size exclusively referenced by this snapshot,
+   * calculated during key-level deep cleaning.
+   */
   public long getExclusiveReplicatedSize() {
     return exclusiveReplicatedSize;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -72,7 +72,15 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
   private String snapshotPath; // snapshot mask
   private boolean deepClean;
   private boolean sstFiltered;
+  /**
+   * The total logical data size (in bytes, unreplicated) referenced by the snapshot
+   * at the time of its creation.
+   */
   private long referencedSize;
+  /**
+   * The total replicated data size (in bytes, replicated) referenced by the snapshot
+   * at the time of its creation.
+   */
   private long referencedReplicatedSize;
   /**
    * The amount of data (in bytes, unreplicated) exclusively referenced by this snapshot,
@@ -345,13 +353,18 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
       return this;
     }
 
-    /** @param referencedSize - Snapshot referenced size. */
+    /**
+     * @param referencedSize - The total logical data size (in bytes, unreplicated)
+     * referenced by the snapshot at the time of its creation.
+     */
     public Builder setReferencedSize(long referencedSize) {
       this.referencedSize = referencedSize;
       return this;
     }
 
-    /** @param referencedReplicatedSize - Snapshot referenced size w/ replication. */
+    /**
+     * @param referencedReplicatedSize - Same as referencedSize, but scaled by the replication factor.
+     */
     public Builder setReferencedReplicatedSize(long referencedReplicatedSize) {
       this.referencedReplicatedSize = referencedReplicatedSize;
       return this;
@@ -593,6 +606,10 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     this.referencedSize = referencedSize;
   }
 
+  /**
+   * Returns the total logical data size (in bytes, unreplicated) referenced by the snapshot
+   * at the time of its creation.
+   */
   public long getReferencedSize() {
     return referencedSize;
   }
@@ -601,6 +618,10 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     this.referencedReplicatedSize = referencedReplicatedSize;
   }
 
+  /**
+   * Returns the total replicated data size (in bytes, replicated) referenced by the snapshot
+   * at the time of its creation.
+   */
   public long getReferencedReplicatedSize() {
     return referencedReplicatedSize;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15077. Explain exclusiveSize and exclusiveSizeDeltaFromDirDeepCleaning

Please describe your PR in detail:
  #### SnapshotInfo.java

  Added comprehensive Javadocs to the metadata representation of Snapshots:

  • Fields: Documented the purpose of all six space and replication size metrics:
      •  referencedSize  &  referencedReplicatedSize : Logical and replicated sizes of active bucket contents at snapshot creation time.
      •  exclusiveSize  &  exclusiveReplicatedSize : Exclusive sizes calculated by  KeyDeletingService  (key-level deep cleaning).
      •  exclusiveSizeDeltaFromDirDeepCleaning  &  exclusiveReplicatedSizeDeltaFromDirDeepCleaning : Exclusive size deltas discovered by
      SnapshotDirectoryCleaningService  (directory-level deep cleaning).
  • Builder: Replaced terse parameter markers (e.g.,  /** @param ... */ ) with detailed descriptions explaining the calculations and units.
  • Getters: Added descriptive method Javadocs for the respective getters.
  ──────
  ### 3. Documentation Changes

  #### Snapshot.md

  Added a new subsection under "System Architecture Deep Dive" titled "Snapshot Space & Size Tracking":

  • Documented the definition of Referenced Size (logical and replicated).
  • Explained the architecture of Exclusive Size Tracking and how it is split between the two independent background services ( KeyDeletingService  and
  SnapshotDirectoryCleaningService ) to prevent write overlaps and correctness bugs.
  • Specified how the true total exclusive size is calculated:
      • Total Exclusive Size = exclusiveSize + exclusiveSizeDeltaFromDirDeepCleaning
      • Total Exclusive Replicated Size = exclusiveReplicatedSize + exclusiveReplicatedSizeDeltaFromDirDeepCleaning

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15077
## How was this patch tested?

Javadoc and markdown user doc only.