### PR TITLE
HDDS-15650. Fix snapshotUsedNamespace underflow when FSO directory is deleted and purged

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -162,7 +162,7 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       // Empty entries won't be added to deleted table so this key shouldn't get added to snapshotUsed space.
       boolean isKeyNonEmpty = !OmKeyInfo.isKeyEmpty(omKeyInfo);
       omBucketInfo.decrUsedBytes(quotaReleased, isKeyNonEmpty);
-      omBucketInfo.decrUsedNamespace(1L, isKeyNonEmpty);
+      omBucketInfo.decrUsedNamespace(1L, isKeyNonEmpty || keyStatus.isDirectory());
 
       // If omKeyInfo has hsync metadata, delete its corresponding open key as well
       String dbOpenKey = null;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -1030,6 +1030,13 @@ public final class OMRequestTestUtils {
         omDirectoryInfo.getName());
     omMetadataManager.getDeletedDirTable().put(ozoneKey, omKeyInfo);
     omMetadataManager.getDirectoryTable().delete(ozoneKey);
+
+    String bucketKey = omMetadataManager.getBucketKey(volume, bucket);
+    OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    if (omBucketInfo != null) {
+      omBucketInfo.decrUsedNamespace(1L, true);
+      omMetadataManager.getBucketTable().put(bucketKey, omBucketInfo);
+    }
     return ozoneKey;
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -332,5 +333,73 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
     // This should succeed after the fix
     assertEquals(OzoneManagerProtocolProtos.Status.OK, response.getOMResponse().getStatus(),
         "Parent delete should succeed after children deleted");
+  }
+
+  @Test
+  public void testSnapshotUsedNamespaceAfterDirectoryDeleteAndPurge() throws Exception {
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager, getBucketLayout());
+
+    String dirName = "dir1";
+    String dirKeyPath = addKeyToDirTable(volumeName, bucketName, dirName);
+
+    long parentObjectID = 0L;
+    long dirObjectID = 12345L;
+    OmDirectoryInfo omDirectoryInfo = OMRequestTestUtils.createOmDirectoryInfo(dirName, dirObjectID, parentObjectID);
+    omMetadataManager.getDirectoryTable().put(dirKeyPath, omDirectoryInfo);
+
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    assertNotNull(omBucketInfo);
+    // Initialize used namespace and snapshot used namespace for test predictability
+    omBucketInfo.incrUsedNamespace(1);
+    omMetadataManager.getBucketTable().put(bucketKey, omBucketInfo);
+
+    // Delete the directory
+    long txnId = 100L;
+    OMRequest deleteRequest = doPreExecute(createDeleteKeyRequest(dirName, false));
+    OMKeyDeleteRequest omKeyDeleteRequest = getOmKeyDeleteRequest(deleteRequest);
+    OMClientResponse deleteResponse = omKeyDeleteRequest.validateAndUpdateCache(ozoneManager, txnId++);
+    assertEquals(OzoneManagerProtocolProtos.Status.OK, deleteResponse.getOMResponse().getStatus());
+
+    OmBucketInfo bucketInfoAfterDelete = omMetadataManager.getBucketTable().get(bucketKey);
+
+    // Perform purge
+    OzoneManagerProtocolProtos.PurgeDirectoriesRequest.Builder purgeDirRequest =
+        OzoneManagerProtocolProtos.PurgeDirectoriesRequest.newBuilder();
+
+    long volumeId = omMetadataManager.getVolumeId(volumeName);
+    long bucketId = bucketInfoAfterDelete.getObjectID();
+
+    OzoneManagerProtocolProtos.PurgePathRequest purgePathRequest =
+        OzoneManagerProtocolProtos.PurgePathRequest.newBuilder()
+            .setVolumeId(volumeId)
+            .setBucketId(bucketId)
+            .setDeletedDir(dirKeyPath)
+            .build();
+
+    purgeDirRequest.addDeletedPath(purgePathRequest);
+    purgeDirRequest.addBucketNameInfos(
+        OzoneManagerProtocolProtos.BucketNameInfo.newBuilder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setBucketId(bucketId)
+            .setVolumeId(volumeId)
+            .build());
+
+    OMRequest purgeRequest = OMRequest.newBuilder()
+        .setCmdType(OzoneManagerProtocolProtos.Type.PurgeDirectories)
+        .setPurgeDirectoriesRequest(purgeDirRequest)
+        .setClientId(UUID.randomUUID().toString())
+        .build();
+
+    OMDirectoriesPurgeRequestWithFSO omPurgeRequest = new OMDirectoriesPurgeRequestWithFSO(purgeRequest);
+    OMClientResponse purgeResponse = omPurgeRequest.validateAndUpdateCache(ozoneManager, txnId);
+    assertEquals(OzoneManagerProtocolProtos.Status.OK, purgeResponse.getOMResponse().getStatus());
+
+    OmBucketInfo bucketInfoAfterPurge = omMetadataManager.getBucketTable().get(bucketKey);
+
+    // We expect snapshotUsedNamespace to not go negative
+    assertTrue(bucketInfoAfterPurge.getSnapshotUsedNamespace() >= 0,
+        "SnapshotUsedNamespace went negative (" + bucketInfoAfterPurge.getSnapshotUsedNamespace() + ") due to bug.");
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15650. Fix snapshotUsedNamespace underflow when FSO directory is deleted and purged

Please describe your PR in detail:
  • The Problem: FSO directories have no blocks, so directory deletion incorrectly evaluated to  isKeyNonEmpty = false . This decremented the active
  bucket namespace  usedNamespace  but did not increment  snapshotUsedNamespace , causing a mismatch when the directory was later purged (unconditionally
  decrementing  snapshotUsedNamespace  by 1 and underflowing the count to  -1 ).
  • The Fix: Updated OMKeyDeleteRequestWithFSO.java to shift the namespace quota to the snapshot namespace on deletion if it is either a non-empty key or a
directory (
  isKeyNonEmpty || keyStatus.isDirectory() ).
  • Test Utils Alignment: Updated mock  deleteDir  helper in OMRequestTestUtils.java to align with actual deletion quota tracking.
  • Regression Test: Added a test case  testSnapshotUsedNamespaceAfterDirectoryDeleteAndPurge  in TestOMKeyDeleteRequestWithFSO.java to verify that
directory deletion
  followed by a purge does not cause negative  snapshotUsedNamespace  values.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14435

## How was this patch tested?

New unit test