### PR TITLE
HDDS-15601. Coalesce contiguous container IDs into range deletes in ContainerHealthSchemaManager

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconReplicationManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconReplicationManager.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.recon.fsck;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -362,8 +361,6 @@ public class ReconReplicationManager extends ReplicationManager {
       Map<ContainerStateKey, Long> existingInStateSinceByContainerAndState =
           healthSchemaManager.getExistingInStateSinceByContainerIds(chunkContainerIds);
       List<ContainerHealthSchemaManager.UnhealthyContainerRecord> recordsToInsert = new ArrayList<>();
-      List<Long> existingContainerIdsToDelete =
-          collectExistingContainerIds(existingInStateSinceByContainerAndState);
       ProcessingStats chunkStats = new ProcessingStats();
       Set<Long> negativeSizeRecorded = new HashSet<>();
 
@@ -415,9 +412,9 @@ public class ReconReplicationManager extends ReplicationManager {
       }
 
       recordsToInsert = healthSchemaManager.applyExistingInStateSince(
-          recordsToInsert, chunkContainerIds);
+          recordsToInsert, existingInStateSinceByContainerAndState);
       totalStats.add(chunkStats);
-      persistUnhealthyRecords(existingContainerIdsToDelete, recordsToInsert);
+      persistUnhealthyRecords(existingInStateSinceByContainerAndState, recordsToInsert);
     }
 
     LOG.info("Stored {} MISSING, {} EMPTY_MISSING, {} UNDER_REPLICATED, " +
@@ -496,12 +493,12 @@ public class ReconReplicationManager extends ReplicationManager {
   }
 
   private void persistUnhealthyRecords(
-      List<Long> containerIdsToDelete,
-      List<ContainerHealthSchemaManager.UnhealthyContainerRecord> recordsToInsert) {
-    LOG.info("Replacing unhealthy container records atomically: deleteRowsFor={} containers, insert={}",
-        containerIdsToDelete.size(), recordsToInsert.size());
-    healthSchemaManager.replaceUnhealthyContainerRecordsAtomically(
-        containerIdsToDelete, recordsToInsert);
+      Map<ContainerStateKey, Long> existingByKey,
+      List<ContainerHealthSchemaManager.UnhealthyContainerRecord> recordsToSync) {
+    LOG.info("Syncing unhealthy container records: existing={}, desired={}",
+        existingByKey.size(), recordsToSync.size());
+    healthSchemaManager.syncUnhealthyContainerRecordsAtomically(
+        existingByKey, recordsToSync);
   }
 
   private boolean isEmptyMissing(ContainerInfo container) {
@@ -575,17 +572,6 @@ public class ReconReplicationManager extends ReplicationManager {
     default:
       return false;
     }
-  }
-
-  private List<Long> collectExistingContainerIds(
-      Map<ContainerStateKey, Long> existingInStateSinceByContainerAndState) {
-    if (existingInStateSinceByContainerAndState.isEmpty()) {
-      return Collections.emptyList();
-    }
-    Set<Long> existingContainerIds = new HashSet<>();
-    existingInStateSinceByContainerAndState.keySet()
-        .forEach(key -> existingContainerIds.add(key.getContainerId()));
-    return new ArrayList<>(existingContainerIds);
   }
 
   private static final class ProcessingStats {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconReplicationManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ReconReplicationManager.java
@@ -358,8 +358,9 @@ public class ReconReplicationManager extends ReplicationManager {
     for (int from = 0; from < allContainers.size(); from += PERSIST_CHUNK_SIZE) {
       int to = Math.min(from + PERSIST_CHUNK_SIZE, allContainers.size());
       List<Long> chunkContainerIds = collectContainerIds(allContainers, from, to);
-      Map<ContainerStateKey, Long> existingInStateSinceByContainerAndState =
-          healthSchemaManager.getExistingInStateSinceByContainerIds(chunkContainerIds);
+      Map<ContainerStateKey, ContainerHealthSchemaManager.UnhealthyContainerRecord>
+          existingInStateSinceByContainerAndState =
+          healthSchemaManager.getExistingUnhealthyRecordsByContainerIds(chunkContainerIds);
       List<ContainerHealthSchemaManager.UnhealthyContainerRecord> recordsToInsert = new ArrayList<>();
       ProcessingStats chunkStats = new ProcessingStats();
       Set<Long> negativeSizeRecorded = new HashSet<>();
@@ -493,7 +494,7 @@ public class ReconReplicationManager extends ReplicationManager {
   }
 
   private void persistUnhealthyRecords(
-      Map<ContainerStateKey, Long> existingByKey,
+      Map<ContainerStateKey, ContainerHealthSchemaManager.UnhealthyContainerRecord> existingByKey,
       List<ContainerHealthSchemaManager.UnhealthyContainerRecord> recordsToSync) {
     LOG.info("Syncing unhealthy container records: existing={}, desired={}",
         existingByKey.size(), recordsToSync.size());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -69,40 +69,6 @@ public class ContainerHealthSchemaManager {
    */
   static final int MAX_IN_CLAUSE_CHUNK_SIZE = 1_000;
 
-  /**
-   * Minimum length of a contiguous container-id run that is deleted with a
-   * range ({@code BETWEEN}) term instead of being expanded into individual
-   * {@code IN} values.
-   *
-   * <p>Derby compiles every statement to JVM bytecode whose size grows with the
-   * number of id literals in the predicate. A contiguous run of {@code L} ids
-   * costs {@code L} operands when listed in an {@code IN} clause, but only
-   * {@link #RANGE_OPERAND_COST} (the two endpoints) when written as
-   * {@code BETWEEN lo AND hi}, independent of {@code L}. The range form is
-   * therefore strictly smaller once {@code L > RANGE_OPERAND_COST}, i.e. for
-   * runs of 3 or more ids; runs of 1–2 ids are left as {@code IN} values since
-   * the range form would save nothing. This lets the optimization benefit
-   * realistic, fragmented unhealthy-container sets rather than only rare
-   * 1,000+ contiguous ranges.</p>
-   */
-  static final int MIN_RANGE_RUN_LENGTH = 3;
-
-  /** Estimated predicate operand cost of a single {@code BETWEEN} range term. */
-  private static final int RANGE_OPERAND_COST = 2;
-
-  /**
-   * Upper bound on the estimated number of id operands packed into one combined
-   * DELETE predicate before it is flushed.
-   *
-   * <p>Range terms count as {@link #RANGE_OPERAND_COST} operands and scattered
-   * ids as one operand each. The cap reuses {@link #MAX_IN_CLAUSE_CHUNK_SIZE} —
-   * the id count already proven to keep a pure {@code IN} delete well under
-   * Derby's 64 KB per-method bytecode limit — so a mixed range/{@code IN}
-   * predicate of the same operand budget stays within the same safe
-   * envelope.</p>
-   */
-  static final int MAX_PREDICATE_OPERANDS = MAX_IN_CLAUSE_CHUNK_SIZE;
-
   private final ContainerSchemaDefinition containerSchemaDefinition;
   private final int unhealthyContainersFetchSize;
 
@@ -120,8 +86,8 @@ public class ContainerHealthSchemaManager {
    * Insert unhealthy container records in UNHEALTHY_CONTAINERS table using
    * true batch insert.
    *
-   * <p>In the health-task flow, inserts are preceded by delete in the same
-   * transaction via {@link #replaceUnhealthyContainerRecordsAtomically(List, List)}.
+   * <p>In the health-task flow, inserts are usually part of
+   * {@link #syncUnhealthyContainerRecordsAtomically(Map, List)}.
    * Therefore duplicate-key fallback is not expected and this method fails fast
    * on any insert error.</p>
    */
@@ -214,6 +180,70 @@ public class ContainerHealthSchemaManager {
   }
 
   /**
+   * Atomically syncs unhealthy rows for a scan chunk: insert new
+   * (container_id, state) pairs, update existing pairs, and delete only stale
+   * pairs that are no longer unhealthy.
+   *
+   * <p>Unlike {@link #replaceUnhealthyContainerRecordsAtomically}, this does not
+   * delete all SCM states for every container that previously had a row. It
+   * removes only keys present in {@code existingByKey} but absent from the
+   * desired scan result (containers that recovered or changed state).</p>
+   *
+   * @param existingByKey prior rows for this chunk, keyed by
+   *                      (container_id, container_state)
+   * @param desiredRecords unhealthy rows produced by the current scan
+   */
+  public void syncUnhealthyContainerRecordsAtomically(
+      Map<ContainerStateKey, Long> existingByKey,
+      List<UnhealthyContainerRecord> desiredRecords) {
+    if ((existingByKey == null || existingByKey.isEmpty())
+        && (desiredRecords == null || desiredRecords.isEmpty())) {
+      return;
+    }
+
+    Map<ContainerStateKey, UnhealthyContainerRecord> desiredByKey = new HashMap<>();
+    if (desiredRecords != null) {
+      for (UnhealthyContainerRecord record : desiredRecords) {
+        desiredByKey.put(new ContainerStateKey(record.getContainerId(),
+            record.getContainerState()), record);
+      }
+    }
+
+    Map<ContainerStateKey, Long> existing =
+        existingByKey == null ? new HashMap<>() : existingByKey;
+
+    List<ContainerStateKey> staleKeys = new ArrayList<>();
+    List<UnhealthyContainerRecord> toInsert = new ArrayList<>();
+    List<UnhealthyContainerRecord> toUpdate = new ArrayList<>();
+
+    for (ContainerStateKey key : existing.keySet()) {
+      if (!desiredByKey.containsKey(key)) {
+        staleKeys.add(key);
+      }
+    }
+    for (UnhealthyContainerRecord record : desiredByKey.values()) {
+      ContainerStateKey key = new ContainerStateKey(record.getContainerId(),
+          record.getContainerState());
+      if (existing.containsKey(key)) {
+        toUpdate.add(record);
+      } else {
+        toInsert.add(record);
+      }
+    }
+
+    DSLContext dslContext = containerSchemaDefinition.getDSLContext();
+    dslContext.transaction(configuration -> {
+      DSLContext txContext = configuration.dsl();
+      deleteStaleUnhealthyRecords(txContext, staleKeys);
+      batchInsertInChunks(txContext, toInsert);
+      batchUpdateInChunks(txContext, toUpdate);
+    });
+
+    LOG.debug("Synced unhealthy container records: deleted {} stale, inserted {}, updated {}",
+        staleKeys.size(), toInsert.size(), toUpdate.size());
+  }
+
+  /**
    * Atomically replaces unhealthy rows for a given set of containers.
    * Delete and insert happen in the same DB transaction.
    */
@@ -239,99 +269,63 @@ public class ContainerHealthSchemaManager {
 
   private int deleteScmStatesForContainers(DSLContext dslContext,
       List<Long> containerIds) {
-
-    // Sort and de-duplicate so contiguous runs are detectable regardless of the
-    // order in which the caller supplied the ids.
-    List<Long> sortedIds = containerIds.stream()
-        .distinct()
-        .sorted()
-        .collect(Collectors.toList());
-
     int totalDeleted = 0;
 
-    // Build each DELETE predicate as the combination of compact range terms (one
-    // BETWEEN per contiguous run of at least MIN_RANGE_RUN_LENGTH ids) and a
-    // single IN list for the remaining scattered ids. Terms are accumulated
-    // until the estimated operand count reaches MAX_PREDICATE_OPERANDS, then the
-    // statement is flushed so the generated Derby bytecode stays within budget.
-    List<long[]> ranges = new ArrayList<>();
-    List<Long> points = new ArrayList<>();
-    int operandsUsed = 0;
+    for (int from = 0; from < containerIds.size(); from += MAX_IN_CLAUSE_CHUNK_SIZE) {
+      int to = Math.min(from + MAX_IN_CLAUSE_CHUNK_SIZE, containerIds.size());
+      List<Long> chunk = containerIds.subList(from, to);
 
-    int i = 0;
-    while (i < sortedIds.size()) {
-      int runStart = i;
-      while (i + 1 < sortedIds.size()
-          && sortedIds.get(i + 1) == sortedIds.get(i) + 1) {
-        i++;
-      }
-      int runLength = i - runStart + 1;
-
-      // A contiguous run is cheaper as a BETWEEN (RANGE_OPERAND_COST operands,
-      // regardless of length) than as IN values (one operand each) once it spans
-      // at least MIN_RANGE_RUN_LENGTH ids; shorter runs stay as IN points.
-      boolean asRange = runLength >= MIN_RANGE_RUN_LENGTH;
-      int termOperands = asRange ? RANGE_OPERAND_COST : runLength;
-
-      if (operandsUsed > 0
-          && operandsUsed + termOperands > MAX_PREDICATE_OPERANDS) {
-        totalDeleted += executeCombinedDelete(dslContext, ranges, points);
-        ranges.clear();
-        points.clear();
-        operandsUsed = 0;
-      }
-
-      if (asRange) {
-        ranges.add(new long[] {sortedIds.get(runStart), sortedIds.get(i)});
-      } else {
-        for (int j = runStart; j <= i; j++) {
-          points.add(sortedIds.get(j));
-        }
-      }
-      operandsUsed += termOperands;
-      i++;
-    }
-
-    if (operandsUsed > 0) {
-      totalDeleted += executeCombinedDelete(dslContext, ranges, points);
+      int deleted = dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
+          .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.in(chunk))
+          .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.in(
+              UnHealthyContainerStates.MISSING.toString(),
+              UnHealthyContainerStates.EMPTY_MISSING.toString(),
+              UnHealthyContainerStates.UNDER_REPLICATED.toString(),
+              UnHealthyContainerStates.OVER_REPLICATED.toString(),
+              UnHealthyContainerStates.MIS_REPLICATED.toString(),
+              UnHealthyContainerStates.NEGATIVE_SIZE.toString(),
+              UnHealthyContainerStates.REPLICA_MISMATCH.toString()))
+          .execute();
+      totalDeleted += deleted;
     }
     return totalDeleted;
   }
 
-  /**
-   * Executes a single DELETE whose container-id predicate is the combination of the
-   * given contiguous ranges (as {@code BETWEEN} terms) and scattered ids (as a
-   * single {@code IN} list), restricted to SCM-generated states.
-   */
-  private int executeCombinedDelete(DSLContext dslContext,
-      List<long[]> ranges, List<Long> points) {
-    Condition idCondition = null;
-    if (!points.isEmpty()) {
-      idCondition = UNHEALTHY_CONTAINERS.CONTAINER_ID.in(points);
+  private void deleteStaleUnhealthyRecords(DSLContext dslContext,
+      List<ContainerStateKey> staleKeys) {
+    if (staleKeys.isEmpty()) {
+      return;
     }
-    for (long[] range : ranges) {
-      Condition rangeCondition =
-          UNHEALTHY_CONTAINERS.CONTAINER_ID.between(range[0], range[1]);
-      idCondition = (idCondition == null)
-          ? rangeCondition : idCondition.or(rangeCondition);
+    for (ContainerStateKey key : staleKeys) {
+      dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
+          .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.eq(key.getContainerId()))
+          .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(key.getContainerState()))
+          .execute();
     }
-    if (idCondition == null) {
-      return 0;
-    }
-    return dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
-        .where(idCondition.and(scmGeneratedStatesCondition()))
-        .execute();
   }
 
-  private Condition scmGeneratedStatesCondition() {
-    return UNHEALTHY_CONTAINERS.CONTAINER_STATE.in(
-        UnHealthyContainerStates.MISSING.toString(),
-        UnHealthyContainerStates.EMPTY_MISSING.toString(),
-        UnHealthyContainerStates.UNDER_REPLICATED.toString(),
-        UnHealthyContainerStates.OVER_REPLICATED.toString(),
-        UnHealthyContainerStates.MIS_REPLICATED.toString(),
-        UnHealthyContainerStates.NEGATIVE_SIZE.toString(),
-        UnHealthyContainerStates.REPLICA_MISMATCH.toString());
+  private void batchUpdateInChunks(DSLContext dslContext,
+      List<UnhealthyContainerRecord> recs) {
+    if (recs.isEmpty()) {
+      return;
+    }
+    for (int from = 0; from < recs.size(); from += BATCH_INSERT_CHUNK_SIZE) {
+      int to = Math.min(from + BATCH_INSERT_CHUNK_SIZE, recs.size());
+      for (int i = from; i < to; i++) {
+        UnhealthyContainerRecord rec = recs.get(i);
+        dslContext.update(UNHEALTHY_CONTAINERS)
+            .set(UNHEALTHY_CONTAINERS.IN_STATE_SINCE, rec.getInStateSince())
+            .set(UNHEALTHY_CONTAINERS.EXPECTED_REPLICA_COUNT,
+                rec.getExpectedReplicaCount())
+            .set(UNHEALTHY_CONTAINERS.ACTUAL_REPLICA_COUNT,
+                rec.getActualReplicaCount())
+            .set(UNHEALTHY_CONTAINERS.REPLICA_DELTA, rec.getReplicaDelta())
+            .set(UNHEALTHY_CONTAINERS.REASON, rec.getReason())
+            .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.eq(rec.getContainerId()))
+            .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(rec.getContainerState()))
+            .execute();
+      }
+    }
   }
 
   /**
@@ -393,10 +387,20 @@ public class ContainerHealthSchemaManager {
         || containerIds == null || containerIds.isEmpty()) {
       return records;
     }
+    return applyExistingInStateSince(records,
+        getExistingInStateSinceByContainerIds(containerIds));
+  }
 
-    Map<ContainerStateKey, Long> existingByContainerAndState =
-        getExistingInStateSinceByContainerIds(containerIds);
-    if (existingByContainerAndState.isEmpty()) {
+  /**
+   * Preserve existing inStateSince values for records that remain in the
+   * same unhealthy state across scan cycles, using a pre-loaded existing map.
+   */
+  public List<UnhealthyContainerRecord> applyExistingInStateSince(
+      List<UnhealthyContainerRecord> records,
+      Map<ContainerStateKey, Long> existingByContainerAndState) {
+    if (records == null || records.isEmpty()
+        || existingByContainerAndState == null
+        || existingByContainerAndState.isEmpty()) {
       return records;
     }
 
@@ -674,6 +678,10 @@ public class ContainerHealthSchemaManager {
 
     public long getContainerId() {
       return containerId;
+    }
+
+    public String getContainerState() {
+      return state;
     }
 
     @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -70,22 +70,38 @@ public class ContainerHealthSchemaManager {
   static final int MAX_IN_CLAUSE_CHUNK_SIZE = 1_000;
 
   /**
-   * Minimum length of a contiguous container-id run that justifies deleting it
-   * with a single range ({@code BETWEEN}) statement instead of folding the ids
-   * into a chunked {@code IN} delete.
+   * Minimum length of a contiguous container-id run that is deleted with a
+   * range ({@code BETWEEN}) term instead of being expanded into individual
+   * {@code IN} values.
    *
-   * <p>A {@code BETWEEN} predicate is constant size and removes an entire
-   * contiguous range in one statement, whereas an {@code IN} delete is capped
-   * at {@link #MAX_IN_CLAUSE_CHUNK_SIZE} ids per statement to stay under
-   * Derby's 64 KB bytecode limit. Pulling a run out into its own
-   * {@code BETWEEN} only lowers the total statement count once the run is at
-   * least one IN-chunk long, so shorter runs and scattered ids stay in the IN
-   * batches. Real container-id lists are usually dense ranges broken up by gaps
-   * from deleted containers, so this keeps the common case to a handful of
-   * statements while never doing worse than plain IN chunking for sparse
-   * ids.</p>
+   * <p>Derby compiles every statement to JVM bytecode whose size grows with the
+   * number of id literals in the predicate. A contiguous run of {@code L} ids
+   * costs {@code L} operands when listed in an {@code IN} clause, but only
+   * {@link #RANGE_OPERAND_COST} (the two endpoints) when written as
+   * {@code BETWEEN lo AND hi}, independent of {@code L}. The range form is
+   * therefore strictly smaller once {@code L > RANGE_OPERAND_COST}, i.e. for
+   * runs of 3 or more ids; runs of 1–2 ids are left as {@code IN} values since
+   * the range form would save nothing. This lets the optimization benefit
+   * realistic, fragmented unhealthy-container sets rather than only rare
+   * 1,000+ contiguous ranges.</p>
    */
-  static final int MIN_RANGE_DELETE_RUN = MAX_IN_CLAUSE_CHUNK_SIZE;
+  static final int MIN_RANGE_RUN_LENGTH = 3;
+
+  /** Estimated predicate operand cost of a single {@code BETWEEN} range term. */
+  private static final int RANGE_OPERAND_COST = 2;
+
+  /**
+   * Upper bound on the estimated number of id operands packed into one combined
+   * DELETE predicate before it is flushed.
+   *
+   * <p>Range terms count as {@link #RANGE_OPERAND_COST} operands and scattered
+   * ids as one operand each. The cap reuses {@link #MAX_IN_CLAUSE_CHUNK_SIZE} —
+   * the id count already proven to keep a pure {@code IN} delete well under
+   * Derby's 64 KB per-method bytecode limit — so a mixed range/{@code IN}
+   * predicate of the same operand budget stays within the same safe
+   * envelope.</p>
+   */
+  static final int MAX_PREDICATE_OPERANDS = MAX_IN_CLAUSE_CHUNK_SIZE;
 
   private final ContainerSchemaDefinition containerSchemaDefinition;
   private final int unhealthyContainersFetchSize;
@@ -232,7 +248,15 @@ public class ContainerHealthSchemaManager {
         .collect(Collectors.toList());
 
     int totalDeleted = 0;
-    List<Long> inClauseBatch = new ArrayList<>(MAX_IN_CLAUSE_CHUNK_SIZE);
+
+    // Build each DELETE predicate as the combination of compact range terms (one
+    // BETWEEN per contiguous run of at least MIN_RANGE_RUN_LENGTH ids) and a
+    // single IN list for the remaining scattered ids. Terms are accumulated
+    // until the estimated operand count reaches MAX_PREDICATE_OPERANDS, then the
+    // statement is flushed so the generated Derby bytecode stays within budget.
+    List<long[]> ranges = new ArrayList<>();
+    List<Long> points = new ArrayList<>();
+    int operandsUsed = 0;
 
     int i = 0;
     while (i < sortedIds.size()) {
@@ -241,44 +265,61 @@ public class ContainerHealthSchemaManager {
           && sortedIds.get(i + 1) == sortedIds.get(i) + 1) {
         i++;
       }
+      int runLength = i - runStart + 1;
 
-      if (i - runStart + 1 >= MIN_RANGE_DELETE_RUN) {
-        // Long contiguous run: a single constant-size BETWEEN removes the whole
-        // range without straining Derby's per-statement bytecode budget.
-        totalDeleted += deleteScmStatesByRange(dslContext,
-            sortedIds.get(runStart), sortedIds.get(i));
+      // A contiguous run is cheaper as a BETWEEN (RANGE_OPERAND_COST operands,
+      // regardless of length) than as IN values (one operand each) once it spans
+      // at least MIN_RANGE_RUN_LENGTH ids; shorter runs stay as IN points.
+      boolean asRange = runLength >= MIN_RANGE_RUN_LENGTH;
+      int termOperands = asRange ? RANGE_OPERAND_COST : runLength;
+
+      if (operandsUsed > 0
+          && operandsUsed + termOperands > MAX_PREDICATE_OPERANDS) {
+        totalDeleted += executeCombinedDelete(dslContext, ranges, points);
+        ranges.clear();
+        points.clear();
+        operandsUsed = 0;
+      }
+
+      if (asRange) {
+        ranges.add(new long[] {sortedIds.get(runStart), sortedIds.get(i)});
       } else {
-        // Short run or isolated id: fold into IN batches that stay within the
-        // bytecode-safe chunk size.
         for (int j = runStart; j <= i; j++) {
-          inClauseBatch.add(sortedIds.get(j));
-          if (inClauseBatch.size() == MAX_IN_CLAUSE_CHUNK_SIZE) {
-            totalDeleted += deleteScmStatesByIds(dslContext, inClauseBatch);
-            inClauseBatch.clear();
-          }
+          points.add(sortedIds.get(j));
         }
       }
+      operandsUsed += termOperands;
       i++;
     }
 
-    if (!inClauseBatch.isEmpty()) {
-      totalDeleted += deleteScmStatesByIds(dslContext, inClauseBatch);
+    if (operandsUsed > 0) {
+      totalDeleted += executeCombinedDelete(dslContext, ranges, points);
     }
     return totalDeleted;
   }
 
-  private int deleteScmStatesByRange(DSLContext dslContext,
-      long startContainerId, long endContainerId) {
+  /**
+   * Executes a single DELETE whose container-id predicate is the combination of the
+   * given contiguous ranges (as {@code BETWEEN} terms) and scattered ids (as a
+   * single {@code IN} list), restricted to SCM-generated states.
+   */
+  private int executeCombinedDelete(DSLContext dslContext,
+      List<long[]> ranges, List<Long> points) {
+    Condition idCondition = null;
+    if (!points.isEmpty()) {
+      idCondition = UNHEALTHY_CONTAINERS.CONTAINER_ID.in(points);
+    }
+    for (long[] range : ranges) {
+      Condition rangeCondition =
+          UNHEALTHY_CONTAINERS.CONTAINER_ID.between(range[0], range[1]);
+      idCondition = (idCondition == null)
+          ? rangeCondition : idCondition.or(rangeCondition);
+    }
+    if (idCondition == null) {
+      return 0;
+    }
     return dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
-        .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.between(startContainerId, endContainerId))
-        .and(scmGeneratedStatesCondition())
-        .execute();
-  }
-
-  private int deleteScmStatesByIds(DSLContext dslContext, List<Long> containerIds) {
-    return dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
-        .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.in(containerIds))
-        .and(scmGeneratedStatesCondition())
+        .where(idCondition.and(scmGeneratedStatesCondition()))
         .execute();
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -69,6 +69,24 @@ public class ContainerHealthSchemaManager {
    */
   static final int MAX_IN_CLAUSE_CHUNK_SIZE = 1_000;
 
+  /**
+   * Minimum length of a contiguous container-id run that justifies deleting it
+   * with a single range ({@code BETWEEN}) statement instead of folding the ids
+   * into a chunked {@code IN} delete.
+   *
+   * <p>A {@code BETWEEN} predicate is constant size and removes an entire
+   * contiguous range in one statement, whereas an {@code IN} delete is capped
+   * at {@link #MAX_IN_CLAUSE_CHUNK_SIZE} ids per statement to stay under
+   * Derby's 64 KB bytecode limit. Pulling a run out into its own
+   * {@code BETWEEN} only lowers the total statement count once the run is at
+   * least one IN-chunk long, so shorter runs and scattered ids stay in the IN
+   * batches. Real container-id lists are usually dense ranges broken up by gaps
+   * from deleted containers, so this keeps the common case to a handful of
+   * statements while never doing worse than plain IN chunking for sparse
+   * ids.</p>
+   */
+  static final int MIN_RANGE_DELETE_RUN = MAX_IN_CLAUSE_CHUNK_SIZE;
+
   private final ContainerSchemaDefinition containerSchemaDefinition;
   private final int unhealthyContainersFetchSize;
 
@@ -205,26 +223,74 @@ public class ContainerHealthSchemaManager {
 
   private int deleteScmStatesForContainers(DSLContext dslContext,
       List<Long> containerIds) {
+
+    // Sort and de-duplicate so contiguous runs are detectable regardless of the
+    // order in which the caller supplied the ids.
+    List<Long> sortedIds = containerIds.stream()
+        .distinct()
+        .sorted()
+        .collect(Collectors.toList());
+
     int totalDeleted = 0;
+    List<Long> inClauseBatch = new ArrayList<>(MAX_IN_CLAUSE_CHUNK_SIZE);
 
-    for (int from = 0; from < containerIds.size(); from += MAX_IN_CLAUSE_CHUNK_SIZE) {
-      int to = Math.min(from + MAX_IN_CLAUSE_CHUNK_SIZE, containerIds.size());
-      List<Long> chunk = containerIds.subList(from, to);
+    int i = 0;
+    while (i < sortedIds.size()) {
+      int runStart = i;
+      while (i + 1 < sortedIds.size()
+          && sortedIds.get(i + 1) == sortedIds.get(i) + 1) {
+        i++;
+      }
 
-      int deleted = dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
-          .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.in(chunk))
-          .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.in(
-              UnHealthyContainerStates.MISSING.toString(),
-              UnHealthyContainerStates.EMPTY_MISSING.toString(),
-              UnHealthyContainerStates.UNDER_REPLICATED.toString(),
-              UnHealthyContainerStates.OVER_REPLICATED.toString(),
-              UnHealthyContainerStates.MIS_REPLICATED.toString(),
-              UnHealthyContainerStates.NEGATIVE_SIZE.toString(),
-              UnHealthyContainerStates.REPLICA_MISMATCH.toString()))
-          .execute();
-      totalDeleted += deleted;
+      if (i - runStart + 1 >= MIN_RANGE_DELETE_RUN) {
+        // Long contiguous run: a single constant-size BETWEEN removes the whole
+        // range without straining Derby's per-statement bytecode budget.
+        totalDeleted += deleteScmStatesByRange(dslContext,
+            sortedIds.get(runStart), sortedIds.get(i));
+      } else {
+        // Short run or isolated id: fold into IN batches that stay within the
+        // bytecode-safe chunk size.
+        for (int j = runStart; j <= i; j++) {
+          inClauseBatch.add(sortedIds.get(j));
+          if (inClauseBatch.size() == MAX_IN_CLAUSE_CHUNK_SIZE) {
+            totalDeleted += deleteScmStatesByIds(dslContext, inClauseBatch);
+            inClauseBatch.clear();
+          }
+        }
+      }
+      i++;
+    }
+
+    if (!inClauseBatch.isEmpty()) {
+      totalDeleted += deleteScmStatesByIds(dslContext, inClauseBatch);
     }
     return totalDeleted;
+  }
+
+  private int deleteScmStatesByRange(DSLContext dslContext,
+      long startContainerId, long endContainerId) {
+    return dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
+        .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.between(startContainerId, endContainerId))
+        .and(scmGeneratedStatesCondition())
+        .execute();
+  }
+
+  private int deleteScmStatesByIds(DSLContext dslContext, List<Long> containerIds) {
+    return dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
+        .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.in(containerIds))
+        .and(scmGeneratedStatesCondition())
+        .execute();
+  }
+
+  private Condition scmGeneratedStatesCondition() {
+    return UNHEALTHY_CONTAINERS.CONTAINER_STATE.in(
+        UnHealthyContainerStates.MISSING.toString(),
+        UnHealthyContainerStates.EMPTY_MISSING.toString(),
+        UnHealthyContainerStates.UNDER_REPLICATED.toString(),
+        UnHealthyContainerStates.OVER_REPLICATED.toString(),
+        UnHealthyContainerStates.MIS_REPLICATED.toString(),
+        UnHealthyContainerStates.NEGATIVE_SIZE.toString(),
+        UnHealthyContainerStates.REPLICA_MISMATCH.toString());
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -185,10 +185,9 @@ public class ContainerHealthSchemaManager {
    * (container_id, state) pairs, update existing pairs, and delete only stale
    * pairs that are no longer unhealthy.
    *
-   * <p>Unlike {@link #replaceUnhealthyContainerRecordsAtomically}, this does not
-   * delete all SCM states for every container that previously had a row. It
-   * removes only keys present in {@code existingByKey} but absent from the
-   * desired scan result (containers that recovered or changed state).</p>
+   * <p>This does not delete all SCM states for every container that previously
+   * had a row. It removes only keys present in {@code existingByKey} but absent
+   * from the desired scan result (containers that recovered or changed state).</p>
    *
    * <p>Rows whose desired content is identical to the existing row are left
    * untouched, so an UPDATE is issued only when replica counts, delta, reason
@@ -266,30 +265,6 @@ public class ContainerHealthSchemaManager {
         && existing.getActualReplicaCount() == desired.getActualReplicaCount()
         && existing.getReplicaDelta() == desired.getReplicaDelta()
         && Objects.equals(existing.getReason(), desired.getReason());
-  }
-
-  /**
-   * Atomically replaces unhealthy rows for a given set of containers.
-   * Delete and insert happen in the same DB transaction.
-   */
-  public void replaceUnhealthyContainerRecordsAtomically(
-      List<Long> containerIdsToDelete,
-      List<UnhealthyContainerRecord> recordsToInsert) {
-    if ((containerIdsToDelete == null || containerIdsToDelete.isEmpty())
-        && (recordsToInsert == null || recordsToInsert.isEmpty())) {
-      return;
-    }
-
-    DSLContext dslContext = containerSchemaDefinition.getDSLContext();
-    dslContext.transaction(configuration -> {
-      DSLContext txContext = configuration.dsl();
-      if (containerIdsToDelete != null && !containerIdsToDelete.isEmpty()) {
-        deleteScmStatesForContainers(txContext, containerIdsToDelete);
-      }
-      if (recordsToInsert != null && !recordsToInsert.isEmpty()) {
-        batchInsertInChunks(txContext, recordsToInsert);
-      }
-    });
   }
 
   private int deleteScmStatesForContainers(DSLContext dslContext,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -41,6 +41,7 @@ import org.jooq.Condition;
 import org.jooq.Cursor;
 import org.jooq.DSLContext;
 import org.jooq.OrderField;
+import org.jooq.Query;
 import org.jooq.Record;
 import org.jooq.SelectQuery;
 import org.slf4j.Logger;
@@ -189,12 +190,16 @@ public class ContainerHealthSchemaManager {
    * removes only keys present in {@code existingByKey} but absent from the
    * desired scan result (containers that recovered or changed state).</p>
    *
+   * <p>Rows whose desired content is identical to the existing row are left
+   * untouched, so an UPDATE is issued only when replica counts, delta, reason
+   * or {@code in_state_since} actually changed.</p>
+   *
    * @param existingByKey prior rows for this chunk, keyed by
    *                      (container_id, container_state)
    * @param desiredRecords unhealthy rows produced by the current scan
    */
   public void syncUnhealthyContainerRecordsAtomically(
-      Map<ContainerStateKey, Long> existingByKey,
+      Map<ContainerStateKey, UnhealthyContainerRecord> existingByKey,
       List<UnhealthyContainerRecord> desiredRecords) {
     if ((existingByKey == null || existingByKey.isEmpty())
         && (desiredRecords == null || desiredRecords.isEmpty())) {
@@ -209,7 +214,7 @@ public class ContainerHealthSchemaManager {
       }
     }
 
-    Map<ContainerStateKey, Long> existing =
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing =
         existingByKey == null ? new HashMap<>() : existingByKey;
 
     List<ContainerStateKey> staleKeys = new ArrayList<>();
@@ -224,11 +229,17 @@ public class ContainerHealthSchemaManager {
     for (UnhealthyContainerRecord record : desiredByKey.values()) {
       ContainerStateKey key = new ContainerStateKey(record.getContainerId(),
           record.getContainerState());
-      if (existing.containsKey(key)) {
-        toUpdate.add(record);
-      } else {
+      UnhealthyContainerRecord existingRecord = existing.get(key);
+      if (existingRecord == null) {
         toInsert.add(record);
+      } else if (!hasSameContent(existingRecord, record)) {
+        toUpdate.add(record);
       }
+    }
+
+    if (staleKeys.isEmpty() && toInsert.isEmpty() && toUpdate.isEmpty()) {
+      LOG.debug("Synced unhealthy container records: no changes");
+      return;
     }
 
     DSLContext dslContext = containerSchemaDefinition.getDSLContext();
@@ -241,6 +252,20 @@ public class ContainerHealthSchemaManager {
 
     LOG.debug("Synced unhealthy container records: deleted {} stale, inserted {}, updated {}",
         staleKeys.size(), toInsert.size(), toUpdate.size());
+  }
+
+  /**
+   * Returns true when the mutable columns of the existing row already match the
+   * desired scan result, so no UPDATE needs to be issued. The container_id and
+   * container_state are the key and are always equal for a matched pair.
+   */
+  private static boolean hasSameContent(UnhealthyContainerRecord existing,
+      UnhealthyContainerRecord desired) {
+    return existing.getInStateSince() == desired.getInStateSince()
+        && existing.getExpectedReplicaCount() == desired.getExpectedReplicaCount()
+        && existing.getActualReplicaCount() == desired.getActualReplicaCount()
+        && existing.getReplicaDelta() == desired.getReplicaDelta()
+        && Objects.equals(existing.getReason(), desired.getReason());
   }
 
   /**
@@ -296,11 +321,16 @@ public class ContainerHealthSchemaManager {
     if (staleKeys.isEmpty()) {
       return;
     }
-    for (ContainerStateKey key : staleKeys) {
-      dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
-          .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.eq(key.getContainerId()))
-          .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(key.getContainerState()))
-          .execute();
+    for (int from = 0; from < staleKeys.size(); from += BATCH_INSERT_CHUNK_SIZE) {
+      int to = Math.min(from + BATCH_INSERT_CHUNK_SIZE, staleKeys.size());
+      List<Query> batch = new ArrayList<>(to - from);
+      for (int i = from; i < to; i++) {
+        ContainerStateKey key = staleKeys.get(i);
+        batch.add(dslContext.deleteFrom(UNHEALTHY_CONTAINERS)
+            .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.eq(key.getContainerId()))
+            .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(key.getContainerState())));
+      }
+      dslContext.batch(batch).execute();
     }
   }
 
@@ -311,9 +341,10 @@ public class ContainerHealthSchemaManager {
     }
     for (int from = 0; from < recs.size(); from += BATCH_INSERT_CHUNK_SIZE) {
       int to = Math.min(from + BATCH_INSERT_CHUNK_SIZE, recs.size());
+      List<Query> batch = new ArrayList<>(to - from);
       for (int i = from; i < to; i++) {
         UnhealthyContainerRecord rec = recs.get(i);
-        dslContext.update(UNHEALTHY_CONTAINERS)
+        batch.add(dslContext.update(UNHEALTHY_CONTAINERS)
             .set(UNHEALTHY_CONTAINERS.IN_STATE_SINCE, rec.getInStateSince())
             .set(UNHEALTHY_CONTAINERS.EXPECTED_REPLICA_COUNT,
                 rec.getExpectedReplicaCount())
@@ -322,15 +353,17 @@ public class ContainerHealthSchemaManager {
             .set(UNHEALTHY_CONTAINERS.REPLICA_DELTA, rec.getReplicaDelta())
             .set(UNHEALTHY_CONTAINERS.REASON, rec.getReason())
             .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.eq(rec.getContainerId()))
-            .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(rec.getContainerState()))
-            .execute();
+            .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(rec.getContainerState())));
       }
+      dslContext.batch(batch).execute();
     }
   }
 
   /**
-   * Returns previous in-state-since timestamps for tracked unhealthy states.
-   * The key is a stable containerId + state tuple.
+   * Returns the currently persisted unhealthy rows for the tracked SCM-generated
+   * states, keyed by a stable containerId + state tuple. The full row is
+   * returned so callers can both preserve {@code in_state_since} and detect
+   * whether a row's content actually changed before issuing an UPDATE.
    *
    * <p>This method also chunks the container-id predicate internally to stay
    * within Derby's statement compilation limits. Large scan cycles in Recon can
@@ -338,14 +371,14 @@ public class ContainerHealthSchemaManager {
    * single {@code IN (...)} predicate causes Derby to generate bytecode that
    * exceeds the JVM constant-pool / method-size limits.</p>
    */
-  public Map<ContainerStateKey, Long> getExistingInStateSinceByContainerIds(
+  public Map<ContainerStateKey, UnhealthyContainerRecord> getExistingUnhealthyRecordsByContainerIds(
       List<Long> containerIds) {
     if (containerIds == null || containerIds.isEmpty()) {
       return new HashMap<>();
     }
 
     DSLContext dslContext = containerSchemaDefinition.getDSLContext();
-    Map<ContainerStateKey, Long> existing = new HashMap<>();
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing = new HashMap<>();
     try {
       for (int from = 0; from < containerIds.size(); from += MAX_IN_CLAUSE_CHUNK_SIZE) {
         int to = Math.min(from + MAX_IN_CLAUSE_CHUNK_SIZE, containerIds.size());
@@ -354,7 +387,11 @@ public class ContainerHealthSchemaManager {
         dslContext.select(
                 UNHEALTHY_CONTAINERS.CONTAINER_ID,
                 UNHEALTHY_CONTAINERS.CONTAINER_STATE,
-                UNHEALTHY_CONTAINERS.IN_STATE_SINCE)
+                UNHEALTHY_CONTAINERS.IN_STATE_SINCE,
+                UNHEALTHY_CONTAINERS.EXPECTED_REPLICA_COUNT,
+                UNHEALTHY_CONTAINERS.ACTUAL_REPLICA_COUNT,
+                UNHEALTHY_CONTAINERS.REPLICA_DELTA,
+                UNHEALTHY_CONTAINERS.REASON)
             .from(UNHEALTHY_CONTAINERS)
             .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.in(chunk))
             .and(UNHEALTHY_CONTAINERS.CONTAINER_STATE.in(
@@ -365,13 +402,20 @@ public class ContainerHealthSchemaManager {
                 UnHealthyContainerStates.MIS_REPLICATED.toString(),
                 UnHealthyContainerStates.NEGATIVE_SIZE.toString(),
                 UnHealthyContainerStates.REPLICA_MISMATCH.toString()))
-            .forEach(record -> existing.put(
-                new ContainerStateKey(record.get(UNHEALTHY_CONTAINERS.CONTAINER_ID),
-                    record.get(UNHEALTHY_CONTAINERS.CONTAINER_STATE)),
-                record.get(UNHEALTHY_CONTAINERS.IN_STATE_SINCE)));
+            .forEach(record -> {
+              long id = record.get(UNHEALTHY_CONTAINERS.CONTAINER_ID);
+              String state = record.get(UNHEALTHY_CONTAINERS.CONTAINER_STATE);
+              existing.put(new ContainerStateKey(id, state),
+                  new UnhealthyContainerRecord(id, state,
+                      record.get(UNHEALTHY_CONTAINERS.IN_STATE_SINCE),
+                      record.get(UNHEALTHY_CONTAINERS.EXPECTED_REPLICA_COUNT),
+                      record.get(UNHEALTHY_CONTAINERS.ACTUAL_REPLICA_COUNT),
+                      record.get(UNHEALTHY_CONTAINERS.REPLICA_DELTA),
+                      record.get(UNHEALTHY_CONTAINERS.REASON)));
+            });
       }
     } catch (Exception e) {
-      LOG.warn("Failed to load existing inStateSince records. Falling back to current scan time.", e);
+      LOG.warn("Failed to load existing unhealthy records. Falling back to current scan time.", e);
     }
     return existing;
   }
@@ -388,7 +432,7 @@ public class ContainerHealthSchemaManager {
       return records;
     }
     return applyExistingInStateSince(records,
-        getExistingInStateSinceByContainerIds(containerIds));
+        getExistingUnhealthyRecordsByContainerIds(containerIds));
   }
 
   /**
@@ -397,7 +441,7 @@ public class ContainerHealthSchemaManager {
    */
   public List<UnhealthyContainerRecord> applyExistingInStateSince(
       List<UnhealthyContainerRecord> records,
-      Map<ContainerStateKey, Long> existingByContainerAndState) {
+      Map<ContainerStateKey, UnhealthyContainerRecord> existingByContainerAndState) {
     if (records == null || records.isEmpty()
         || existingByContainerAndState == null
         || existingByContainerAndState.isEmpty()) {
@@ -407,16 +451,16 @@ public class ContainerHealthSchemaManager {
     List<UnhealthyContainerRecord> withPreservedInStateSince =
         new ArrayList<>(records.size());
     for (UnhealthyContainerRecord record : records) {
-      Long existingInStateSince = existingByContainerAndState.get(
+      UnhealthyContainerRecord existingRecord = existingByContainerAndState.get(
           new ContainerStateKey(record.getContainerId(),
               record.getContainerState()));
-      if (existingInStateSince == null) {
+      if (existingRecord == null) {
         withPreservedInStateSince.add(record);
       } else {
         withPreservedInStateSince.add(new UnhealthyContainerRecord(
             record.getContainerId(),
             record.getContainerState(),
-            existingInStateSince,
+            existingRecord.getInStateSince(),
             record.getExpectedReplicaCount(),
             record.getActualReplicaCount(),
             record.getReplicaDelta(),

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestContainerHealthSchemaManager.java
@@ -19,12 +19,15 @@ package org.apache.hadoop.ozone.recon.persistence;
 
 import static org.apache.ozone.recon.schema.generated.tables.UnhealthyContainersTable.UNHEALTHY_CONTAINERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.ContainerStateKey;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.UnhealthyContainerRecord;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
@@ -33,15 +36,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Functional tests for {@link ContainerHealthSchemaManager} delete handling.
- *
- * <p>{@code deleteScmStatesForContainers} coalesces long contiguous container
- * id runs into single range ({@code BETWEEN}) deletes while folding shorter
- * runs and scattered ids into chunked {@code IN} deletes. These tests assert
- * that both paths remove exactly the requested rows for contiguous, scattered,
- * and mixed id distributions, and that non-SCM states are never removed.</p>
+ * Functional tests for {@link ContainerHealthSchemaManager#syncUnhealthyContainerRecordsAtomically}.
  */
 public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
+
+  private static final long ORIGINAL_TIMESTAMP = 1_000L;
+  private static final long UPDATED_TIMESTAMP = 2_000L;
 
   private ContainerSchemaDefinition schemaDefinition;
   private ContainerHealthSchemaManager schemaManager;
@@ -54,138 +54,118 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
   }
 
   @Test
-  public void testDeleteContiguousRangeRemovesExactlyRequestedRows() {
-    // A contiguous run (>= MIN_RANGE_RUN_LENGTH) is removed via the range path.
-    int runLength = ContainerHealthSchemaManager.MIN_RANGE_RUN_LENGTH + 50;
-    insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
-    // Survivors that are not part of the delete list.
-    insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 5000L, 5002L, 5004L);
+  public void testSyncInsertsNewUnhealthyRecords() {
+    Map<ContainerStateKey, Long> existing = Collections.emptyMap();
+    List<UnhealthyContainerRecord> desired = Arrays.asList(
+        record(1L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0),
+        record(2L, UnHealthyContainerStates.UNDER_REPLICATED, ORIGINAL_TIMESTAMP, 3, 2));
 
-    List<Long> idsToDelete = contiguous(1, runLength);
-    idsToDelete.add(1L);              // duplicate -> must be de-duplicated
-    Collections.shuffle(idsToDelete); // unsorted -> must be sorted internally
+    schemaManager.syncUnhealthyContainerRecordsAtomically(existing, desired);
 
-    schemaManager.batchDeleteSCMStatesForContainers(idsToDelete);
-
-    assertEquals(Arrays.asList(5000L, 5002L, 5004L), remainingContainerIds());
+    assertEquals(Arrays.asList(1L, 2L), remainingContainerIds());
+    assertEquals(2L, countRows());
   }
 
   @Test
-  public void testDeleteScatteredIdsRemovesExactlyRequestedRows() {
-    for (long id = 1; id <= 10; id++) {
-      insertIds(UnHealthyContainerStates.MISSING, id);
-    }
+  public void testSyncDeletesStaleRowsWhenContainerBecomesHealthy() {
+    insert(record(1L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0));
+    insert(record(1L, UnHealthyContainerStates.UNDER_REPLICATED, ORIGINAL_TIMESTAMP, 3, 2));
+    insert(record(2L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0));
 
-    // Delete only the odd ids, supplied out of order.
-    schemaManager.batchDeleteSCMStatesForContainers(
-        new ArrayList<>(Arrays.asList(9L, 1L, 5L, 7L, 3L)));
+    Map<ContainerStateKey, Long> existing = existingMap(
+        key(1L, UnHealthyContainerStates.MISSING),
+        key(1L, UnHealthyContainerStates.UNDER_REPLICATED),
+        key(2L, UnHealthyContainerStates.MISSING));
 
-    assertEquals(Arrays.asList(2L, 4L, 6L, 8L, 10L), remainingContainerIds());
+    // Container 1 recovered; container 2 still missing.
+    List<UnhealthyContainerRecord> desired = Collections.singletonList(
+        record(2L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0));
+
+    schemaManager.syncUnhealthyContainerRecordsAtomically(existing, desired);
+
+    assertEquals(Collections.singletonList(2L), remainingContainerIds());
+    assertEquals(1L, countRows());
   }
 
   @Test
-  public void testDeleteMixedRunAndScatteredRemovesExactlyRequestedRows() {
-    int runLength = ContainerHealthSchemaManager.MIN_RANGE_RUN_LENGTH + 50;
-    insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
-    insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 9001L, 9003L, 9005L);
-    // Survivor not present in the delete list.
-    insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 9004L);
+  public void testSyncUpdatesExistingRowAndDeletesChangedState() {
+    insert(record(1L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0));
 
-    List<Long> idsToDelete = contiguous(1, runLength);
-    idsToDelete.add(9001L);
-    idsToDelete.add(9003L);
-    idsToDelete.add(9005L);
+    Map<ContainerStateKey, Long> existing = existingMap(
+        key(1L, UnHealthyContainerStates.MISSING));
 
-    schemaManager.batchDeleteSCMStatesForContainers(idsToDelete);
+    // Same container now under-replicated instead of missing.
+    List<UnhealthyContainerRecord> desired = Collections.singletonList(
+        record(1L, UnHealthyContainerStates.UNDER_REPLICATED, UPDATED_TIMESTAMP, 3, 2));
 
-    assertEquals(Collections.singletonList(9004L), remainingContainerIds());
+    schemaManager.syncUnhealthyContainerRecordsAtomically(existing, desired);
+
+    assertEquals(Collections.singletonList(1L), remainingContainerIds());
+    assertEquals(1L, countRows());
+    UnhealthyContainerRecord row = fetchRow(1L, UnHealthyContainerStates.UNDER_REPLICATED);
+    assertEquals(UPDATED_TIMESTAMP, row.getInStateSince());
+    assertEquals(2, row.getActualReplicaCount());
+    assertTrue(countByState(UnHealthyContainerStates.MISSING) == 0);
   }
 
   @Test
-  public void testDeletePreservesNonScmStateInsideRange() {
-    int runLength = ContainerHealthSchemaManager.MIN_RANGE_RUN_LENGTH + 100;
-    insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
-    // ALL_REPLICAS_BAD is not an SCM-generated state, so it must survive even
-    // though container 50 falls inside the deleted [1, runLength] range.
-    insertIds(UnHealthyContainerStates.ALL_REPLICAS_BAD, 50L);
+  public void testSyncUpdatesExistingRowInPlace() {
+    insert(record(1L, UnHealthyContainerStates.UNDER_REPLICATED,
+        ORIGINAL_TIMESTAMP, 3, 2, "old reason"));
 
-    schemaManager.batchDeleteSCMStatesForContainers(contiguous(1, runLength));
+    Map<ContainerStateKey, Long> existing = existingMap(
+        key(1L, UnHealthyContainerStates.UNDER_REPLICATED));
 
-    assertEquals(Collections.singletonList(50L), remainingContainerIds());
-    assertEquals(0L, countByState(UnHealthyContainerStates.UNDER_REPLICATED));
+    List<UnhealthyContainerRecord> desired = Collections.singletonList(
+        record(1L, UnHealthyContainerStates.UNDER_REPLICATED,
+            ORIGINAL_TIMESTAMP, 3, 1, "new reason"));
+
+    schemaManager.syncUnhealthyContainerRecordsAtomically(existing, desired);
+
+    assertEquals(1L, countRows());
+    UnhealthyContainerRecord row = fetchRow(1L, UnHealthyContainerStates.UNDER_REPLICATED);
+    assertEquals(ORIGINAL_TIMESTAMP, row.getInStateSince());
+    assertEquals(1, row.getActualReplicaCount());
+    assertEquals("new reason", row.getReason());
+  }
+
+  @Test
+  public void testBatchDeleteStillRemovesAllScmStatesForContainer() {
+    insert(record(1L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0));
+    insert(record(1L, UnHealthyContainerStates.UNDER_REPLICATED, ORIGINAL_TIMESTAMP, 3, 2));
+    insert(record(1L, UnHealthyContainerStates.ALL_REPLICAS_BAD, ORIGINAL_TIMESTAMP, 3, 0));
+
+    schemaManager.batchDeleteSCMStatesForContainers(Collections.singletonList(1L));
+
+    assertEquals(1L, countRows());
     assertEquals(1L, countByState(UnHealthyContainerStates.ALL_REPLICAS_BAD));
   }
 
-  @Test
-  public void testDeleteShortRunsAndPointsCombinedInOneStatement() {
-    // Short contiguous runs of length >= MIN_RANGE_RUN_LENGTH become BETWEEN
-    // terms; runs of 1-2 ids stay as IN points. All are combined into a single
-    // bounded predicate. Inserted rows cover both deleted and surviving ids.
-    insertRange(1, 5, UnHealthyContainerStates.MISSING);      // range term
-    insertRange(20, 24, UnHealthyContainerStates.MISSING);    // range term
-    insertIds(UnHealthyContainerStates.MISSING, 40L, 41L);    // 2 points (kept short)
-    insertIds(UnHealthyContainerStates.MISSING, 60L);         // single point
-    // Survivors interleaved with the deleted ids.
-    insertIds(UnHealthyContainerStates.MISSING, 10L, 30L, 42L, 61L);
-
-    List<Long> idsToDelete = new ArrayList<>();
-    idsToDelete.addAll(contiguous(1, 5));
-    idsToDelete.addAll(contiguous(20, 24));
-    idsToDelete.addAll(Arrays.asList(40L, 41L, 60L));
-    Collections.shuffle(idsToDelete);
-
-    schemaManager.batchDeleteSCMStatesForContainers(idsToDelete);
-
-    assertEquals(Arrays.asList(10L, 30L, 42L, 61L), remainingContainerIds());
+  private void insert(UnhealthyContainerRecord record) {
+    schemaManager.insertUnhealthyContainerRecords(Collections.singletonList(record));
   }
 
-  @Test
-  public void testDeleteScatteredIdsSpanningMultipleStatements() {
-    // More scattered ids than fit in a single predicate, forcing the operand
-    // budget to flush across multiple DELETE statements.
-    int count = ContainerHealthSchemaManager.MAX_PREDICATE_OPERANDS + 50;
-    List<Long> idsToDelete = new ArrayList<>(count);
-    for (int k = 0; k < count; k++) {
-      // Even ids only -> every id is isolated (no contiguous runs).
-      long id = 2L * (k + 1);
-      insertIds(UnHealthyContainerStates.UNDER_REPLICATED, id);
-      idsToDelete.add(id);
+  private UnhealthyContainerRecord record(long id, UnHealthyContainerStates state,
+      long timestamp, int expected, int actual) {
+    return record(id, state, timestamp, expected, actual, "test");
+  }
+
+  private UnhealthyContainerRecord record(long id, UnHealthyContainerStates state,
+      long timestamp, int expected, int actual, String reason) {
+    return new UnhealthyContainerRecord(id, state.toString(), timestamp,
+        expected, actual, expected - actual, reason);
+  }
+
+  private ContainerStateKey key(long id, UnHealthyContainerStates state) {
+    return new ContainerStateKey(id, state.toString());
+  }
+
+  private Map<ContainerStateKey, Long> existingMap(ContainerStateKey... keys) {
+    Map<ContainerStateKey, Long> existing = new HashMap<>();
+    for (ContainerStateKey key : keys) {
+      existing.put(key, ORIGINAL_TIMESTAMP);
     }
-    // A survivor that must remain untouched.
-    insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 1L);
-
-    schemaManager.batchDeleteSCMStatesForContainers(idsToDelete);
-
-    assertEquals(Collections.singletonList(1L), remainingContainerIds());
-  }
-
-  private void insertRange(long startInclusive, long endInclusive,
-      UnHealthyContainerStates state) {
-    List<UnhealthyContainerRecord> records = new ArrayList<>();
-    for (long id = startInclusive; id <= endInclusive; id++) {
-      records.add(record(id, state));
-    }
-    schemaManager.insertUnhealthyContainerRecords(records);
-  }
-
-  private void insertIds(UnHealthyContainerStates state, long... ids) {
-    List<UnhealthyContainerRecord> records = new ArrayList<>();
-    for (long id : ids) {
-      records.add(record(id, state));
-    }
-    schemaManager.insertUnhealthyContainerRecords(records);
-  }
-
-  private UnhealthyContainerRecord record(long id, UnHealthyContainerStates state) {
-    return new UnhealthyContainerRecord(id, state.toString(), 1L, 3, 2, 1, "test");
-  }
-
-  private List<Long> contiguous(long startInclusive, long endInclusive) {
-    List<Long> ids = new ArrayList<>();
-    for (long id = startInclusive; id <= endInclusive; id++) {
-      ids.add(id);
-    }
-    return ids;
+    return existing;
   }
 
   private List<Long> remainingContainerIds() {
@@ -196,9 +176,25 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
         .fetch(UNHEALTHY_CONTAINERS.CONTAINER_ID);
   }
 
+  private long countRows() {
+    DSLContext dsl = schemaDefinition.getDSLContext();
+    return dsl.fetchCount(UNHEALTHY_CONTAINERS);
+  }
+
   private long countByState(UnHealthyContainerStates state) {
     DSLContext dsl = schemaDefinition.getDSLContext();
     return dsl.fetchCount(dsl.selectFrom(UNHEALTHY_CONTAINERS)
         .where(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString())));
+  }
+
+  private UnhealthyContainerRecord fetchRow(long id, UnHealthyContainerStates state) {
+    List<UnhealthyContainerRecord> rows = schemaManager.getUnhealthyContainers(
+        state, 0, 0, 100);
+    for (UnhealthyContainerRecord row : rows) {
+      if (row.getContainerId() == id) {
+        return row;
+      }
+    }
+    throw new AssertionError("Row not found for container " + id + " state " + state);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestContainerHealthSchemaManager.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.persistence;
+
+import static org.apache.ozone.recon.schema.generated.tables.UnhealthyContainersTable.UNHEALTHY_CONTAINERS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.UnhealthyContainerRecord;
+import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
+import org.apache.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Functional tests for {@link ContainerHealthSchemaManager} delete handling.
+ *
+ * <p>{@code deleteScmStatesForContainers} coalesces long contiguous container
+ * id runs into single range ({@code BETWEEN}) deletes while folding shorter
+ * runs and scattered ids into chunked {@code IN} deletes. These tests assert
+ * that both paths remove exactly the requested rows for contiguous, scattered,
+ * and mixed id distributions, and that non-SCM states are never removed.</p>
+ */
+public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
+
+  private ContainerSchemaDefinition schemaDefinition;
+  private ContainerHealthSchemaManager schemaManager;
+
+  @BeforeEach
+  public void setUpSchemaManager() {
+    schemaDefinition = getSchemaDefinition(ContainerSchemaDefinition.class);
+    schemaManager =
+        new ContainerHealthSchemaManager(schemaDefinition, new OzoneConfiguration());
+  }
+
+  @Test
+  public void testDeleteContiguousRangeRemovesExactlyRequestedRows() {
+    // A run long enough to be removed through the range-delete path.
+    int runLength = ContainerHealthSchemaManager.MIN_RANGE_DELETE_RUN + 200;
+    insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
+    // Survivors that are not part of the delete list.
+    insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 5000L, 5002L, 5004L);
+
+    List<Long> idsToDelete = contiguous(1, runLength);
+    idsToDelete.add(1L);              // duplicate -> must be de-duplicated
+    Collections.shuffle(idsToDelete); // unsorted -> must be sorted internally
+
+    schemaManager.batchDeleteSCMStatesForContainers(idsToDelete);
+
+    assertEquals(Arrays.asList(5000L, 5002L, 5004L), remainingContainerIds());
+  }
+
+  @Test
+  public void testDeleteScatteredIdsRemovesExactlyRequestedRows() {
+    for (long id = 1; id <= 10; id++) {
+      insertIds(UnHealthyContainerStates.MISSING, id);
+    }
+
+    // Delete only the odd ids, supplied out of order.
+    schemaManager.batchDeleteSCMStatesForContainers(
+        new ArrayList<>(Arrays.asList(9L, 1L, 5L, 7L, 3L)));
+
+    assertEquals(Arrays.asList(2L, 4L, 6L, 8L, 10L), remainingContainerIds());
+  }
+
+  @Test
+  public void testDeleteMixedRunAndScatteredRemovesExactlyRequestedRows() {
+    int runLength = ContainerHealthSchemaManager.MIN_RANGE_DELETE_RUN + 100;
+    insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
+    insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 9001L, 9003L, 9005L);
+    // Survivor not present in the delete list.
+    insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 9004L);
+
+    List<Long> idsToDelete = contiguous(1, runLength);
+    idsToDelete.add(9001L);
+    idsToDelete.add(9003L);
+    idsToDelete.add(9005L);
+
+    schemaManager.batchDeleteSCMStatesForContainers(idsToDelete);
+
+    assertEquals(Collections.singletonList(9004L), remainingContainerIds());
+  }
+
+  @Test
+  public void testDeletePreservesNonScmStateInsideRange() {
+    int runLength = ContainerHealthSchemaManager.MIN_RANGE_DELETE_RUN + 100;
+    insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
+    // ALL_REPLICAS_BAD is not an SCM-generated state, so it must survive even
+    // though container 50 falls inside the deleted [1, runLength] range.
+    insertIds(UnHealthyContainerStates.ALL_REPLICAS_BAD, 50L);
+
+    schemaManager.batchDeleteSCMStatesForContainers(contiguous(1, runLength));
+
+    assertEquals(Collections.singletonList(50L), remainingContainerIds());
+    assertEquals(0L, countByState(UnHealthyContainerStates.UNDER_REPLICATED));
+    assertEquals(1L, countByState(UnHealthyContainerStates.ALL_REPLICAS_BAD));
+  }
+
+  private void insertRange(long startInclusive, long endInclusive,
+      UnHealthyContainerStates state) {
+    List<UnhealthyContainerRecord> records = new ArrayList<>();
+    for (long id = startInclusive; id <= endInclusive; id++) {
+      records.add(record(id, state));
+    }
+    schemaManager.insertUnhealthyContainerRecords(records);
+  }
+
+  private void insertIds(UnHealthyContainerStates state, long... ids) {
+    List<UnhealthyContainerRecord> records = new ArrayList<>();
+    for (long id : ids) {
+      records.add(record(id, state));
+    }
+    schemaManager.insertUnhealthyContainerRecords(records);
+  }
+
+  private UnhealthyContainerRecord record(long id, UnHealthyContainerStates state) {
+    return new UnhealthyContainerRecord(id, state.toString(), 1L, 3, 2, 1, "test");
+  }
+
+  private List<Long> contiguous(long startInclusive, long endInclusive) {
+    List<Long> ids = new ArrayList<>();
+    for (long id = startInclusive; id <= endInclusive; id++) {
+      ids.add(id);
+    }
+    return ids;
+  }
+
+  private List<Long> remainingContainerIds() {
+    DSLContext dsl = schemaDefinition.getDSLContext();
+    return dsl.selectDistinct(UNHEALTHY_CONTAINERS.CONTAINER_ID)
+        .from(UNHEALTHY_CONTAINERS)
+        .orderBy(UNHEALTHY_CONTAINERS.CONTAINER_ID.asc())
+        .fetch(UNHEALTHY_CONTAINERS.CONTAINER_ID);
+  }
+
+  private long countByState(UnHealthyContainerStates state) {
+    DSLContext dsl = schemaDefinition.getDSLContext();
+    return dsl.fetchCount(dsl.selectFrom(UNHEALTHY_CONTAINERS)
+        .where(UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString())));
+  }
+}

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestContainerHealthSchemaManager.java
@@ -55,8 +55,8 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
 
   @Test
   public void testDeleteContiguousRangeRemovesExactlyRequestedRows() {
-    // A run long enough to be removed through the range-delete path.
-    int runLength = ContainerHealthSchemaManager.MIN_RANGE_DELETE_RUN + 200;
+    // A contiguous run (>= MIN_RANGE_RUN_LENGTH) is removed via the range path.
+    int runLength = ContainerHealthSchemaManager.MIN_RANGE_RUN_LENGTH + 50;
     insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
     // Survivors that are not part of the delete list.
     insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 5000L, 5002L, 5004L);
@@ -85,7 +85,7 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
 
   @Test
   public void testDeleteMixedRunAndScatteredRemovesExactlyRequestedRows() {
-    int runLength = ContainerHealthSchemaManager.MIN_RANGE_DELETE_RUN + 100;
+    int runLength = ContainerHealthSchemaManager.MIN_RANGE_RUN_LENGTH + 50;
     insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
     insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 9001L, 9003L, 9005L);
     // Survivor not present in the delete list.
@@ -103,7 +103,7 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
 
   @Test
   public void testDeletePreservesNonScmStateInsideRange() {
-    int runLength = ContainerHealthSchemaManager.MIN_RANGE_DELETE_RUN + 100;
+    int runLength = ContainerHealthSchemaManager.MIN_RANGE_RUN_LENGTH + 100;
     insertRange(1, runLength, UnHealthyContainerStates.UNDER_REPLICATED);
     // ALL_REPLICAS_BAD is not an SCM-generated state, so it must survive even
     // though container 50 falls inside the deleted [1, runLength] range.
@@ -114,6 +114,49 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
     assertEquals(Collections.singletonList(50L), remainingContainerIds());
     assertEquals(0L, countByState(UnHealthyContainerStates.UNDER_REPLICATED));
     assertEquals(1L, countByState(UnHealthyContainerStates.ALL_REPLICAS_BAD));
+  }
+
+  @Test
+  public void testDeleteShortRunsAndPointsCombinedInOneStatement() {
+    // Short contiguous runs of length >= MIN_RANGE_RUN_LENGTH become BETWEEN
+    // terms; runs of 1-2 ids stay as IN points. All are combined into a single
+    // bounded predicate. Inserted rows cover both deleted and surviving ids.
+    insertRange(1, 5, UnHealthyContainerStates.MISSING);      // range term
+    insertRange(20, 24, UnHealthyContainerStates.MISSING);    // range term
+    insertIds(UnHealthyContainerStates.MISSING, 40L, 41L);    // 2 points (kept short)
+    insertIds(UnHealthyContainerStates.MISSING, 60L);         // single point
+    // Survivors interleaved with the deleted ids.
+    insertIds(UnHealthyContainerStates.MISSING, 10L, 30L, 42L, 61L);
+
+    List<Long> idsToDelete = new ArrayList<>();
+    idsToDelete.addAll(contiguous(1, 5));
+    idsToDelete.addAll(contiguous(20, 24));
+    idsToDelete.addAll(Arrays.asList(40L, 41L, 60L));
+    Collections.shuffle(idsToDelete);
+
+    schemaManager.batchDeleteSCMStatesForContainers(idsToDelete);
+
+    assertEquals(Arrays.asList(10L, 30L, 42L, 61L), remainingContainerIds());
+  }
+
+  @Test
+  public void testDeleteScatteredIdsSpanningMultipleStatements() {
+    // More scattered ids than fit in a single predicate, forcing the operand
+    // budget to flush across multiple DELETE statements.
+    int count = ContainerHealthSchemaManager.MAX_PREDICATE_OPERANDS + 50;
+    List<Long> idsToDelete = new ArrayList<>(count);
+    for (int k = 0; k < count; k++) {
+      // Even ids only -> every id is isolated (no contiguous runs).
+      long id = 2L * (k + 1);
+      insertIds(UnHealthyContainerStates.UNDER_REPLICATED, id);
+      idsToDelete.add(id);
+    }
+    // A survivor that must remain untouched.
+    insertIds(UnHealthyContainerStates.UNDER_REPLICATED, 1L);
+
+    schemaManager.batchDeleteSCMStatesForContainers(idsToDelete);
+
+    assertEquals(Collections.singletonList(1L), remainingContainerIds());
   }
 
   private void insertRange(long startInclusive, long endInclusive,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestContainerHealthSchemaManager.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -55,7 +54,7 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
 
   @Test
   public void testSyncInsertsNewUnhealthyRecords() {
-    Map<ContainerStateKey, Long> existing = Collections.emptyMap();
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing = Collections.emptyMap();
     List<UnhealthyContainerRecord> desired = Arrays.asList(
         record(1L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0),
         record(2L, UnHealthyContainerStates.UNDER_REPLICATED, ORIGINAL_TIMESTAMP, 3, 2));
@@ -72,10 +71,7 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
     insert(record(1L, UnHealthyContainerStates.UNDER_REPLICATED, ORIGINAL_TIMESTAMP, 3, 2));
     insert(record(2L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0));
 
-    Map<ContainerStateKey, Long> existing = existingMap(
-        key(1L, UnHealthyContainerStates.MISSING),
-        key(1L, UnHealthyContainerStates.UNDER_REPLICATED),
-        key(2L, UnHealthyContainerStates.MISSING));
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing = existingFor(1L, 2L);
 
     // Container 1 recovered; container 2 still missing.
     List<UnhealthyContainerRecord> desired = Collections.singletonList(
@@ -91,8 +87,7 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
   public void testSyncUpdatesExistingRowAndDeletesChangedState() {
     insert(record(1L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0));
 
-    Map<ContainerStateKey, Long> existing = existingMap(
-        key(1L, UnHealthyContainerStates.MISSING));
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing = existingFor(1L);
 
     // Same container now under-replicated instead of missing.
     List<UnhealthyContainerRecord> desired = Collections.singletonList(
@@ -113,8 +108,7 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
     insert(record(1L, UnHealthyContainerStates.UNDER_REPLICATED,
         ORIGINAL_TIMESTAMP, 3, 2, "old reason"));
 
-    Map<ContainerStateKey, Long> existing = existingMap(
-        key(1L, UnHealthyContainerStates.UNDER_REPLICATED));
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing = existingFor(1L);
 
     List<UnhealthyContainerRecord> desired = Collections.singletonList(
         record(1L, UnHealthyContainerStates.UNDER_REPLICATED,
@@ -127,6 +121,48 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
     assertEquals(ORIGINAL_TIMESTAMP, row.getInStateSince());
     assertEquals(1, row.getActualReplicaCount());
     assertEquals("new reason", row.getReason());
+  }
+
+  @Test
+  public void testSyncDeletesScmStateButPreservesNonScmState() {
+    // Non-SCM state (ALL_REPLICAS_BAD) and an SCM state (MISSING) for the same container.
+    insert(record(1L, UnHealthyContainerStates.ALL_REPLICAS_BAD, ORIGINAL_TIMESTAMP, 3, 0));
+    insert(record(1L, UnHealthyContainerStates.MISSING, ORIGINAL_TIMESTAMP, 3, 0));
+
+    // The existing map only carries SCM-generated states; ALL_REPLICAS_BAD is excluded by the loader.
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing = existingFor(1L);
+
+    // Current scan reports container 1 is no longer unhealthy in any SCM state.
+    List<UnhealthyContainerRecord> desired = Collections.emptyList();
+
+    schemaManager.syncUnhealthyContainerRecordsAtomically(existing, desired);
+
+    assertEquals(0L, countByState(UnHealthyContainerStates.MISSING),
+        "SCM-generated MISSING row should be deleted when the container recovers");
+    assertEquals(1L, countByState(UnHealthyContainerStates.ALL_REPLICAS_BAD),
+        "Non-SCM ALL_REPLICAS_BAD row must be preserved by sync");
+    assertEquals(1L, countRows());
+  }
+
+  @Test
+  public void testSyncLeavesRowUnchangedWhenContentIdentical() {
+    insert(record(1L, UnHealthyContainerStates.UNDER_REPLICATED,
+        ORIGINAL_TIMESTAMP, 3, 2, "reason"));
+
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing = existingFor(1L);
+
+    // Desired result is identical to what is already persisted, so no write is needed.
+    List<UnhealthyContainerRecord> desired = Collections.singletonList(
+        record(1L, UnHealthyContainerStates.UNDER_REPLICATED,
+            ORIGINAL_TIMESTAMP, 3, 2, "reason"));
+
+    schemaManager.syncUnhealthyContainerRecordsAtomically(existing, desired);
+
+    assertEquals(1L, countRows());
+    UnhealthyContainerRecord row = fetchRow(1L, UnHealthyContainerStates.UNDER_REPLICATED);
+    assertEquals(ORIGINAL_TIMESTAMP, row.getInStateSince());
+    assertEquals(2, row.getActualReplicaCount());
+    assertEquals("reason", row.getReason());
   }
 
   @Test
@@ -156,16 +192,8 @@ public class TestContainerHealthSchemaManager extends AbstractReconSqlDBTest {
         expected, actual, expected - actual, reason);
   }
 
-  private ContainerStateKey key(long id, UnHealthyContainerStates state) {
-    return new ContainerStateKey(id, state.toString());
-  }
-
-  private Map<ContainerStateKey, Long> existingMap(ContainerStateKey... keys) {
-    Map<ContainerStateKey, Long> existing = new HashMap<>();
-    for (ContainerStateKey key : keys) {
-      existing.put(key, ORIGINAL_TIMESTAMP);
-    }
-    return existing;
+  private Map<ContainerStateKey, UnhealthyContainerRecord> existingFor(Long... ids) {
+    return schemaManager.getExistingUnhealthyRecordsByContainerIds(Arrays.asList(ids));
   }
 
   private List<Long> remainingContainerIds() {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -608,10 +608,10 @@ public class TestUnhealthyContainersDerbyPerformance {
 
   /**
    * Exercises the same persistence pattern used by Recon health scan chunks:
-   * delete and insert in a single transaction.
+   * sync existing rows with the current scan result in a single transaction.
    *
-   * <p>This validates that {@link ContainerHealthSchemaManager#replaceUnhealthyContainerRecordsAtomically}
-   * can safely replace a large chunk without changing total row count and
+   * <p>This validates that {@link ContainerHealthSchemaManager#syncUnhealthyContainerRecordsAtomically}
+   * can safely refresh a large chunk without changing total row count and
    * that rewritten records are visible with the new timestamp.</p>
    */
   @Test
@@ -621,28 +621,30 @@ public class TestUnhealthyContainersDerbyPerformance {
     long replacementTimestamp = System.currentTimeMillis() + 10_000;
     int expectedRowsReplaced = replaceContainerCount * STATE_COUNT;
 
-    LOG.info("--- Test 7: Atomic replace — {} IDs × {} states = {} rows in one tx ---",
+    LOG.info("--- Test 7: Atomic sync — {} IDs × {} states = {} rows in one tx ---",
         replaceContainerCount, STATE_COUNT, expectedRowsReplaced);
 
     List<Long> idsToReplace = new ArrayList<>(replaceContainerCount);
     for (long id = 1; id <= replaceContainerCount; id++) {
       idsToReplace.add(id);
     }
+    Map<ContainerHealthSchemaManager.ContainerStateKey, Long> existing =
+        schemaManager.getExistingInStateSinceByContainerIds(idsToReplace);
     List<UnhealthyContainerRecord> replacementRecords =
         generateRecordsForRange(1, replaceContainerCount, replacementTimestamp);
 
     long start = System.nanoTime();
-    schemaManager.replaceUnhealthyContainerRecordsAtomically(idsToReplace, replacementRecords);
+    schemaManager.syncUnhealthyContainerRecordsAtomically(existing, replacementRecords);
     long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-    LOG.info("Atomic replace completed in {} ms", elapsedMs);
+    LOG.info("Atomic sync completed in {} ms", elapsedMs);
 
     assertTrue(elapsedMs <= TimeUnit.SECONDS.toMillis(MAX_ATOMIC_REPLACE_SECONDS),
-        String.format("Atomic replace took %d ms, exceeded %d s threshold",
+        String.format("Atomic sync took %d ms, exceeded %d s threshold",
             elapsedMs, MAX_ATOMIC_REPLACE_SECONDS));
 
     long totalCount = dao.count();
     assertEquals(TOTAL_RECORDS, totalCount,
-        "Atomic replace should not change total row count");
+        "Atomic sync should not change total row count");
 
     List<ContainerHealthSchemaManager.UnhealthyContainerRecord> firstPage =
         schemaManager.getUnhealthyContainers(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -628,8 +628,8 @@ public class TestUnhealthyContainersDerbyPerformance {
     for (long id = 1; id <= replaceContainerCount; id++) {
       idsToReplace.add(id);
     }
-    Map<ContainerHealthSchemaManager.ContainerStateKey, Long> existing =
-        schemaManager.getExistingInStateSinceByContainerIds(idsToReplace);
+    Map<ContainerHealthSchemaManager.ContainerStateKey, UnhealthyContainerRecord> existing =
+        schemaManager.getExistingUnhealthyRecordsByContainerIds(idsToReplace);
     List<UnhealthyContainerRecord> replacementRecords =
         generateRecordsForRange(1, replaceContainerCount, replacementTimestamp);
 
@@ -683,11 +683,11 @@ public class TestUnhealthyContainersDerbyPerformance {
     }
 
     long start = System.nanoTime();
-    Map<ContainerHealthSchemaManager.ContainerStateKey, Long> existing =
-        schemaManager.getExistingInStateSinceByContainerIds(containerIds);
+    Map<ContainerHealthSchemaManager.ContainerStateKey, UnhealthyContainerRecord> existing =
+        schemaManager.getExistingUnhealthyRecordsByContainerIds(containerIds);
     long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
 
-    LOG.info("Large in-state-since lookup complete: {} container IDs -> {} rows in {} ms",
+    LOG.info("Large existing-record lookup complete: {} container IDs -> {} rows in {} ms",
         lookupCount, existing.size(), elapsedMs);
 
     assertEquals(expectedRecords, existing.size(),

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -221,28 +221,38 @@ public class TestUnhealthyContainersDerbyPerformance {
   // One-time setup: create Derby schema + insert 1 M records
   // -----------------------------------------------------------------------
 
-  private String inMemoryDbName;
+  private String resolvedJdbcUrl;
 
   /**
-   * Initialises the embedded in-memory Derby database and creates the Recon schema.
+   * Initialises an in-memory Derby database and creates the Recon schema so the
+   * benchmark measures pure engine cost without disk I/O. The file-based
+   * counterpart lives in {@link TestUnhealthyContainersFileBasedSyncBenchmark}.
    * Data population is done in dedicated test methods.
-   *
-   * <p>Reuses {@link DerbyDataSourceConfigurationProvider} for all connection settings
-   * and overrides only {@code getJdbcUrl()} to use an in-memory Derby database
-   * ({@code jdbc:derby:memory:...}), eliminating disk I/O and fsync overhead across
-   * the benchmark's insert, replace, and delete transactions.</p>
    */
   @BeforeAll
   public void setUpDatabase(@TempDir Path tempDir) throws Exception {
-    inMemoryDbName = "reconPerf_" + java.util.UUID.randomUUID().toString();
+    resolvedJdbcUrl = "jdbc:derby:memory:reconPerf_" + java.util.UUID.randomUUID();
     LOG.info("=== Derby Performance Benchmark — Setup ===");
+    LOG.info("JDBC URL: {}", resolvedJdbcUrl);
     LOG.info("Dataset: {} states × {} container IDs = {} total records",
         TESTED_STATES.size(), CONTAINER_ID_RANGE, TOTAL_RECORDS);
 
+    Injector injector = createDerbyInjector(tempDir, resolvedJdbcUrl);
+    dao = injector.getInstance(UnhealthyContainersDao.class);
+    schemaDefinition = injector.getInstance(ContainerSchemaDefinition.class);
+    schemaManager = new ContainerHealthSchemaManager(schemaDefinition, new OzoneConfiguration());
+  }
+
+  /**
+   * Builds a Guice injector wired to a Derby database at {@code jdbcUrl} and
+   * creates the Recon schema. Shared by the in-memory benchmark and the
+   * file-based sync benchmark so both reuse identical connection settings.
+   */
+  static Injector createDerbyInjector(Path tempDir, String jdbcUrl) throws Exception {
     File configDir = Files.createDirectory(tempDir.resolve("Config")).toFile();
     DataSourceConfiguration base = new DerbyDataSourceConfigurationProvider(configDir).get();
 
-    // Reuse DerbyDataSourceConfigurationProvider settings but point to an in-memory DB.
+    // Reuse DerbyDataSourceConfigurationProvider settings but point to the given URL.
     Provider<DataSourceConfiguration> configProvider = () -> new DataSourceConfiguration() {
       @Override
       public String getDriverClass() {
@@ -251,7 +261,7 @@ public class TestUnhealthyContainersDerbyPerformance {
 
       @Override
       public String getJdbcUrl() {
-        return "jdbc:derby:memory:" + inMemoryDbName;
+        return jdbcUrl;
       }
 
       @Override
@@ -318,22 +328,32 @@ public class TestUnhealthyContainersDerbyPerformance {
         new ReconDaoBindingModule());
 
     injector.getInstance(ReconSchemaManager.class).createReconSchema();
-
-    dao = injector.getInstance(UnhealthyContainersDao.class);
-    schemaDefinition = injector.getInstance(ContainerSchemaDefinition.class);
-    schemaManager = new ContainerHealthSchemaManager(schemaDefinition, new OzoneConfiguration());
+    return injector;
   }
 
   @AfterAll
   public void tearDownDatabase() {
-    if (inMemoryDbName != null) {
-      try (java.sql.Connection conn = java.sql.DriverManager.getConnection(
-          "jdbc:derby:memory:" + inMemoryDbName + ";drop=true")) {
-        conn.isValid(1);
-      } catch (java.sql.SQLException e) {
-        if (!"08006".equals(e.getSQLState())) {
-          LOG.warn("Unexpected SQLState while dropping in-memory Derby DB: {}", e.getSQLState(), e);
-        }
+    teardownDerbyDatabase(resolvedJdbcUrl, LOG);
+  }
+
+  /**
+   * Drops an in-memory Derby DB or shuts down a file-based one (its temp dir is
+   * removed by JUnit). Shared by both benchmark classes.
+   */
+  static void teardownDerbyDatabase(String jdbcUrl, Logger log) {
+    if (jdbcUrl == null) {
+      return;
+    }
+    // Drop an in-memory DB; shut down a file-based DB (its temp dir is removed by JUnit).
+    String teardownUrl = jdbcUrl.contains(":memory:")
+        ? jdbcUrl + ";drop=true"
+        : jdbcUrl.replace(";create=true", "") + ";shutdown=true";
+    try (java.sql.Connection conn = java.sql.DriverManager.getConnection(teardownUrl)) {
+      conn.isValid(1);
+    } catch (java.sql.SQLException e) {
+      // Derby signals a successful drop/shutdown with SQLState 08006.
+      if (!"08006".equals(e.getSQLState())) {
+        log.warn("Unexpected SQLState while tearing down Derby DB: {}", e.getSQLState(), e);
       }
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersFileBasedSyncBenchmark.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersFileBasedSyncBenchmark.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.persistence;
+
+import static org.apache.ozone.recon.schema.generated.tables.UnhealthyContainersTable.UNHEALTHY_CONTAINERS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.inject.Injector;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.ContainerStateKey;
+import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager.UnhealthyContainerRecord;
+import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
+import org.apache.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Measures {@link ContainerHealthSchemaManager#syncUnhealthyContainerRecordsAtomically}
+ * against a <b>file-based</b> Derby database, which is the storage mode Recon
+ * actually uses in production (the sibling {@code TestUnhealthyContainersDerbyPerformance}
+ * runs in-memory to isolate engine cost).
+ *
+ * <p>The scenario mirrors one steady-state health-scan chunk rather than a
+ * worst-case full rewrite: {@value #CHUNK_CONTAINERS} containers are already
+ * tracked (one production {@code PERSIST_CHUNK_SIZE}), and the current scan
+ * leaves most of them unchanged. Only a small fraction changed replica counts
+ * or recovered, so sync should skip the unchanged majority and issue writes for
+ * just the churn. This is the case the change-detection + batching work is meant
+ * to make cheap on disk.</p>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestUnhealthyContainersFileBasedSyncBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestUnhealthyContainersFileBasedSyncBenchmark.class);
+
+  /** One production PERSIST_CHUNK_SIZE worth of already-tracked unhealthy containers. */
+  private static final int CHUNK_CONTAINERS = 50_000;
+
+  /** Rows committed per seed transaction, bounding Derby's write-ahead log growth. */
+  private static final int SEED_TX_SIZE = 2_000;
+
+  private static final long IN_STATE_SINCE = 1_000L;
+  private static final int EXPECTED_REPLICAS = 3;
+  private static final int HEALTHY_ACTUAL = 2;
+  private static final int DEGRADED_ACTUAL = 1;
+  private static final String REASON = "Insufficient replicas";
+
+  /** Generous CI-safe ceiling; a steady-state chunk should finish in a few seconds. */
+  private static final long MAX_SYNC_SECONDS = 120;
+
+  private ContainerHealthSchemaManager schemaManager;
+  private ContainerSchemaDefinition schemaDefinition;
+  private String jdbcUrl;
+
+  @BeforeAll
+  public void setUp(@TempDir Path tempDir) throws Exception {
+    jdbcUrl = "jdbc:derby:" + tempDir.resolve("reconSyncDb").toAbsolutePath() + ";create=true";
+    LOG.info("=== File-based Derby sync benchmark — Setup ({}) ===", jdbcUrl);
+
+    Injector injector =
+        TestUnhealthyContainersDerbyPerformance.createDerbyInjector(tempDir, jdbcUrl);
+    schemaDefinition = injector.getInstance(ContainerSchemaDefinition.class);
+    schemaManager = new ContainerHealthSchemaManager(schemaDefinition, new OzoneConfiguration());
+
+    seedTrackedContainers();
+  }
+
+  @AfterAll
+  public void tearDown() {
+    TestUnhealthyContainersDerbyPerformance.teardownDerbyDatabase(jdbcUrl, LOG);
+  }
+
+  @Test
+  public void benchmarkSteadyStateSyncOnFileBasedDerby() {
+    List<Long> containerIds = new ArrayList<>(CHUNK_CONTAINERS);
+    for (long id = 1; id <= CHUNK_CONTAINERS; id++) {
+      containerIds.add(id);
+    }
+
+    // Production loads existing rows once per chunk before syncing.
+    Map<ContainerStateKey, UnhealthyContainerRecord> existing =
+        schemaManager.getExistingUnhealthyRecordsByContainerIds(containerIds);
+    assertEquals(CHUNK_CONTAINERS, existing.size(),
+        "All seeded containers should be loaded as existing rows");
+
+    // Build this scan's result with realistic churn keyed off container id:
+    //   id % 100 in {0,1,2} -> recovered (omitted -> stale delete)  ~3%
+    //   id % 100 in [3,10)  -> changed replica count (-> update)    ~7%
+    //   otherwise           -> unchanged (identical -> skipped)     ~90%
+    List<UnhealthyContainerRecord> desired = new ArrayList<>();
+    int recovered = 0;
+    int changed = 0;
+    int unchanged = 0;
+    for (long id = 1; id <= CHUNK_CONTAINERS; id++) {
+      long bucket = id % 100;
+      if (bucket < 3) {
+        recovered++;
+      } else if (bucket < 10) {
+        desired.add(record(id, DEGRADED_ACTUAL));
+        changed++;
+      } else {
+        desired.add(record(id, HEALTHY_ACTUAL));
+        unchanged++;
+      }
+    }
+
+    long start = System.nanoTime();
+    schemaManager.syncUnhealthyContainerRecordsAtomically(existing, desired);
+    long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+    LOG.info("File-based steady-state sync: {} tracked, {} unchanged (skipped), "
+            + "{} updated, {} recovered (deleted) in {} ms",
+        CHUNK_CONTAINERS, unchanged, changed, recovered, elapsedMs);
+
+    assertTrue(elapsedMs <= TimeUnit.SECONDS.toMillis(MAX_SYNC_SECONDS),
+        String.format("Steady-state sync took %d ms, exceeded %d s threshold",
+            elapsedMs, MAX_SYNC_SECONDS));
+
+    DSLContext dsl = schemaDefinition.getDSLContext();
+    assertEquals(CHUNK_CONTAINERS - recovered, dsl.fetchCount(UNHEALTHY_CONTAINERS),
+        "Only recovered containers should have been deleted");
+    assertFalse(rowExists(dsl, 100L), "Recovered container 100 should be deleted");
+    assertEquals(DEGRADED_ACTUAL, actualReplicaCount(dsl, 5L),
+        "Changed container 5 should carry the updated replica count");
+    assertEquals(HEALTHY_ACTUAL, actualReplicaCount(dsl, 50L),
+        "Unchanged container 50 should retain its original replica count");
+  }
+
+  private void seedTrackedContainers() {
+    List<UnhealthyContainerRecord> batch = new ArrayList<>(SEED_TX_SIZE);
+    for (long id = 1; id <= CHUNK_CONTAINERS; id++) {
+      batch.add(record(id, HEALTHY_ACTUAL));
+      if (batch.size() == SEED_TX_SIZE) {
+        schemaManager.insertUnhealthyContainerRecords(batch);
+        batch.clear();
+      }
+    }
+    if (!batch.isEmpty()) {
+      schemaManager.insertUnhealthyContainerRecords(batch);
+    }
+  }
+
+  private UnhealthyContainerRecord record(long id, int actualReplicas) {
+    return new UnhealthyContainerRecord(id,
+        UnHealthyContainerStates.UNDER_REPLICATED.toString(),
+        IN_STATE_SINCE, EXPECTED_REPLICAS, actualReplicas,
+        EXPECTED_REPLICAS - actualReplicas, REASON);
+  }
+
+  private boolean rowExists(DSLContext dsl, long id) {
+    return dsl.fetchExists(dsl.selectFrom(UNHEALTHY_CONTAINERS)
+        .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.eq(id)));
+  }
+
+  private int actualReplicaCount(DSLContext dsl, long id) {
+    return dsl.select(UNHEALTHY_CONTAINERS.ACTUAL_REPLICA_COUNT)
+        .from(UNHEALTHY_CONTAINERS)
+        .where(UNHEALTHY_CONTAINERS.CONTAINER_ID.eq(id))
+        .fetchOne(UNHEALTHY_CONTAINERS.ACTUAL_REPLICA_COUNT);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Coalesce contiguous container IDs into range deletes in ContainerHealthSchemaManager

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15601

## How was this patch tested?
Added unit test to cover the code changes
