### PR TITLE
HDDS-15621. TestSecureOzoneCluster fails locally

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -63,7 +63,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -541,9 +540,9 @@ final class TestSecureOzoneCluster {
       conf.setTimeDuration(OMConfigKeys.DELEGATION_TOKEN_MAX_LIFETIME_KEY, 7, TimeUnit.DAYS);
       IllegalArgumentException exception = assertThrows(
           IllegalArgumentException.class, () -> setupOm(conf));
-      assertTrue(exception.getMessage().contains("Secret key expiry duration hdds.secret.key.expiry.duration "  +
+      assertThat(exception.getMessage()).contains("Secret key expiry duration hdds.secret.key.expiry.duration "  +
           "should be greater than value of (ozone.manager.delegation.token.max-lifetime + " +
-          "ozone.manager.delegation.remover.scan.interval + hdds.secret.key.rotate.duration"));
+          "ozone.manager.delegation.remover.scan.interval + hdds.secret.key.rotate.duration");
     } finally {
       if (scm != null) {
         scm.stop();
@@ -1357,14 +1356,11 @@ final class TestSecureOzoneCluster {
     assertThat(cn).isEqualTo(SCM_SUB_CA + "@localhost");
 
     LocalDate today = ZonedDateTime.now().toLocalDate();
-    Date invalidDate;
 
     // Make sure the end date is honored.
-    invalidDate = java.sql.Date.valueOf(today.plus(1, ChronoUnit.DAYS));
-    assertTrue(cert.getNotAfter().after(invalidDate));
-
-    invalidDate = java.sql.Date.valueOf(today.plus(400, ChronoUnit.DAYS));
-    assertTrue(cert.getNotAfter().before(invalidDate));
+    assertThat(cert.getNotAfter())
+        .isAfter(java.sql.Date.valueOf(today.plus(1, ChronoUnit.DAYS)))
+        .isBefore(java.sql.Date.valueOf(today.plus(400, ChronoUnit.DAYS)));
 
     assertThat(cert.getSubjectDN().toString()).contains(scmId);
     assertThat(cert.getSubjectDN().toString()).contains(clusterId);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -1352,12 +1352,9 @@ final class TestSecureOzoneCluster {
     if (m.matches()) {
       cn = m.group(1);
     }
-    String hostName = InetAddress.getLocalHost().getHostName();
-
     // Subject name should be om login user in real world but in this test
     // UGI has scm user context.
-    assertThat(cn).contains(SCM_SUB_CA);
-    assertThat(cn).contains(hostName);
+    assertThat(cn).isEqualTo(SCM_SUB_CA + "@localhost");
 
     LocalDate today = ZonedDateTime.now().toLocalDate();
     Date invalidDate;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestSecureOzoneCluster` fails locally (also reproducible in `flaky-test-check`):

```
Expecting actual:
  "scm-sub@localhost"
to contain:
  "<hostname>" 
	at org.apache.hadoop.ozone.TestSecureOzoneCluster.validateCertificate(TestSecureOzoneCluster.java:1360)
	at org.apache.hadoop.ozone.TestSecureOzoneCluster.testSecureOmReInit(TestSecureOzoneCluster.java:883)
```

because SCM is configured to `localhost`:

https://github.com/apache/ozone/blob/f9552d0bb5818f3a15b90ee58b06a45c3631ae11/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java#L213

but the test expects the actual hostname in certificate issuer name.

Also improve assertions by replacing `assertTrue` with `assertThat`.

https://issues.apache.org/jira/browse/HDDS-15621

## How was this patch tested?

```
$ mvn -am -pl :ozone-integration-test -Dtest='TestSecureOzoneCluster' -DskipRecon clean test
...
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 232.2 s -- in org.apache.hadoop.ozone.TestSecureOzoneCluster
...
```