### PR TITLE
HDDS-15582. Skip performance test of unused batchDeleteSCMStatesForContainers

### DIFF
--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -717,7 +717,7 @@ public class TestUnhealthyContainersDerbyPerformance {
    */
   @Test
   @Order(9)
-  @Slow("HDDS-15882")
+  @Slow("HDDS-15582")
   public void testBatchDeletePerformanceOneMillionRecords() {
     int deleteCount = CONTAINER_ID_RANGE;               // 200 000 container IDs
     int expectedDeleted = deleteCount * STATE_COUNT;    // 1 000 000 rows
@@ -769,7 +769,7 @@ public class TestUnhealthyContainersDerbyPerformance {
    */
   @Test
   @Order(10)
-  @Slow("HDDS-15882")
+  @Slow("HDDS-15582")
   public void testCountByStateAfterFullDelete() {
     int expectedPerState = 0;
     LOG.info("--- Test 10: COUNT by state after full delete (expected {} each) ---",

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUnhealthyContainersDerbyPerformance.java
@@ -45,6 +45,7 @@ import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
 import org.apache.ozone.recon.schema.ReconSchemaGenerationModule;
 import org.apache.ozone.recon.schema.generated.tables.daos.UnhealthyContainersDao;
+import org.apache.ozone.test.tag.Slow;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -716,6 +717,7 @@ public class TestUnhealthyContainersDerbyPerformance {
    */
   @Test
   @Order(9)
+  @Slow("HDDS-15882")
   public void testBatchDeletePerformanceOneMillionRecords() {
     int deleteCount = CONTAINER_ID_RANGE;               // 200 000 container IDs
     int expectedDeleted = deleteCount * STATE_COUNT;    // 1 000 000 rows
@@ -767,6 +769,7 @@ public class TestUnhealthyContainersDerbyPerformance {
    */
   @Test
   @Order(10)
+  @Slow("HDDS-15882")
   public void testCountByStateAfterFullDelete() {
     int expectedPerState = 0;
     LOG.info("--- Test 10: COUNT by state after full delete (expected {} each) ---",


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ContainerHealthSchemaManager.batchDeleteSCMStatesForContainers` is only called from tests, production code uses `replaceUnhealthyContainerRecordsAtomically` instead.  This PR disables `TestUnhealthyContainersDerbyPerformance` test case for `batchDeleteSCMStatesForContainers` (and follow-up `testCountByStateAfterFullDelete`) in CI to save time.  The test can still be run locally.

https://issues.apache.org/jira/browse/HDDS-15582

## How was this patch tested?

Before:

```
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 314.6 s -- in org.apache.hadoop.ozone.recon.persistence.TestUnhealthyContainersDerbyPerformance
```

After:

```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 199.9 s -- in org.apache.hadoop.ozone.recon.persistence.TestUnhealthyContainersDerbyPerformance
```

https://github.com/adoroszlai/ozone/actions/runs/27824224044/job/82350278873#step:13:3745