### PR TITLE
HDDS-15623. Disk check may not completely read test file

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java
@@ -33,6 +33,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
+import org.apache.commons.io.IOUtils;
 import org.apache.ratis.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,7 +168,7 @@ public final class DiskCheckUtil {
       // Read data back from the test file.
       byte[] readBytes = new byte[numBytesToWrite];
       try (InputStream fis = Files.newInputStream(testFile.toPath())) {
-        int numBytesRead = fis.read(readBytes);
+        int numBytesRead = IOUtils.read(fis, readBytes);
         if (numBytesRead != numBytesToWrite) {
           logError(storageDir, String.format("%d bytes written to file %s " +
                   "but %d bytes were read back.", numBytesToWrite,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java
@@ -153,15 +153,18 @@ public final class DiskCheckUtil {
       } catch (SyncFailedException syncEx) {
         logError(storageDir, String.format("Could not sync file %s to disk.",
             testFile.getAbsolutePath()), syncEx);
+        FileUtils.deleteFileQuietly(testFile);
         return false;
       } catch (IOException ioEx) {
         String msg = ioEx.getMessage();
         if (msg != null && msg.contains(LINUX_DISK_FULL_MESSAGE)) {
           LOG.warn("Could not write file {} for volume check", testFile.getAbsolutePath(), ioEx);
+          FileUtils.deleteFileQuietly(testFile);
           return true;
         }
         logError(storageDir, String.format("Could not write file %s " +
             "for volume check.", testFile.getAbsolutePath()), ioEx);
+        FileUtils.deleteFileQuietly(testFile);
         return false;
       }
 
@@ -173,15 +176,18 @@ public final class DiskCheckUtil {
           logError(storageDir, String.format("%d bytes written to file %s " +
                   "but %d bytes were read back.", numBytesToWrite,
               testFile.getAbsolutePath(), numBytesRead));
+          FileUtils.deleteFileQuietly(testFile);
           return false;
         }
       } catch (FileNotFoundException | NoSuchFileException notFoundEx) {
         logError(storageDir, String.format("Could not find file %s " +
             "for volume check.", testFile.getAbsolutePath()), notFoundEx);
+        FileUtils.deleteFileQuietly(testFile);
         return false;
       } catch (IOException ioEx) {
         logError(storageDir, String.format("Could not read file %s " +
             "for volume check.", testFile.getAbsolutePath()), ioEx);
+        FileUtils.deleteFileQuietly(testFile);
         return false;
       }
 
@@ -190,6 +196,7 @@ public final class DiskCheckUtil {
         logError(storageDir, String.format("%d Bytes read from file " +
                 "%s do not match the %d bytes that were written.",
             writtenBytes.length, testFile.getAbsolutePath(), readBytes.length));
+        FileUtils.deleteFileQuietly(testFile);
         return false;
       }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.io.SyncFailedException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
@@ -142,9 +143,10 @@ public final class DiskCheckUtil {
     public boolean checkReadWrite(File storageDir,
         File testFileDir, int numBytesToWrite) {
       File testFile = new File(testFileDir, "disk-check-" + UUID.randomUUID());
+      Path testPath = testFile.toPath();
       byte[] writtenBytes = new byte[numBytesToWrite];
       RANDOM.nextBytes(writtenBytes);
-      try (OutputStream fos = FileUtils.newOutputStreamForceAtClose(testFile, CREATE, TRUNCATE_EXISTING, WRITE)) {
+      try (OutputStream fos = FileUtils.newOutputStreamForceAtClose(testPath, CREATE, TRUNCATE_EXISTING, WRITE)) {
         fos.write(writtenBytes);
       } catch (FileNotFoundException | NoSuchFileException notFoundEx) {
         logError(storageDir, String.format("Could not find file %s for " +
@@ -153,41 +155,41 @@ public final class DiskCheckUtil {
       } catch (SyncFailedException syncEx) {
         logError(storageDir, String.format("Could not sync file %s to disk.",
             testFile.getAbsolutePath()), syncEx);
-        FileUtils.deleteFileQuietly(testFile);
+        FileUtils.deletePathQuietly(testPath);
         return false;
       } catch (IOException ioEx) {
         String msg = ioEx.getMessage();
         if (msg != null && msg.contains(LINUX_DISK_FULL_MESSAGE)) {
           LOG.warn("Could not write file {} for volume check", testFile.getAbsolutePath(), ioEx);
-          FileUtils.deleteFileQuietly(testFile);
+          FileUtils.deletePathQuietly(testPath);
           return true;
         }
         logError(storageDir, String.format("Could not write file %s " +
             "for volume check.", testFile.getAbsolutePath()), ioEx);
-        FileUtils.deleteFileQuietly(testFile);
+        FileUtils.deletePathQuietly(testPath);
         return false;
       }
 
       // Read data back from the test file.
       byte[] readBytes = new byte[numBytesToWrite];
-      try (InputStream fis = Files.newInputStream(testFile.toPath())) {
+      try (InputStream fis = Files.newInputStream(testPath)) {
         int numBytesRead = IOUtils.read(fis, readBytes);
         if (numBytesRead != numBytesToWrite) {
           logError(storageDir, String.format("%d bytes written to file %s " +
                   "but %d bytes were read back.", numBytesToWrite,
               testFile.getAbsolutePath(), numBytesRead));
-          FileUtils.deleteFileQuietly(testFile);
+          FileUtils.deletePathQuietly(testPath);
           return false;
         }
       } catch (FileNotFoundException | NoSuchFileException notFoundEx) {
         logError(storageDir, String.format("Could not find file %s " +
             "for volume check.", testFile.getAbsolutePath()), notFoundEx);
-        FileUtils.deleteFileQuietly(testFile);
+        FileUtils.deletePathQuietly(testPath);
         return false;
       } catch (IOException ioEx) {
         logError(storageDir, String.format("Could not read file %s " +
             "for volume check.", testFile.getAbsolutePath()), ioEx);
-        FileUtils.deleteFileQuietly(testFile);
+        FileUtils.deletePathQuietly(testPath);
         return false;
       }
 
@@ -196,7 +198,7 @@ public final class DiskCheckUtil {
         logError(storageDir, String.format("%d Bytes read from file " +
                 "%s do not match the %d bytes that were written.",
             writtenBytes.length, testFile.getAbsolutePath(), readBytes.length));
-        FileUtils.deleteFileQuietly(testFile);
+        FileUtils.deletePathQuietly(testPath);
         return false;
       }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestDiskCheckUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestDiskCheckUtil.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mockStatic;
 import java.io.File;
 import java.nio.file.FileSystemException;
 import java.nio.file.OpenOption;
+import java.nio.file.Path;
 import org.apache.ratis.util.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -98,12 +99,11 @@ public class TestDiskCheckUtil {
   public void testCheckReadWriteDiskFull() {
     try (MockedStatic<FileUtils> mockService = mockStatic(FileUtils.class)) {
       // fos.write(writtenBytes) also through FileSystemException with the message
-      mockService.when(() -> FileUtils.newOutputStreamForceAtClose(any(File.class), any(OpenOption[].class)))
+      mockService.when(() -> FileUtils.newOutputStreamForceAtClose(any(Path.class), any(OpenOption[].class)))
           .thenThrow(new FileSystemException("No space left on device"));
 
-      String path = testDir.getAbsolutePath();
       assertThrows(FileSystemException.class,
-          () -> FileUtils.newOutputStreamForceAtClose(new File(path), new OpenOption[2]));
+          () -> FileUtils.newOutputStreamForceAtClose(testDir.toPath(), new OpenOption[2]));
 
       // Test that checkReadWrite returns true for the disk full case
       boolean result = DiskCheckUtil.checkReadWrite(testDir, testDir, 1024);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestDiskCheckUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestDiskCheckUtil.java
@@ -84,7 +84,10 @@ public class TestDiskCheckUtil {
   @Test
   public void testReadWrite() {
     assertTrue(DiskCheckUtil.checkReadWrite(testDir, testDir, 10));
+    assertTestFileDeleted();
+  }
 
+  private void assertTestFileDeleted() {
     // Test file should have been deleted.
     File[] children = testDir.listFiles();
     assertNotNull(children);
@@ -105,6 +108,7 @@ public class TestDiskCheckUtil {
       // Test that checkReadWrite returns true for the disk full case
       boolean result = DiskCheckUtil.checkReadWrite(testDir, testDir, 1024);
       assertTrue(result, "checkReadWrite should return true when disk is full");
+      assertTestFileDeleted();
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Disk read/write check may not completely read the test file with `InputStream.read()`.
    https://github.com/apache/ozone/blob/9649e0ee3b653c96cb58aaa0dd2eea6c42026979/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DiskCheckUtil.java#L167-L175
    Use [`IOUtils.read`](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/IOUtils.html#read(java.io.InputStream,byte%5B%5D)) to fully read the input.
2. Delete the test file even if the check fails for any reason.
3. Convert `File.toPath` once.

https://issues.apache.org/jira/browse/HDDS-15623

## How was this patch tested?

Updated unit test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/27831059411
