### PR TITLE
HDDS-15610. Fix deletedBlocks summary size corruption in SCM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
@@ -586,10 +586,10 @@ public class SCMDeletedBlockTransactionStatusManager {
   }
 
   private void descDeletedBlocksSummary(TxBlockInfo txBlockInfo) {
-    totalTxCount.addAndGet(-1);
-    totalBlockCount.addAndGet(-txBlockInfo.getTotalBlockCount());
-    totalBlocksSize.addAndGet(-txBlockInfo.getTotalBlockSize());
-    totalReplicatedBlocksSize.addAndGet(-txBlockInfo.getTotalReplicatedBlockSize());
+    totalTxCount.updateAndGet(v -> Math.max(0, v - 1));
+    totalBlockCount.updateAndGet(v -> Math.max(0, v - txBlockInfo.getTotalBlockCount()));
+    totalBlocksSize.updateAndGet(v -> Math.max(0, v - txBlockInfo.getTotalBlockSize()));
+    totalReplicatedBlocksSize.updateAndGet(v -> Math.max(0, v - txBlockInfo.getTotalReplicatedBlockSize()));
   }
 
   @VisibleForTesting
@@ -675,15 +675,76 @@ public class SCMDeletedBlockTransactionStatusManager {
 
   private void initDataDistributionData() throws IOException {
     DeletedBlocksTransactionSummary summary = loadDeletedBlocksSummary();
-    if (summary != null) {
+    if (isSummaryValid(summary)) {
+      // Fast path (O(1)): persisted summary exists and has no negative values.
+      // This is the normal path on every routine leader election.
       totalTxCount.set(summary.getTotalTransactionCount());
       totalBlockCount.set(summary.getTotalBlockCount());
       totalBlocksSize.set(summary.getTotalBlockSize());
       totalReplicatedBlocksSize.set(summary.getTotalBlockReplicatedSize());
-      LOG.info("Storage space distribution is initialized with totalTxCount {}, totalBlockCount {}, " +
-              "totalBlocksSize {} and totalReplicatedBlocksSize {}", totalTxCount.get(),
-          totalBlockCount.get(), totalBlocksSize.get(), totalReplicatedBlocksSize.get());
+      LOG.info("Storage space distribution loaded from persisted summary: totalTxCount {}, totalBlockCount {}, " +
+              "totalBlocksSize {} and totalReplicatedBlocksSize {}",
+          totalTxCount.get(), totalBlockCount.get(), totalBlocksSize.get(), totalReplicatedBlocksSize.get());
+      return;
     }
+
+    // Slow path (O(pending-backlog)): the persisted summary is either absent (first boot
+    // after STORAGE_SPACE_DISTRIBUTION is finalized on a cluster that predates the
+    // accounting code) or it already contains negative values written by a pre-fix leader.
+    // In both cases the only reliable source of truth is the deletedBlocks CF itself.
+    // This scan runs at most once per cluster lifecycle: as soon as the corrected totals
+    // are written back via the next addTransactions / removeTransactions call, every
+    // subsequent leader election will take the fast path above.
+    if (summary == null) {
+      LOG.info("No persisted deleted-blocks summary found; recomputing from deletedBlocks CF.");
+    } else {
+      LOG.warn("Persisted deleted-blocks summary contains negative values " +
+          "(totalBlocksSize={}, totalReplicatedBlocksSize={}); " +
+          "recomputing from deletedBlocks CF to repair.",
+          summary.getTotalBlockSize(), summary.getTotalBlockReplicatedSize());
+    }
+    long txCount = 0;
+    long blockCount = 0;
+    long blockSize = 0;
+    long replicatedSize = 0;
+    try (Table.KeyValueIterator<Long, DeletedBlocksTransaction> iter =
+             deletedBlockLogStateManager.getReadOnlyIterator()) {
+      while (iter.hasNext()) {
+        DeletedBlocksTransaction tx = iter.next().getValue();
+        txCount++;
+        blockCount += tx.getLocalIDCount();
+        if (tx.hasTotalBlockSize()) {
+          blockSize += tx.getTotalBlockSize();
+        }
+        if (tx.hasTotalBlockReplicatedSize()) {
+          replicatedSize += tx.getTotalBlockReplicatedSize();
+        }
+      }
+    }
+    totalTxCount.set(txCount);
+    totalBlockCount.set(blockCount);
+    totalBlocksSize.set(blockSize);
+    totalReplicatedBlocksSize.set(replicatedSize);
+    LOG.info("Storage space distribution recomputed from deletedBlocks CF: totalTxCount {}, totalBlockCount {}, " +
+            "totalBlocksSize {} and totalReplicatedBlocksSize {}",
+        totalTxCount.get(), totalBlockCount.get(), totalBlocksSize.get(), totalReplicatedBlocksSize.get());
+  }
+
+  /**
+   * Returns true when the persisted summary can be used directly without a DB scan.
+   *
+   * Both size fields must be strictly positive. A zero value means either:
+   * (a) the deletedBlocks table is genuinely empty — in which case the DB scan is
+   *     O(0) and effectively free, or
+   * (b) the counter was clamped from a negative value by a previous leader running
+   *     buggy code — in which case the DB scan is the correct one-time repair.
+   * Treating zero the same as negative keeps the detection and repair path unified
+   * and ensures that a clamped-zero is never silently accepted as a valid starting point.
+   */
+  private static boolean isSummaryValid(DeletedBlocksTransactionSummary summary) {
+    return summary != null
+        && summary.getTotalBlockSize() > 0
+        && summary.getTotalBlockReplicatedSize() > 0;
   }
 
   private DeletedBlocksTransactionSummary loadDeletedBlocksSummary() throws IOException {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -961,6 +961,122 @@ public class TestDeletedBlockLog {
         .thenReturn(replicaSet);
   }
 
+  /**
+   * Regression test: summary goes negative when STORAGE_SPACE_DISTRIBUTION is first finalized
+   * on a cluster whose existing pending DeletedBlocksTransactions were written without a
+   * persisted summary (old leader, pre-accounting code).
+   *
+   * Scenario: "old leader" adds transactions to the deletedBlocks CF with size fields set
+   * (feature is finalized) but never writes a summary to statefulConfigTable.  The new leader
+   * finds no persisted summary, falls back to a one-time DB scan, recomputes the correct
+   * totals, and then drives them to exactly zero as DNs commit — never going negative.
+   */
+  @Test
+  public void testSummaryNotNegativeWhenPersistedSummaryAbsent() throws Exception {
+    final int txCount = 10;
+
+    // Simulate the "old leader": feature is finalized so size fields are populated in each
+    // transaction proto, but the summary path in addTransactions is suppressed so nothing
+    // is persisted to statefulConfigTable.
+    SCMDeletedBlockTransactionStatusManager.setDisableDataDistributionForTest(true);
+    try {
+      addTransactions(generateData(txCount), true);
+      mockContainerHealthResult(true);
+
+      SCMDeletedBlockTransactionStatusManager statusManager =
+          deletedBlockLog.getSCMDeletedBlockTransactionStatusManager();
+      assertEquals(0L, statusManager.getTransactionSummary().getTotalTransactionCount(),
+          "Old leader left summary at zero");
+      assertEquals(0L, statusManager.getTransactionSummary().getTotalBlockSize(),
+          "Old leader left block size at zero");
+
+      // New leader takes over with the summary path re-enabled.
+      // initDataDistributionData() finds no persisted summary → triggers one-time DB scan.
+      SCMDeletedBlockTransactionStatusManager.setDisableDataDistributionForTest(false);
+      deletedBlockLog.onBecomeLeader();
+
+      HddsProtos.DeletedBlocksTransactionSummary summary = statusManager.getTransactionSummary();
+      assertEquals(txCount, summary.getTotalTransactionCount(),
+          "DB scan must recover the correct transaction count");
+      assertTrue(summary.getTotalBlockSize() > 0,
+          "DB scan must recover a positive block size; got " + summary.getTotalBlockSize());
+      assertTrue(summary.getTotalBlockReplicatedSize() > 0,
+          "DB scan must recover a positive replicated size; got " + summary.getTotalBlockReplicatedSize());
+
+      // All DNs commit. descDeletedBlocksSummary fires for each transaction.
+      // Without the fix the counter starts at 0 and goes deeply negative.
+      // With the fix it starts at the DB-computed value and lands at exactly 0.
+      List<DeletedBlocksTransaction> blocks = getTransactions(txCount * BLOCKS_PER_TXN * THREE);
+      assertEquals(txCount * THREE, blocks.size());
+      commitTransactions(blocks);
+      scmHADBTransactionBuffer.flush();
+
+      summary = statusManager.getTransactionSummary();
+      assertThat(summary.getTotalBlockSize())
+          .as("Block size must not go negative after all transactions committed")
+          .isGreaterThanOrEqualTo(0L);
+      assertThat(summary.getTotalBlockReplicatedSize())
+          .as("Replicated block size must not go negative after all transactions committed")
+          .isGreaterThanOrEqualTo(0L);
+      assertEquals(0L, summary.getTotalBlockSize(),
+          "Block size must be exactly 0 after all pending transactions committed");
+      assertEquals(0L, summary.getTotalBlockReplicatedSize(),
+          "Replicated block size must be exactly 0 after all pending transactions committed");
+    } finally {
+      SCMDeletedBlockTransactionStatusManager.setDisableDataDistributionForTest(false);
+    }
+  }
+
+  /**
+   * Ensures the fast path (O(1) load from statefulConfigTable) is taken on a normal leader
+   * election where the persisted summary is valid (non-negative).  This is the common
+   * production path and must not trigger a DB scan.
+   *
+   * Verification: after a leader change the in-memory counters exactly match what was
+   * persisted by the previous leader, and they reach zero once all pending transactions
+   * are committed.
+   */
+  @Test
+  public void testSummaryFastPathOnNormalLeaderChange() throws Exception {
+    final int txCount = 10;
+    mockContainerHealthResult(true);
+
+    // Add transactions with full accounting enabled → persists a valid summary.
+    addTransactions(generateData(txCount), true);
+    scmHADBTransactionBuffer.flush();
+
+    SCMDeletedBlockTransactionStatusManager statusManager =
+        deletedBlockLog.getSCMDeletedBlockTransactionStatusManager();
+    HddsProtos.DeletedBlocksTransactionSummary before = statusManager.getTransactionSummary();
+    assertEquals(txCount, before.getTotalTransactionCount());
+    assertTrue(before.getTotalBlockSize() > 0);
+
+    // Simulate a leader change. initDataDistributionData() must take the fast path
+    // (the LOG output will say "loaded from persisted summary", not "recomputed from CF").
+    deletedBlockLog.onBecomeLeader();
+
+    HddsProtos.DeletedBlocksTransactionSummary after = statusManager.getTransactionSummary();
+    assertEquals(before.getTotalTransactionCount(), after.getTotalTransactionCount(),
+        "Fast path must restore the exact transaction count");
+    assertEquals(before.getTotalBlockSize(), after.getTotalBlockSize(),
+        "Fast path must restore the exact block size");
+    assertEquals(before.getTotalBlockReplicatedSize(), after.getTotalBlockReplicatedSize(),
+        "Fast path must restore the exact replicated block size");
+
+    // Commit all transactions; counters must reach 0 without going negative.
+    List<DeletedBlocksTransaction> blocks = getTransactions(txCount * BLOCKS_PER_TXN * THREE);
+    assertEquals(txCount * THREE, blocks.size());
+    commitTransactions(blocks);
+    scmHADBTransactionBuffer.flush();
+
+    HddsProtos.DeletedBlocksTransactionSummary done = statusManager.getTransactionSummary();
+    assertThat(done.getTotalBlockSize())
+        .as("Block size must not go negative after commit")
+        .isGreaterThanOrEqualTo(0L);
+    assertEquals(0L, done.getTotalBlockSize());
+    assertEquals(0L, done.getTotalBlockReplicatedSize());
+  }
+
   private void mockInadequateReplicaUnhealthyContainerInfo(long containerID,
       int count) throws IOException {
     List<DatanodeDetails> dns = dnList.subList(0, 2);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestDeletedBlocksSummaryAfterLeaderChange.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestDeletedBlocksSummaryAfterLeaderChange.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
+import org.apache.hadoop.hdds.scm.block.SCMDeletedBlockTransactionStatusManager;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ContainerStateManager;
+import org.apache.hadoop.hdds.scm.ha.SCMHADBTransactionBuffer;
+import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.common.DeletedBlock;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration regression test for the bug where the pending deletion block-size
+ * summary in SCM goes negative after a leader change.
+ *
+ * <p>Root cause: a leader version that had STORAGE_SPACE_DISTRIBUTION finalized
+ * (so it set totalBlockSize / totalBlockReplicatedSize on each
+ * DeletedBlocksTransaction proto) but predated the summary accounting code
+ * (so it never wrote a summary to statefulConfigTable). When a new leader with
+ * the accounting code took over it found null summary, left counters at 0, then
+ * decremented them as datanodes committed transactions — driving the totals
+ * deeply negative.  Those negative values were Raft-replicated and reloaded on
+ * every subsequent restart.
+ *
+ * <p>This test simulates that exact scenario using
+ * {@code setDisableDataDistributionForTest(true)} to suppress summary writes
+ * while allowing size fields to be set on each transaction proto.
+ *
+ * <p><strong>To verify the test guards the fix:</strong> revert either change in
+ * {@code SCMDeletedBlockTransactionStatusManager} ({@code isSummaryValid} or
+ * {@code descDeletedBlocksSummary}) and the assertions will fail.
+ */
+public class TestDeletedBlocksSummaryAfterLeaderChange {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestDeletedBlocksSummaryAfterLeaderChange.class);
+
+  private static final int NUM_SCMS = 3;
+  private static final int NUM_DATANODES = 3;
+  private static final int TX_COUNT = 20;
+  private static final long BLOCK_SIZE = 1024 * 1024L; // 1 MB per block
+  private static final int BLOCKS_PER_TX = 5;
+
+  private MiniOzoneHAClusterImpl cluster;
+
+  @BeforeEach
+  public void init() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL, 100, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 50, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL, 500, TimeUnit.MILLISECONDS);
+
+    ScmConfig scmConfig = conf.getObject(ScmConfig.class);
+    scmConfig.setBlockDeletionInterval(Duration.ofMillis(100));
+    conf.setFromObject(scmConfig);
+    conf.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
+
+    // Build the cluster — call setters on the typed builder variable first,
+    // then call build() separately so the return type stays MiniOzoneHAClusterImpl.
+    MiniOzoneHAClusterImpl.Builder clusterBuilder = MiniOzoneCluster.newHABuilder(conf);
+    clusterBuilder
+        .setSCMServiceId("scm-service-test")
+        .setNumOfStorageContainerManagers(NUM_SCMS)
+        .setNumOfActiveSCMs(NUM_SCMS)
+        .setNumOfOzoneManagers(1)
+        .setNumDatanodes(NUM_DATANODES);
+    cluster = clusterBuilder.build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @AfterEach
+  public void shutdown() {
+    SCMDeletedBlockTransactionStatusManager.setDisableDataDistributionForTest(false);
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  /**
+   * Phase 1: simulate "old leader" — accounting disabled so TXs are written
+   * with size fields but no summary entry reaches statefulConfigTable.
+   * Phase 2: trigger leader transfer; the new leader must fall back to a DB
+   * scan and report a positive summary immediately.
+   * Phase 3: force-commit all transactions; the summary counters must stay >= 0.
+   */
+  @Test
+  public void testSummaryNonNegativeAfterLeaderChangeWithNoPersistedSummary()
+      throws Exception {
+
+    SCMDeletedBlockTransactionStatusManager.setDisableDataDistributionForTest(true);
+
+    StorageContainerManager oldLeader = getLeader();
+    assertNotNull(oldLeader, "Cluster must have an SCM leader at test start");
+
+    Map<Long, List<DeletedBlock>> txData = generateData(TX_COUNT);
+    DeletedBlockLogImpl oldLog =
+        (DeletedBlockLogImpl) oldLeader.getScmBlockManager().getDeletedBlockLog();
+    oldLog.addTransactions(txData);
+    flushBuffer(oldLeader);
+
+    HddsProtos.DeletedBlocksTransactionSummary oldSummary =
+        oldLog.getSCMDeletedBlockTransactionStatusManager().getTransactionSummary();
+    assertEquals(0L, oldSummary.getTotalTransactionCount(),
+        "Old leader must not have written a summary");
+    assertEquals(0L, oldSummary.getTotalBlockSize(),
+        "Old leader block-size summary must be zero");
+    assertEquals(TX_COUNT, oldLog.getNumOfValidTransactions(),
+        "All transactions must be in the deletedBlocks CF");
+
+    SCMDeletedBlockTransactionStatusManager.setDisableDataDistributionForTest(false);
+
+    String newLeaderScmId = pickDifferentScmId(oldLeader);
+    cluster.getStorageContainerLocationClient().transferLeadership(newLeaderScmId);
+
+    StorageContainerManager newLeader = waitForNewLeader(oldLeader);
+    assertNotNull(newLeader, "A new leader must be elected after transfer");
+    assertNotEquals(oldLeader.getScmId(), newLeader.getScmId(),
+        "The new leader must be a different SCM node");
+
+    DeletedBlockLogImpl newLog =
+        (DeletedBlockLogImpl) newLeader.getScmBlockManager().getDeletedBlockLog();
+    SCMDeletedBlockTransactionStatusManager newStatusManager =
+        newLog.getSCMDeletedBlockTransactionStatusManager();
+
+    HddsProtos.DeletedBlocksTransactionSummary summaryAfterTransfer =
+        newStatusManager.getTransactionSummary();
+
+    assertThat(summaryAfterTransfer.getTotalBlockSize())
+        .as("Block size must be > 0 after leader change (DB scan must have found the TXs)")
+        .isGreaterThan(0L);
+    assertThat(summaryAfterTransfer.getTotalBlockReplicatedSize())
+        .as("Replicated block size must be > 0 after leader change")
+        .isGreaterThan(0L);
+    assertEquals(TX_COUNT, summaryAfterTransfer.getTotalTransactionCount(),
+        "Transaction count must match the number of TXs added");
+
+    long expectedBlockSize = (long) TX_COUNT * BLOCKS_PER_TX * BLOCK_SIZE;
+    long expectedReplicatedSize = expectedBlockSize * 3;
+    assertEquals(expectedBlockSize, summaryAfterTransfer.getTotalBlockSize(),
+        "Block size must exactly match the DB-scanned total");
+    assertEquals(expectedReplicatedSize, summaryAfterTransfer.getTotalBlockReplicatedSize(),
+        "Replicated block size must exactly match the DB-scanned total");
+
+    // Exercise descDeletedBlocksSummary's clamping by directly committing all
+    // pending transactions via removeTransactions().
+    Map<Long, SCMDeletedBlockTransactionStatusManager.TxBlockInfo> txSizeMap =
+        newStatusManager.getTxSizeMap();
+    ArrayList<Long> allTxIds = new ArrayList<>();
+
+    try (Table.KeyValueIterator<Long, DeletedBlocksTransaction> iter =
+             newLog.getDeletedBlockLogStateManager().getReadOnlyIterator()) {
+      while (iter.hasNext()) {
+        Table.KeyValue<Long, DeletedBlocksTransaction> kv = iter.next();
+        DeletedBlocksTransaction tx = kv.getValue();
+        allTxIds.add(tx.getTxID());
+        if (tx.hasTotalBlockSize() && tx.hasTotalBlockReplicatedSize()) {
+          txSizeMap.put(tx.getTxID(),
+              new SCMDeletedBlockTransactionStatusManager.TxBlockInfo(
+                  tx.getLocalIDCount(),
+                  tx.getTotalBlockSize(),
+                  tx.getTotalBlockReplicatedSize()));
+        }
+      }
+    }
+    assertEquals(TX_COUNT, allTxIds.size(),
+        "All transactions must be present in the deletedBlocks CF before removal");
+
+    newStatusManager.removeTransactions(allTxIds);
+
+    HddsProtos.DeletedBlocksTransactionSummary summaryAfterDeletion =
+        newStatusManager.getTransactionSummary();
+
+    assertThat(summaryAfterDeletion.getTotalBlockSize())
+        .as("Block size must be >= 0 after all transactions processed")
+        .isGreaterThanOrEqualTo(0L);
+    assertThat(summaryAfterDeletion.getTotalBlockReplicatedSize())
+        .as("Replicated block size must be >= 0 after all transactions processed")
+        .isGreaterThanOrEqualTo(0L);
+
+    LOG.info("Final summary: txCount={}, blockSize={}, replicatedSize={}",
+        summaryAfterDeletion.getTotalTransactionCount(),
+        summaryAfterDeletion.getTotalBlockSize(),
+        summaryAfterDeletion.getTotalBlockReplicatedSize());
+  }
+
+  /**
+   * When the persisted summary is valid (> 0), the new leader must take the
+   * fast O(1) path (load from statefulConfigTable) and restore the exact
+   * counters that the old leader had written.
+   */
+  @Test
+  public void testSummaryFastPathOnNormalLeaderTransfer() throws Exception {
+    StorageContainerManager oldLeader = getLeader();
+    assertNotNull(oldLeader);
+
+    Map<Long, List<DeletedBlock>> txData = generateData(TX_COUNT);
+    DeletedBlockLogImpl oldLog =
+        (DeletedBlockLogImpl) oldLeader.getScmBlockManager().getDeletedBlockLog();
+    oldLog.addTransactions(txData);
+    flushBuffer(oldLeader);
+
+    HddsProtos.DeletedBlocksTransactionSummary before =
+        oldLog.getSCMDeletedBlockTransactionStatusManager().getTransactionSummary();
+    assertThat(before.getTotalBlockSize()).isGreaterThan(0L);
+    assertEquals(TX_COUNT, before.getTotalTransactionCount());
+
+    String newLeaderScmId = pickDifferentScmId(oldLeader);
+    cluster.getStorageContainerLocationClient().transferLeadership(newLeaderScmId);
+
+    StorageContainerManager newLeader = waitForNewLeader(oldLeader);
+    assertNotNull(newLeader);
+
+    HddsProtos.DeletedBlocksTransactionSummary after =
+        ((DeletedBlockLogImpl) newLeader.getScmBlockManager().getDeletedBlockLog())
+            .getSCMDeletedBlockTransactionStatusManager().getTransactionSummary();
+
+    assertEquals(before.getTotalTransactionCount(), after.getTotalTransactionCount(),
+        "Transaction count must be identical after normal leader transfer");
+    assertEquals(before.getTotalBlockSize(), after.getTotalBlockSize(),
+        "Block size must be identical after normal leader transfer (fast path)");
+    assertEquals(before.getTotalBlockReplicatedSize(), after.getTotalBlockReplicatedSize(),
+        "Replicated block size must be identical after normal leader transfer");
+  }
+
+  private StorageContainerManager getLeader() {
+    return cluster.getStorageContainerManagersList().stream()
+        .filter(scm -> scm.getScmContext().isLeaderReady())
+        .findFirst()
+        .orElse(null);
+  }
+
+  private StorageContainerManager waitForNewLeader(StorageContainerManager oldLeader)
+      throws Exception {
+    final StorageContainerManager[] holder = new StorageContainerManager[1];
+    GenericTestUtils.waitFor((BooleanSupplier) () -> {
+      StorageContainerManager candidate = getLeader();
+      if (candidate != null && !candidate.getScmId().equals(oldLeader.getScmId())) {
+        holder[0] = candidate;
+        return true;
+      }
+      return false;
+    }, 200, 30_000);
+    return holder[0];
+  }
+
+  private String pickDifferentScmId(StorageContainerManager current) {
+    for (StorageContainerManager scm : cluster.getStorageContainerManagersList()) {
+      if (!scm.getScmId().equals(current.getScmId())) {
+        return scm.getScmId();
+      }
+    }
+    throw new IllegalStateException("No other SCM found in cluster");
+  }
+
+  private void flushBuffer(StorageContainerManager scm) throws IOException {
+    DBTransactionBuffer buf = scm.getScmHAManager().getDBTransactionBuffer();
+    if (buf instanceof SCMHADBTransactionBuffer) {
+      ((SCMHADBTransactionBuffer) buf).flush();
+    }
+  }
+
+  /**
+   * Registers a synthetic container in the current leader's ContainerStateManager
+   * with CLOSED state and one replica on each datanode so the block-deleting
+   * service dispatches deletion commands rather than immediately purging the TX
+   * via ContainerNotFoundException.
+   */
+  private void registerContainer(long containerID) throws Exception {
+    StorageContainerManager leader = getLeader();
+    ContainerInfo container = new ContainerInfo.Builder()
+        .setContainerID(containerID)
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
+        .setState(HddsProtos.LifeCycleState.CLOSED)
+        .setOwner("TestDeletedBlocksSummary")
+        .setPipelineID(PipelineID.randomId())
+        .build();
+    Set<ContainerReplica> replicas = cluster.getHddsDatanodes()
+        .subList(0, NUM_DATANODES)
+        .stream()
+        .map(dn -> ContainerReplica.newBuilder()
+            .setContainerID(container.containerID())
+            .setContainerState(State.CLOSED)
+            .setDatanodeDetails(dn.getDatanodeDetails())
+            .build())
+        .collect(Collectors.toSet());
+    ContainerStateManager csm = leader.getContainerManager().getContainerStateManager();
+    csm.addContainer(container.getProtobuf());
+    for (ContainerReplica replica : replicas) {
+      csm.updateContainerReplica(replica);
+    }
+  }
+
+  /**
+   * Generates synthetic deletion-transaction data with explicit block sizes and
+   * registers each container in the leader's ContainerStateManager.
+   */
+  private Map<Long, List<DeletedBlock>> generateData(int txCount) throws Exception {
+    Map<Long, List<DeletedBlock>> data = new HashMap<>();
+    int containerBase = RandomUtils.secure().randomInt(10_000, 50_000);
+    int localBase = RandomUtils.secure().randomInt(0, 1_000);
+    for (int i = 0; i < txCount; i++) {
+      long containerID = containerBase + i;
+      registerContainer(containerID);
+      List<DeletedBlock> blocks = new ArrayList<>(BLOCKS_PER_TX);
+      for (int j = 0; j < BLOCKS_PER_TX; j++) {
+        blocks.add(new DeletedBlock(
+            new BlockID(containerID, localBase + j),
+            BLOCK_SIZE,
+            BLOCK_SIZE * 3,
+            BLOCK_SIZE));
+      }
+      data.put(containerID, blocks);
+    }
+    return data;
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?


During an SCM restart or a leader switch, the SCM defaults the summary value to 0. If a decrement operation happens on top of this unpersisted state, the value drops into the negative range.
If the summary value is 0 or less during initializeDataDistribution, the system will fallback to iterating over the deletedTable to accurately recalculate the distribution, instead of relying on the potentially corrupted/unpersisted summary.

## What is the link to the Apache JIRA

HDDS-15610

## How was this patch tested?

Tested using added unit test and integration test and validated in CI
