### PR TITLE
HDDS-15222. Fix intermittent failure in testSnapshotNameConsistency

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerHASnapshot.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.om.snapshot;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
@@ -43,7 +42,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.RDBCheckpointUtils;
-import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -59,7 +57,6 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -200,23 +197,18 @@ public class TestOzoneManagerHASnapshot {
    * passed or empty.
    */
   @Test
-  @Flaky("HDDS-15222")
   public void testSnapshotNameConsistency() throws Exception {
-    store.createSnapshot(volumeName, bucketName, "");
+    String snapshotName = store.createSnapshot(volumeName, bucketName, "");
     List<OzoneManager> ozoneManagers = cluster.getOzoneManagersList();
     List<String> snapshotNames = new ArrayList<>();
 
     for (OzoneManager ozoneManager : ozoneManagers) {
       await(120_000, 100, () -> {
-        String snapshotPrefix = OM_KEY_PREFIX + volumeName +
-            OM_KEY_PREFIX + bucketName;
-        SnapshotInfo snapshotInfo = null;
-        try (Table.KeyValueIterator<String, SnapshotInfo>
-                 iterator = ozoneManager.getMetadataManager()
-            .getSnapshotInfoTable().iterator(snapshotPrefix)) {
-          while (iterator.hasNext()) {
-            snapshotInfo = iterator.next().getValue();
-          }
+        SnapshotInfo snapshotInfo;
+        try {
+          snapshotInfo = ozoneManager.getMetadataManager()
+              .getSnapshotInfoTable()
+              .get(SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName));
         } catch (IOException e) {
           throw new RuntimeException(e);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test-only change

**Problem.** `testSnapshotNameConsistency` intermittently fails with `expected: <1> but was: <2>`. It checks that an empty-name snapshot ends up with the same auto-generated name on all 3 OMs, but the check only waited for **any** snapshot to exist on each OM, then read the lexicographically-last entry from the snapshot table. Because the bucket is shared across all test methods and earlier tests (one restarts the leader OM) leave snapshots behind with uneven replication, different OMs could pick different "last" snapshots, yielding two names and the flaky failure.

**Fix.** Follow the sibling `testSnapshotIdConsistency`: capture the name returned by `createSnapshot` and wait on each OM for that **exact** snapshot key, instead of scanning for the last entry. This removes the dependency on leftover snapshots and replication order, and the `@Flaky` tag plus now-unused imports are dropped. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15222

## How was this patch tested?

- Reproduced deterministically by injecting a leftover snapshot on one OM:
  - On the old test it fails with `expected: <1> but was: <2>`, same as the report.
  - With that same setup, the fixed test passes, so the race is really gone.
- A normal run of the test and `checkstyle.sh` both pass.
- `flaky-test-check` workflow on this branch: 10 splits x 10 iterations, 100/100 passed ([run](https://github.com/chihsuan/ozone/actions/runs/27859757372)).

Generated-by: Claude Code (Claude Opus 4.8)
