### PR TITLE
HDDS-14977. Intermittent failure in TestDeadNodeHandler.testOnMessage

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -269,6 +269,12 @@ public class TestDeadNodeHandler {
     nodeManager.addDatanodeCommand(datanode1.getID(), cmd);
     nodeManager.setNodeOperationalState(datanode1,
         HddsProtos.NodeOperationalState.IN_SERVICE);
+    // Changing the operational state of a DEAD node fires a DEAD_NODE event on
+    // SCM's event queue. Let SCM's own DeadNodeHandler process it here, so its
+    // asynchronous topology removal does not race with the handlers driven
+    // below (it could otherwise remove the node right after
+    // HealthyReadOnlyNodeHandler re-adds it).
+    ((EventQueue) scm.getEventQueue()).processAll(60000L);
     setNodeHealthState(datanode1, HddsProtos.NodeState.DEAD);
     deadNodeHandler.onMessage(datanode1, publisher);
     //datanode1 has been removed from ClusterNetworkTopology, another

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -73,7 +73,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -100,6 +99,11 @@ public class TestDeadNodeHandler {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
         0, TimeUnit.SECONDS);
+    // The test drives node health transitions manually. Disable the periodic
+    // health check so it does not resurrect a node forced to DEAD (the node's
+    // heartbeat stays fresh), which would race with the handlers under test.
+    conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL,
+        1, TimeUnit.HOURS);
     conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 2);
     conf.setStorageSize(OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN,
         10, StorageUnit.MB);
@@ -139,7 +143,6 @@ public class TestDeadNodeHandler {
 
   @Test
   @SuppressWarnings("checkstyle:MethodLength")
-  @Flaky("HDDS-14977")
   public void testOnMessage(@TempDir File tempDir) throws Exception {
     //GIVEN
     DatanodeDetails datanode1 = MockDatanodeDetails.randomDatanodeDetails();


### PR DESCRIPTION

## What changes were proposed in this pull request?

Test-only change.


**Problem.** `TestDeadNodeHandler.testOnMessage` is flaky because it manually drives the node handlers while a live SCM concurrently mutates the shared `NetworkTopology`. Two background mutations race with the test:

1. The `NodeStateManager` periodic health check (default 3s) sees the forced-`DEAD` node still has a fresh heartbeat and resurrects it (`DEAD -> HEALTHY_READONLY`), re-adding it to the topology -> `expected: <false> but was: <true>`.
2. Changing the `DEAD` node to `IN_SERVICE` fires a `DEAD_NODE` event, and SCM's own `DeadNodeHandler` asynchronously removes the node, nulling its parent between the `add` and `getParent` in `HealthyReadOnlyNodeHandler` -> `NullPointerException: Parent == null`.

The production guards from HDDS-14834 are correct; the test just does not isolate itself from these background mutations.

**Fix.** Two test-only changes, both matching existing patterns in `TestSCMNodeManager`:

1. Set the heartbeat process interval high in `setup()` so the periodic check never fires during the test.
2. Drain SCM's event queue (`processAll`) right after the operational-state change, so the async `DeadNodeHandler` finishes before the test drives the handlers.

The `@Flaky` tag is removed now that the root causes are gone.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14977

## How was this patch tested?

- Reproduced each failure deterministically by widening its race window on the unfixed test: shrinking the heartbeat interval to 1ms gave the `expected: <false> but was: <true>` signature 6/6; injecting a stall around the async removal gave the `Parent == null` NPE 3/3 at the exact lines reported in the Jira.
- Validated each fix by re-running with the same injected stall still in place: the fixed test passes (the periodic check no longer resurrects, and the event queue is drained before the handlers run).
- Ran the `flaky-test-check` workflow for the whole class (`test-name=ALL`, 10 splits × 10 iterations = 100 runs): all green. https://github.com/chihsuan/ozone/actions/runs/27890936708 An earlier single-method run missed the second window; running `ALL` exercises the cross-thread interaction that opens it.
- Full `TestDeadNodeHandler` class passes locally over repeated runs; `checkstyle` clean.
