### PR TITLE
HDDS-15628. [DiskBalancer] Preserve report output order for datanodes with the same density.

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
@@ -86,7 +86,9 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
 
     // Display consolidated report for successful nodes
     if (!successNodes.isEmpty() && !reports.isEmpty()) {
-      List<DatanodeDiskBalancerInfoProto> reportList = new ArrayList<>(reports.values());
+      List<DatanodeDiskBalancerInfoProto> reportList = successNodes.stream()
+          .map(reports::get)
+          .collect(toList());
       System.out.println(generateReport(reportList));
     }
   }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDiskBalancerSubCommands.java
@@ -698,6 +698,30 @@ public class TestDiskBalancerSubCommands {
   }
 
   @Test
+  public void testReportDiskBalancerWithSameDensityKeepsInputOrder() throws Exception {
+    DiskBalancerReportSubcommand cmd = new DiskBalancerReportSubcommand();
+
+    DatanodeDiskBalancerInfoProto reportProto1 = createReportProto("host-1", 0.5, 10.0);
+    DatanodeDiskBalancerInfoProto reportProto2 = createReportProto("host-2", 0.5, 10.0);
+
+    when(mockProtocol.getDiskBalancerInfo())
+        .thenReturn(reportProto2, reportProto1);
+
+    try (DiskBalancerMocks mocks = setupAllMocks()) {
+
+      CommandLine c = new CommandLine(cmd);
+      c.parseArgs("host-2", "host-1");
+      cmd.call();
+
+      String output = outContent.toString(DEFAULT_ENCODING);
+      int host2Index = output.indexOf("host-2");
+      int host1Index = output.indexOf("host-1");
+      assertThat(host2Index).isGreaterThanOrEqualTo(0);
+      assertThat(host1Index).isGreaterThan(host2Index);
+    }
+  }
+
+  @Test
   public void testReportDiskBalancerWithStdin() throws Exception {
     DiskBalancerReportSubcommand cmd = new DiskBalancerReportSubcommand();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes DiskBalancer report output stable when multiple datanodes have the same `currentVolumeDensitySum`.

Previously, the report command collected successful datanode reports from `ConcurrentHashMap.values()` before sorting by density. Since `ConcurrentHashMap` does not preserve insertion order, datanodes with the same density could be displayed in an order different from the user-provided datanode order.

This patch builds the report list according to the successful datanode order instead. The existing density sort is stable, so datanodes with different density values are still sorted by `currentVolumeDensitySum` in descending order, while datanodes with the same density keep the input order.

## What is the link to the Apache JIRA

JIRA: HDDS-15628. [DiskBalancer] Preserve report output order for datanodes with the same density.

## How was this patch tested?

Add Junit Test.

For example, when running:

```
ozone admin datanode diskbalancer report host-2 host-1
```

and both datanodes have the same density, the output should keep host-2 before host-1.

Before the fix:

```
Report result:
Datanode: host-1 (127.0.0.1:19864)
Aggregate VolumeDataDensity: 14.09%

-------

Datanode: host-2 (127.0.0.1:19864)
Aggregate VolumeDataDensity: 14.09%
```

After the fix:

```
Report result:
Datanode: host-2 (127.0.0.1:19864)
Aggregate VolumeDataDensity: 14.09%

-------

Datanode: host-1 (127.0.0.1:19864)
Aggregate VolumeDataDensity: 14.09%
```