### PR TITLE
HDDS-15629. [DiskBalancer] Fix missing parenthesis in report utilization note.

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
@@ -167,7 +167,7 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
         .append(" IdealUsage +/- Threshold are considered balanced.%n")
         .append("  - VolumeDensity: Deviation of a particular volume's utilization from IdealUsage.%n")
         .append("  - Utilization: how much a particular volume is utilized ")
-        .append("effectiveUsedSpace / ozoneCapacity) in %%.%n")
+        .append("(effectiveUsedSpace / ozoneCapacity) in %%.%n")
         .append("  - OzoneCapacity: Ozone data volume capacity.%n")
         .append("  - OzoneAvailable: Ozone data volume available space.%n")
         .append("  - OzoneUsed: Ozone data volume used space.%n")


### PR DESCRIPTION
## What changes were proposed in this pull request?

The DiskBalancer report command prints a Note section that explains each reported field. The Utilization note currently has a formatting issue: the formula is missing the opening parenthesis before effectiveUsedSpace.

- Current text:

```
  Utilization: how much a particular volume is utilized effectiveUsedSpace / ozoneCapacity) in %.
```

- Expected text:

```
  Utilization: how much a particular volume is utilized (effectiveUsedSpace / ozoneCapacity) in %.
```

This is a minor documentation/output text fix. It does not change DiskBalancer behavior or report calculation logic.

## What is the link to the Apache JIRA

JIRA: HDDS-15629. [DiskBalancer] Fix missing parenthesis in report utilization note.

## How was this patch tested?

None Junit Test.