### PR TITLE
HDDS-14577. Handle missing metadata dir when updating container state

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -393,8 +393,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     try {
       if (!getContainerFile().getParentFile().exists()) {
         // Metadata directory is absent (e.g. MISSING_METADATA_DIR detected by scanner).
-        // Attempting to write the .container file would fail, and writing a partial file
-        // with only the state field is more harmful than not writing one at all.
+        // Attempting to write the .container file would fail
         // The in-memory UNHEALTHY state is sufficient: SCM will receive it via ICR
         // and schedule deletion without requiring a persisted .container file.
         containerData.setState(UNHEALTHY);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -299,6 +299,12 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       throws StorageContainerException {
     File tempContainerFile = null;
     try {
+      // The metadata directory may be absent when writing the UNHEALTHY marker after
+      // a MISSING_METADATA_DIR corruption is detected. Recreate it so the state can be persisted.
+      File metadataDir = containerFile.getParentFile();
+      if (!metadataDir.exists() && !metadataDir.mkdirs()) {
+        throw new IOException("Failed to create metadata directory: " + metadataDir);
+      }
       tempContainerFile = createTempFile(containerFile);
       ContainerDataYaml.createContainerFile(containerData, tempContainerFile);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -299,12 +299,6 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       throws StorageContainerException {
     File tempContainerFile = null;
     try {
-      // The metadata directory may be absent when writing the UNHEALTHY marker after
-      // a MISSING_METADATA_DIR corruption is detected. Recreate it so the state can be persisted.
-      File metadataDir = containerFile.getParentFile();
-      if (!metadataDir.exists() && !metadataDir.mkdirs()) {
-        throw new IOException("Failed to create metadata directory: " + metadataDir);
-      }
       tempContainerFile = createTempFile(containerFile);
       ContainerDataYaml.createContainerFile(containerData, tempContainerFile);
 
@@ -397,7 +391,18 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     writeLock();
     final State prevState = containerData.getState();
     try {
-      updateContainerState(UNHEALTHY);
+      if (!getContainerFile().getParentFile().exists()) {
+        // Metadata directory is absent (e.g. MISSING_METADATA_DIR detected by scanner).
+        // Attempting to write the .container file would fail, and writing a partial file
+        // with only the state field is more harmful than not writing one at all.
+        // The in-memory UNHEALTHY state is sufficient: SCM will receive it via ICR
+        // and schedule deletion without requiring a persisted .container file.
+        containerData.setState(UNHEALTHY);
+        LOG.debug("Skipping .container file update for container {} with missing metadata directory",
+            containerData.getContainerID());
+      } else {
+        updateContainerState(UNHEALTHY);
+      }
       clearPendingPutBlockCache();
     } finally {
       writeUnlock();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -783,7 +783,7 @@ public class TestKeyValueContainer {
     assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY,
         keyValueContainer.getContainerState());
 
-    // The metadata directory must NOT be recreated; no partial .container file should be written.
+    // Regression guards: if a future change adds mkdirs/persist logic, these catch it early.
     assertFalse(metadataDir.exists(), "Metadata dir should not be recreated by markContainerUnhealthy");
     assertFalse(keyValueContainer.getContainerFile().exists(),
         "Container file should not be written when metadata dir is missing");

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V3;
 import static org.apache.hadoop.ozone.container.checksum.ContainerMerkleTreeTestUtils.buildTestTree;
 import static org.apache.hadoop.ozone.container.checksum.ContainerMerkleTreeTestUtils.verifyAllDataChecksumsMatch;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.CONTAINER_SCHEMA_V3_ENABLED;
+import static org.apache.hadoop.ozone.container.keyvalue.TestContainerCorruptions.MISSING_METADATA_DIR;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -760,21 +761,20 @@ public class TestKeyValueContainer {
   }
 
   /**
-   * When a container's metadata directory is missing (MISSING_METADATA_DIR), marking the container
-   * UNHEALTHY must succeed and persist the state to disk. Previously the call failed with
-   * StorageContainerException because writeToContainerFile tried to create a temp file inside
-   * the missing directory.
+   * When a container's metadata directory is missing (MISSING_METADATA_DIR detected by the scanner),
+   * markContainerUnhealthy must succeed without throwing. Writing a partial .container file with only
+   * the state field would lose other metadata and is more harmful than writing nothing. The in-memory
+   * UNHEALTHY state is sufficient for SCM to receive it via ICR and schedule deletion.
    */
   @ContainerTestVersionInfo.ContainerTest
   public void testMarkUnhealthyWithMissingMetadataDir(ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
 
-    // Simulate MISSING_METADATA_DIR: delete the entire metadata directory.
+    // Simulate MISSING_METADATA_DIR using the same corruption helper used in scanner tests.
     File metadataDir = new File(keyValueContainerData.getMetadataPath());
     assertTrue(metadataDir.exists(), "Metadata dir should exist before corruption");
-    FileUtils.deleteDirectory(metadataDir);
-    assertFalse(metadataDir.exists(), "Metadata dir should be gone after deletion");
+    MISSING_METADATA_DIR.applyTo(keyValueContainer);
 
     // markContainerUnhealthy must not throw even though the metadata dir is absent.
     keyValueContainer.markContainerUnhealthy();
@@ -783,14 +783,10 @@ public class TestKeyValueContainer {
     assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY,
         keyValueContainer.getContainerState());
 
-    // The metadata directory must have been recreated and the .container file written.
-    assertTrue(metadataDir.exists(), "Metadata dir should be recreated by markContainerUnhealthy");
-    File containerFile = keyValueContainer.getContainerFile();
-    assertTrue(containerFile.exists(), "Container file should exist after markContainerUnhealthy");
-
-    // The persisted state must be UNHEALTHY.
-    KeyValueContainerData reloaded = (KeyValueContainerData) ContainerDataYaml.readContainerFile(containerFile);
-    assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY, reloaded.getState());
+    // The metadata directory must NOT be recreated; no partial .container file should be written.
+    assertFalse(metadataDir.exists(), "Metadata dir should not be recreated by markContainerUnhealthy");
+    assertFalse(keyValueContainer.getContainerFile().exists(),
+        "Container file should not be written when metadata dir is missing");
   }
 
   @ContainerTestVersionInfo.ContainerTest

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -759,6 +759,40 @@ public class TestKeyValueContainer {
     assertNotNull(keyValueContainer.getContainerReport());
   }
 
+  /**
+   * When a container's metadata directory is missing (MISSING_METADATA_DIR), marking the container
+   * UNHEALTHY must succeed and persist the state to disk. Previously the call failed with
+   * StorageContainerException because writeToContainerFile tried to create a temp file inside
+   * the missing directory.
+   */
+  @ContainerTestVersionInfo.ContainerTest
+  public void testMarkUnhealthyWithMissingMetadataDir(ContainerTestVersionInfo versionInfo) throws Exception {
+    init(versionInfo);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+
+    // Simulate MISSING_METADATA_DIR: delete the entire metadata directory.
+    File metadataDir = new File(keyValueContainerData.getMetadataPath());
+    assertTrue(metadataDir.exists(), "Metadata dir should exist before corruption");
+    FileUtils.deleteDirectory(metadataDir);
+    assertFalse(metadataDir.exists(), "Metadata dir should be gone after deletion");
+
+    // markContainerUnhealthy must not throw even though the metadata dir is absent.
+    keyValueContainer.markContainerUnhealthy();
+
+    // In-memory state must be UNHEALTHY.
+    assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY,
+        keyValueContainer.getContainerState());
+
+    // The metadata directory must have been recreated and the .container file written.
+    assertTrue(metadataDir.exists(), "Metadata dir should be recreated by markContainerUnhealthy");
+    File containerFile = keyValueContainer.getContainerFile();
+    assertTrue(containerFile.exists(), "Container file should exist after markContainerUnhealthy");
+
+    // The persisted state must be UNHEALTHY.
+    KeyValueContainerData reloaded = (KeyValueContainerData) ContainerDataYaml.readContainerFile(containerFile);
+    assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY, reloaded.getState());
+  }
+
   @ContainerTestVersionInfo.ContainerTest
   public void testUpdateContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the container metadata scanner detects a MISSING_METADATA_DIR corruption, it attempts to persist the UNHEALTHY state by writing the .container file. However, writeToContainerFile creates a temp file inside the metadata directory itself — the very directory that is missing — causing a secondary StorageContainerException: Failed to create tmp file. This produces a spurious WARN and leaves the UNHEALTHY state un-persisted on disk; the state is lost on the next datanode restart.

The fix adds a single guard in KeyValueContainer.writeToContainerFile: if the metadata directory does not exist, it will skip create the temp file. 

## What is the link to the Apache JIRA

HDDS-14577

## How was this patch tested?

Added new testcases

Tested manually using following steps

Added follwoing configs
```
OZONE-SITE.XML_hdds.container.scrub.metadata.scan.interval=30s
OZONE-SITE.XML_hdds.container.scrub.min.gap=0s
OZONE-SITE.XML_hdds.container.report.interval=5s
```
executed following commands
```
ozone sh volume create /vol1
ozone sh bucket create /vol1/bucket1
ozone freon ockg -v vol1 -b bucket1 -n 100

# DN

find /data/hdds -type d -name metadata
# Pick one (example: container 1)
CONTAINER_ID=1
METADATA_DIR=$(find /data/hdds -path "*/${CONTAINER_ID}/metadata" -type d | head -1)
echo "Deleting: $METADATA_DIR"
rm -rf "$METADATA_DIR"

# check logs
docker logs  ozone-datanode-1 > > container.log 2>&1
cat container.log|grep 'Skipping .container '
2026-07-08 06:14:46,561 [ContainerMetadataScanner] INFO keyvalue.KeyValueContainer: Skipping .container file update for container 1 with missing metadata directory

# logs made info for testing purpose locally
```
