### PR TITLE
HDDS-15634. Avoid updating container delete transaction ID on SCM delete log append

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -77,11 +77,8 @@ public final class ContainerInfo implements Comparable<ContainerInfo> {
   // field and hence maintain the original output.
   @JsonIgnore
   private final ContainerID containerID;
-  // Delete Transaction Id is updated when new transaction for a container
-  // is stored in SCM delete Table.
-  // TODO: Replication Manager should consider deleteTransactionId so that
-  // replica with higher deleteTransactionId is preferred over replica with
-  // lower deleteTransactionId.
+  // Deprecated SCM-side delete transaction ID retained for old persisted data, SCM no longer updates this field.
+  @Deprecated
   private long deleteTransactionId;
   // The sequenceId of a close container cannot change, and all the
   // container replica should have the same sequenceId.
@@ -218,16 +215,19 @@ public final class ContainerInfo implements Comparable<ContainerInfo> {
     numberOfKeys = value;
   }
 
+  /**
+   * Legacy SCM-side delete transaction ID. SCM no longer updates this field.
+   *
+   * @deprecated SCM no longer updates this field. Use DN-side container data
+   *             for delete transaction tracking.
+   */
+  @Deprecated
   public long getDeleteTransactionId() {
     return deleteTransactionId;
   }
 
   public long getSequenceId() {
     return sequenceId;
-  }
-
-  public void updateDeleteTransactionId(long transactionId) {
-    deleteTransactionId = max(transactionId, deleteTransactionId);
   }
 
   public void updateSequenceId(long sequenceID) {
@@ -464,6 +464,7 @@ public final class ContainerInfo implements Comparable<ContainerInfo> {
       return this;
     }
 
+    @Deprecated
     public Builder setDeleteTransactionId(long deleteTransactionID) {
       this.deleteTransactionId = deleteTransactionID;
       return this;

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -267,7 +267,8 @@ message ContainerInfoProto {
     required uint64 numberOfKeys = 5;
     optional int64 stateEnterTime = 6;
     required string owner = 7;
-    optional int64 deleteTransactionId = 8;
+    // Legacy SCM-side delete transaction ID. SCM no longer updates this field.
+    optional int64 deleteTransactionId = 8 [deprecated = true];
     optional int64 sequenceId = 9;
     optional ReplicationFactor replicationFactor  = 10;
     required ReplicationType replicationType  = 11;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -21,15 +21,12 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHADBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
@@ -53,7 +50,6 @@ public class DeletedBlockLogStateManagerImpl
 
   private Table<Long, DeletedBlocksTransaction> deletedTable;
   private Table<String, ByteString> statefulConfigTable;
-  private ContainerManager containerManager;
   private final SCMHADBTransactionBuffer transactionBuffer;
   private final Set<Long> deletingTxIDs;
   public static final String SERVICE_NAME = DeletedBlockLogStateManager.class.getSimpleName();
@@ -62,7 +58,6 @@ public class DeletedBlockLogStateManagerImpl
              Table<String, ByteString> statefulServiceConfigTable,
              ContainerManager containerManager, SCMHADBTransactionBuffer txBuffer) {
     this.deletedTable = deletedTable;
-    this.containerManager = containerManager;
     this.transactionBuffer = txBuffer;
     this.deletingTxIDs = ConcurrentHashMap.newKeySet();
     this.statefulConfigTable = statefulServiceConfigTable;
@@ -146,17 +141,12 @@ public class DeletedBlockLogStateManagerImpl
   @Override
   public void addTransactionsToDB(ArrayList<DeletedBlocksTransaction> txs,
       DeletedBlocksTransactionSummary summary) throws IOException {
-    Map<ContainerID, Long> containerIdToTxnIdMap = new HashMap<>();
     for (DeletedBlocksTransaction tx : txs) {
-      long tid = tx.getTxID();
-      containerIdToTxnIdMap.compute(ContainerID.valueOf(tx.getContainerID()),
-          (k, v) -> v != null && v > tid ? v : tid);
       transactionBuffer.addToBuffer(deletedTable, tx.getTxID(), tx);
     }
     if (summary != null) {
       transactionBuffer.addToBuffer(statefulConfigTable, SERVICE_NAME, summary.toByteString());
     }
-    containerManager.updateDeleteTransactionId(containerIdToTxnIdMap);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -21,7 +21,6 @@ import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
@@ -204,16 +203,6 @@ public interface ContainerManager {
    */
   void removeContainerReplica(ContainerID containerID, ContainerReplica replica)
       throws ContainerNotFoundException, ContainerReplicaNotFoundException;
-
-  /**
-   * Update deleteTransactionId according to deleteTransactionMap.
-   *
-   * @param deleteTransactionMap Maps the containerId to latest delete
-   *                             transaction id for the container.
-   * @throws IOException
-   */
-  void updateDeleteTransactionId(Map<ContainerID, Long> deleteTransactionMap)
-      throws IOException;
 
   default ContainerInfo getMatchingContainer(long size, String owner,
                                      Pipeline pipeline) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Random;
 import java.util.Set;
@@ -257,7 +256,6 @@ public class ContainerManagerImpl implements ContainerManager {
         .setStateEnterTime(Time.now())
         .setOwner(owner)
         .setContainerID(containerID.getId())
-        .setDeleteTransactionId(0)
         .setReplicationType(pipeline.getType());
 
     if (pipeline.getReplicationConfig() instanceof ECReplicationConfig) {
@@ -355,12 +353,6 @@ public class ContainerManagerImpl implements ContainerManager {
     } else {
       throw new ContainerNotFoundException(cid);
     }
-  }
-
-  @Override
-  public void updateDeleteTransactionId(
-      final Map<ContainerID, Long> deleteTransactionMap) throws IOException {
-    containerStateManager.updateDeleteTransactionId(deleteTransactionMap);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.container;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -227,6 +228,16 @@ public interface ContainerStateManager extends SCMHandler {
    */
   @Replicate
   void updateContainerInfo(HddsProtos.ContainerInfoProto containerInfo)
+      throws IOException;
+
+  /**
+   * Legacy no-op retained for SCM HA compatibility with old method names.
+   * SCM no longer maintains ContainerInfo deleteTransactionId.
+   *
+   * @deprecated SCM no longer updates ContainerInfo deleteTransactionId.
+   */
+  @Deprecated
+  void updateDeleteTransactionId(Map<ContainerID, Long> deleteTransactionMap)
       throws IOException;
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.container;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -228,16 +227,6 @@ public interface ContainerStateManager extends SCMHandler {
    */
   @Replicate
   void updateContainerInfo(HddsProtos.ContainerInfoProto containerInfo)
-      throws IOException;
-
-  /**
-   * Legacy no-op retained for SCM HA compatibility with old method names.
-   * SCM no longer maintains ContainerInfo deleteTransactionId.
-   *
-   * @deprecated SCM no longer updates ContainerInfo deleteTransactionId.
-   */
-  @Deprecated
-  void updateDeleteTransactionId(Map<ContainerID, Long> deleteTransactionMap)
       throws IOException;
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.container;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -191,13 +190,6 @@ public interface ContainerStateManager extends SCMHandler {
    */
   @Replicate
   void transitionDeletingOrDeletedToTargetState(HddsProtos.ContainerID id, LifeCycleState targetState)
-      throws IOException;
-
-  /**
-   *
-   */
-  // Make this as @Replicate
-  void updateDeleteTransactionId(Map<ContainerID, Long> deleteTransactionMap)
       throws IOException;
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -585,12 +585,6 @@ public final class ContainerStateManagerImpl
     }
   }
 
-  @Override
-  public void updateDeleteTransactionId(Map<ContainerID, Long> deleteTransactionMap) {
-    // Legacy SCM HA method retained as a no-op. SCM no longer maintains the
-    // ContainerInfo deleteTransactionId; DN-side container data tracks it.
-  }
-
   private AutoCloseableLock readLock() {
     return AutoCloseableLock.acquire(lock.readLock());
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -585,6 +585,12 @@ public final class ContainerStateManagerImpl
     }
   }
 
+  @Override
+  public void updateDeleteTransactionId(Map<ContainerID, Long> deleteTransactionMap) {
+    // Legacy SCM HA method retained as a no-op. SCM no longer maintains the
+    // ContainerInfo deleteTransactionId; DN-side container data tracks it.
+  }
+
   private AutoCloseableLock readLock() {
     return AutoCloseableLock.acquire(lock.readLock());
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -485,28 +485,6 @@ public final class ContainerStateManagerImpl
   }
 
   @Override
-  public void updateDeleteTransactionId(
-      final Map<ContainerID, Long> deleteTransactionMap) throws IOException {
-
-    // TODO: Refactor this. Error handling is not done.
-    for (Map.Entry<ContainerID, Long> transaction :
-        deleteTransactionMap.entrySet()) {
-      ContainerID containerID = transaction.getKey();
-      try (AutoCloseableLock ignored = writeLock(containerID)) {
-        final ContainerInfo info = containers.getContainerInfo(
-            transaction.getKey());
-        if (info == null) {
-          LOG.warn("Cannot find container {}, transaction id is {}",
-              transaction.getKey(), transaction.getValue());
-          continue;
-        }
-        info.updateDeleteTransactionId(transaction.getValue());
-        transactionBuffer.addToBuffer(containerStore, info.containerID(), info);
-      }
-    }
-  }
-
-  @Override
   public ContainerInfo getMatchingContainer(final long size, String owner,
       PipelineID pipelineID, NavigableSet<ContainerID> containerIDs) {
     if (containerIDs.isEmpty()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.ha.invoker;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -184,6 +185,11 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
         final Object[] args = {arg0, arg1, arg2};
         invoker.invokeReplicateDirect(ReplicateMethod.updateContainerStateWithSequenceId, args);
       }
+
+      @Override
+      public void updateDeleteTransactionId(Map arg0) throws IOException {
+        invoker.getImpl().updateDeleteTransactionId(arg0);
+      }
     };
   }
 
@@ -309,8 +315,8 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
       return Message.EMPTY;
 
     case "updateDeleteTransactionId":
-      // Legacy HA compatibility: old SCMs may replicate this operation during
-      // rolling upgrade or log replay. SCM no longer maintains this field.
+      final Map arg29 = p.length > 0 ? (Map) p[0] : null;
+      getImpl().updateDeleteTransactionId(arg29);
       return Message.EMPTY;
 
     default:

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.ha.invoker;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -185,11 +184,6 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
         final Object[] args = {arg0, arg1, arg2};
         invoker.invokeReplicateDirect(ReplicateMethod.updateContainerStateWithSequenceId, args);
       }
-
-      @Override
-      public void updateDeleteTransactionId(Map arg0) throws IOException {
-        invoker.getImpl().updateDeleteTransactionId(arg0);
-      }
     };
   }
 
@@ -312,11 +306,6 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
       final LifeCycleEvent arg27 = p.length > 1 ? (LifeCycleEvent) p[1] : null;
       final Long arg28 = p.length > 2 ? (Long) p[2] : null;
       getImpl().updateContainerStateWithSequenceId(arg26, arg27, arg28);
-      return Message.EMPTY;
-
-    case "updateDeleteTransactionId":
-      final Map arg29 = p.length > 0 ? (Map) p[0] : null;
-      getImpl().updateDeleteTransactionId(arg29);
       return Message.EMPTY;
 
     default:

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.ha.invoker;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -185,11 +184,6 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
         final Object[] args = {arg0, arg1, arg2};
         invoker.invokeReplicateDirect(ReplicateMethod.updateContainerStateWithSequenceId, args);
       }
-
-      @Override
-      public void updateDeleteTransactionId(Map arg0) throws IOException {
-        invoker.getImpl().updateDeleteTransactionId(arg0);
-      }
     };
   }
 
@@ -315,8 +309,8 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
       return Message.EMPTY;
 
     case "updateDeleteTransactionId":
-      final Map arg29 = p.length > 0 ? (Map) p[0] : null;
-      getImpl().updateDeleteTransactionId(arg29);
+      // Legacy HA compatibility: old SCMs may replicate this operation during
+      // rolling upgrade or log replay. SCM no longer maintains this field.
       return Message.EMPTY;
 
     default:

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -321,7 +320,6 @@ public class TestDeletedBlockLog {
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
       assertEquals(0, containerInfo.getDeleteTransactionId());
     }
-    verify(containerManager, never()).updateDeleteTransactionId(any());
   }
 
   private void mockContainerHealthResult(Boolean healthy) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -25,9 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -165,22 +165,6 @@ public class TestDeletedBlockLog {
         });
     when(containerManager.getContainers())
         .thenReturn(new ArrayList<>(containers.values()));
-    doAnswer(invocationOnMock -> {
-      Map<ContainerID, Long> map =
-          (Map<ContainerID, Long>) invocationOnMock.getArguments()[0];
-      for (Map.Entry<ContainerID, Long> e : map.entrySet()) {
-        ContainerInfo info = containers.get(e.getKey());
-        try {
-          assertThat(e.getValue()).isGreaterThan(info.getDeleteTransactionId());
-        } catch (AssertionError err) {
-          throw new Exception("New TxnId " + e.getValue() + " < " + info
-              .getDeleteTransactionId());
-        }
-        info.updateDeleteTransactionId(e.getValue());
-        scmHADBTransactionBuffer.addToBuffer(containerTable, e.getKey(), info);
-      }
-      return null;
-    }).when(containerManager).updateDeleteTransactionId(any());
   }
 
   private void updateContainerMetadata(long cid,
@@ -312,7 +296,8 @@ public class TestDeletedBlockLog {
   }
 
   @Test
-  public void testContainerManagerTransactionId() throws Exception {
+  public void testAddTransactionsDoesNotUpdateContainerTransactionId()
+      throws Exception {
     // Initially all containers should have deleteTransactionId as 0
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
       assertEquals(0, containerInfo.getDeleteTransactionId());
@@ -329,12 +314,14 @@ public class TestDeletedBlockLog {
 
     scmHADBTransactionBuffer.flush();
     // After flush there should be 30 transactions in deleteTable
-    // All containers should have positive deleteTransactionId
+    // SCM does not update ContainerInfo deleteTransactionId when adding delete
+    // transactions.
     mockContainerHealthResult(true);
     assertEquals(30 * THREE, getAllTransactions().size());
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
-      assertThat(containerInfo.getDeleteTransactionId()).isGreaterThan(0);
+      assertEquals(0, containerInfo.getDeleteTransactionId());
     }
+    verify(containerManager, never()).updateDeleteTransactionId(any());
   }
 
   private void mockContainerHealthResult(Boolean healthy) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -584,7 +584,7 @@ public final class ScmInvokerCodeGenerator {
   void printProxyClass() {
     printf("return new %s() {", apiName);
     try (UncheckedAutoCloseable ignored = printScope(false, 1)) {
-      for (Method m : getMethods(null, false)) {
+      for (Method m : getMethods(m -> m.getAnnotation(Deprecated.class) == null || !m.isDefault())) {
         printProxyClassMethod(m);
       }
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -250,7 +250,7 @@ public class TestBlockDeletion {
     // Delete transactionIds for the containers should be 0.
     // NOTE: this test assumes that all the container is KetValueContainer. If
     // other container types is going to be added, this test should be checked.
-    matchContainerTransactionIds();
+    verifyDeleteTransactionIds();
 
     assertEquals(0L,
         metrics.getNumBlockDeletionTransactionCreated());
@@ -293,8 +293,9 @@ public class TestBlockDeletion {
 
     // Few containers with deleted blocks
     assertThat(containerIdsWithDeletedBlocks).isNotEmpty();
-    // Containers in the DN and SCM should have same delete transactionIds
-    matchContainerTransactionIds();
+    // DN-side delete transactionIds should advance after deletion. SCM-side
+    // ContainerInfo deleteTransactionId is not updated by DeletedBlockLog.
+    verifyDeleteTransactionIds();
 
     // Verify transactions committed
     GenericTestUtils.waitFor(() -> {
@@ -308,11 +309,10 @@ public class TestBlockDeletion {
       }
     }, 500, 10000);
 
-    // After DN restart, containers in the DN and SCM should have same delete
-    // transactionIds. The assertion verifies that the state of containerInfos
-    // in DN and SCM is consistent after DN restart.
+    // After DN restart, delete transactionIds should remain persisted on DN.
+    // SCM-side ContainerInfo deleteTransactionId should remain unchanged.
     cluster.restartHddsDatanode(0, true);
-    matchContainerTransactionIds();
+    verifyDeleteTransactionIds();
 
     assertEquals(metrics.getNumBlockDeletionTransactionCreated(),
         metrics.getNumBlockDeletionTransactionCompleted());
@@ -716,7 +716,7 @@ public class TestBlockDeletion {
     }
   }
 
-  private void matchContainerTransactionIds() throws IOException {
+  private void verifyDeleteTransactionIds() throws IOException {
     for (HddsDatanodeService datanode : cluster.getHddsDatanodes()) {
       ContainerSet dnContainerSet =
           datanode.getDatanodeStateMachine().getContainer().getContainerSet();
@@ -724,19 +724,17 @@ public class TestBlockDeletion {
       dnContainerSet.listContainer(0, 10000, containerDataList);
       for (ContainerData containerData : containerDataList) {
         long containerId = containerData.getContainerID();
-        if (containerIdsWithDeletedBlocks.contains(containerId)) {
-          assertThat(scm.getContainerInfo(containerId).getDeleteTransactionId())
-              .isGreaterThan(0);
-          maxTransactionId = max(maxTransactionId,
-              scm.getContainerInfo(containerId).getDeleteTransactionId());
-        } else {
-          assertEquals(
-              scm.getContainerInfo(containerId).getDeleteTransactionId(), 0);
-        }
-        assertEquals(
+        long dnDeleteTransactionId =
             ((KeyValueContainerData) dnContainerSet.getContainer(containerId)
-                .getContainerData()).getDeleteTransactionId(),
+                .getContainerData()).getDeleteTransactionId();
+        assertEquals(0,
             scm.getContainerInfo(containerId).getDeleteTransactionId());
+        if (containerIdsWithDeletedBlocks.contains(containerId)) {
+          assertThat(dnDeleteTransactionId).isGreaterThan(0);
+          maxTransactionId = max(maxTransactionId, dnDeleteTransactionId);
+        } else {
+          assertEquals(0, dnDeleteTransactionId);
+        }
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce long-tail latency of OM allocateBlock

When SCM handles `DeleteScmKeyBlocks` requests, `AllocateScmBlock` can see high tail latency because `SequenceIdGenerator#getNextId` waits for `SCMStateMachine` to finish applying DeleteScmKeyBlocks's `DeletedBlockLogStateManagerImpl#addTransactionsToDB`.

Profiling shows a large part of `DeletedBlockLogStateManagerImpl#addTransactionsToDB` time is spent updating SCM-side `ContainerInfo#deleteTransactionId`.
This field is not used by current SCM business logic, while DN-side delete transaction tracking is maintained independently.

This commit removes the SCM-side `ContainerInfo#deleteTransactionId` update from `addTransactionsToDB` to reduce unnecessary StateMachine apply work and improve write tail latency.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15634


## How was this patch tested?
existing test

https://github.com/xichen01/ozone/actions/runs/27909174625

