### PR TITLE
HDDS-15579. Replace SimpleSpanProcessor with BatchSpanProcessor

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -29,7 +29,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
@@ -106,9 +105,11 @@ public final class TracingUtil {
     if (batchSpanProcessor == null) {
       return;
     }
-    CompletableResultCode result = batchSpanProcessor.forceFlush().join(10, TimeUnit.SECONDS);
-    if (!result.isDone()) {
-      LOG.warn("Tracing flush did not complete within 10s; some spans may be lost");
+    try {
+      // Best-effort: wait up to 10s for span export; remaining spans may be dropped on exit.
+      batchSpanProcessor.forceFlush().join(10, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      LOG.warn("Tracing flush: forceFlush failed", e);
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -29,6 +29,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
@@ -105,10 +106,9 @@ public final class TracingUtil {
     if (batchSpanProcessor == null) {
       return;
     }
-    try {
-      batchSpanProcessor.forceFlush().join(10, TimeUnit.SECONDS);
-    } catch (Exception e) {
-      LOG.warn("Tracing flush: forceFlush failed", e);
+    CompletableResultCode result = batchSpanProcessor.forceFlush().join(10, TimeUnit.SECONDS);
+    if (!result.isDone()) {
+      LOG.warn("Tracing flush did not complete within 10s; some spans may be lost");
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -54,7 +54,7 @@ public final class TracingUtil {
 
   private static volatile boolean isInit = false;
   private static Tracer tracer = OpenTelemetry.noop().getTracer("noop");
-  private static SdkTracerProvider sdkTracerProvider;
+  private static volatile SdkTracerProvider sdkTracerProvider;
   private static BatchSpanProcessor batchSpanProcessor;
 
   private TracingUtil() {
@@ -134,7 +134,7 @@ public final class TracingUtil {
       return;
     }
     try {
-      sdkTracerProvider.shutdown();
+      sdkTracerProvider.shutdown().join(10L, TimeUnit.SECONDS);
     } catch (Exception e) {
       LOG.warn("Tracing shutdown failed", e);
     } finally {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -31,12 +31,13 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.ratis.util.function.CheckedRunnable;
@@ -54,6 +55,7 @@ public final class TracingUtil {
   private static volatile boolean isInit = false;
   private static Tracer tracer = OpenTelemetry.noop().getTracer("noop");
   private static SdkTracerProvider sdkTracerProvider;
+  private static BatchSpanProcessor batchSpanProcessor;
 
   private TracingUtil() {
   }
@@ -95,13 +97,35 @@ public final class TracingUtil {
     initTracing(serviceName, tracingConfig);
   }
 
-  private static void shutdownTracing() {
-    if (sdkTracerProvider != null) {
-      sdkTracerProvider.shutdown();
-      sdkTracerProvider = null;
+  /**
+   * Drain the BatchSpanProcessor queue without shutting down.
+   * Call from short-lived CLIs before the JVM exits.
+   */
+  public static synchronized void flushTracing() {
+    if (batchSpanProcessor == null) {
+      return;
     }
-    tracer = OpenTelemetry.noop().getTracer("noop");
-    isInit = false;
+    try {
+      batchSpanProcessor.forceFlush().join(10, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      LOG.warn("Tracing flush: forceFlush failed", e);
+    }
+  }
+
+  private static void shutdownTracing() {
+    if (sdkTracerProvider == null) {
+      return;
+    }
+    try {
+      sdkTracerProvider.shutdown();
+    } catch (Exception e) {
+      LOG.warn("Tracing shutdown failed", e);
+    } finally {
+      sdkTracerProvider = null;
+      batchSpanProcessor = null;
+      tracer = OpenTelemetry.noop().getTracer("noop");
+      isInit = false;
+    }
   }
 
   private static void initialize(String serviceName, TracingConfig tracingConfig) {
@@ -119,7 +143,7 @@ public final class TracingUtil {
         .setEndpoint(otelEndPoint)
         .build();
 
-    SimpleSpanProcessor spanProcessor = SimpleSpanProcessor.builder(spanExporter).build();
+    batchSpanProcessor = BatchSpanProcessor.builder(spanExporter).build();
 
     // Choose sampler based on span sampling config. If it is empty use trace based sampling only.
     // else use custom SpanSampler.
@@ -132,7 +156,7 @@ public final class TracingUtil {
     }
 
     SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
-        .addSpanProcessor(spanProcessor)
+        .addSpanProcessor(batchSpanProcessor)
         .setResource(resource)
         .setSampler(sampler)
         .build();
@@ -145,6 +169,7 @@ public final class TracingUtil {
       sdkTracerProvider = tracerProvider;
     } catch (RuntimeException e) {
       tracerProvider.shutdown();
+      batchSpanProcessor = null;
       throw e;
     }
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -112,6 +112,22 @@ public final class TracingUtil {
     }
   }
 
+  /**
+   * This function initializes tracing, runs the command in a span, and exports spans before returning for CLI spans.
+   */
+  public static <R, E extends Exception> R execute(
+      String serviceName,
+      String spanName,
+      ConfigurationSource conf,
+      CheckedSupplier<R, E> supplier) throws E {
+    initTracing(serviceName, conf);
+    try {
+      return executeInNewSpan(spanName, supplier);
+    } finally {
+      flushTracing();
+    }
+  }
+
   private static void shutdownTracing() {
     if (sdkTracerProvider == null) {
       return;

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -101,7 +101,12 @@ public abstract class Shell extends GenericCli {
 
     TracingUtil.initTracing("shell", getOzoneConf());
     String spanName = spec.name() + " " + String.join(" ", parseResult.originalArgs());
-    return TracingUtil.executeInNewSpan(spanName, () -> new CommandLine.RunLast().execute(parseResult));
+    try {
+      return TracingUtil.executeInNewSpan(spanName,
+          () -> new CommandLine.RunLast().execute(parseResult));
+    } finally {
+      TracingUtil.flushTracing();
+    }
   }
 
   private void installBatchExceptionHandler() {

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -99,14 +99,9 @@ public abstract class Shell extends GenericCli {
       return 0;
     }
 
-    TracingUtil.initTracing("shell", getOzoneConf());
     String spanName = spec.name() + " " + String.join(" ", parseResult.originalArgs());
-    try {
-      return TracingUtil.executeInNewSpan(spanName,
-          () -> new CommandLine.RunLast().execute(parseResult));
-    } finally {
-      TracingUtil.flushTracing();
-    }
+    return TracingUtil.execute("shell", spanName, getOzoneConf(),
+        () -> new CommandLine.RunLast().execute(parseResult));
   }
 
   private void installBatchExceptionHandler() {

--- a/hadoop-ozone/dist/src/main/compose/ozone/monitoring.conf
+++ b/hadoop-ozone/dist/src/main/compose/ozone/monitoring.conf
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 OZONE-SITE.XML_hdds.prometheus.endpoint.enabled=true
-OZONE-SITE.XML_hdds.tracing.enabled=true
+OZONE-SITE.XML_ozone.tracing.enabled=true
 OZONE-SITE.XML_ozone.metastore.rocksdb.statistics=ALL
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -59,7 +59,11 @@ public class Freon extends GenericCli implements ExtensibleParentCommand {
     HddsServerUtil.initializeMetrics(conf, "ozone-freon");
     TracingUtil.initTracing("freon", conf);
     String spanName = "ozone freon " + String.join(" ", argv);
-    return TracingUtil.executeInNewSpan(spanName, () -> super.execute(argv));
+    try {
+      return TracingUtil.executeInNewSpan(spanName, () -> super.execute(argv));
+    } finally {
+      TracingUtil.flushTracing();
+    }
   }
 
   @Override

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -57,13 +57,8 @@ public class Freon extends GenericCli implements ExtensibleParentCommand {
   public int execute(String[] argv) {
     conf = getOzoneConf();
     HddsServerUtil.initializeMetrics(conf, "ozone-freon");
-    TracingUtil.initTracing("freon", conf);
     String spanName = "ozone freon " + String.join(" ", argv);
-    try {
-      return TracingUtil.executeInNewSpan(spanName, () -> super.execute(argv));
-    } finally {
-      TracingUtil.flushTracing();
-    }
+    return TracingUtil.execute("freon", spanName, conf, () -> super.execute(argv));
   }
 
   @Override

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
@@ -78,16 +78,10 @@ public class OzoneFsShell extends FsShell {
   public static void main(String[] argv) throws Exception {
     OzoneFsShell shell = newShellInstance();
     OzoneConfiguration conf = new OzoneConfiguration();
-    TracingUtil.initTracing("FsShell", conf);
     conf.setQuietMode(false);
     shell.setConf(conf);
     String spanName = "ozone fs " + String.join(" ", argv);
-    int res;
-    try {
-      res = TracingUtil.executeInNewSpan(spanName, () -> shell.execute(argv));
-    } finally {
-      TracingUtil.flushTracing();
-    }
+    int res = TracingUtil.execute("FsShell", spanName, conf, () -> shell.execute(argv));
 
     System.exit(res);
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
@@ -78,10 +78,12 @@ public class OzoneFsShell extends FsShell {
   public static void main(String[] argv) throws Exception {
     OzoneFsShell shell = newShellInstance();
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setQuietMode(false);
-    shell.setConf(conf);
     String spanName = "ozone fs " + String.join(" ", argv);
-    int res = TracingUtil.execute("FsShell", spanName, conf, () -> shell.execute(argv));
+    int res = TracingUtil.execute("FsShell", spanName, conf, () -> {
+      conf.setQuietMode(false);
+      shell.setConf(conf);
+      return shell.execute(argv);
+    });
 
     System.exit(res);
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
@@ -82,8 +82,13 @@ public class OzoneFsShell extends FsShell {
     conf.setQuietMode(false);
     shell.setConf(conf);
     String spanName = "ozone fs " + String.join(" ", argv);
-    int res = TracingUtil.executeInNewSpan(spanName,
-        () -> shell.execute(argv));
+    int res;
+    try {
+      res = TracingUtil.executeInNewSpan(spanName, () -> shell.execute(argv));
+    } finally {
+      TracingUtil.flushTracing();
+    }
+
     System.exit(res);
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneRatis.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneRatis.java
@@ -38,17 +38,12 @@ public class OzoneRatis extends GenericCli {
 
   @Override
   public int execute(String[] argv) {
-    TracingUtil.initTracing("shell", getOzoneConf());
     String spanName = "ozone ratis " + String.join(" ", argv);
-    try {
-      return TracingUtil.executeInNewSpan(spanName, () -> {
-        // TODO: When Ozone has RATIS-2155, update this line to use the RatisShell.Builder
-        //       in order to setup TLS and other confs.
-        final RatisShell shell = new RatisShell(System.out);
-        return shell.run(argv);
-      });
-    } finally {
-      TracingUtil.flushTracing();
-    }
+    return TracingUtil.execute("shell", spanName, getOzoneConf(), () -> {
+      // TODO: When Ozone has RATIS-2155, update this line to use the RatisShell.Builder
+      //       in order to setup TLS and other confs.
+      final RatisShell shell = new RatisShell(System.out);
+      return shell.run(argv);
+    });
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneRatis.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneRatis.java
@@ -39,12 +39,16 @@ public class OzoneRatis extends GenericCli {
   @Override
   public int execute(String[] argv) {
     TracingUtil.initTracing("shell", getOzoneConf());
-    String spanName = "ozone ratis" + String.join(" ", argv);
-    return TracingUtil.executeInNewSpan(spanName, () -> {
-      // TODO: When Ozone has RATIS-2155, update this line to use the RatisShell.Builder
-      //       in order to setup TLS and other confs.
-      final RatisShell shell = new RatisShell(System.out);
-      return shell.run(argv);
-    });
+    String spanName = "ozone ratis " + String.join(" ", argv);
+    try {
+      return TracingUtil.executeInNewSpan(spanName, () -> {
+        // TODO: When Ozone has RATIS-2155, update this line to use the RatisShell.Builder
+        //       in order to setup TLS and other confs.
+        final RatisShell shell = new RatisShell(System.out);
+        return shell.run(argv);
+      });
+    } finally {
+      TracingUtil.flushTracing();
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
while running tracing while creating 100000 keys.
with tracing enabled it currently takes around 25-30 min but with it off it takes around 1-2 min.
currently we are using simplespanprocessor which works synchronously for spans being exported , therefore taking so long.

We should change usage to batchspanprocessor which does the same thing asynchronously

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15579

## How was this patch tested?

Manual test.
#### Command:
```
bash-5.1$ ozone freon rk --num-of-volumes 1 --num-of-buckets 1 --num-of-keys 100000 --num-of-threads 24 --key-size 1KB
```
#### BEFORE:
```
***************************************************
Status: Success
Git Base Revision: 9d50c6884666e794e45102260a4017bb31802e1b
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 100000
Average Time spent in volume creation: 00:00:00,002
Average Time spent in bucket creation: 00:00:00,000
Average Time spent in key creation: 00:07:39,104
Average Time spent in key write: 00:00:00,298
Total bytes written: 102400000
Total Execution time: 00:36:29,767
***************************************************
```

#### AFTER:
```
***************************************************
Status: Success
Git Base Revision: 9d50c6884666e794e45102260a4017bb31802e1b
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 100000
Average Time spent in volume creation: 00:00:00,001
Average Time spent in bucket creation: 00:00:00,000
Average Time spent in key creation: 00:00:11,312
Average Time spent in key write: 00:00:00,216
Total bytes written: 102400000
Total Execution time: 00:00:57,661
***************************************************
```
