### PR TITLE
HDDS-15602. Read pipeline ID does not need to use secure random

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.nio.ByteBuffer;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -54,7 +55,9 @@ public final class PipelineID {
   }
 
   public static PipelineID insecureRandomId() {
-    return new PipelineID(new UUID(UUIDUtil.insecureRandomUUIDBytes()));
+    byte[] bytes = UUIDUtil.insecureRandomUUIDBytes();
+    ByteBuffer buf = ByteBuffer.wrap(bytes);
+    return new PipelineID(new UUID(buf.getLong(), buf.getLong()));
   }
 
   public static PipelineID valueOf(UUID id) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.UuidCodec;
+import org.apache.hadoop.ozone.util.UUIDUtil;
 import org.apache.ratis.util.MemoizedSupplier;
 
 /**
@@ -50,6 +51,10 @@ public final class PipelineID {
 
   public static PipelineID randomId() {
     return new PipelineID(UUID.randomUUID());
+  }
+
+  public static PipelineID insecureRandomId() {
+    return new PipelineID(new UUID(UUIDUtil.insecureRandomUUIDBytes()));
   }
 
   public static PipelineID valueOf(UUID id) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
@@ -54,6 +54,13 @@ public final class PipelineID {
     return new PipelineID(UUID.randomUUID());
   }
 
+  /**
+   * Generates a random PipelineID using {@link java.util.Random} instead of
+   * {@link java.security.SecureRandom}. This avoids contention on the shared
+   * {@code SecureRandom} instance and is suitable for non-sensitive,
+   * throwaway IDs such as read pipelines, where predictability of the next
+   * ID has no security impact.
+   */
   public static PipelineID insecureRandomId() {
     byte[] bytes = UUIDUtil.insecureRandomUUIDBytes();
     ByteBuffer buf = ByteBuffer.wrap(bytes);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/UUIDUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/UUIDUtil.java
@@ -18,16 +18,29 @@
 package org.apache.hadoop.ozone.util;
 
 import java.security.SecureRandom;
+import java.util.Random;
 
 /**
  * Helper methods to deal with random UUIDs.
  */
 public final class UUIDUtil {
   private static final ThreadLocal<SecureRandom> GENERATOR = ThreadLocal.withInitial(SecureRandom::new);
+  private static final ThreadLocal<Random> INSECURE_GENERATOR = ThreadLocal.withInitial(Random::new);
 
   public static byte[] randomUUIDBytes() {
     final byte[] bytes = new byte[16];
     GENERATOR.get().nextBytes(bytes);
+    // See RFC 4122 section 4.4
+    bytes[6]  &= 0x0f;
+    bytes[6]  |= 0x40;
+    bytes[8]  &= 0x3f;
+    bytes[8]  |= 0x80;
+    return bytes;
+  }
+
+  public static byte[] insecureRandomUUIDBytes() {
+    final byte[] bytes = new byte[16];
+    INSECURE_GENERATOR.get().nextBytes(bytes);
     // See RFC 4122 section 4.4
     bytes[6]  &= 0x0f;
     bytes[6]  |= 0x40;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/UUIDUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/UUIDUtil.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.util;
 
 import java.security.SecureRandom;
 import java.util.Random;
+import java.util.function.Consumer;
 
 /**
  * Helper methods to deal with random UUIDs.
@@ -28,19 +29,16 @@ public final class UUIDUtil {
   private static final ThreadLocal<Random> INSECURE_GENERATOR = ThreadLocal.withInitial(Random::new);
 
   public static byte[] randomUUIDBytes() {
-    final byte[] bytes = new byte[16];
-    GENERATOR.get().nextBytes(bytes);
-    // See RFC 4122 section 4.4
-    bytes[6]  &= 0x0f;
-    bytes[6]  |= 0x40;
-    bytes[8]  &= 0x3f;
-    bytes[8]  |= 0x80;
-    return bytes;
+    return getUUIDBytes(GENERATOR.get()::nextBytes);
   }
 
   public static byte[] insecureRandomUUIDBytes() {
+    return getUUIDBytes(INSECURE_GENERATOR.get()::nextBytes);
+  }
+
+  private static byte[] getUUIDBytes(Consumer<byte[]> generator) {
     final byte[] bytes = new byte[16];
-    INSECURE_GENERATOR.get().nextBytes(bytes);
+    generator.accept(bytes);
     // See RFC 4122 section 4.4
     bytes[6]  &= 0x0f;
     bytes[6]  |= 0x40;

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -226,12 +226,6 @@
       <artifactId>hdds-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>4.0.4</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
   <build>
     <testResources>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -226,6 +226,12 @@
       <artifactId>hdds-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.4</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <build>
     <testResources>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
@@ -17,7 +17,10 @@
 
 package org.apache.hadoop.hdds.scm.container;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -163,6 +166,12 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
         .append(this.containerID, that.containerID)
         .append(this.datanodeDetails, that.datanodeDetails)
         .build();
+  }
+
+  public static List<DatanodeDetails> toDatanodeDetailsList(Set<ContainerReplica> replicas) {
+    return replicas.stream()
+        .map(ContainerReplica::getDatanodeDetails)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -130,6 +130,8 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
 
     dns.sort(Comparator.comparing(nodeStatusMap::get, CREATE_FOR_READ_COMPARATOR));
 
+    // Use insecureRandomId for throwaway read pipeline IDs to avoid
+    // contention on the shared SecureRandom instance.
     return Pipeline.newBuilder()
         .setId(PipelineID.insecureRandomId())
         .setState(Pipeline.PipelineState.ALLOCATED)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -103,7 +103,10 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
       ecIndex++;
     }
 
-    return createPipelineInternal(replicationConfig, nodes, dnIndexes);
+    return newPipelineBuilder(replicationConfig, nodes)
+        .setId(PipelineID.randomId())
+        .setReplicaIndexes(dnIndexes)
+        .build();
   }
 
   @Override
@@ -132,23 +135,9 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
 
     // Use insecureRandomId for throwaway read pipeline IDs to avoid
     // contention on the shared SecureRandom instance.
-    return Pipeline.newBuilder()
+    return newPipelineBuilder(replicationConfig, dns)
         .setId(PipelineID.insecureRandomId())
-        .setState(Pipeline.PipelineState.ALLOCATED)
-        .setReplicationConfig(replicationConfig)
-        .setNodes(dns)
         .setReplicaIndexes(map)
-        .build();
-  }
-
-  private Pipeline createPipelineInternal(ECReplicationConfig repConfig,
-      List<DatanodeDetails> dns, Map<DatanodeDetails, Integer> indexes) {
-    return Pipeline.newBuilder()
-        .setId(PipelineID.randomId())
-        .setState(Pipeline.PipelineState.ALLOCATED)
-        .setReplicationConfig(repConfig)
-        .setNodes(dns)
-        .setReplicaIndexes(indexes)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -130,7 +130,13 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
 
     dns.sort(Comparator.comparing(nodeStatusMap::get, CREATE_FOR_READ_COMPARATOR));
 
-    return createPipelineInternal(replicationConfig, dns, map);
+    return Pipeline.newBuilder()
+        .setId(PipelineID.insecureRandomId())
+        .setState(Pipeline.PipelineState.ALLOCATED)
+        .setReplicationConfig(replicationConfig)
+        .setNodes(dns)
+        .setReplicaIndexes(map)
+        .build();
   }
 
   private Pipeline createPipelineInternal(ECReplicationConfig repConfig,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
@@ -139,4 +139,11 @@ public abstract class PipelineProvider<REPLICATION_CONFIG
     }
     return dns;
   }
+
+  protected Pipeline.Builder newPipelineBuilder(ReplicationConfig replicationConfig, List<DatanodeDetails> nodes) {
+    return Pipeline.newBuilder()
+        .setNodes(nodes)
+        .setReplicationConfig(replicationConfig)
+        .setState(Pipeline.PipelineState.ALLOCATED);
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -182,6 +182,7 @@ public class RatisPipelineProvider
     DatanodeDetails suggestedLeader = leaderChoosePolicy.chooseLeader(dns);
 
     Pipeline pipeline = newPipelineBuilder(RatisReplicationConfig.getInstance(factor), dns)
+        .setId(PipelineID.randomId())
         .setSuggestedLeaderId(suggestedLeader != null ? suggestedLeader.getID() : null)
         .build();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -225,6 +225,8 @@ public class RatisPipelineProvider
   public Pipeline createForRead(
       RatisReplicationConfig replicationConfig,
       Set<ContainerReplica> replicas) {
+    // Use insecureRandomId for throwaway read pipeline IDs to avoid
+    // contention on the shared SecureRandom instance.
     return Pipeline.newBuilder()
         .setId(PipelineID.insecureRandomId())
         .setState(PipelineState.ALLOCATED)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -225,10 +225,14 @@ public class RatisPipelineProvider
   public Pipeline createForRead(
       RatisReplicationConfig replicationConfig,
       Set<ContainerReplica> replicas) {
-    return create(replicationConfig, replicas
-        .stream()
-        .map(ContainerReplica::getDatanodeDetails)
-        .collect(Collectors.toList()));
+    return Pipeline.newBuilder()
+        .setId(PipelineID.insecureRandomId())
+        .setState(PipelineState.ALLOCATED)
+        .setReplicationConfig(replicationConfig)
+        .setNodes(replicas.stream()
+            .map(ContainerReplica::getDatanodeDetails)
+            .collect(Collectors.toList()))
+        .build();
   }
 
   private List<DatanodeDetails> filterPipelineEngagement() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -182,13 +181,8 @@ public class RatisPipelineProvider
 
     DatanodeDetails suggestedLeader = leaderChoosePolicy.chooseLeader(dns);
 
-    Pipeline pipeline = Pipeline.newBuilder()
-        .setId(PipelineID.randomId())
-        .setState(PipelineState.ALLOCATED)
-        .setReplicationConfig(RatisReplicationConfig.getInstance(factor))
-        .setNodes(dns)
-        .setSuggestedLeaderId(
-            suggestedLeader != null ? suggestedLeader.getID() : null)
+    Pipeline pipeline = newPipelineBuilder(RatisReplicationConfig.getInstance(factor), dns)
+        .setSuggestedLeaderId(suggestedLeader != null ? suggestedLeader.getID() : null)
         .build();
 
     // Send command to datanodes to create pipeline
@@ -213,11 +207,8 @@ public class RatisPipelineProvider
   @Override
   public Pipeline create(RatisReplicationConfig replicationConfig,
       List<DatanodeDetails> nodes) {
-    return Pipeline.newBuilder()
+    return newPipelineBuilder(replicationConfig, nodes)
         .setId(PipelineID.randomId())
-        .setState(PipelineState.ALLOCATED)
-        .setReplicationConfig(replicationConfig)
-        .setNodes(nodes)
         .build();
   }
 
@@ -227,13 +218,8 @@ public class RatisPipelineProvider
       Set<ContainerReplica> replicas) {
     // Use insecureRandomId for throwaway read pipeline IDs to avoid
     // contention on the shared SecureRandom instance.
-    return Pipeline.newBuilder()
+    return newPipelineBuilder(replicationConfig, ContainerReplica.toDatanodeDetailsList(replicas))
         .setId(PipelineID.insecureRandomId())
-        .setState(PipelineState.ALLOCATED)
-        .setReplicationConfig(replicationConfig)
-        .setNodes(replicas.stream()
-            .map(ContainerReplica::getDatanodeDetails)
-            .collect(Collectors.toList()))
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -84,6 +84,8 @@ public class SimplePipelineProvider
   @Override
   public Pipeline createForRead(StandaloneReplicationConfig replicationConfig,
       Set<ContainerReplica> replicas) {
+    // Use insecureRandomId for throwaway read pipeline IDs to avoid
+    // contention on the shared SecureRandom instance.
     return Pipeline.newBuilder()
         .setId(PipelineID.insecureRandomId())
         .setState(PipelineState.OPEN)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -84,10 +84,14 @@ public class SimplePipelineProvider
   @Override
   public Pipeline createForRead(StandaloneReplicationConfig replicationConfig,
       Set<ContainerReplica> replicas) {
-    return create(replicationConfig, replicas
-        .stream()
-        .map(ContainerReplica::getDatanodeDetails)
-        .collect(Collectors.toList()));
+    return Pipeline.newBuilder()
+        .setId(PipelineID.insecureRandomId())
+        .setState(PipelineState.OPEN)
+        .setReplicationConfig(replicationConfig)
+        .setNodes(replicas.stream()
+            .map(ContainerReplica::getDatanodeDetails)
+            .collect(Collectors.toList()))
+        .build();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -61,23 +61,16 @@ public class SimplePipelineProvider
     }
 
     Collections.shuffle(dns);
-    return Pipeline.newBuilder()
+    return newPipelineBuilder(replicationConfig, dns.subList(0, replicationConfig.getReplicationFactor().getNumber()))
         .setId(PipelineID.randomId())
-        .setState(PipelineState.OPEN)
-        .setReplicationConfig(replicationConfig)
-        .setNodes(dns.subList(0,
-            replicationConfig.getReplicationFactor().getNumber()))
         .build();
   }
 
   @Override
   public Pipeline create(StandaloneReplicationConfig replicationConfig,
       List<DatanodeDetails> nodes) {
-    return Pipeline.newBuilder()
+    return newPipelineBuilder(replicationConfig, nodes)
         .setId(PipelineID.randomId())
-        .setState(PipelineState.OPEN)
-        .setReplicationConfig(replicationConfig)
-        .setNodes(nodes)
         .build();
   }
 
@@ -86,13 +79,8 @@ public class SimplePipelineProvider
       Set<ContainerReplica> replicas) {
     // Use insecureRandomId for throwaway read pipeline IDs to avoid
     // contention on the shared SecureRandom instance.
-    return Pipeline.newBuilder()
+    return newPipelineBuilder(replicationConfig, ContainerReplica.toDatanodeDetailsList(replicas))
         .setId(PipelineID.insecureRandomId())
-        .setState(PipelineState.OPEN)
-        .setReplicationConfig(replicationConfig)
-        .setNodes(replicas.stream()
-            .map(ContainerReplica::getDatanodeDetails)
-            .collect(Collectors.toList()))
         .build();
   }
 
@@ -101,4 +89,9 @@ public class SimplePipelineProvider
 
   }
 
+  @Override
+  protected Pipeline.Builder newPipelineBuilder(ReplicationConfig replicationConfig, List<DatanodeDetails> nodes) {
+    return super.newPipelineBuilder(replicationConfig, nodes)
+        .setState(PipelineState.OPEN);
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We found that the CPU time of createPipelineForRead during high read traffic is mostly spent waiting on the SecureRandom monitor lock during the UUID random generation. SecureRandom is static and therefore lock should be static which also contends with all other UUID generation and can affect performance (as per Amdahl's law). I don't think it is required to use SecureRandom for read pipeline ID since the read pipeline ID is not sensitive (AFAIK it's throwaway ID) and predicting the next read pipeline ID should not have any security implication


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15602

## How was this patch tested?

CI