### PR TITLE
HDDS-15638. Conditional DeleteObjects

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -352,7 +352,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     if (request.getObjects() != null) {
       Map<String, ErrorInfo> undeletedKeyResultMap;
       boolean hasConditionalDeletes = request.getObjects().stream()
-          .anyMatch(d -> StringUtils.isNotBlank(d.getETag()));
+          .anyMatch(d -> StringUtils.isNotBlank(d.getIfMatch()));
       long startNanos = Time.monotonicNowNanos();
       try {
         S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());
@@ -409,11 +409,11 @@ public class BucketEndpoint extends BucketOperationHandler {
       MultiDeleteResponse result, boolean quiet, List<String> failedDeletes)
       throws IOException {
     String key = deleteObject.getKey();
-    if (StringUtils.isNotBlank(deleteObject.getETag())) {
+    if (StringUtils.isNotBlank(deleteObject.getIfMatch())) {
       try {
         OzoneKeyDetails keyDetails = bucket.getKey(key);
         String currentETag = keyDetails.getMetadata().get(ETAG);
-        if (!S3ConditionalRequest.matchesETag(deleteObject.getETag(), currentETag)) {
+        if (!S3ConditionalRequest.matchesETag(deleteObject.getIfMatch(), currentETag)) {
           addPreconditionFailedError(result, key);
           return;
         }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -413,7 +413,7 @@ public class BucketEndpoint extends BucketOperationHandler {
       try {
         OzoneKeyDetails keyDetails = bucket.getKey(key);
         String currentETag = keyDetails.getMetadata().get(ETAG);
-        if (!S3ConditionalRequest.matchesETag(deleteObject.getIfMatch(), currentETag)) {
+        if (!S3ConditionalRequest.eTagMatches(deleteObject.getIfMatch(), currentETag)) {
           addPreconditionFailedError(result, key);
           return;
         }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -30,6 +30,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapInQuotes;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,7 @@ import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.audit.S3GAction;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.ErrorInfo;
@@ -349,25 +351,35 @@ public class BucketEndpoint extends BucketOperationHandler {
 
     if (request.getObjects() != null) {
       Map<String, ErrorInfo> undeletedKeyResultMap;
-      for (DeleteObject keyToDelete : request.getObjects()) {
-        deleteKeys.add(keyToDelete.getKey());
-      }
+      boolean hasConditionalDeletes = request.getObjects().stream()
+          .anyMatch(d -> StringUtils.isNotBlank(d.getETag()));
       long startNanos = Time.monotonicNowNanos();
       try {
         S3Owner.verifyBucketOwnerCondition(getHeaders(), bucketName, bucket.getOwner());
-        undeletedKeyResultMap = bucket.deleteKeys(deleteKeys, true);
-        for (DeleteObject d : request.getObjects()) {
-          ErrorInfo error = undeletedKeyResultMap.get(d.getKey());
-          boolean deleted = error == null ||
-              // if the key is not found, it is assumed to be successfully deleted
-              ResultCodes.KEY_NOT_FOUND.name().equals(error.getCode());
-          if (deleted) {
-            deleteKeys.remove(d.getKey());
-            if (!request.isQuiet()) {
-              result.addDeleted(new DeletedObject(d.getKey()));
+        if (hasConditionalDeletes) {
+          for (DeleteObject keyToDelete : request.getObjects()) {
+            deleteKeys.add(keyToDelete.getKey());
+            deleteSingleObject(bucket, keyToDelete, result, request.isQuiet(),
+                deleteKeys);
+          }
+        } else {
+          for (DeleteObject keyToDelete : request.getObjects()) {
+            deleteKeys.add(keyToDelete.getKey());
+          }
+          undeletedKeyResultMap = bucket.deleteKeys(deleteKeys, true);
+          for (DeleteObject d : request.getObjects()) {
+            ErrorInfo error = undeletedKeyResultMap.get(d.getKey());
+            boolean deleted = error == null ||
+                // if the key is not found, it is assumed to be successfully deleted
+                ResultCodes.KEY_NOT_FOUND.name().equals(error.getCode());
+            if (deleted) {
+              deleteKeys.remove(d.getKey());
+              if (!request.isQuiet()) {
+                result.addDeleted(new DeletedObject(d.getKey()));
+              }
+            } else {
+              result.addError(new Error(d.getKey(), error.getCode(), error.getMessage()));
             }
-          } else {
-            result.addError(new Error(d.getKey(), error.getCode(), error.getMessage()));
           }
         }
         getMetrics().updateDeleteKeySuccessStats(startNanos);
@@ -391,6 +403,48 @@ public class BucketEndpoint extends BucketOperationHandler {
     }
 
     return result;
+  }
+
+  private void deleteSingleObject(OzoneBucket bucket, DeleteObject deleteObject,
+      MultiDeleteResponse result, boolean quiet, List<String> failedDeletes)
+      throws IOException {
+    String key = deleteObject.getKey();
+    if (StringUtils.isNotBlank(deleteObject.getETag())) {
+      try {
+        OzoneKeyDetails keyDetails = bucket.getKey(key);
+        String currentETag = keyDetails.getMetadata().get(ETAG);
+        if (!S3ConditionalRequest.matchesETag(deleteObject.getETag(), currentETag)) {
+          addPreconditionFailedError(result, key);
+          return;
+        }
+      } catch (OMException ex) {
+        if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
+          addPreconditionFailedError(result, key);
+          return;
+        }
+        throw ex;
+      }
+    }
+
+    Map<String, ErrorInfo> undeletedKeyResultMap =
+        bucket.deleteKeys(Collections.singletonList(key), true);
+    ErrorInfo error = undeletedKeyResultMap.get(key);
+    boolean deleted = error == null ||
+        ResultCodes.KEY_NOT_FOUND.name().equals(error.getCode());
+    if (deleted) {
+      failedDeletes.remove(key);
+      if (!quiet) {
+        result.addDeleted(new DeletedObject(key));
+      }
+    } else {
+      result.addError(new Error(key, error.getCode(), error.getMessage()));
+    }
+  }
+
+  private static void addPreconditionFailedError(MultiDeleteResponse result,
+      String key) {
+    result.addError(new Error(key, S3ErrorTable.PRECOND_FAILED.getCode(),
+        S3ErrorTable.PRECOND_FAILED.getErrorMessage()));
   }
 
   private void addKey(ListObjectResponse response, OzoneKey next) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
@@ -69,8 +69,8 @@ public class MultiDeleteRequest {
     @XmlElement(name = "VersionId")
     private String versionId;
 
-    @XmlElement(name = "ETag")
-    private String etag;
+    @XmlElement(name = S3Consts.IF_MATCH_HEADER)
+    private String ifMatch;
 
     public DeleteObject() {
     }
@@ -79,9 +79,9 @@ public class MultiDeleteRequest {
       this.key = key;
     }
 
-    public DeleteObject(String key, String etag) {
+    public DeleteObject(String key, String ifMatch) {
       this.key = key;
-      this.etag = etag;
+      this.ifMatch = ifMatch;
     }
 
     public String getKey() {
@@ -100,12 +100,12 @@ public class MultiDeleteRequest {
       this.versionId = versionId;
     }
 
-    public String getETag() {
-      return etag;
+    public String getIfMatch() {
+      return ifMatch;
     }
 
-    public void setETag(String eTag) {
-      this.etag = eTag;
+    public void setIfMatch(String ifMatch) {
+      this.ifMatch = ifMatch;
     }
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequest.java
@@ -69,11 +69,19 @@ public class MultiDeleteRequest {
     @XmlElement(name = "VersionId")
     private String versionId;
 
+    @XmlElement(name = "ETag")
+    private String etag;
+
     public DeleteObject() {
     }
 
     public DeleteObject(String key) {
       this.key = key;
+    }
+
+    public DeleteObject(String key, String etag) {
+      this.key = key;
+      this.etag = etag;
     }
 
     public String getKey() {
@@ -90,6 +98,14 @@ public class MultiDeleteRequest {
 
     public void setVersionId(String versionId) {
       this.versionId = versionId;
+    }
+
+    public String getETag() {
+      return etag;
+    }
+
+    public void setETag(String eTag) {
+      this.etag = eTag;
     }
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3ConditionalRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3ConditionalRequest.java
@@ -195,12 +195,8 @@ final class S3ConditionalRequest {
     ObjectEndpoint.addLastModifiedDate(responseBuilder, key);
     return responseBuilder.build();
   }
-
-  static boolean matchesETag(String headerValue, String currentETag) {
-    return eTagMatches(headerValue, currentETag);
-  }
-
-  private static boolean eTagMatches(String headerValue, String currentETag) {
+  
+  public static boolean eTagMatches(String headerValue, String currentETag) {
     if (headerValue == null) {
       return false;
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3ConditionalRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3ConditionalRequest.java
@@ -195,7 +195,7 @@ final class S3ConditionalRequest {
     ObjectEndpoint.addLastModifiedDate(responseBuilder, key);
     return responseBuilder.build();
   }
-  
+
   public static boolean eTagMatches(String headerValue, String currentETag) {
     if (headerValue == null) {
       return false;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3ConditionalRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3ConditionalRequest.java
@@ -196,6 +196,10 @@ final class S3ConditionalRequest {
     return responseBuilder.build();
   }
 
+  static boolean matchesETag(String headerValue, String currentETag) {
+    return eTagMatches(headerValue, currentETag);
+  }
+
   private static boolean eTagMatches(String headerValue, String currentETag) {
     if (headerValue == null) {
       return false;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultiDeleteRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultiDeleteRequestUnmarshaller.java
@@ -67,12 +67,12 @@ public class TestMultiDeleteRequestUnmarshaller {
   }
 
   @Test
-  public void fromStreamWithETag() throws IOException {
+  public void fromStreamWithIfMatch() throws IOException {
     ByteArrayInputStream inputBody =
         new ByteArrayInputStream(
             ("<Delete xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">"
-                + "<Object><Key>key1</Key><ETag>\"abc\"</ETag></Object>"
-                + "<Object><Key>key2</Key><ETag>*</ETag></Object>"
+                + "<Object><Key>key1</Key><If-Match>\"abc\"</If-Match></Object>"
+                + "<Object><Key>key2</Key><If-Match>*</If-Match></Object>"
                 + "</Delete>")
                 .getBytes(UTF_8));
 
@@ -80,9 +80,9 @@ public class TestMultiDeleteRequestUnmarshaller {
 
     assertEquals(2, multiDeleteRequest.getObjects().size());
     assertEquals("key1", multiDeleteRequest.getObjects().get(0).getKey());
-    assertEquals("\"abc\"", multiDeleteRequest.getObjects().get(0).getETag());
+    assertEquals("\"abc\"", multiDeleteRequest.getObjects().get(0).getIfMatch());
     assertEquals("key2", multiDeleteRequest.getObjects().get(1).getKey());
-    assertEquals("*", multiDeleteRequest.getObjects().get(1).getETag());
+    assertEquals("*", multiDeleteRequest.getObjects().get(1).getIfMatch());
   }
 
   private MultiDeleteRequest unmarshall(ByteArrayInputStream inputBody)

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultiDeleteRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultiDeleteRequestUnmarshaller.java
@@ -66,6 +66,25 @@ public class TestMultiDeleteRequestUnmarshaller {
     assertEquals(3, multiDeleteRequest.getObjects().size());
   }
 
+  @Test
+  public void fromStreamWithETag() throws IOException {
+    ByteArrayInputStream inputBody =
+        new ByteArrayInputStream(
+            ("<Delete xmlns=\"" + S3Consts.S3_XML_NAMESPACE + "\">"
+                + "<Object><Key>key1</Key><ETag>\"abc\"</ETag></Object>"
+                + "<Object><Key>key2</Key><ETag>*</ETag></Object>"
+                + "</Delete>")
+                .getBytes(UTF_8));
+
+    MultiDeleteRequest multiDeleteRequest = unmarshall(inputBody);
+
+    assertEquals(2, multiDeleteRequest.getObjects().size());
+    assertEquals("key1", multiDeleteRequest.getObjects().get(0).getKey());
+    assertEquals("\"abc\"", multiDeleteRequest.getObjects().get(0).getETag());
+    assertEquals("key2", multiDeleteRequest.getObjects().get(1).getKey());
+    assertEquals("*", multiDeleteRequest.getObjects().get(1).getETag());
+  }
+
   private MultiDeleteRequest unmarshall(ByteArrayInputStream inputBody)
       throws IOException {
     return new MultiDeleteRequestUnmarshaller()

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_XML;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
+import static org.apache.hadoop.ozone.s3.util.S3Utils.parseETag;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -148,17 +149,17 @@ public class TestObjectMultiDelete {
   }
 
   @Test
-  public void conditionalDeleteMatchingETag() throws Exception {
+  public void conditionalDeleteMatchingIfMatch() throws Exception {
     OzoneClient client = new OzoneClientStub();
-    OzoneBucket bucket = initTestDataWithEtags(client);
+    OzoneBucket bucket = initConditionalDeleteTestData(client);
 
     BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
         .build();
 
     MultiDeleteRequest mdr = new MultiDeleteRequest();
-    mdr.getObjects().add(new DeleteObject("key1", "\"etag-1\""));
-    mdr.getObjects().add(new DeleteObject("key2", "etag-2"));
+    mdr.getObjects().add(new DeleteObject("key1", "\"match-1\""));
+    mdr.getObjects().add(new DeleteObject("key2", "match-2"));
 
     MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
 
@@ -168,16 +169,16 @@ public class TestObjectMultiDelete {
   }
 
   @Test
-  public void conditionalDeleteMismatchedETag() throws Exception {
+  public void conditionalDeleteMismatchedIfMatch() throws Exception {
     OzoneClient client = new OzoneClientStub();
-    initTestDataWithEtags(client);
+    initConditionalDeleteTestData(client);
 
     BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
         .build();
 
     MultiDeleteRequest mdr = new MultiDeleteRequest();
-    mdr.getObjects().add(new DeleteObject("key1", "\"wrong-etag\""));
+    mdr.getObjects().add(new DeleteObject("key1", "\"wrong-match\""));
 
     MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
 
@@ -190,14 +191,14 @@ public class TestObjectMultiDelete {
   @Test
   public void conditionalDeleteMissingKeyFails() throws Exception {
     OzoneClient client = new OzoneClientStub();
-    initTestDataWithEtags(client);
+    initConditionalDeleteTestData(client);
 
     BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
         .build();
 
     MultiDeleteRequest mdr = new MultiDeleteRequest();
-    mdr.getObjects().add(new DeleteObject("missing-key", "\"etag-1\""));
+    mdr.getObjects().add(new DeleteObject("missing-key", "\"match-1\""));
 
     MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
 
@@ -207,9 +208,9 @@ public class TestObjectMultiDelete {
   }
 
   @Test
-  public void conditionalDeleteWildcardETag() throws Exception {
+  public void conditionalDeleteWildcardIfMatch() throws Exception {
     OzoneClient client = new OzoneClientStub();
-    OzoneBucket bucket = initTestDataWithEtags(client);
+    OzoneBucket bucket = initConditionalDeleteTestData(client);
 
     BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
@@ -233,14 +234,14 @@ public class TestObjectMultiDelete {
   @Test
   public void conditionalDeleteMixedWithUnconditional() throws Exception {
     OzoneClient client = new OzoneClientStub();
-    OzoneBucket bucket = initTestDataWithEtags(client);
+    OzoneBucket bucket = initConditionalDeleteTestData(client);
 
     BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(client)
         .build();
 
     MultiDeleteRequest mdr = new MultiDeleteRequest();
-    mdr.getObjects().add(new DeleteObject("key1", "\"etag-1\""));
+    mdr.getObjects().add(new DeleteObject("key1", "\"match-1\""));
     mdr.getObjects().add(new DeleteObject("key2"));
     mdr.getObjects().add(new DeleteObject("missing-unconditional"));
 
@@ -263,20 +264,20 @@ public class TestObjectMultiDelete {
     return bucket;
   }
 
-  private OzoneBucket initTestDataWithEtags(OzoneClient client) throws IOException {
+  private OzoneBucket initConditionalDeleteTestData(OzoneClient client) throws IOException {
     client.getObjectStore().createS3Bucket("b1");
 
     OzoneBucket bucket = client.getObjectStore().getS3Bucket("b1");
-    createKeyWithEtag(bucket, "key1", "etag-1");
-    createKeyWithEtag(bucket, "key2", "etag-2");
-    createKeyWithEtag(bucket, "key3", "etag-3");
+    createKeyWithIfMatchTarget(bucket, "key1", "\"match-1\"");
+    createKeyWithIfMatchTarget(bucket, "key2", "match-2");
+    createKeyWithIfMatchTarget(bucket, "key3", "match-3");
     return bucket;
   }
 
-  private static void createKeyWithEtag(OzoneBucket bucket, String keyName,
-      String etag) throws IOException {
+  private static void createKeyWithIfMatchTarget(OzoneBucket bucket, String keyName,
+      String ifMatch) throws IOException {
     Map<String, String> metadata = new HashMap<>();
-    metadata.put(ETAG, etag);
+    metadata.put(ETAG, parseETag(ifMatch));
     try (OzoneOutputStream out = bucket.createKey(keyName, 1,
         bucket.getReplicationConfig(), metadata, emptyMap())) {
       out.write('x');

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
@@ -17,14 +17,20 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
+import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_XML;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.xml.bind.JAXBException;
@@ -32,6 +38,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.s3.endpoint.MultiDeleteRequest.DeleteObject;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
@@ -140,6 +147,110 @@ public class TestObjectMultiDelete {
     assertEquals(3, Sets.newHashSet(bucket.listKeys("")).size());
   }
 
+  @Test
+  public void conditionalDeleteMatchingETag() throws Exception {
+    OzoneClient client = new OzoneClientStub();
+    OzoneBucket bucket = initTestDataWithEtags(client);
+
+    BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
+        .setClient(client)
+        .build();
+
+    MultiDeleteRequest mdr = new MultiDeleteRequest();
+    mdr.getObjects().add(new DeleteObject("key1", "\"etag-1\""));
+    mdr.getObjects().add(new DeleteObject("key2", "etag-2"));
+
+    MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
+
+    assertEquals(2, response.getDeletedObjects().size());
+    assertEquals(0, response.getErrors().size());
+    assertEquals(singleton("key3"), listKeyNames(bucket));
+  }
+
+  @Test
+  public void conditionalDeleteMismatchedETag() throws Exception {
+    OzoneClient client = new OzoneClientStub();
+    initTestDataWithEtags(client);
+
+    BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
+        .setClient(client)
+        .build();
+
+    MultiDeleteRequest mdr = new MultiDeleteRequest();
+    mdr.getObjects().add(new DeleteObject("key1", "\"wrong-etag\""));
+
+    MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
+
+    assertEquals(0, response.getDeletedObjects().size());
+    assertEquals(1, response.getErrors().size());
+    assertEquals(PRECOND_FAILED.getCode(), response.getErrors().get(0).getCode());
+    assertEquals("key1", response.getErrors().get(0).getKey());
+  }
+
+  @Test
+  public void conditionalDeleteMissingKeyFails() throws Exception {
+    OzoneClient client = new OzoneClientStub();
+    initTestDataWithEtags(client);
+
+    BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
+        .setClient(client)
+        .build();
+
+    MultiDeleteRequest mdr = new MultiDeleteRequest();
+    mdr.getObjects().add(new DeleteObject("missing-key", "\"etag-1\""));
+
+    MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
+
+    assertEquals(0, response.getDeletedObjects().size());
+    assertEquals(1, response.getErrors().size());
+    assertEquals(PRECOND_FAILED.getCode(), response.getErrors().get(0).getCode());
+  }
+
+  @Test
+  public void conditionalDeleteWildcardETag() throws Exception {
+    OzoneClient client = new OzoneClientStub();
+    OzoneBucket bucket = initTestDataWithEtags(client);
+
+    BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
+        .setClient(client)
+        .build();
+
+    MultiDeleteRequest mdr = new MultiDeleteRequest();
+    mdr.getObjects().add(new DeleteObject("key1", "*"));
+    mdr.getObjects().add(new DeleteObject("missing-key", "*"));
+
+    MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
+
+    assertEquals(1, response.getDeletedObjects().size());
+    assertEquals("key1", response.getDeletedObjects().get(0).getKey());
+    assertEquals(1, response.getErrors().size());
+    assertEquals("missing-key", response.getErrors().get(0).getKey());
+    assertEquals(PRECOND_FAILED.getCode(), response.getErrors().get(0).getCode());
+    assertTrue(listKeyNames(bucket).contains("key2"));
+    assertTrue(listKeyNames(bucket).contains("key3"));
+  }
+
+  @Test
+  public void conditionalDeleteMixedWithUnconditional() throws Exception {
+    OzoneClient client = new OzoneClientStub();
+    OzoneBucket bucket = initTestDataWithEtags(client);
+
+    BucketEndpoint rest = EndpointBuilder.newBucketEndpointBuilder()
+        .setClient(client)
+        .build();
+
+    MultiDeleteRequest mdr = new MultiDeleteRequest();
+    mdr.getObjects().add(new DeleteObject("key1", "\"etag-1\""));
+    mdr.getObjects().add(new DeleteObject("key2"));
+    mdr.getObjects().add(new DeleteObject("missing-unconditional"));
+
+    MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
+
+    assertEquals(3, response.getDeletedObjects().size());
+    assertEquals(0, response.getErrors().size());
+    assertEquals(singleton("key3"), listKeyNames(bucket));
+  }
+
   private OzoneBucket initTestData(OzoneClient client) throws IOException {
     client.getObjectStore().createS3Bucket("b1");
 
@@ -150,5 +261,31 @@ public class TestObjectMultiDelete {
     bucket.createKey("key2", 0).close();
     bucket.createKey("key3", 0).close();
     return bucket;
+  }
+
+  private OzoneBucket initTestDataWithEtags(OzoneClient client) throws IOException {
+    client.getObjectStore().createS3Bucket("b1");
+
+    OzoneBucket bucket = client.getObjectStore().getS3Bucket("b1");
+    createKeyWithEtag(bucket, "key1", "etag-1");
+    createKeyWithEtag(bucket, "key2", "etag-2");
+    createKeyWithEtag(bucket, "key3", "etag-3");
+    return bucket;
+  }
+
+  private static void createKeyWithEtag(OzoneBucket bucket, String keyName,
+      String etag) throws IOException {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put(ETAG, etag);
+    try (OzoneOutputStream out = bucket.createKey(keyName, 1,
+        bucket.getReplicationConfig(), metadata, emptyMap())) {
+      out.write('x');
+    }
+  }
+
+  private static Set<String> listKeyNames(OzoneBucket bucket) throws IOException {
+    return Sets.newHashSet(bucket.listKeys("")).stream()
+        .map(OzoneKey::getName)
+        .collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change adds support for conditional DeleteObjects in the Ozone S3 Gateway, aligned with the [AWS S3 DeleteObjects API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) for general purpose buckets.

Clients can include an optional <ETag> element per object in the DeleteObjects XML body. The gateway deletes an object only when its current ETag matches the provided value. If the precondition fails, the per-object response includes a PreconditionFailed error instead of deleting the object.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15638

## How was this patch tested?

Unit Test
