### PR TITLE
HDDS-15409. SCM Pipeline Add SupportedStorageTier Field

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StorageTier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StorageTier.java
@@ -104,6 +104,13 @@ public enum StorageTier {
     return isUniform;
   }
 
+  public StorageType getUniformStorageType() {
+    if (!isUniform()) {
+      throw new IllegalArgumentException("Uniform storage type is not supported");
+    }
+    return storageTypes.get(0);
+  }
+
   /**
    * Maps a StorageTier to its corresponding StorageType based on replication type.
    *

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StorageTierUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StorageTierUtil.java
@@ -17,7 +17,9 @@
 
 package org.apache.hadoop.hdds.client;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 
@@ -45,22 +47,31 @@ public final class StorageTierUtil {
     }
   }
 
-  /**
-   * Returns the StorageType for uniform StorageTier.
-   *
-   * @param storageTier the StorageTier to get StorageType from
-   * @return The uniform StorageTier corresponding StorageType
-   * @throws SCMException if the StorageTier is non-uniform or the EMPTY StorageTier
-   */
-  public static StorageType getStorageTypeForUniformStorageTier(StorageTier storageTier, ReplicationConfig config)
-      throws SCMException {
-    validateNotEmpty(storageTier);
-    List<StorageType> storageTypes = storageTier.getStorageTypes(config.getRequiredNodes());
-    if (storageTier.isUniform()) {
-      return storageTypes.get(0);
-    } else {
-      throw new SCMException("Unsupported non-uniform storage tier " + storageTier,
-          SCMException.ResultCodes.UNSUPPORTED_NON_UNIFORM_STORAGE_TIER);
+  public static List<StorageTier> findSupportedStorageTiers(
+      List<Set<StorageType>> dnStorageTypes) {
+    List<StorageTier> supportedStorageTiers = new ArrayList<>();
+    if (dnStorageTypes.isEmpty()) {
+      return supportedStorageTiers;
     }
+    // We only support uniform storage tiers currently
+    for (StorageTier storageTier : StorageTier.values()) {
+      if (storageTier.equals(StorageTier.EMPTY)) {
+        continue;
+      }
+      if (!storageTier.isUniform()) {
+        throw new UnsupportedOperationException(storageTier + " is not a uniform storage tier");
+      }
+      boolean supportedTier = true;
+      for (Set<StorageType> dnStorageType : dnStorageTypes) {
+        if (!dnStorageType.contains(storageTier.getUniformStorageType())) {
+          supportedTier = false;
+          break;
+        }
+      }
+      if (supportedTier) {
+        supportedStorageTiers.add(storageTier);
+      }
+    }
+    return supportedStorageTiers;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -42,6 +44,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicatedReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -86,6 +89,9 @@ public final class Pipeline {
   private Instant creationTimestamp;
   // suggested leader id with high priority
   private final DatanodeID suggestedLeaderId;
+  private List<StorageTier> supportedStorageTier;
+
+  private final ReadWriteLock lock;
 
   private final Instant stateEnterTime;
 
@@ -114,6 +120,8 @@ public final class Pipeline {
     replicaIndexes = b.replicaIndexes;
     creationTimestamp = b.creationTimestamp != null ? b.creationTimestamp : Instant.now();
     stateEnterTime = Instant.now();
+    supportedStorageTier = b.supportedStorageTier;
+    lock = new ReentrantReadWriteLock();
   }
 
   public static Codec<Pipeline> getCodec() {
@@ -168,6 +176,32 @@ public final class Pipeline {
    */
   public DatanodeID getSuggestedLeaderId() {
     return suggestedLeaderId;
+  }
+
+  /**
+   * Return the Pipeline supported StorageTier.
+   *
+   * @return Supported StorageTier
+   */
+  public List<StorageTier> getSupportedStorageTier() {
+    lock.readLock().lock();
+    try {
+      return supportedStorageTier;
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Set the storageTier supported by the pipeline.
+   */
+  public void setSupportedStorageTier(List<StorageTier> supportedStorageTier) {
+    lock.writeLock().lock();
+    try {
+      this.supportedStorageTier = supportedStorageTier;
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
   /**
@@ -399,6 +433,12 @@ public final class Pipeline {
       builder.setSuggestedLeaderDatanodeID(suggestedLeaderId.toProto());
     }
 
+    if (supportedStorageTier != null) {
+      for (StorageTier storageTier : supportedStorageTier) {
+        builder.addSupportedStorageTier(storageTier.toProto());
+      }
+    }
+
     // To save the message size on wire, only transfer the node order based on
     // network topology
     if (!nodesInOrder.isEmpty()) {
@@ -488,6 +528,10 @@ public final class Pipeline {
       HddsProtos.UUID uuid = pipeline.getSuggestedLeaderID();
       suggestedLeaderId = DatanodeID.of(uuid);
     }
+    List<StorageTier> supportedStorageTier = new ArrayList<>();
+    for (HddsProtos.StorageTierProto storageTierProto : pipeline.getSupportedStorageTierList()) {
+      supportedStorageTier.add(StorageTier.fromProto(storageTierProto));
+    }
 
     final ReplicationConfig config = ReplicationConfig
         .fromProto(pipeline.getType(), pipeline.getFactor(),
@@ -501,6 +545,7 @@ public final class Pipeline {
         .setLeaderId(leaderId)
         .setSuggestedLeaderId(suggestedLeaderId)
         .setNodeOrder(pipeline.getMemberOrdersList())
+        .setSupportedStorageTier(supportedStorageTier)
         .setCreateTimestamp(pipeline.getCreationTimeStamp());
   }
 
@@ -548,6 +593,7 @@ public final class Pipeline {
     b.append(']')
         .append(", ReplicationConfig: ").append(replicationConfig)
         .append(", State:").append(getPipelineState())
+        .append(", SupportStorageTier:").append(getSupportedStorageTier())
         .append(", leaderId:").append(leaderId != null ? leaderId.toString() : "")
         .append(", CreationTimestamp").append(getCreationTimestamp().atZone(ZoneId.systemDefault()))
         .append('}');
@@ -572,6 +618,7 @@ public final class Pipeline {
     private Instant creationTimestamp = null;
     private DatanodeID suggestedLeaderId = null;
     private Map<DatanodeDetails, Integer> replicaIndexes = ImmutableMap.of();
+    private List<StorageTier> supportedStorageTier;
 
     private Builder() { }
 
@@ -594,6 +641,7 @@ public final class Pipeline {
         }
         replicaIndexes = b.build();
       }
+      this.supportedStorageTier = pipeline.getSupportedStorageTier();
     }
 
     public Builder setId(DatanodeID datanodeID) {
@@ -673,6 +721,11 @@ public final class Pipeline {
 
     public Builder setReplicaIndexes(Map<DatanodeDetails, Integer> indexes) {
       this.replicaIndexes = indexes == null ? ImmutableMap.of() : ImmutableMap.copyOf(indexes);
+      return this;
+    }
+
+    public Builder setSupportedStorageTier(List<StorageTier> supportedStorageTier) {
+      this.supportedStorageTier = supportedStorageTier;
       return this;
     }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -89,7 +89,8 @@ public final class Pipeline {
   private Instant creationTimestamp;
   // suggested leader id with high priority
   private final DatanodeID suggestedLeaderId;
-  private List<StorageTier> supportedStorageTier;
+
+  private final StorageTier supportedStorageTier;
 
   private final ReadWriteLock lock;
 
@@ -183,24 +184,12 @@ public final class Pipeline {
    *
    * @return Supported StorageTier
    */
-  public List<StorageTier> getSupportedStorageTier() {
+  public StorageTier getSupportedStorageTier() {
     lock.readLock().lock();
     try {
       return supportedStorageTier;
     } finally {
       lock.readLock().unlock();
-    }
-  }
-
-  /**
-   * Set the storageTier supported by the pipeline.
-   */
-  public void setSupportedStorageTier(List<StorageTier> supportedStorageTier) {
-    lock.writeLock().lock();
-    try {
-      this.supportedStorageTier = supportedStorageTier;
-    } finally {
-      lock.writeLock().unlock();
     }
   }
 
@@ -433,10 +422,10 @@ public final class Pipeline {
       builder.setSuggestedLeaderDatanodeID(suggestedLeaderId.toProto());
     }
 
+    // To simplify Pipeline management, we currently only support Pipelines with a single StorageTier.
+    // However, to facilitate future expansion, StorageTier is still defined using `repeat` in the proto file.
     if (supportedStorageTier != null) {
-      for (StorageTier storageTier : supportedStorageTier) {
-        builder.addSupportedStorageTier(storageTier.toProto());
-      }
+      builder.addSupportedStorageTier(supportedStorageTier.toProto());
     }
 
     // To save the message size on wire, only transfer the node order based on
@@ -528,9 +517,11 @@ public final class Pipeline {
       HddsProtos.UUID uuid = pipeline.getSuggestedLeaderID();
       suggestedLeaderId = DatanodeID.of(uuid);
     }
-    List<StorageTier> supportedStorageTier = new ArrayList<>();
+    StorageTier supportedStorageTier = null;
+    // To simplify Pipeline management, we currently only support Pipelines with a single StorageTier.
+    // However, to facilitate future expansion, StorageTier is still defined using `repeat` in the proto file.
     for (HddsProtos.StorageTierProto storageTierProto : pipeline.getSupportedStorageTierList()) {
-      supportedStorageTier.add(StorageTier.fromProto(storageTierProto));
+      supportedStorageTier = StorageTier.fromProto(storageTierProto);
     }
 
     final ReplicationConfig config = ReplicationConfig
@@ -618,7 +609,7 @@ public final class Pipeline {
     private Instant creationTimestamp = null;
     private DatanodeID suggestedLeaderId = null;
     private Map<DatanodeDetails, Integer> replicaIndexes = ImmutableMap.of();
-    private List<StorageTier> supportedStorageTier;
+    private StorageTier supportedStorageTier;
 
     private Builder() { }
 
@@ -724,7 +715,7 @@ public final class Pipeline {
       return this;
     }
 
-    public Builder setSupportedStorageTier(List<StorageTier> supportedStorageTier) {
+    public Builder setSupportedStorageTier(StorageTier supportedStorageTier) {
       this.supportedStorageTier = supportedStorageTier;
       return this;
     }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/StorageTierUtilTest.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/StorageTierUtilTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.fs.StorageType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Provides {@link StorageTierUtil} factory methods for testing.
+ */
+class StorageTierUtilTest {
+  @Test
+  void testFindSupportedStorageTiers() {
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.SSD),
+            setOf(StorageType.SSD),
+            setOf(StorageType.SSD)),
+        1, setOf(StorageTier.SSD));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD)),
+        1, setOf(StorageTier.SSD));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD, StorageType.DISK)),
+        2, setOf(StorageTier.SSD, StorageTier.DISK));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.SSD, StorageType.DISK, StorageType.ARCHIVE),
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD, StorageType.DISK)),
+        2, setOf(StorageTier.SSD, StorageTier.DISK));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.SSD, StorageType.DISK, StorageType.ARCHIVE),
+            setOf(StorageType.SSD, StorageType.DISK, StorageType.ARCHIVE),
+            setOf(StorageType.SSD, StorageType.DISK, StorageType.ARCHIVE)),
+        3, setOf(StorageTier.SSD, StorageTier.DISK, StorageTier.ARCHIVE));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.SSD, StorageType.DISK)),
+        2, setOf(StorageTier.SSD, StorageTier.DISK));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.SSD)),
+        1, setOf(StorageTier.SSD));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.DISK)),
+        1, setOf(StorageTier.DISK));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.ARCHIVE)),
+        1, setOf(StorageTier.ARCHIVE));
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD, StorageType.DISK),
+            setOf(StorageType.SSD, StorageType.DISK)),
+        2, setOf(StorageTier.SSD, StorageTier.DISK));
+  }
+
+  @Test
+  void testFindInvalidStorageTiers() {
+    assertStorageTiers(createDnStorageTypes(),  0, new HashSet<>());
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.DISK),
+            setOf(StorageType.SSD),
+            setOf(StorageType.SSD)),
+        0, new HashSet<>());
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.DISK),
+            setOf(StorageType.DISK),
+            setOf(StorageType.SSD)),
+        0, new HashSet<>());
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.ARCHIVE),
+            setOf(StorageType.DISK),
+            setOf(StorageType.SSD)),
+        0, new HashSet<>());
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.RAM_DISK),
+            setOf(StorageType.SSD),
+            setOf(StorageType.SSD)),
+        0, new HashSet<>());
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.RAM_DISK),
+            setOf(StorageType.RAM_DISK),
+            setOf(StorageType.RAM_DISK)),
+        0, new HashSet<>());
+
+    assertStorageTiers(createDnStorageTypes(
+            setOf(StorageType.PROVIDED),
+            setOf(StorageType.PROVIDED),
+            setOf(StorageType.PROVIDED)),
+        0, new HashSet<>());
+  }
+
+  private void assertStorageTiers(List<Set<StorageType>> dnStorageTypes,
+      int expectedSize, Set<StorageTier> expectedTiers) {
+    List<StorageTier> supportedTiers =
+        StorageTierUtil.findSupportedStorageTiers(dnStorageTypes);
+    HashSet<StorageTier> tiers = new HashSet<>(supportedTiers);
+    assertEquals(expectedSize, tiers.size());
+    assertEquals(expectedTiers, tiers);
+  }
+
+  private List<Set<StorageType>> createDnStorageTypes(Set<StorageType>... storageSets) {
+    return Arrays.asList(storageSets);
+  }
+
+  private Set<StorageType> setOf(StorageType... types) {
+    return new HashSet<>(Arrays.asList(types));
+  }
+
+  private Set<StorageTier> setOf(StorageTier... tiers) {
+    return new HashSet<>(Arrays.asList(tiers));
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
@@ -132,31 +132,6 @@ public final class StorageLocationReport implements StorageLocationReportMXBean 
     return fsAvailable;
   }
 
-  public static StorageType getStorageType(StorageTypeProto proto) throws
-      IllegalArgumentException {
-    StorageType storageType;
-    switch (proto) {
-    case SSD:
-      storageType = StorageType.SSD;
-      break;
-    case DISK:
-      storageType = StorageType.DISK;
-      break;
-    case ARCHIVE:
-      storageType = StorageType.ARCHIVE;
-      break;
-    case PROVIDED:
-      storageType = StorageType.PROVIDED;
-      break;
-    case RAM_DISK:
-      storageType = StorageType.RAM_DISK;
-      break;
-    default:
-      throw new IllegalArgumentException("Illegal Storage Type specified: " + proto);
-    }
-    return storageType;
-  }
-
   /**
    * Returns the StorageReportProto protoBuf message for the Storage Location
    * report.

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -143,6 +143,7 @@ message Pipeline {
 
     optional DatanodeIDProto leaderDatanodeID = 101;
     optional DatanodeIDProto suggestedLeaderDatanodeID = 102;
+    repeated StorageTierProto supportedStorageTier = 103;
 }
 
 message KeyValue {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeUtils.java
@@ -43,6 +43,9 @@ public final class NodeUtils {
     List<Set<StorageType>> dnStorageTypes = new ArrayList<>();
     for (DatanodeDetails dn : dns) {
       DatanodeInfo datanodeInfo = nodeManager.getDatanodeInfo(dn);
+      if (datanodeInfo == null) {
+        throw new IllegalStateException("Cannot get Datanode : " + dn.getUuidString() + " Info");
+      }
       dnStorageTypes.add(getDatanodeStorageTypes(datanodeInfo));
     }
     return StorageTierUtil.findSupportedStorageTiers(dnStorageTypes);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.node;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.client.StorageTier;
+import org.apache.hadoop.hdds.client.StorageTierUtil;
+import org.apache.hadoop.hdds.client.StorageTypeUtils;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.StorageTypeProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+
+/**
+ * Util class for Node operations.
+ */
+public final class NodeUtils {
+
+  private NodeUtils() {
+  }
+
+  public static List<StorageTier> getDatanodesStorageTypes(
+      List<DatanodeDetails> dns, NodeManager nodeManager) {
+    List<Set<StorageType>> dnStorageTypes = new ArrayList<>();
+    for (DatanodeDetails dn : dns) {
+      DatanodeInfo datanodeInfo = nodeManager.getDatanodeInfo(dn);
+      dnStorageTypes.add(getDatanodeStorageTypes(datanodeInfo));
+    }
+    return StorageTierUtil.findSupportedStorageTiers(dnStorageTypes);
+  }
+
+  public static Set<StorageType> getDatanodeStorageTypes(
+      DatanodeInfo datanodeInfo) {
+    List<StorageReportProto> storageReportProtos =
+        datanodeInfo.getStorageReports();
+    if (storageReportProtos == null || storageReportProtos.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    Set<StorageType> uniqueStorageTypes = new HashSet<>();
+    for (StorageReportProto storageReportProto : storageReportProtos) {
+      uniqueStorageTypes.add(StorageTypeUtils.getFromProtobuf((
+          storageReportProto.getStorageType())));
+    }
+    return uniqueStorageTypes;
+  }
+
+  public static StorageTypeProto getStorageTypeFromStorageReportProto(
+      StorageReportProto storageReportProto) {
+    return storageReportProto.hasStorageType()
+        ? storageReportProto.getStorageType() : StorageTypeProto.DISK;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -757,7 +757,7 @@ public class SCMNodeManager implements NodeManager {
               datanodeInfo.getID());
         }
       } catch (PipelineNotFoundException e) {
-        LOG.debug("Reported Datanode {} pipeline {} is not found",
+        LOG.warn("Reported Datanode {} pipeline {} is not found",
             datanodeInfo.getID(), pipelineId);
       } catch (RuntimeException e) {
         LOG.warn("Failed to update supported storage tiers for Pipeline ID {} "

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import javax.management.ObjectName;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -713,12 +714,56 @@ public class SCMNodeManager implements NodeManager {
         datanodeInfo.updateStorageReports(nodeReport.getStorageReportList());
         datanodeInfo.updateMetaDataStorageReports(nodeReport.
             getMetadataStorageReportList());
+        updateSupportedStorageTier(datanodeInfo);
         metrics.incNumNodeReportProcessed();
       }
     } catch (NodeNotFoundException e) {
       metrics.incNumNodeReportProcessingFailed();
       LOG.warn("Got node report from unregistered datanode {}",
           datanodeDetails);
+    }
+  }
+
+  private void updateSupportedStorageTier(DatanodeInfo datanodeInfo) {
+    if (scmContext.getScm() == null) {
+      LOG.debug("Skip the updating of Pipeline supported StorageTier for Recon");
+      return;
+    }
+
+    PipelineManager pipelineManager = scmContext.getScm().getPipelineManager();
+    if (pipelineManager == null) {
+      LOG.debug("Skip the updating of Pipeline supported StorageTier for Recon");
+      return;
+    }
+
+    Set<PipelineID> pipelines = nodeStateManager.getPipelineByDnID(
+        datanodeInfo.getID());
+    for (PipelineID pipelineId : pipelines) {
+      try {
+        Pipeline pipeline = pipelineManager.getPipeline(pipelineId);
+        Set<StorageTier> currentTiers =
+            pipeline.getSupportedStorageTier() != null
+                ? new HashSet<>(pipeline.getSupportedStorageTier())
+                : Collections.emptySet();
+        List<StorageTier> newSupportedTiers =
+            NodeUtils.getDatanodesStorageTypes(pipeline.getNodes(), this);
+        Set<StorageTier> newSupportedTierSet =
+            new HashSet<>(newSupportedTiers);
+        if (!currentTiers.equals(newSupportedTierSet)) {
+          pipeline.setSupportedStorageTier(newSupportedTiers);
+          LOG.info("Updated supported storage tiers for Pipeline ID {} from {} "
+                  + "to {} by Datanode {}",
+              pipeline.getId(), currentTiers, newSupportedTierSet,
+              datanodeInfo.getID());
+        }
+      } catch (PipelineNotFoundException e) {
+        LOG.debug("Reported Datanode {} pipeline {} is not found",
+            datanodeInfo.getID(), pipelineId);
+      } catch (RuntimeException e) {
+        LOG.warn("Failed to update supported storage tiers for Pipeline ID {} "
+                + "by Datanode {} due to: {}",
+            pipelineId, datanodeInfo.getID(), e.getMessage(), e);
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -53,7 +53,6 @@ import java.util.stream.Collectors;
 import javax.management.ObjectName;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
-import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -714,56 +713,12 @@ public class SCMNodeManager implements NodeManager {
         datanodeInfo.updateStorageReports(nodeReport.getStorageReportList());
         datanodeInfo.updateMetaDataStorageReports(nodeReport.
             getMetadataStorageReportList());
-        updateSupportedStorageTier(datanodeInfo);
         metrics.incNumNodeReportProcessed();
       }
     } catch (NodeNotFoundException e) {
       metrics.incNumNodeReportProcessingFailed();
       LOG.warn("Got node report from unregistered datanode {}",
           datanodeDetails);
-    }
-  }
-
-  private void updateSupportedStorageTier(DatanodeInfo datanodeInfo) {
-    if (scmContext.getScm() == null) {
-      LOG.debug("Skip the updating of Pipeline supported StorageTier for Recon");
-      return;
-    }
-
-    PipelineManager pipelineManager = scmContext.getScm().getPipelineManager();
-    if (pipelineManager == null) {
-      LOG.debug("Skip the updating of Pipeline supported StorageTier for Recon");
-      return;
-    }
-
-    Set<PipelineID> pipelines = nodeStateManager.getPipelineByDnID(
-        datanodeInfo.getID());
-    for (PipelineID pipelineId : pipelines) {
-      try {
-        Pipeline pipeline = pipelineManager.getPipeline(pipelineId);
-        Set<StorageTier> currentTiers =
-            pipeline.getSupportedStorageTier() != null
-                ? new HashSet<>(pipeline.getSupportedStorageTier())
-                : Collections.emptySet();
-        List<StorageTier> newSupportedTiers =
-            NodeUtils.getDatanodesStorageTypes(pipeline.getNodes(), this);
-        Set<StorageTier> newSupportedTierSet =
-            new HashSet<>(newSupportedTiers);
-        if (!currentTiers.equals(newSupportedTierSet)) {
-          pipeline.setSupportedStorageTier(newSupportedTiers);
-          LOG.info("Updated supported storage tiers for Pipeline ID {} from {} "
-                  + "to {} by Datanode {}",
-              pipeline.getId(), currentTiers, newSupportedTierSet,
-              datanodeInfo.getID());
-        }
-      } catch (PipelineNotFoundException e) {
-        LOG.warn("Reported Datanode {} pipeline {} is not found",
-            datanodeInfo.getID(), pipelineId);
-      } catch (RuntimeException e) {
-        LOG.warn("Failed to update supported storage tiers for Pipeline ID {} "
-                + "by Datanode {} due to: {}",
-            pipelineId, datanodeInfo.getID(), e.getMessage(), e);
-      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -114,8 +114,9 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
       dnIndexes.put(dn, ecIndex);
       ecIndex++;
     }
-
-    return createPipelineInternal(replicationConfig, nodes, dnIndexes);
+    List<StorageTier> storageTiers =
+        NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
+    return createPipelineInternal(replicationConfig, nodes, dnIndexes, storageTiers);
   }
 
   @Override
@@ -142,13 +143,12 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
 
     dns.sort(Comparator.comparing(nodeStatusMap::get, CREATE_FOR_READ_COMPARATOR));
 
-    return createPipelineInternal(replicationConfig, dns, map);
+    // Read Pipelines do not require storage tiers, so the calculation of storage tiers can be omitted.
+    return createPipelineInternal(replicationConfig, dns, map, new ArrayList<>());
   }
 
   private Pipeline createPipelineInternal(ECReplicationConfig repConfig,
-      List<DatanodeDetails> dns, Map<DatanodeDetails, Integer> indexes) {
-    List<StorageTier> storageTiers =
-        NodeUtils.getDatanodesStorageTypes(dns, getNodeManager());
+      List<DatanodeDetails> dns, Map<DatanodeDetails, Integer> indexes, List<StorageTier> storageTiers) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(Pipeline.PipelineState.ALLOCATED)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -28,15 +28,16 @@ import java.util.Set;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.StorageTier;
-import org.apache.hadoop.hdds.client.StorageTierUtil;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.NodeUtils;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,10 +91,16 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
       StorageTier storageTier)
       throws IOException {
-    StorageType storageType = StorageTierUtil.getStorageTypeForUniformStorageTier(storageTier, replicationConfig);
+    StorageType storageType = storageTier.getUniformStorageType();
     List<DatanodeDetails> dns = placementPolicy
         .chooseDatanodes(excludedNodes, favoredNodes,
             replicationConfig.getRequiredNodes(), 0, this.containerSizeBytes, storageType);
+    List<StorageTier> storageTiers =
+        NodeUtils.getDatanodesStorageTypes(dns, getNodeManager());
+    if (!storageTiers.contains(storageTier)) {
+      throw new SCMException(String.format("Cannot create pipeline for StorageTier %s replicationConfig: %s",
+          storageTier, replicationConfig), SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
     return create(replicationConfig, dns);
   }
 
@@ -140,12 +147,15 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
 
   private Pipeline createPipelineInternal(ECReplicationConfig repConfig,
       List<DatanodeDetails> dns, Map<DatanodeDetails, Integer> indexes) {
+    List<StorageTier> storageTiers =
+        NodeUtils.getDatanodesStorageTypes(dns, getNodeManager());
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(Pipeline.PipelineState.ALLOCATED)
         .setReplicationConfig(repConfig)
         .setNodes(dns)
         .setReplicaIndexes(indexes)
+        .setSupportedStorageTier(storageTiers)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -95,28 +95,26 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
     List<DatanodeDetails> dns = placementPolicy
         .chooseDatanodes(excludedNodes, favoredNodes,
             replicationConfig.getRequiredNodes(), 0, this.containerSizeBytes, storageType);
-    List<StorageTier> storageTiers =
-        NodeUtils.getDatanodesStorageTypes(dns, getNodeManager());
-    if (!storageTiers.contains(storageTier)) {
-      throw new SCMException(String.format("Cannot create pipeline for StorageTier %s replicationConfig: %s",
-          storageTier, replicationConfig), SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
-    }
-    return create(replicationConfig, dns);
+    return create(replicationConfig, dns, storageTier);
   }
 
   @Override
   protected Pipeline create(ECReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes) {
-
+      List<DatanodeDetails> nodes, StorageTier storageTier) throws IOException {
+    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
+    if (!storageTiers.contains(storageTier)) {
+      throw new SCMException(String.format("Cannot create pipeline for "
+              + "StorageTier %s replicationConfig: %s",
+          storageTier, replicationConfig),
+          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
     Map<DatanodeDetails, Integer> dnIndexes = new HashMap<>();
     int ecIndex = 1;
     for (DatanodeDetails dn : nodes) {
       dnIndexes.put(dn, ecIndex);
       ecIndex++;
     }
-    List<StorageTier> storageTiers =
-        NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
-    return createPipelineInternal(replicationConfig, nodes, dnIndexes, storageTiers);
+    return createPipelineInternal(replicationConfig, nodes, dnIndexes, Collections.singletonList(storageTier));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -114,7 +114,7 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
       dnIndexes.put(dn, ecIndex);
       ecIndex++;
     }
-    return createPipelineInternal(replicationConfig, nodes, dnIndexes, Collections.singletonList(storageTier));
+    return createPipelineInternal(replicationConfig, nodes, dnIndexes, storageTier);
   }
 
   @Override
@@ -142,18 +142,18 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
     dns.sort(Comparator.comparing(nodeStatusMap::get, CREATE_FOR_READ_COMPARATOR));
 
     // Read Pipelines do not require storage tiers, so the calculation of storage tiers can be omitted.
-    return createPipelineInternal(replicationConfig, dns, map, new ArrayList<>());
+    return createPipelineInternal(replicationConfig, dns, map, null);
   }
 
   private Pipeline createPipelineInternal(ECReplicationConfig repConfig,
-      List<DatanodeDetails> dns, Map<DatanodeDetails, Integer> indexes, List<StorageTier> storageTiers) {
+      List<DatanodeDetails> dns, Map<DatanodeDetails, Integer> indexes, StorageTier storageTier) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(Pipeline.PipelineState.ALLOCATED)
         .setReplicationConfig(repConfig)
         .setNodes(dns)
         .setReplicaIndexes(indexes)
-        .setSupportedStorageTier(storageTiers)
+        .setSupportedStorageTier(storageTier)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineFactory.java
@@ -108,10 +108,9 @@ public class PipelineFactory {
   }
 
   public Pipeline create(ReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes
-  ) {
+      List<DatanodeDetails> nodes, StorageTier storageTier) throws IOException {
     return providers.get(replicationConfig.getReplicationType())
-        .create(replicationConfig, nodes);
+        .create(replicationConfig, nodes, storageTier);
   }
 
   public Pipeline createForRead(ReplicationConfig replicationConfig,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.NavigableSet;
 import java.util.Set;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -53,8 +54,9 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
 
   Pipeline createPipeline(
       ReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes
-  );
+      List<DatanodeDetails> nodes,
+      StorageTier storageTier
+  ) throws IOException;
 
   Pipeline createPipelineForRead(
       ReplicationConfig replicationConfig, Set<ContainerReplica> replicas);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -317,11 +318,12 @@ public class PipelineManagerImpl implements PipelineManager {
   @Override
   public Pipeline createPipeline(
       ReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes
-  ) {
+      List<DatanodeDetails> nodes,
+      StorageTier storageTier
+  ) throws IOException {
     // This will mostly be used to create dummy pipeline for SimplePipelines.
     // We don't update the metrics for SimplePipelines.
-    return pipelineFactory.create(replicationConfig, nodes);
+    return pipelineFactory.create(replicationConfig, nodes, storageTier);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -85,7 +85,8 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   static int currentRatisThreePipelineCount(
       NodeManager nodeManager,
       PipelineStateManager stateManager,
-      DatanodeDetails datanodeDetails) {
+      DatanodeDetails datanodeDetails,
+      StorageType storageType) {
     // Safe to cast collection's size to int
     return (int) nodeManager.getPipelines(datanodeDetails).stream()
         .map(id -> {
@@ -97,15 +98,15 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
             return null;
           }
         })
-        .filter(PipelinePlacementPolicy::isNonClosedRatisThreePipeline)
+        .filter(p -> isNonClosedRatisThreePipeline(p, storageType))
         .count();
   }
 
   /** Filter the given datanodes within its pipeline limit. */
-  List<DatanodeDetails> filterPipelineLimit(Iterable<DatanodeDetails> datanodes) {
+  List<DatanodeDetails> filterPipelineLimit(Iterable<DatanodeDetails> datanodes, StorageType storageType) {
     final SortedList<DatanodeDetails> sorted = new SortedList<>(DatanodeDetails.class);
     for (DatanodeDetails d : datanodes) {
-      final int count = currentRatisThreePipelineCount(nodeManager, stateManager, d);
+      final int count = currentRatisThreePipelineCount(nodeManager, stateManager, d, storageType);
       if (count < nodeManager.pipelineLimit(d)) {
         sorted.add(d, count);
       }
@@ -113,10 +114,21 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     return sorted;
   }
 
-  private static boolean isNonClosedRatisThreePipeline(Pipeline p) {
+  private static boolean isNonClosedRatisThreePipeline(Pipeline p, StorageType storageType) {
+    boolean matchedTier = false;
+    if (storageType != null) {
+      try {
+        // TODO: Do we need to return true if getSupportedStorageTier() is empty
+        //  otherwise this might cause more pipelines to be created than necessary
+        matchedTier = p.getSupportedStorageTier().getUniformStorageType().equals(storageType);
+      } catch (IllegalArgumentException e) {
+        LOG.debug("Cannot convert pipeline storage tier {} to storage type.", p.getSupportedStorageTier(), e);
+        return false;
+      }
+    }
     return p != null && p.getReplicationConfig()
         .equals(RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
-        && !p.isClosed();
+        && !p.isClosed() && matchedTier;
   }
 
   @Override
@@ -182,7 +194,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     // filter nodes that meet the size and pipeline engagement criteria.
     // Pipeline placement doesn't take node space left into account.
     // Sort the DNs by pipeline load.
-    final List<DatanodeDetails> healthyList = filterPipelineLimit(healthyNodes);
+    final List<DatanodeDetails> healthyList = filterPipelineLimit(healthyNodes, storageType);
 
     if (healthyList.size() < nodesRequired) {
       if (LOG.isDebugEnabled()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
@@ -89,7 +89,7 @@ public abstract class PipelineProvider<REPLICATION_CONFIG
                                          long dataSizeRequired, StorageTier storageTier)
       throws SCMException {
     StorageTierUtil.validateNotEmpty(storageTier);
-    StorageType storageType = StorageTierUtil.getStorageTypeForUniformStorageTier(storageTier, replicationConfig);
+    StorageType storageType = storageTier.getUniformStorageType();
     int nodesRequired = replicationConfig.getRequiredNodes();
     List<DatanodeDetails> healthyDNs = pickAllNodesNotUsed(replicationConfig);
     List<DatanodeDetails> healthyDNsWithSpace = healthyDNs.stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
@@ -74,8 +74,8 @@ public abstract class PipelineProvider<REPLICATION_CONFIG
 
   protected abstract Pipeline create(
       REPLICATION_CONFIG replicationConfig,
-      List<DatanodeDetails> nodes
-  );
+      List<DatanodeDetails> nodes,
+      StorageTier storageTier) throws IOException;
 
   protected abstract Pipeline createForRead(
       REPLICATION_CONFIG replicationConfig,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -18,9 +18,14 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -29,6 +34,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.node.NodeUtils;
 import org.apache.hadoop.hdds.scm.safemode.SafeModeManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.PipelineReportFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventHandler;
@@ -119,6 +125,7 @@ public class PipelineReportHandler implements
 
     setReportedDatanode(pipeline, dn);
     setPipelineLeaderId(report, pipeline, dn);
+    updateSupportedStorageTiers(pipeline);
 
     if (pipeline.getPipelineState() == Pipeline.PipelineState.ALLOCATED) {
       if (LOGGER.isDebugEnabled()) {
@@ -136,6 +143,28 @@ public class PipelineReportHandler implements
       if (scmSafeModeManager.getInSafeMode()) {
         publisher.fireEvent(SCMEvents.OPEN_PIPELINE, pipeline);
       }
+    }
+  }
+
+  private void updateSupportedStorageTiers(Pipeline pipeline) {
+    try {
+      Set<StorageTier> currentSupportedTiers =
+          pipeline.getSupportedStorageTier() != null
+              ? new HashSet<>(pipeline.getSupportedStorageTier())
+              : Collections.emptySet();
+
+      Set<StorageTier> newSupportedTiers =
+          new HashSet<>(NodeUtils.getDatanodesStorageTypes(pipeline.getNodes(),
+              scmContext.getScm().getScmNodeManager()));
+
+      if (!currentSupportedTiers.equals(newSupportedTiers)) {
+        pipeline.setSupportedStorageTier(new ArrayList<>(newSupportedTiers));
+        LOGGER.info("Updated supported storage tiers for Pipeline ID {} from {} to {}",
+            pipeline.getId(), currentSupportedTiers, newSupportedTiers);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to update supported storage tiers for Pipeline ID {} due to: {}",
+          pipeline.getId(), e.getMessage(), e);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -18,14 +18,9 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
-import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -34,7 +29,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
-import org.apache.hadoop.hdds.scm.node.NodeUtils;
 import org.apache.hadoop.hdds.scm.safemode.SafeModeManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.PipelineReportFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventHandler;
@@ -125,7 +119,6 @@ public class PipelineReportHandler implements
 
     setReportedDatanode(pipeline, dn);
     setPipelineLeaderId(report, pipeline, dn);
-    updateSupportedStorageTiers(pipeline);
 
     if (pipeline.getPipelineState() == Pipeline.PipelineState.ALLOCATED) {
       if (LOGGER.isDebugEnabled()) {
@@ -143,28 +136,6 @@ public class PipelineReportHandler implements
       if (scmSafeModeManager.getInSafeMode()) {
         publisher.fireEvent(SCMEvents.OPEN_PIPELINE, pipeline);
       }
-    }
-  }
-
-  private void updateSupportedStorageTiers(Pipeline pipeline) {
-    try {
-      Set<StorageTier> currentSupportedTiers =
-          pipeline.getSupportedStorageTier() != null
-              ? new HashSet<>(pipeline.getSupportedStorageTier())
-              : Collections.emptySet();
-
-      Set<StorageTier> newSupportedTiers =
-          new HashSet<>(NodeUtils.getDatanodesStorageTypes(pipeline.getNodes(),
-              scmContext.getScm().getScmNodeManager()));
-
-      if (!currentSupportedTiers.equals(newSupportedTiers)) {
-        pipeline.setSupportedStorageTier(new ArrayList<>(newSupportedTiers));
-        LOGGER.info("Updated supported storage tiers for Pipeline ID {} from {} to {}",
-            pipeline.getId(), currentSupportedTiers, newSupportedTiers);
-      }
-    } catch (Exception e) {
-      LOGGER.warn("Failed to update supported storage tiers for Pipeline ID {} due to: {}",
-          pipeline.getId(), e.getMessage(), e);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -229,6 +229,11 @@ public class RatisPipelineProvider
   public Pipeline create(RatisReplicationConfig replicationConfig,
       List<DatanodeDetails> nodes) {
     List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
+    return createPipelineInternal(replicationConfig, nodes, storageTiers);
+  }
+
+  private Pipeline createPipelineInternal(RatisReplicationConfig replicationConfig,
+      List<DatanodeDetails> nodes, List<StorageTier> storageTiers) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.ALLOCATED)
@@ -242,10 +247,11 @@ public class RatisPipelineProvider
   public Pipeline createForRead(
       RatisReplicationConfig replicationConfig,
       Set<ContainerReplica> replicas) {
-    return create(replicationConfig, replicas
+    // Read Pipelines do not require storage tiers, so the calculation of storage tiers can be omitted.
+    return createPipelineInternal(replicationConfig, replicas
         .stream()
         .map(ContainerReplica::getDatanodeDetails)
-        .collect(Collectors.toList()));
+        .collect(Collectors.toList()), new ArrayList<>());
   }
 
   private List<DatanodeDetails> filterPipelineEngagement() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,6 +41,7 @@ import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.NodeUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState;
 import org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms.LeaderChoosePolicy;
 import org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms.LeaderChoosePolicyFactory;
@@ -154,8 +156,8 @@ public class RatisPipelineProvider
           : String.format(": %d", pipelineNumberLimit);
 
       throw new SCMException(
-          String.format("Cannot create pipeline as it would exceed the limit %s replicationConfig: %s",
-              limitInfo, replicationConfig),
+          String.format("Cannot create pipeline for StorageTier %s as it would exceed the limit %s " +
+                  "replicationConfig: %s", storageTier, limitInfo, replicationConfig),
           SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE
       );
     }
@@ -169,7 +171,7 @@ public class RatisPipelineProvider
       break;
     case THREE:
       StorageTierUtil.validateNotEmpty(storageTier);
-      StorageType storageType = StorageTierUtil.getStorageTypeForUniformStorageTier(storageTier, replicationConfig);
+      StorageType storageType = storageTier.getUniformStorageType();
       List<DatanodeDetails> excludeDueToEngagement = filterPipelineEngagement();
       if (!excludeDueToEngagement.isEmpty()) {
         if (excludedNodes.isEmpty()) {
@@ -188,6 +190,12 @@ public class RatisPipelineProvider
 
     DatanodeDetails suggestedLeader = leaderChoosePolicy.chooseLeader(dns);
 
+    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(dns, getNodeManager());
+    if (!storageTiers.contains(storageTier)) {
+      throw new SCMException(String.format("Cannot create pipeline for StorageTier %s replicationConfig: %s",
+              storageTier, replicationConfig), SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
+    Preconditions.checkArgument(storageTiers.contains(storageTier));
     Pipeline pipeline = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.ALLOCATED)
@@ -195,6 +203,7 @@ public class RatisPipelineProvider
         .setNodes(dns)
         .setSuggestedLeaderId(
             suggestedLeader != null ? suggestedLeader.getID() : null)
+        .setSupportedStorageTier(storageTiers)
         .build();
 
     // Send command to datanodes to create pipeline
@@ -207,8 +216,8 @@ public class RatisPipelineProvider
     createCommand.setTerm(scmContext.getTermOfLeader());
 
     dns.forEach(node -> {
-      LOG.info("Sending CreatePipelineCommand for pipeline:{} to datanode:{}",
-          pipeline.getId(), node);
+      LOG.info("Sending CreatePipelineCommand for pipeline:{} to datanode:{} storageTier:{}",
+          pipeline.getId(), node, storageTier);
       eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
           new CommandForDatanode<>(node, createCommand));
     });
@@ -219,11 +228,13 @@ public class RatisPipelineProvider
   @Override
   public Pipeline create(RatisReplicationConfig replicationConfig,
       List<DatanodeDetails> nodes) {
+    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.ALLOCATED)
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
+        .setSupportedStorageTier(storageTiers)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -227,9 +227,15 @@ public class RatisPipelineProvider
 
   @Override
   public Pipeline create(RatisReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes) {
+      List<DatanodeDetails> nodes, StorageTier storageTier) throws IOException {
     List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
-    return createPipelineInternal(replicationConfig, nodes, storageTiers);
+    if (!storageTiers.contains(storageTier)) {
+      throw new SCMException(String.format("Cannot create pipeline for "
+              + "StorageTier %s replicationConfig: %s",
+          storageTier, replicationConfig),
+          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
+    return createPipelineInternal(replicationConfig, nodes, Collections.singletonList(storageTier));
   }
 
   private Pipeline createPipelineInternal(RatisReplicationConfig replicationConfig,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -172,7 +172,7 @@ public class RatisPipelineProvider
     case THREE:
       StorageTierUtil.validateNotEmpty(storageTier);
       StorageType storageType = storageTier.getUniformStorageType();
-      List<DatanodeDetails> excludeDueToEngagement = filterPipelineEngagement();
+      List<DatanodeDetails> excludeDueToEngagement = filterPipelineEngagement(storageTier);
       if (!excludeDueToEngagement.isEmpty()) {
         if (excludedNodes.isEmpty()) {
           excludedNodes = excludeDueToEngagement;
@@ -203,7 +203,7 @@ public class RatisPipelineProvider
         .setNodes(dns)
         .setSuggestedLeaderId(
             suggestedLeader != null ? suggestedLeader.getID() : null)
-        .setSupportedStorageTier(storageTiers)
+        .setSupportedStorageTier(storageTier)
         .build();
 
     // Send command to datanodes to create pipeline
@@ -235,17 +235,17 @@ public class RatisPipelineProvider
           storageTier, replicationConfig),
           SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
     }
-    return createPipelineInternal(replicationConfig, nodes, Collections.singletonList(storageTier));
+    return createPipelineInternal(replicationConfig, nodes, storageTier);
   }
 
   private Pipeline createPipelineInternal(RatisReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes, List<StorageTier> storageTiers) {
+      List<DatanodeDetails> nodes, StorageTier storageTier) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.ALLOCATED)
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
-        .setSupportedStorageTier(storageTiers)
+        .setSupportedStorageTier(storageTier)
         .build();
   }
 
@@ -257,16 +257,18 @@ public class RatisPipelineProvider
     return createPipelineInternal(replicationConfig, replicas
         .stream()
         .map(ContainerReplica::getDatanodeDetails)
-        .collect(Collectors.toList()), new ArrayList<>());
+        .collect(Collectors.toList()), null);
   }
 
-  private List<DatanodeDetails> filterPipelineEngagement() {
+  private List<DatanodeDetails> filterPipelineEngagement(StorageTier storageTier) {
     final NodeManager nodeManager = getNodeManager();
     final PipelineStateManager stateManager = getPipelineStateManager();
     final List<DatanodeDetails> healthyNodes = nodeManager.getNodes(NodeStatus.inServiceHealthy());
     final List<DatanodeDetails> excluded = new ArrayList<>();
+    final StorageType storageType = storageTier.getUniformStorageType();
     for (DatanodeDetails d : healthyNodes) {
-      final int count = PipelinePlacementPolicy.currentRatisThreePipelineCount(nodeManager, stateManager, d);
+      final int count = PipelinePlacementPolicy.currentRatisThreePipelineCount(
+          nodeManager, stateManager, d, storageType);
       if (count >= nodeManager.pipelineLimit(d)) {
         excluded.add(d);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -90,10 +91,8 @@ public class SimplePipelineProvider
         .build();
   }
 
-  @Override
-  public Pipeline create(StandaloneReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes) {
-    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
+  private Pipeline createPipelineInternal(StandaloneReplicationConfig replicationConfig,
+      List<DatanodeDetails> nodes, List<StorageTier> storageTiers) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.OPEN)
@@ -104,12 +103,20 @@ public class SimplePipelineProvider
   }
 
   @Override
+  public Pipeline create(StandaloneReplicationConfig replicationConfig,
+      List<DatanodeDetails> nodes) {
+    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
+    return createPipelineInternal(replicationConfig, nodes, storageTiers);
+  }
+
+  @Override
   public Pipeline createForRead(StandaloneReplicationConfig replicationConfig,
       Set<ContainerReplica> replicas) {
-    return create(replicationConfig, replicas
+    // Read Pipelines do not require storage tiers, so the calculation of storage tiers can be omitted.
+    return createPipelineInternal(replicationConfig, replicas
         .stream()
         .map(ContainerReplica::getDatanodeDetails)
-        .collect(Collectors.toList()));
+        .collect(Collectors.toList()), new ArrayList<>());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -29,8 +29,10 @@ import org.apache.hadoop.hdds.client.StorageTierUtil;
 import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState;
 
 /**
@@ -56,7 +58,7 @@ public class SimplePipelineProvider
   public Pipeline create(StandaloneReplicationConfig replicationConfig,
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes, StorageTier storageTier)
       throws IOException {
-    StorageType storageType = StorageTierUtil.getStorageTypeForUniformStorageTier(storageTier, replicationConfig);
+    StorageType storageType = storageTier.getUniformStorageType();
     List<DatanodeDetails> dns = pickNodesNotUsed(replicationConfig);
     dns = dns.stream().filter(dn ->
             ((DatanodeInfo) dn).getStorageReports().stream()
@@ -73,23 +75,31 @@ public class SimplePipelineProvider
     }
 
     Collections.shuffle(dns);
+    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(dns, getNodeManager());
+    if (!storageTiers.contains(storageTier)) {
+      throw new SCMException(String.format("Cannot create pipeline for StorageTier %s replicationConfig: %s",
+          storageTier, replicationConfig), SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.OPEN)
         .setReplicationConfig(replicationConfig)
         .setNodes(dns.subList(0,
             replicationConfig.getReplicationFactor().getNumber()))
+        .setSupportedStorageTier(storageTiers)
         .build();
   }
 
   @Override
   public Pipeline create(StandaloneReplicationConfig replicationConfig,
       List<DatanodeDetails> nodes) {
+    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.OPEN)
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
+        .setSupportedStorageTier(storageTiers)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -87,18 +87,18 @@ public class SimplePipelineProvider
         .setReplicationConfig(replicationConfig)
         .setNodes(dns.subList(0,
             replicationConfig.getReplicationFactor().getNumber()))
-        .setSupportedStorageTier(storageTiers)
+        .setSupportedStorageTier(storageTier)
         .build();
   }
 
   private Pipeline createPipelineInternal(StandaloneReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes, List<StorageTier> storageTiers) {
+      List<DatanodeDetails> nodes, StorageTier storageTier) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.OPEN)
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
-        .setSupportedStorageTier(storageTiers)
+        .setSupportedStorageTier(storageTier)
         .build();
   }
 
@@ -112,7 +112,7 @@ public class SimplePipelineProvider
           storageTier, replicationConfig),
           SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
     }
-    return createPipelineInternal(replicationConfig, nodes, Collections.singletonList(storageTier));
+    return createPipelineInternal(replicationConfig, nodes, storageTier);
   }
 
   @Override
@@ -122,7 +122,7 @@ public class SimplePipelineProvider
     return createPipelineInternal(replicationConfig, replicas
         .stream()
         .map(ContainerReplica::getDatanodeDetails)
-        .collect(Collectors.toList()), new ArrayList<>());
+        .collect(Collectors.toList()), null);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -104,9 +104,15 @@ public class SimplePipelineProvider
 
   @Override
   public Pipeline create(StandaloneReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes) {
+      List<DatanodeDetails> nodes, StorageTier storageTier) throws IOException {
     List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
-    return createPipelineInternal(replicationConfig, nodes, storageTiers);
+    if (!storageTiers.contains(storageTier)) {
+      throw new SCMException(String.format("Cannot create pipeline for "
+              + "StorageTier %s replicationConfig: %s",
+          storageTier, replicationConfig),
+          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
+    return createPipelineInternal(replicationConfig, nodes, Collections.singletonList(storageTier));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
@@ -119,6 +120,8 @@ public class MockNodeManager implements NodeManager {
   private PendingContainerTracker pendingContainerTracker;
   private final OzoneConfiguration conf = new OzoneConfiguration();
   private StorageType storageType = null;
+
+  private Map<DatanodeID, StorageType> nodeStorageTypeMap = new HashMap<>();
 
   {
     this.healthyNodes = new LinkedList<>();
@@ -289,10 +292,12 @@ public class MockNodeManager implements NodeManager {
         long capacity = nodeMetricMap.get(dd).getCapacity().get();
         long used = nodeMetricMap.get(dd).getScmUsed().get();
         long remaining = nodeMetricMap.get(dd).getRemaining().get();
+        StorageType nodeStorageType = nodeStorageTypeMap.get(dd.getID()) != null ?
+            nodeStorageTypeMap.get(dd.getID()) : storageType;
         StorageReportProto storage1 = HddsTestUtils.createStorageReport(
             di.getID(), "/data1-" + di.getID(),
             capacity, used, remaining,
-            storageType == null ? null : getStorageTypeProto(storageType));
+            nodeStorageType == null ? null : getStorageTypeProto(nodeStorageType));
         MetadataStorageReportProto metaStorage1 =
             HddsTestUtils.createMetadataStorageReport(
                 "/metadata1-" + di.getID(), capacity, used, remaining, null);
@@ -457,9 +462,12 @@ public class MockNodeManager implements NodeManager {
     long capacity = nodeMetricMap.get(dd).getCapacity().get();
     long used = nodeMetricMap.get(dd).getScmUsed().get();
     long remaining = nodeMetricMap.get(dd).getRemaining().get();
+    StorageType nodeStorageType = nodeStorageTypeMap.get(dd.getID()) != null ?
+        nodeStorageTypeMap.get(dd.getID()) : storageType;
     StorageReportProto storage1 = HddsTestUtils.createStorageReport(
         di.getID(), "/data1-" + di.getUuidString(),
-        capacity, used, remaining, null);
+        capacity, used, remaining,
+        nodeStorageType == null ? null : StorageTypeUtils.getStorageTypeProto(nodeStorageType));
     MetadataStorageReportProto metaStorage1 =
         HddsTestUtils.createMetadataStorageReport(
             "/metadata1-" + di.getUuidString(), capacity, used,
@@ -1045,5 +1053,9 @@ public class MockNodeManager implements NodeManager {
       this.currentState = currentState;
     }
 
+  }
+
+  public void setStorageTypeForNode(DatanodeID uuid, StorageType st) {
+    this.nodeStorageTypeMap.put(uuid, st);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -480,7 +480,7 @@ public class TestSCMNodeManager {
         () -> scm.getPipelineManager().createPipeline(config),
         "3 nodes should not have been found for a pipeline.");
     assertThat(ex.getMessage())
-        .contains("Cannot create pipeline as it would exceed the limit per datanode: " + limit);
+        .contains("Cannot create pipeline for StorageTier DISK as it would exceed the limit per datanode: " + limit);
   }
 
   private void assertPipelines(HddsProtos.ReplicationFactor factor,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -123,7 +123,7 @@ public class MockPipelineManager implements PipelineManager {
         .setId(PipelineID.randomId())
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
-        .setSupportedStorageTier(Collections.singletonList(storageTier))
+        .setSupportedStorageTier(storageTier)
         .setState(Pipeline.PipelineState.OPEN)
         .build();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -83,7 +84,8 @@ public class MockPipelineManager implements PipelineManager {
       pipeline = createPipeline(replicationConfig,
           ImmutableList.of(MockDatanodeDetails.randomDatanodeDetails(),
               MockDatanodeDetails.randomDatanodeDetails(),
-              MockDatanodeDetails.randomDatanodeDetails()));
+              MockDatanodeDetails.randomDatanodeDetails()),
+          StorageTier.getDefaultTier());
     }
 
     stateManager.addPipeline(pipeline.getProtobufMessage(
@@ -116,11 +118,12 @@ public class MockPipelineManager implements PipelineManager {
 
   @Override
   public Pipeline createPipeline(final ReplicationConfig replicationConfig,
-      final List<DatanodeDetails> nodes) {
+      final List<DatanodeDetails> nodes, StorageTier storageTier) {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
+        .setSupportedStorageTier(Collections.singletonList(storageTier))
         .setState(Pipeline.PipelineState.OPEN)
         .build();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeUtils;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 
@@ -71,6 +72,8 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
       return super.create(replicationConfig, storageTier);
     } else {
       Pipeline initialPipeline = super.create(replicationConfig, storageTier);
+      List<StorageTier> storageTiers =
+          NodeUtils.getDatanodesStorageTypes(initialPipeline.getNodes(), getNodeManager());
       Pipeline pipeline = Pipeline.newBuilder()
           .setId(initialPipeline.getId())
           // overwrite pipeline state to main ALLOCATED
@@ -79,6 +82,7 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
               .fromProtoTypeAndFactor(initialPipeline.getType(),
                   replicationConfig.getReplicationFactor()))
           .setNodes(initialPipeline.getNodes())
+          .setSupportedStorageTier(storageTiers)
           .build();
       return pipeline;
     }
@@ -95,11 +99,14 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
   @Override
   public Pipeline create(RatisReplicationConfig replicationConfig,
       List<DatanodeDetails> nodes) {
+    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(Pipeline.PipelineState.OPEN)
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
+        .setSupportedStorageTier(storageTiers)
         .build();
   }
+
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
@@ -103,7 +103,7 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
         .setState(Pipeline.PipelineState.OPEN)
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
-        .setSupportedStorageTier(Collections.singletonList(storageTier))
+        .setSupportedStorageTier(storageTier)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -26,7 +27,6 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.node.NodeUtils;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 
@@ -72,8 +72,6 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
       return super.create(replicationConfig, storageTier);
     } else {
       Pipeline initialPipeline = super.create(replicationConfig, storageTier);
-      List<StorageTier> storageTiers =
-          NodeUtils.getDatanodesStorageTypes(initialPipeline.getNodes(), getNodeManager());
       Pipeline pipeline = Pipeline.newBuilder()
           .setId(initialPipeline.getId())
           // overwrite pipeline state to main ALLOCATED
@@ -82,7 +80,7 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
               .fromProtoTypeAndFactor(initialPipeline.getType(),
                   replicationConfig.getReplicationFactor()))
           .setNodes(initialPipeline.getNodes())
-          .setSupportedStorageTier(storageTiers)
+          .setSupportedStorageTier(initialPipeline.getSupportedStorageTier())
           .build();
       return pipeline;
     }
@@ -98,14 +96,14 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
 
   @Override
   public Pipeline create(RatisReplicationConfig replicationConfig,
-      List<DatanodeDetails> nodes) {
-    List<StorageTier> storageTiers = NodeUtils.getDatanodesStorageTypes(nodes, getNodeManager());
+      List<DatanodeDetails> nodes, StorageTier storageTier)
+      throws IOException {
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(Pipeline.PipelineState.OPEN)
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
-        .setSupportedStorageTier(storageTiers)
+        .setSupportedStorageTier(Collections.singletonList(storageTier))
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -50,10 +51,12 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -95,6 +98,8 @@ public class TestECPipelineProvider {
 
     when(nodeManager.getNodeStatus(any()))
         .thenReturn(NodeStatus.inServiceHealthy());
+    when(nodeManager.getDatanodeInfo(any()))
+        .thenAnswer(invocation -> createDatanodeInfo(invocation.getArgument(0)));
   }
 
   @Test
@@ -221,6 +226,16 @@ public class TestECPipelineProvider {
       replicas.add(r);
     }
     return replicas;
+  }
+
+  private DatanodeInfo createDatanodeInfo(DatanodeDetails dn) {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(dn,
+        NodeStatus.inServiceHealthy(), null,
+        HddsTestUtils.ROLL_INTERVAL_MS_DEFAULT);
+    datanodeInfo.updateStorageReports(Collections.singletonList(
+        HddsTestUtils.createStorageReport(dn.getID(),
+            "/data-" + dn.getUuidString(), 100)));
+    return datanodeInfo;
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -63,10 +63,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
@@ -161,6 +163,18 @@ public class TestPipelineManagerImpl {
     if (dbStore != null) {
       dbStore.close();
     }
+  }
+
+  private PipelineManagerImpl createPipelineManager(NodeManager manager, boolean isLeader)
+      throws IOException {
+    return PipelineManagerImpl.newPipelineManager(conf,
+        SCMHAManagerStub.getInstance(isLeader),
+        manager,
+        SCMDBDefinition.PIPELINES.getTable(dbStore),
+        new EventQueue(),
+        scmContext,
+        serviceManager,
+        testClock);
   }
 
   private PipelineManagerImpl createPipelineManager(boolean isLeader)
@@ -377,7 +391,7 @@ public class TestPipelineManagerImpl {
       // get pipeline report from each dn in the pipeline
       PipelineReportHandler pipelineReportHandler =
           new PipelineReportHandler(scmSafeModeManager, pipelineManager,
-              SCMContext.emptyContext(), conf);
+              scmContext, conf);
       nodes.subList(0, 2).forEach(dn -> sendPipelineReport(dn, pipeline,
           pipelineReportHandler, false));
       sendPipelineReport(nodes.get(nodes.size() - 1), pipeline,
@@ -403,6 +417,68 @@ public class TestPipelineManagerImpl {
       assertThrows(PipelineNotFoundException.class,
           () -> pipelineManager.getPipeline(pipeline.getId()));
     }
+  }
+
+  @Test
+  public void testPipelineReportUpdateSupportedStorageTier() throws Exception {
+    // Set Env
+    int nodeCount = 3;
+    MockNodeManager localNodeManager = new MockNodeManager(true, nodeCount, StorageType.DISK);
+    SCMContext localScmContext = spy(SCMContext.emptyContext());
+    StorageContainerManager localScm = mock(StorageContainerManager.class);
+    when(localScm.getScmNodeManager()).thenReturn(localNodeManager);
+    when(localScmContext.getScm()).thenReturn(localScm);
+
+    PipelineManagerImpl pipelineManager = createPipelineManager(localNodeManager, true);
+    SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(conf,
+        localNodeManager, pipelineManager, mock(ContainerManager.class),
+        serviceManager, new EventQueue(), scmContext);
+    List<DatanodeDetails> nodes = localNodeManager.getNodes(NodeStatus.inServiceHealthy());
+    assertEquals(nodeCount, nodes.size());
+    Pipeline pipeline = pipelineManager.createPipeline(RatisReplicationConfig
+        .getInstance(ReplicationFactor.THREE));
+    assertTrue(pipeline.getSupportedStorageTier().contains(StorageTier.DISK));
+
+    assertFalse(pipelineManager.getPipeline(pipeline.getId()).isHealthy());
+    PipelineReportHandler pipelineReportHandler = new PipelineReportHandler(
+        scmSafeModeManager, pipelineManager, localScmContext, conf);
+    nodes.subList(0, 2).forEach(dn -> sendPipelineReport(dn, pipeline,
+        pipelineReportHandler, false));
+    sendPipelineReport(nodes.get(nodes.size() - 1), pipeline,
+        pipelineReportHandler, true);
+
+    // All the Datanode Volume StorageType is DISK so the Pipeline StorageTier will be StorageTier.DISK
+    assertTrue(pipelineManager.getPipeline(pipeline.getId()).isHealthy());
+    assertTrue(pipelineManager.getPipeline(pipeline.getId()).isOpen());
+    assertEquals(1, pipeline.getSupportedStorageTier().size());
+    assertTrue(pipeline.getSupportedStorageTier().contains(StorageTier.DISK));
+
+    // Only the first Datanode updated its NodeReport to SSD,
+    // Pipeline's Datanode StorageType [SSD, DISK, DISK] is not a valid StorageTier
+    localNodeManager.setStorageTypeForNode(nodes.get(0).getID(), StorageType.SSD);
+    sendPipelineReport(nodes.get(0), pipeline, pipelineReportHandler, false);
+    assertEquals(0,
+        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier().size());
+
+    // The first and second Datanode updated its NodeReport to SSD
+    // Pipeline's Datanode StorageType [SSD, SSD, DISK] is not a valid StorageTier
+    localNodeManager.setStorageTypeForNode(nodes.get(1).getID(), StorageType.SSD);
+    sendPipelineReport(nodes.get(1), pipeline, pipelineReportHandler, false);
+    assertEquals(0,
+        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier().size());
+
+    // The first and second Datanode updated its NodeReport to SSD
+    // Pipeline's Datanode StorageType [SSD, SSD, SSD] is StorageTier.SSD
+    localNodeManager.setStorageTypeForNode(nodes.get(2).getID(), StorageType.SSD);
+    sendPipelineReport(nodes.get(2), pipeline, pipelineReportHandler, true);
+    assertEquals(1,
+        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier().size());
+    assertTrue(pipelineManager.getPipeline(pipeline.getId())
+        .getSupportedStorageTier().contains(StorageTier.SSD));
+
+    // close the pipeline and clean up
+    pipelineManager.closePipeline(pipeline.getId());
+    pipelineManager.close();
   }
 
   @Test
@@ -478,7 +554,7 @@ public class TestPipelineManagerImpl {
         serviceManager, new EventQueue(), scmContext);
     PipelineReportHandler pipelineReportHandler =
         new PipelineReportHandler(scmSafeModeManager, pipelineManager,
-            SCMContext.emptyContext(), conf);
+            scmContext, conf);
 
     // Report pipelines with leaders
     List<DatanodeDetails> nodes = pipeline.getNodes();
@@ -855,7 +931,7 @@ public class TestPipelineManagerImpl {
         = new HealthyPipelineChoosePolicy();
     ContainerManager containerManager
         = mock(ContainerManager.class);
-    
+
     WritableContainerProvider<ReplicationConfig> provider;
     String owner = "TEST";
     Pipeline allocatedPipeline;
@@ -876,7 +952,7 @@ public class TestPipelineManagerImpl {
     ContainerInfo container = HddsTestUtils.
             getContainer(HddsProtos.LifeCycleState.OPEN,
                 allocatedPipeline.getId());
-    
+
     pipelineManager.addContainerToPipeline(
         allocatedPipeline.getId(), container.containerID());
     doReturn(container).when(containerManager).getMatchingContainer(anyLong(),
@@ -902,7 +978,7 @@ public class TestPipelineManagerImpl {
       return call.callRealMethod();
     }).when(pipelineManagerSpy).waitOnePipelineReady(any(), anyLong());
 
-    
+
     ContainerInfo c = provider.getContainer(1, repConfig,
         owner, new ExcludeList());
     assertEquals(c, container, "Expected container was returned");

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -420,7 +420,7 @@ public class TestPipelineManagerImpl {
   }
 
   @Test
-  public void testPipelineReportUpdateSupportedStorageTier() throws Exception {
+  public void testPipelineReportDoesNotUpdateSupportedStorageTier() throws Exception {
     // Set Env
     int nodeCount = 3;
     MockNodeManager localNodeManager = new MockNodeManager(true, nodeCount, StorageType.DISK);
@@ -437,7 +437,8 @@ public class TestPipelineManagerImpl {
     assertEquals(nodeCount, nodes.size());
     Pipeline pipeline = pipelineManager.createPipeline(RatisReplicationConfig
         .getInstance(ReplicationFactor.THREE));
-    assertTrue(pipeline.getSupportedStorageTier().contains(StorageTier.DISK));
+    assertEquals(Collections.singletonList(StorageTier.DISK),
+        pipeline.getSupportedStorageTier());
 
     assertFalse(pipelineManager.getPipeline(pipeline.getId()).isHealthy());
     PipelineReportHandler pipelineReportHandler = new PipelineReportHandler(
@@ -450,31 +451,27 @@ public class TestPipelineManagerImpl {
     // All the Datanode Volume StorageType is DISK so the Pipeline StorageTier will be StorageTier.DISK
     assertTrue(pipelineManager.getPipeline(pipeline.getId()).isHealthy());
     assertTrue(pipelineManager.getPipeline(pipeline.getId()).isOpen());
-    assertEquals(1, pipeline.getSupportedStorageTier().size());
-    assertTrue(pipeline.getSupportedStorageTier().contains(StorageTier.DISK));
+    assertEquals(Collections.singletonList(StorageTier.DISK),
+        pipeline.getSupportedStorageTier());
 
     // Only the first Datanode updated its NodeReport to SSD,
-    // Pipeline's Datanode StorageType [SSD, DISK, DISK] is not a valid StorageTier
+    // but the Pipeline supportedStorageTier keeps the StorageTier selected at creation.
     localNodeManager.setStorageTypeForNode(nodes.get(0).getID(), StorageType.SSD);
     sendPipelineReport(nodes.get(0), pipeline, pipelineReportHandler, false);
-    assertEquals(0,
-        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier().size());
+    assertEquals(Collections.singletonList(StorageTier.DISK),
+        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
 
     // The first and second Datanode updated its NodeReport to SSD
-    // Pipeline's Datanode StorageType [SSD, SSD, DISK] is not a valid StorageTier
     localNodeManager.setStorageTypeForNode(nodes.get(1).getID(), StorageType.SSD);
     sendPipelineReport(nodes.get(1), pipeline, pipelineReportHandler, false);
-    assertEquals(0,
-        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier().size());
+    assertEquals(Collections.singletonList(StorageTier.DISK),
+        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
 
     // The first and second Datanode updated its NodeReport to SSD
-    // Pipeline's Datanode StorageType [SSD, SSD, SSD] is StorageTier.SSD
     localNodeManager.setStorageTypeForNode(nodes.get(2).getID(), StorageType.SSD);
     sendPipelineReport(nodes.get(2), pipeline, pipelineReportHandler, true);
-    assertEquals(1,
-        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier().size());
-    assertTrue(pipelineManager.getPipeline(pipeline.getId())
-        .getSupportedStorageTier().contains(StorageTier.SSD));
+    assertEquals(Collections.singletonList(StorageTier.DISK),
+        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
 
     // close the pipeline and clean up
     pipelineManager.closePipeline(pipeline.getId());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -437,8 +437,7 @@ public class TestPipelineManagerImpl {
     assertEquals(nodeCount, nodes.size());
     Pipeline pipeline = pipelineManager.createPipeline(RatisReplicationConfig
         .getInstance(ReplicationFactor.THREE));
-    assertEquals(Collections.singletonList(StorageTier.DISK),
-        pipeline.getSupportedStorageTier());
+    assertEquals(StorageTier.DISK, pipeline.getSupportedStorageTier());
 
     assertFalse(pipelineManager.getPipeline(pipeline.getId()).isHealthy());
     PipelineReportHandler pipelineReportHandler = new PipelineReportHandler(
@@ -451,27 +450,23 @@ public class TestPipelineManagerImpl {
     // All the Datanode Volume StorageType is DISK so the Pipeline StorageTier will be StorageTier.DISK
     assertTrue(pipelineManager.getPipeline(pipeline.getId()).isHealthy());
     assertTrue(pipelineManager.getPipeline(pipeline.getId()).isOpen());
-    assertEquals(Collections.singletonList(StorageTier.DISK),
-        pipeline.getSupportedStorageTier());
+    assertEquals(StorageTier.DISK, pipeline.getSupportedStorageTier());
 
     // Only the first Datanode updated its NodeReport to SSD,
     // but the Pipeline supportedStorageTier keeps the StorageTier selected at creation.
     localNodeManager.setStorageTypeForNode(nodes.get(0).getID(), StorageType.SSD);
     sendPipelineReport(nodes.get(0), pipeline, pipelineReportHandler, false);
-    assertEquals(Collections.singletonList(StorageTier.DISK),
-        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
+    assertEquals(StorageTier.DISK, pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
 
     // The first and second Datanode updated its NodeReport to SSD
     localNodeManager.setStorageTypeForNode(nodes.get(1).getID(), StorageType.SSD);
     sendPipelineReport(nodes.get(1), pipeline, pipelineReportHandler, false);
-    assertEquals(Collections.singletonList(StorageTier.DISK),
-        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
+    assertEquals(StorageTier.DISK, pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
 
     // The first and second Datanode updated its NodeReport to SSD
     localNodeManager.setStorageTypeForNode(nodes.get(2).getID(), StorageType.SSD);
     sendPipelineReport(nodes.get(2), pipeline, pipelineReportHandler, true);
-    assertEquals(Collections.singletonList(StorageTier.DISK),
-        pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
+    assertEquals(StorageTier.DISK, pipelineManager.getPipeline(pipeline.getId()).getSupportedStorageTier());
 
     // close the pipeline and clean up
     pipelineManager.closePipeline(pipeline.getId());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -114,11 +115,13 @@ public class TestPipelinePlacementPolicy {
 
   private List<DatanodeDetails> nodesWithOutRackAwareness = new ArrayList<>();
   private List<DatanodeDetails> nodesWithRackAwareness = new ArrayList<>();
-  private final StorageType storageType = StorageType.DEFAULT;
+  private final StorageTier storageTier = StorageTier.DISK;
+  private StorageType storageType = StorageType.DEFAULT;
 
   @BeforeEach
   public void init() throws Exception {
     cluster = initTopology();
+    storageType = storageTier.getUniformStorageType();
     // start with nodes with rack awareness.
     nodeManager = new MockNodeManager(cluster, getNodesWithRackAwareness(),
         false, PIPELINE_PLACEMENT_MAX_NODES_COUNT, storageType);
@@ -290,6 +293,7 @@ public class TestPipelinePlacementPolicy {
             .setState(Pipeline.PipelineState.ALLOCATED)
             .setReplicationConfig(RatisReplicationConfig.getInstance(
                 ReplicationFactor.THREE))
+            .setSupportedStorageTier(storageTier)
             .setNodes(nodes)
             .build();
         HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
@@ -647,6 +651,7 @@ public class TestPipelinePlacementPolicy {
               .setReplicationConfig(ReplicationConfig
                   .fromProtoTypeAndFactor(RATIS, THREE))
               .setNodes(dnList)
+              .setSupportedStorageTier(storageTier)
               .build();
 
           pipelineProto = pipeline.getProtobufMessage(
@@ -674,7 +679,7 @@ public class TestPipelinePlacementPolicy {
 
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
-        stateManager, healthyNodes.get(0));
+        stateManager, healthyNodes.get(0), StorageType.DEFAULT);
     assertEquals(pipelineCount, 0);
 
     // Check datanode with one RATIS/ONE pipeline
@@ -684,7 +689,7 @@ public class TestPipelinePlacementPolicy {
 
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
-        stateManager, healthyNodes.get(1));
+        stateManager, healthyNodes.get(1), StorageType.DEFAULT);
     assertEquals(pipelineCount, 0);
 
     // Check datanode with one RATIS/THREE pipeline
@@ -696,7 +701,7 @@ public class TestPipelinePlacementPolicy {
 
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
-        stateManager, healthyNodes.get(2));
+        stateManager, healthyNodes.get(2), StorageType.DEFAULT);
     assertEquals(pipelineCount, 1);
 
     // Check datanode with one RATIS/ONE and one STANDALONE/ONE pipeline
@@ -706,7 +711,7 @@ public class TestPipelinePlacementPolicy {
 
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
-        stateManager, healthyNodes.get(1));
+        stateManager, healthyNodes.get(1), StorageType.DEFAULT);
     assertEquals(pipelineCount, 0);
 
     // Check datanode with one RATIS/ONE and one STANDALONE/ONE pipeline and
@@ -720,7 +725,7 @@ public class TestPipelinePlacementPolicy {
 
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
-        stateManager, healthyNodes.get(1));
+        stateManager, healthyNodes.get(1), StorageType.DEFAULT);
     assertEquals(pipelineCount, 2);
   }
 
@@ -767,7 +772,7 @@ public class TestPipelinePlacementPolicy {
     createPipelineWithReplicationConfig(p2Dns, RATIS, THREE);
 
     assertEquals(2, PipelinePlacementPolicy.currentRatisThreePipelineCount(
-        localNodeManager, localStateManager, target));
+        localNodeManager, localStateManager, target, storageType));
 
     // 3) Verifies node is filtered out when choosing nodes for new pipeline
     int nodesRequired = HddsProtos.ReplicationFactor.THREE.getNumber();
@@ -790,6 +795,7 @@ public class TestPipelinePlacementPolicy {
         .setReplicationConfig(ReplicationConfig
             .fromProtoTypeAndFactor(replicationType, replicationFactor))
         .setNodes(dnList)
+        .setSupportedStorageTier(storageTier)
         .build();
 
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
-import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -88,6 +87,7 @@ public class TestRatisPipelineProvider {
   private File testDir;
   private DBStore dbStore;
   private int nodeCount = 10;
+  private List<DatanodeDetails> datanodeList;
 
   public void init(int maxPipelinePerNode, StorageTier storageTier) throws Exception {
     init(maxPipelinePerNode, new OzoneConfiguration(), storageTier);
@@ -102,11 +102,12 @@ public class TestRatisPipelineProvider {
       StorageTier storageTier) throws Exception {
     assertTrue(storageTier.isUniform(), "Only support uniform StorageTier");
     assertFalse(storageTier.equals(StorageTier.EMPTY), "not support the EMPTY StorageTier");
-    StorageType storageType = storageTier.getStorageTypes(
-        RatisReplicationConfig.getInstance(ReplicationFactor.ONE).getRequiredNodes()).get(0);
+    StorageType storageType = storageTier.
+        getStorageTypes(ReplicationFactor.ONE.getNumber()).get(0);
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, dir.getAbsolutePath());
     dbStore = DBStoreBuilder.createDBStore(conf, SCMDBDefinition.get());
     nodeManager = new MockNodeManager(true, nodeCount, storageType);
+    datanodeList = nodeManager.getNodes(NodeStatus.inServiceHealthy());
     nodeManager.setNumPipelinePerDatanode(maxPipelinePerNode);
     SCMHAManager scmhaManager = SCMHAManagerStub.getInstance(true);
     conf.setInt(OZONE_DATANODE_PIPELINE_LIMIT,
@@ -132,11 +133,12 @@ public class TestRatisPipelineProvider {
   private static void assertPipelineProperties(
       Pipeline pipeline, HddsProtos.ReplicationFactor expectedFactor,
       HddsProtos.ReplicationType expectedReplicationType,
-      Pipeline.PipelineState expectedState) {
+      Pipeline.PipelineState expectedState, StorageTier expectedStorageTier) {
     assertEquals(expectedState, pipeline.getPipelineState());
     assertEquals(expectedReplicationType, pipeline.getType());
     assertEquals(expectedFactor.getNumber(), pipeline.getReplicationConfig().getRequiredNodes());
     assertEquals(expectedFactor.getNumber(), pipeline.getNodes().size());
+    assertTrue(pipeline.getSupportedStorageTier().contains(expectedStorageTier));
   }
 
   private void createPipelineAndAssertions(
@@ -145,7 +147,7 @@ public class TestRatisPipelineProvider {
     Pipeline pipeline = provider.create(RatisReplicationConfig
         .getInstance(factor), storageTier);
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
-        Pipeline.PipelineState.ALLOCATED);
+        Pipeline.PipelineState.ALLOCATED, storageTier);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
@@ -156,7 +158,7 @@ public class TestRatisPipelineProvider {
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
-        Pipeline.PipelineState.ALLOCATED);
+        Pipeline.PipelineState.ALLOCATED, storageTier);
     // New pipeline should not overlap with the previous created pipeline
     assertThat(intersection(pipeline.getNodes(), pipeline1.getNodes()).size())
         .isLessThan(factor.getNumber());
@@ -184,7 +186,7 @@ public class TestRatisPipelineProvider {
   private List<DatanodeDetails> createListOfNodes(int count) {
     List<DatanodeDetails> nodes = new ArrayList<>();
     for (int i = 0; i < count; i++) {
-      nodes.add(MockDatanodeDetails.randomDatanodeDetails());
+      nodes.add(datanodeList.get(i));
     }
     return nodes;
   }
@@ -197,7 +199,7 @@ public class TestRatisPipelineProvider {
     Pipeline pipeline = provider.create(RatisReplicationConfig
         .getInstance(factor), storageTier);
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
-        Pipeline.PipelineState.ALLOCATED);
+        Pipeline.PipelineState.ALLOCATED, storageTier);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
@@ -206,7 +208,7 @@ public class TestRatisPipelineProvider {
     Pipeline pipeline1 = provider.create(RatisReplicationConfig
         .getInstance(factor), storageTier);
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
-        Pipeline.PipelineState.ALLOCATED);
+        Pipeline.PipelineState.ALLOCATED, storageTier);
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto1);
@@ -223,13 +225,13 @@ public class TestRatisPipelineProvider {
         provider.create(RatisReplicationConfig.getInstance(factor),
             createListOfNodes(factor.getNumber()));
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
-        Pipeline.PipelineState.OPEN);
+        Pipeline.PipelineState.OPEN, StorageTier.getDefaultTier());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     pipeline = provider.create(RatisReplicationConfig.getInstance(factor),
         createListOfNodes(factor.getNumber()));
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
-        Pipeline.PipelineState.OPEN);
+        Pipeline.PipelineState.OPEN, StorageTier.getDefaultTier());
   }
 
   @Test
@@ -248,8 +250,7 @@ public class TestRatisPipelineProvider {
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
         healthyNodes);
     Pipeline pipeline3 = provider.createForRead(
-        RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
-        replicas);
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), replicas);
 
     assertEquals(pipeline1.getNodeSet(), pipeline2.getNodeSet());
     assertEquals(pipeline2.getNodeSet(), pipeline3.getNodeSet());
@@ -288,7 +289,7 @@ public class TestRatisPipelineProvider {
     Pipeline pipeline = provider.create(
         RatisReplicationConfig.getInstance(factor), storageTier);
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
-        Pipeline.PipelineState.ALLOCATED);
+        Pipeline.PipelineState.ALLOCATED, storageTier);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     nodeManager.addPipeline(pipeline);
@@ -459,7 +460,8 @@ public class TestRatisPipelineProvider {
 
     // Validate exception message.
     String expectedError = String.format(
-        "Cannot create pipeline as it would exceed the limit per datanode: %d replicationConfig: RATIS/THREE", limit);
+        "Cannot create pipeline for StorageTier DISK as it would exceed the limit per" +
+            " datanode: %d replicationConfig: RATIS/THREE", limit);
     assertEquals(expectedError, exception.getMessage());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -138,7 +138,8 @@ public class TestRatisPipelineProvider {
     assertEquals(expectedReplicationType, pipeline.getType());
     assertEquals(expectedFactor.getNumber(), pipeline.getReplicationConfig().getRequiredNodes());
     assertEquals(expectedFactor.getNumber(), pipeline.getNodes().size());
-    assertTrue(pipeline.getSupportedStorageTier().contains(expectedStorageTier));
+    assertEquals(Collections.singletonList(expectedStorageTier),
+        pipeline.getSupportedStorageTier());
   }
 
   private void createPipelineAndAssertions(
@@ -223,13 +224,15 @@ public class TestRatisPipelineProvider {
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
     Pipeline pipeline =
         provider.create(RatisReplicationConfig.getInstance(factor),
-            createListOfNodes(factor.getNumber()));
+            createListOfNodes(factor.getNumber()),
+            StorageTier.getDefaultTier());
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.OPEN, StorageTier.getDefaultTier());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     pipeline = provider.create(RatisReplicationConfig.getInstance(factor),
-        createListOfNodes(factor.getNumber()));
+        createListOfNodes(factor.getNumber()),
+        StorageTier.getDefaultTier());
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.OPEN, StorageTier.getDefaultTier());
   }
@@ -245,10 +248,10 @@ public class TestRatisPipelineProvider {
 
     Pipeline pipeline1 = provider.create(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
-        healthyNodes);
+        healthyNodes, StorageTier.getDefaultTier());
     Pipeline pipeline2 = provider.create(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
-        healthyNodes);
+        healthyNodes, StorageTier.getDefaultTier());
     Pipeline pipeline3 = provider.createForRead(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE), replicas);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -18,10 +18,12 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import static org.apache.commons.collections4.CollectionUtils.intersection;
+import static org.apache.hadoop.hdds.client.StorageTypeUtils.getStorageTypeProto;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.CANNOT_CREATE_PIPELINE_FOR_EMPTY_TIER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,6 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,19 +56,26 @@ import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackScatter;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -138,8 +150,7 @@ public class TestRatisPipelineProvider {
     assertEquals(expectedReplicationType, pipeline.getType());
     assertEquals(expectedFactor.getNumber(), pipeline.getReplicationConfig().getRequiredNodes());
     assertEquals(expectedFactor.getNumber(), pipeline.getNodes().size());
-    assertEquals(Collections.singletonList(expectedStorageTier),
-        pipeline.getSupportedStorageTier());
+    assertEquals(expectedStorageTier, pipeline.getSupportedStorageTier());
   }
 
   private void createPipelineAndAssertions(
@@ -182,6 +193,63 @@ public class TestRatisPipelineProvider {
   public void testCreatePipelineWithFactorOne(StorageTier storageTier) throws Exception {
     init(1, storageTier);
     createPipelineAndAssertions(HddsProtos.ReplicationFactor.ONE, storageTier);
+  }
+
+  @Test
+  public void testPipelineEngagementLimitIsStorageTierAware() throws Exception {
+    init(1, StorageTier.DISK);
+    List<DatanodeDetails> diskAndSsdNodes = datanodeList.stream()
+        .map(TestRatisPipelineProvider::datanodeInfoWithDiskAndSsd)
+        .collect(Collectors.toList());
+    MockNodeManager nodeManagerSpy = spy(nodeManager);
+    doAnswer(invocation -> diskAndSsdNodes)
+        .when(nodeManagerSpy).getNodes(any(NodeStatus.class));
+    doAnswer(invocation -> datanodeInfoWithDiskAndSsd(invocation.getArgument(0)))
+        .when(nodeManagerSpy).getDatanodeInfo(any(DatanodeDetails.class));
+    RatisPipelineProvider localProvider = new RatisPipelineProvider(
+        nodeManagerSpy, stateManager, new OzoneConfiguration(), new EventQueue(), SCMContext.emptyContext());
+    for (int i = 0; i < 2; i++) {
+      addPipeline(diskAndSsdNodes.subList(i * 3, i * 3 + 3),
+          Pipeline.PipelineState.OPEN,
+          RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+          StorageTier.DISK);
+    }
+
+    Pipeline pipeline = localProvider.create(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), StorageTier.SSD);
+
+    assertPipelineProperties(pipeline, ReplicationFactor.THREE,
+        REPLICATION_TYPE, Pipeline.PipelineState.ALLOCATED, StorageTier.SSD);
+  }
+
+  @Test
+  public void testGlobalPipelineNumberLimitIsNotStorageTierAware() throws Exception {
+    OzoneConfiguration pipelineLimitConf = new OzoneConfiguration();
+    pipelineLimitConf.setInt(OZONE_SCM_RATIS_PIPELINE_LIMIT, 1);
+    init(0, pipelineLimitConf, StorageTier.DISK);
+    List<DatanodeDetails> diskAndSsdNodes = datanodeList.stream()
+        .map(TestRatisPipelineProvider::datanodeInfoWithDiskAndSsd)
+        .collect(Collectors.toList());
+    MockNodeManager nodeManagerSpy = spy(nodeManager);
+    doAnswer(invocation -> diskAndSsdNodes)
+        .when(nodeManagerSpy).getNodes(any(NodeStatus.class));
+    doAnswer(invocation -> datanodeInfoWithDiskAndSsd(invocation.getArgument(0)))
+        .when(nodeManagerSpy).getDatanodeInfo(any(DatanodeDetails.class));
+    RatisPipelineProvider localProvider = new RatisPipelineProvider(
+        nodeManagerSpy, stateManager, pipelineLimitConf, new EventQueue(),
+        SCMContext.emptyContext());
+    for (int i = 0; i < 2; i++) {
+      addPipeline(diskAndSsdNodes.subList(i * 3, i * 3 + 3),
+          Pipeline.PipelineState.OPEN,
+          RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+          StorageTier.DISK);
+    }
+
+    SCMException exception = assertThrows(SCMException.class, () ->
+        localProvider.create(
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE), StorageTier.SSD));
+
+    assertThat(exception.getMessage()).contains("would exceed the limit");
   }
 
   private List<DatanodeDetails> createListOfNodes(int count) {
@@ -278,14 +346,14 @@ public class TestRatisPipelineProvider {
     for (int i = 0; i < maxPipelinePerNode; i++) {
       // Saturate pipeline counts on all the 1st 3 DNs.
       addPipeline(dns, Pipeline.PipelineState.OPEN,
-          RatisReplicationConfig.getInstance(factor));
+          RatisReplicationConfig.getInstance(factor), storageTier);
     }
     Set<DatanodeDetails> membersOfOpenPipelines = new HashSet<>(dns);
 
     // Use up next 3 DNs for a closed pipeline.
     dns = healthyNodes.subList(3, 6);
     addPipeline(dns, Pipeline.PipelineState.CLOSED,
-        RatisReplicationConfig.getInstance(factor));
+        RatisReplicationConfig.getInstance(factor), storageTier);
     Set<DatanodeDetails> membersOfClosedPipelines = new HashSet<>(dns);
 
     // only 2 healthy DNs left that are not part of any pipeline
@@ -485,13 +553,14 @@ public class TestRatisPipelineProvider {
 
   private void addPipeline(
       List<DatanodeDetails> dns,
-      Pipeline.PipelineState open, ReplicationConfig replicationConfig)
+      Pipeline.PipelineState open, ReplicationConfig replicationConfig, StorageTier storageTier)
       throws IOException, TimeoutException {
     Pipeline openPipeline = Pipeline.newBuilder()
         .setReplicationConfig(replicationConfig)
         .setNodes(dns)
         .setState(open)
         .setId(PipelineID.randomId())
+        .setSupportedStorageTier(storageTier)
         .build();
     HddsProtos.Pipeline pipelineProto = openPipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
@@ -527,4 +596,24 @@ public class TestRatisPipelineProvider {
         StorageTier.ARCHIVE
     );
   }
+
+  private static DatanodeInfo datanodeInfoWithDiskAndSsd(DatanodeDetails dn) {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        dn, NodeStatus.inServiceHealthy(), UpgradeUtils.defaultLayoutVersionProto(),
+        HddsTestUtils.ROLL_INTERVAL_MS_DEFAULT);
+    List<StorageReportProto> storageReports = new ArrayList<>();
+    long capacity = 10L * 1024 * 1024 * 1024;
+    storageReports.add(HddsTestUtils.createStorageReport(
+        dn.getID(), "/disk-" + dn.getUuidString(),
+        capacity, 0L, capacity, getStorageTypeProto(StorageType.DISK)));
+    storageReports.add(HddsTestUtils.createStorageReport(
+        dn.getID(), "/ssd-" + dn.getUuidString(),
+        capacity, 0L, capacity, getStorageTypeProto(StorageType.SSD)));
+    MetadataStorageReportProto metadataReport = HddsTestUtils.createMetadataStorageReport(
+        "/metadata-" + dn.getUuidString(), capacity, 0L, capacity, null);
+    datanodeInfo.updateStorageReports(storageReports);
+    datanodeInfo.updateMetaDataStorageReports(Collections.singletonList(metadataReport));
+    return datanodeInfo;
+  }
+
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.ClientVersion;
@@ -63,6 +63,7 @@ public class TestSimplePipelineProvider {
   @TempDir
   private File testDir;
   private DBStore dbStore;
+  private List<DatanodeDetails> datanodeList;
 
   @BeforeEach
   public void startup() throws Exception {
@@ -78,6 +79,7 @@ public class TestSimplePipelineProvider {
     StorageType storageType = storageTier.getStorageTypes(
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE).getRequiredNodes()).get(0);
     NodeManager nodeManager = new MockNodeManager(true, 10, storageType);
+    datanodeList = nodeManager.getNodes(NodeStatus.inServiceHealthy());
     SCMHAManager scmhaManager = SCMHAManagerStub.getInstance(true);
     stateManager = PipelineStateManagerImpl.newBuilder()
         .setPipelineStore(SCMDBDefinition.PIPELINES.getTable(dbStore))
@@ -109,6 +111,7 @@ public class TestSimplePipelineProvider {
     assertEquals(pipeline.getReplicationConfig().getRequiredNodes(), factor.getNumber());
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    assertTrue(pipeline.getSupportedStorageTier().contains(storageTier));
 
     factor = HddsProtos.ReplicationFactor.ONE;
     Pipeline pipeline1 =
@@ -122,12 +125,13 @@ public class TestSimplePipelineProvider {
             .getReplicationFactor(), factor);
     assertEquals(pipeline1.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline1.getNodes().size(), factor.getNumber());
+    assertTrue(pipeline.getSupportedStorageTier().contains(storageTier));
   }
 
   private List<DatanodeDetails> createListOfNodes(int nodeCount) {
     List<DatanodeDetails> nodes = new ArrayList<>();
     for (int i = 0; i < nodeCount; i++) {
-      nodes.add(MockDatanodeDetails.randomDatanodeDetails());
+      nodes.add(datanodeList.get(i));
     }
     return nodes;
   }
@@ -147,6 +151,7 @@ public class TestSimplePipelineProvider {
             .getReplicationFactor(), factor);
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    assertTrue(pipeline.getSupportedStorageTier().contains(StorageTier.getDefaultTier()));
 
     factor = HddsProtos.ReplicationFactor.ONE;
     pipeline = provider.create(StandaloneReplicationConfig.getInstance(factor),
@@ -157,6 +162,7 @@ public class TestSimplePipelineProvider {
             .getReplicationFactor(), factor);
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    assertTrue(pipeline.getSupportedStorageTier().contains(StorageTier.getDefaultTier()));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -22,6 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,22 +34,29 @@ import java.util.stream.Stream;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.StorageTypeProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -112,8 +122,7 @@ public class TestSimplePipelineProvider {
     assertEquals(pipeline.getReplicationConfig().getRequiredNodes(), factor.getNumber());
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
-    assertEquals(Collections.singletonList(storageTier),
-        pipeline.getSupportedStorageTier());
+    assertEquals(storageTier, pipeline.getSupportedStorageTier());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     Pipeline pipeline1 =
@@ -127,8 +136,7 @@ public class TestSimplePipelineProvider {
             .getReplicationFactor(), factor);
     assertEquals(pipeline1.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline1.getNodes().size(), factor.getNumber());
-    assertEquals(Collections.singletonList(storageTier),
-        pipeline1.getSupportedStorageTier());
+    assertEquals(storageTier, pipeline1.getSupportedStorageTier());
   }
 
   private List<DatanodeDetails> createListOfNodes(int nodeCount) {
@@ -155,8 +163,7 @@ public class TestSimplePipelineProvider {
             .getReplicationFactor(), factor);
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
-    assertEquals(Collections.singletonList(StorageTier.getDefaultTier()),
-        pipeline.getSupportedStorageTier());
+    assertEquals(StorageTier.getDefaultTier(), pipeline.getSupportedStorageTier());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     pipeline = provider.create(StandaloneReplicationConfig.getInstance(factor),
@@ -168,8 +175,51 @@ public class TestSimplePipelineProvider {
             .getReplicationFactor(), factor);
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
-    assertEquals(Collections.singletonList(StorageTier.getDefaultTier()),
-        pipeline.getSupportedStorageTier());
+    assertEquals(StorageTier.getDefaultTier(), pipeline.getSupportedStorageTier());
+  }
+
+  @Test
+  public void testCreatedPipelineOnlySupportsRequestedStorageTier()
+      throws Exception {
+    NodeManager nodeManager = mock(NodeManager.class);
+    PipelineStateManager pipelineStateManager = mock(PipelineStateManager.class);
+    List<DatanodeDetails> nodes = new ArrayList<>();
+    for (int i = 0; i < HddsProtos.ReplicationFactor.THREE.getNumber(); i++) {
+      nodes.add(createDatanodeInfoWithStorageReports(
+          StorageTypeProto.DISK, StorageTypeProto.SSD));
+    }
+    when(nodeManager.getNodes(NodeStatus.inServiceHealthy()))
+        .thenReturn(nodes);
+    when(nodeManager.getDatanodeInfo(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(pipelineStateManager.getPipelines(
+            any(ReplicationConfig.class)))
+        .thenReturn(Collections.emptyList());
+
+    PipelineProvider pipelineProvider =
+        new SimplePipelineProvider(nodeManager, pipelineStateManager);
+    Pipeline pipeline = pipelineProvider.create(StandaloneReplicationConfig.getInstance(
+        HddsProtos.ReplicationFactor.THREE), StorageTier.DISK);
+
+    assertEquals(StorageTier.DISK, pipeline.getSupportedStorageTier());
+  }
+
+  private DatanodeInfo createDatanodeInfoWithStorageReports(
+      HddsProtos.StorageTypeProto... storageTypes) {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(), UpgradeUtils.defaultLayoutVersionProto(),
+        HddsTestUtils.ROLL_INTERVAL_MS_DEFAULT);
+    List<StorageReportProto> storageReports = new ArrayList<>();
+    for (HddsProtos.StorageTypeProto storageType : storageTypes) {
+      storageReports.add(StorageReportProto.newBuilder()
+          .setStorageUuid(datanodeInfo.getUuidString() + "-" + storageType)
+          .setStorageLocation("/data-" + storageType)
+          .setStorageType(storageType)
+          .build());
+    }
+    datanodeInfo.updateStorageReports(storageReports);
+    return datanodeInfo;
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.StorageType;
@@ -111,7 +112,8 @@ public class TestSimplePipelineProvider {
     assertEquals(pipeline.getReplicationConfig().getRequiredNodes(), factor.getNumber());
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
-    assertTrue(pipeline.getSupportedStorageTier().contains(storageTier));
+    assertEquals(Collections.singletonList(storageTier),
+        pipeline.getSupportedStorageTier());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     Pipeline pipeline1 =
@@ -125,7 +127,8 @@ public class TestSimplePipelineProvider {
             .getReplicationFactor(), factor);
     assertEquals(pipeline1.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline1.getNodes().size(), factor.getNumber());
-    assertTrue(pipeline.getSupportedStorageTier().contains(storageTier));
+    assertEquals(Collections.singletonList(storageTier),
+        pipeline1.getSupportedStorageTier());
   }
 
   private List<DatanodeDetails> createListOfNodes(int nodeCount) {
@@ -143,7 +146,8 @@ public class TestSimplePipelineProvider {
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
     Pipeline pipeline =
         provider.create(StandaloneReplicationConfig.getInstance(factor),
-            createListOfNodes(factor.getNumber()));
+            createListOfNodes(factor.getNumber()),
+            StorageTier.getDefaultTier());
     assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
     assertEquals(
@@ -151,18 +155,21 @@ public class TestSimplePipelineProvider {
             .getReplicationFactor(), factor);
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
-    assertTrue(pipeline.getSupportedStorageTier().contains(StorageTier.getDefaultTier()));
+    assertEquals(Collections.singletonList(StorageTier.getDefaultTier()),
+        pipeline.getSupportedStorageTier());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     pipeline = provider.create(StandaloneReplicationConfig.getInstance(factor),
-        createListOfNodes(factor.getNumber()));
+        createListOfNodes(factor.getNumber()),
+        StorageTier.getDefaultTier());
     assertEquals(pipeline.getType(), HddsProtos.ReplicationType.STAND_ALONE);
     assertEquals(
         ((StandaloneReplicationConfig) pipeline.getReplicationConfig())
             .getReplicationFactor(), factor);
     assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
     assertEquals(pipeline.getNodes().size(), factor.getNumber());
-    assertTrue(pipeline.getSupportedStorageTier().contains(StorageTier.getDefaultTier()));
+    assertEquals(Collections.singletonList(StorageTier.getDefaultTier()),
+        pipeline.getSupportedStorageTier());
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/hdds/protocol/StorageTierTest.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/hdds/protocol/StorageTierTest.java
@@ -59,7 +59,8 @@ class StorageTierTest {
       }
       for (ReplicationConfig replicationConfig : Arrays.asList(ratisOne, ratisThree,
           standaloneOne, standaloneThree)) {
-        List<StorageType> storageTypes = tier.getStorageTypes(replicationConfig.getRequiredNodes());
+        List<StorageType> storageTypes = tier.getStorageTypes(
+            replicationConfig.getRequiredNodes());
         if (tier.equals(StorageTier.EMPTY)) {
           assertEquals(0, storageTypes.size());
         } else {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
@@ -104,6 +104,10 @@ public class TestSCMRestart {
     assertNotSame(ratisPipeline2AfterRestart, ratisPipeline2);
     assertEquals(ratisPipeline1AfterRestart, ratisPipeline1);
     assertEquals(ratisPipeline2AfterRestart, ratisPipeline2);
+    assertEquals(ratisPipeline1AfterRestart.getSupportedStorageTier(),
+        ratisPipeline1.getSupportedStorageTier());
+    assertEquals(ratisPipeline2AfterRestart.getSupportedStorageTier(),
+        ratisPipeline2.getSupportedStorageTier());
 
     // Try creating a new container, it should be from the same pipeline
     // as was before restart

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -82,6 +82,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -821,7 +822,7 @@ public class TestKeyManagerImpl {
     assumeFalse(nodeList.get(0).equals(nodeList.get(2)));
     // create a pipeline using 3 datanodes
     Pipeline pipeline = scm.getPipelineManager().createPipeline(
-        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), nodeList);
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), nodeList, StorageTier.getDefaultTier());
     List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
     List<OmKeyLocationInfo> locationList =
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.recon.scm;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.collections4.map.DefaultedMap;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.recon.scm;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.collections4.map.DefaultedMap;
@@ -64,7 +65,7 @@ public class ReconPipelineFactory extends PipelineFactory {
 
     @Override
     public Pipeline create(ReplicationConfig config,
-                           List<DatanodeDetails> nodes) {
+                           List<DatanodeDetails> nodes, StorageTier storageTier) {
       throw new UnsupportedOperationException(
           "Trying to create pipeline in Recon, which is prohibited!");
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
SCM Pipeline Add `supportedStorageTier` Field

- Set `supportedStorageTier` for Pipeline when the Pipeline be created
- Pipeline can support zero or more different types of `StorageTier`, depending on the Volume `StorageType` of the Datanodes that make up the Pipeline.  
  - For example, if the three Datanodes of a 3 replica Pipeline have SSD and DISK `StorageType` Volumes, then the Pipeline `supportedStorageTier` is `StorageTier.SSD` and `StorageTier.DISK`
- The `supportedStorageTier` by the Pipeline is not fixed. This field will be set when the Pipeline is created and will be updated in the `PipelineReportHandler` and `NodeReportHandler`. 
   - When the `StorageType` of the Volume of the Datanode in the Pipeline changes (for example, the Datanode configuration is manually modified), the `supportedStorageTier` of the Pipeline will also change


---
FYI:
- Releated doc and discuss: https://github.com/apache/ozone/pull/6989
- A preview version for the full "Ozone Storage Policy"  feature: https://github.com/ivandika3/ozone/tree/refs/heads/backport-storage-policy-storage-class


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15409


## How was this patch tested?
unit test