### PR TITLE
HDDS-15446. Expose Hard Min Free Space Threshold via JMX

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
@@ -61,6 +61,10 @@ public class VolumeInfoMetrics implements MetricsSource {
       Interns.info("MinFreeSpace",
           "Minimum free space threshold (soft limit) reported to SCM, " +
           "derived from hdds.datanode.volume.min.free.space.percent / hdds.datanode.volume.min.free.space");
+  private static final MetricsInfo HARD_MIN_FREE_SPACE =
+      Interns.info("HardMinFreeSpace",
+          "Minimum free space threshold (hard limit) enforced locally for writes, " +
+          "derived from hdds.datanode.volume.min.free.space.hard.limit.percent");
   private static final MetricsInfo NON_OZONE_USED =
       Interns.info("NonOzoneUsed",
           "Space on the filesystem consumed by non-Ozone workloads " +
@@ -254,6 +258,7 @@ public class VolumeInfoMetrics implements MetricsSource {
           .addGauge(FS_AVAILABLE, fsUsage.getAvailable())
           .addGauge(FS_USED, fsUsage.getCapacity() - fsUsage.getAvailable())
           .addGauge(MIN_FREE_SPACE, volume.getReportedFreeSpaceToSpare(ozoneCapacity))
+          .addGauge(HARD_MIN_FREE_SPACE, volume.getFreeSpaceToSpare(ozoneCapacity))
           .addGauge(NON_OZONE_USED, VolumeUsage.getOtherUsed(fsUsage));
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
@@ -64,7 +64,8 @@ public class VolumeInfoMetrics implements MetricsSource {
   private static final MetricsInfo HARD_MIN_FREE_SPACE =
       Interns.info("HardMinFreeSpace",
           "Minimum free space threshold (hard limit) enforced locally for writes, " +
-          "derived from hdds.datanode.volume.min.free.space.hard.limit.percent");
+          "derived from hdds.datanode.volume.min.free.space.hard.limit.percent " +
+          "/ hdds.datanode.volume.min.free.space");
   private static final MetricsInfo NON_OZONE_USED =
       Interns.info("NonOzoneUsed",
           "Space on the filesystem consumed by non-Ozone workloads " +

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -61,6 +61,7 @@
         <th>Filesystem Available</th>
         <th>Filesystem Used</th>
         <th>Min Free Space</th>
+        <th>Hard Min Free Space</th>
         <th>Non-Ozone Used</th>
         <th>Containers</th>
         <th>State</th>
@@ -79,6 +80,7 @@
         <td>{{volumeInfo.FilesystemAvailable}}</td>
         <td>{{volumeInfo.FilesystemUsed}}</td>
         <td>{{volumeInfo.MinFreeSpace}}</td>
+        <td>{{volumeInfo.HardMinFreeSpace}}</td>
         <td>{{volumeInfo.NonOzoneUsed}}</td>
         <td>{{volumeInfo.Containers}}</td>
         <td>{{volumeInfo["tag.VolumeState"]}}</td>

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn.js
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn.js
@@ -38,6 +38,7 @@
                  volume.FilesystemAvailable = transform(volume.FilesystemAvailable);
                  volume.FilesystemUsed = transform(volume.FilesystemUsed);
                  volume.MinFreeSpace = transform(volume.MinFreeSpace);
+                 volume.HardMinFreeSpace = transform(volume.HardMinFreeSpace);
                  volume.NonOzoneUsed = transform(volume.NonOzoneUsed);
                 })
                 });

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeInfoMetrics.java
@@ -45,6 +45,7 @@ class TestVolumeInfoMetrics {
     when(volume.getCommittedBytes()).thenReturn(10L);
     when(volume.getContainers()).thenReturn(3L);
     when(volume.getReportedFreeSpaceToSpare(anyLong())).thenReturn(20L);
+    when(volume.getFreeSpaceToSpare(anyLong())).thenReturn(15L);
 
     VolumeUsage volumeUsage = mock(VolumeUsage.class);
     when(volume.getVolumeUsage()).thenReturn(volumeUsage);
@@ -80,6 +81,7 @@ class TestVolumeInfoMetrics {
       assertThat(findMetric(all, "FilesystemUsed")).isEqualTo(900L); // FilesystemCapacity - FilesystemAvailable
 
       assertThat(findMetric(all, "MinFreeSpace")).isEqualTo(20L);
+      assertThat(findMetric(all, "HardMinFreeSpace")).isEqualTo(15L);
       // NonOzoneUsed = FilesystemUsed - OzoneUsed = 900 - 500
       assertThat(findMetric(all, "NonOzoneUsed")).isEqualTo(400L);
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The hard minimum free space threshold is not available via JMX on Datanodes. The write path rejection logic uses the hard threshold, which is exposed through the getFreeSpaceToSpare method on HddsVolume. This PR exposes the metric in JMX.

## What is the link to the Apache JIRA
[HDDS-15446](https://issues.apache.org/jira/browse/HDDS-15446)

## How was this patch tested?
1. Unit test was updated.
2. Tested Manually:
```bash
bash-5.1$ curl -XGET http://ozone-datanode-1:9882/jmx?qry=Hadoop:service=HddsDatanode,name=VolumeInfoMetrics-/data/hdds
{
  "beans" : [ {
    "name" : "Hadoop:service=HddsDatanode,name=VolumeInfoMetrics-/data/hdds",
    "modelerType" : "VolumeInfoMetrics-/data/hdds",
    "tag.Context" : "ozone",
    "tag.DatanodeUuid" : "5fa333c2-71a4-43bc-b95f-968a925cefa6",
    "tag.StorageType" : "DISK",
    "tag.VolumeType" : "DATA_VOLUME",
    "tag.StorageDirectory" : "/data/hdds/hdds",
    "tag.VolumeState" : "NORMAL",
    "tag.Hostname" : "3319dfbfbcbf",
    "AvailableSpaceInsufficient" : 0,
    "DbCompactLatencyNumOps" : 0,
    "DbCompactLatencyAvgTime" : 0.0,
    "NumContainerCreateRequestsInSoftBandMinFreeSpace" : 0,
    "NumContainerCreateRequestsRejectedHardMinFreeSpace" : 0,
    "NumScans" : 1,
    "NumScansSkipped" : 0,
    "NumWriteRequestsInSoftBandMinFreeSpace" : 0,
    "NumWriteRequestsRejectedHardMinFreeSpace" : 0,
    "ReservedCrossesLimit" : 1,
    "Committed" : 0,
    "LayoutVersion" : 1,
    "Containers" : 0,
    "OzoneCapacity" : 105076655700,
    "OzoneAvailable" : 91655196672,
    "OzoneUsed" : 4382720,
    "Reserved" : 10508716,
    "FilesystemCapacity" : 105087164416,
    "FilesystemAvailable" : 91655196672,
    "FilesystemUsed" : 13431967744,
    "MinFreeSpace" : 104857600,
    "HardMinFreeSpace" : 104857600,
    "NonOzoneUsed" : 13427585024
  } ]
}bash-5.1$
```

3. DN UI shows the new metric:
<img width="1868" height="846" alt="image" src="https://github.com/user-attachments/assets/e6ce90fc-5ad8-4fbb-81bd-06b4627da030" />
