### PR TITLE
HDDS-14187. Use BatchOperation to batch writes to tables of FSORepairTool

### DIFF
--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -103,6 +103,7 @@ public class FSORepairTool extends RepairTool {
 
   @CommandLine.Option(names = {"--batch-size"},
       defaultValue = "10000",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       description = "Number of entries to buffer before flushing a batch of writes to temp.db.")
   private int tempDbBatchSize;
 

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -89,8 +89,17 @@ public class FSORepairTool extends RepairTool {
   private static final String REACHABLE_TABLE = "reachable";
   private static final String PENDING_TO_DELETE_TABLE = "pendingToDelete";
 
+  private static int tempDbBatchSize = 10_000;
+
   @VisibleForTesting
-  static int tempDbBatchSize = 10_000;
+  static void setTempDbBatchSize(int batchSize) {
+    tempDbBatchSize = batchSize;
+  }
+
+  @VisibleForTesting
+  static int getTempDbBatchSize() {
+    return tempDbBatchSize;
+  }
 
   @CommandLine.Option(names = {"--db"},
       required = true,

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.repair.om;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
@@ -87,6 +88,9 @@ public class FSORepairTool extends RepairTool {
   private static final Logger LOG = LoggerFactory.getLogger(FSORepairTool.class);
   private static final String REACHABLE_TABLE = "reachable";
   private static final String PENDING_TO_DELETE_TABLE = "pendingToDelete";
+
+  @VisibleForTesting
+  static int tempDbBatchSize = 10_000;
 
   @CommandLine.Option(names = {"--db"},
       required = true,
@@ -287,29 +291,31 @@ public class FSORepairTool extends RepairTool {
       // Directory keys should have the form /volumeID/bucketID/parentID/name.
       Stack<String> dirKeyStack = new Stack<>();
 
-      // Since the tool uses parent directories to check for reachability, add
-      // a reachable entry for the bucket as well.
-      addReachableEntry(volume, bucket, bucket);
-      // Initialize the stack with all immediate child directories of the
-      // bucket, and mark them all as reachable.
-      Collection<String> childDirs = getChildDirectoriesAndMarkAsReachable(volume, bucket, bucket);
-      dirKeyStack.addAll(childDirs);
-
-      while (!dirKeyStack.isEmpty()) {
-        // Get one directory and process its immediate children.
-        String currentDirKey = dirKeyStack.pop();
-        OmDirectoryInfo currentDir = directoryTable.get(currentDirKey);
-        if (currentDir == null) {
-          if (isVerbose()) {
-            info("Directory key" + currentDirKey + "to be processed was not found in the directory table.");
-          }
-          continue;
-        }
-
-        // TODO revisit this for a more memory efficient implementation,
-        //  possibly making better use of RocksDB iterators.
-        childDirs = getChildDirectoriesAndMarkAsReachable(volume, bucket, currentDir);
+      try (BatchedTempWriter writer = new BatchedTempWriter(reachableTable)) {
+        // Since the tool uses parent directories to check for reachability, add
+        // a reachable entry for the bucket as well.
+        addReachableEntry(volume, bucket, bucket, writer);
+        // Initialize the stack with all immediate child directories of the
+        // bucket, and mark them all as reachable.
+        Collection<String> childDirs = getChildDirectoriesAndMarkAsReachable(volume, bucket, bucket, writer);
         dirKeyStack.addAll(childDirs);
+
+        while (!dirKeyStack.isEmpty()) {
+          // Get one directory and process its immediate children.
+          String currentDirKey = dirKeyStack.pop();
+          OmDirectoryInfo currentDir = directoryTable.get(currentDirKey);
+          if (currentDir == null) {
+            if (isVerbose()) {
+              info("Directory key" + currentDirKey + "to be processed was not found in the directory table.");
+            }
+            continue;
+          }
+
+          // TODO revisit this for a more memory efficient implementation,
+          //  possibly making better use of RocksDB iterators.
+          childDirs = getChildDirectoriesAndMarkAsReachable(volume, bucket, currentDir, writer);
+          dirKeyStack.addAll(childDirs);
+        }
       }
     }
 
@@ -321,48 +327,50 @@ public class FSORepairTool extends RepairTool {
       // Find all deleted directories in this bucket and process their children
       String bucketPrefix = OM_KEY_PREFIX + volume.getObjectID() + OM_KEY_PREFIX + bucket.getObjectID();
 
-      try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> deletedDirIterator =
-               deletedDirectoryTable.iterator()) {
-        deletedDirIterator.seek(bucketPrefix);
-        while (deletedDirIterator.hasNext()) {
-          Table.KeyValue<String, OmKeyInfo> deletedDirEntry = deletedDirIterator.next();
-          String deletedDirKey = deletedDirEntry.getKey();
+      try (BatchedTempWriter writer = new BatchedTempWriter(pendingToDeleteTable)) {
+        try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> deletedDirIterator =
+                 deletedDirectoryTable.iterator()) {
+          deletedDirIterator.seek(bucketPrefix);
+          while (deletedDirIterator.hasNext()) {
+            Table.KeyValue<String, OmKeyInfo> deletedDirEntry = deletedDirIterator.next();
+            String deletedDirKey = deletedDirEntry.getKey();
 
-          // Only process deleted directories in this bucket
-          if (!deletedDirKey.startsWith(bucketPrefix)) {
-            break;
+            // Only process deleted directories in this bucket
+            if (!deletedDirKey.startsWith(bucketPrefix)) {
+              break;
+            }
+
+            // Extract the objectID from the deleted directory entry
+            OmKeyInfo deletedDirInfo = deletedDirEntry.getValue();
+            long deletedObjectID = deletedDirInfo.getObjectID();
+
+            // Build the prefix that children would have: /volID/bucketID/deletedObjectID/
+            String childPrefix = OM_KEY_PREFIX + volume.getObjectID() + OM_KEY_PREFIX + bucket.getObjectID() +
+                OM_KEY_PREFIX + deletedObjectID + OM_KEY_PREFIX;
+
+            // Find all children of this deleted directory and mark as pendingToDelete
+            Collection<String> childDirs = getChildDirectoriesAndMarkAsPendingToDelete(childPrefix, writer);
+            dirKeyStack.addAll(childDirs);
+          }
+        }
+
+        while (!dirKeyStack.isEmpty()) {
+          // Get one directory and process its immediate children.
+          String currentDirKey = dirKeyStack.pop();
+          OmDirectoryInfo currentDir = directoryTable.get(currentDirKey);
+          if (currentDir == null) {
+            if (isVerbose()) {
+              info("Directory key" + currentDirKey + "to be processed was not found in the directory table.");
+            }
+            continue;
           }
 
-          // Extract the objectID from the deleted directory entry
-          OmKeyInfo deletedDirInfo = deletedDirEntry.getValue();
-          long deletedObjectID = deletedDirInfo.getObjectID();
-
-          // Build the prefix that children would have: /volID/bucketID/deletedObjectID/
+          // For pendingToDelete directories, we need to build the prefix based on their objectID
           String childPrefix = OM_KEY_PREFIX + volume.getObjectID() + OM_KEY_PREFIX + bucket.getObjectID() +
-              OM_KEY_PREFIX + deletedObjectID + OM_KEY_PREFIX;
-
-          // Find all children of this deleted directory and mark as pendingToDelete
-          Collection<String> childDirs = getChildDirectoriesAndMarkAsPendingToDelete(childPrefix);
+              OM_KEY_PREFIX + currentDir.getObjectID() + OM_KEY_PREFIX;
+          Collection<String> childDirs = getChildDirectoriesAndMarkAsPendingToDelete(childPrefix, writer);
           dirKeyStack.addAll(childDirs);
         }
-      }
-
-      while (!dirKeyStack.isEmpty()) {
-        // Get one directory and process its immediate children.
-        String currentDirKey = dirKeyStack.pop();
-        OmDirectoryInfo currentDir = directoryTable.get(currentDirKey);
-        if (currentDir == null) {
-          if (isVerbose()) {
-            info("Directory key" + currentDirKey + "to be processed was not found in the directory table.");
-          }
-          continue;
-        }
-
-        // For pendingToDelete directories, we need to build the prefix based on their objectID
-        String childPrefix = OM_KEY_PREFIX + volume.getObjectID() + OM_KEY_PREFIX + bucket.getObjectID() +
-            OM_KEY_PREFIX + currentDir.getObjectID() + OM_KEY_PREFIX;
-        Collection<String> childDirs = getChildDirectoriesAndMarkAsPendingToDelete(childPrefix);
-        dirKeyStack.addAll(childDirs);
       }
     }
 
@@ -467,7 +475,7 @@ public class FSORepairTool extends RepairTool {
     }
 
     private Collection<String> getChildDirectoriesAndMarkAsReachable(OmVolumeArgs volume, OmBucketInfo bucket,
-        WithObjectID currentDir) throws IOException {
+        WithObjectID currentDir, BatchedTempWriter writer) throws IOException {
 
       Collection<String> childDirs = new ArrayList<>();
 
@@ -486,7 +494,7 @@ public class FSORepairTool extends RepairTool {
             break;
           }
           // This directory was reached by search.
-          addReachableEntry(volume, bucket, childDirEntry.getValue());
+          addReachableEntry(volume, bucket, childDirEntry.getValue(), writer);
           childDirs.add(childDirKey);
           reachableStats.addDir();
         }
@@ -495,7 +503,8 @@ public class FSORepairTool extends RepairTool {
       return childDirs;
     }
 
-    private Collection<String> getChildDirectoriesAndMarkAsPendingToDelete(String dirPrefix) throws IOException {
+    private Collection<String> getChildDirectoriesAndMarkAsPendingToDelete(String dirPrefix,
+        BatchedTempWriter writer) throws IOException {
       Collection<String> childDirs = new ArrayList<>();
 
       // Find child directories and mark them as pendingToDelete
@@ -515,7 +524,7 @@ public class FSORepairTool extends RepairTool {
           // Ensure this is an immediate child, not a deeper descendant
           String relativePath = childDirKey.substring(dirPrefix.length());
           if (!relativePath.contains(OM_KEY_PREFIX)) {
-            addPendingToDeleteEntry(childDirKey);
+            addPendingToDeleteEntry(childDirKey, writer);
             childDirs.add(childDirKey);
             pendingToDeleteStats.addDir();
           }
@@ -537,7 +546,7 @@ public class FSORepairTool extends RepairTool {
           // Ensure this is an immediate child, not a deeper descendant
           String relativePath = childFileKey.substring(dirPrefix.length());
           if (!relativePath.contains(OM_KEY_PREFIX)) {
-            addPendingToDeleteEntry(childFileKey);
+            addPendingToDeleteEntry(childFileKey, writer);
             pendingToDeleteStats.addFile(childFileEntry.getValue().getDataSize());
           }
         }
@@ -546,23 +555,55 @@ public class FSORepairTool extends RepairTool {
       return childDirs;
     }
 
+    /** Buffers writes to a temp.db table and flushes them in bounded batches. */
+    private final class BatchedTempWriter implements AutoCloseable {
+      private final Table<String, CodecBuffer> table;
+      private BatchOperation batch;
+      private int pending;
+
+      BatchedTempWriter(Table<String, CodecBuffer> table) {
+        this.table = table;
+        this.batch = tempDB.initBatchOperation();
+      }
+
+      void put(String key) throws IOException {
+        table.putWithBatch(batch, key, CodecBuffer.getEmptyBuffer());
+        if (++pending >= tempDbBatchSize) {
+          flush();
+        }
+      }
+
+      private void flush() throws IOException {
+        tempDB.commitBatchOperation(batch);
+        batch.close();
+        batch = tempDB.initBatchOperation();
+        pending = 0;
+      }
+
+      @Override
+      public void close() throws IOException {
+        if (pending > 0) {
+          tempDB.commitBatchOperation(batch);
+        }
+        batch.close();
+      }
+    }
+
     /**
      * Add the specified object to the reachable table, indicating it is part
      * of the connected FSO tree.
      */
-    private void addReachableEntry(OmVolumeArgs volume, OmBucketInfo bucket, WithObjectID object) throws IOException {
-      String reachableKey = buildReachableKey(volume, bucket, object);
-      // No value is needed for this table.
-      reachableTable.put(reachableKey, CodecBuffer.getEmptyBuffer());
+    private void addReachableEntry(OmVolumeArgs volume, OmBucketInfo bucket, WithObjectID object,
+        BatchedTempWriter writer) throws IOException {
+      writer.put(buildReachableKey(volume, bucket, object));
     }
 
     /**
      * Add the specified object to the pendingToDelete table, indicating it is part
      * of the disconnected FSO tree.
      */
-    private void addPendingToDeleteEntry(String originalKey) throws IOException {
-      // No value is needed for this table.
-      pendingToDeleteTable.put(originalKey, CodecBuffer.getEmptyBuffer());
+    private void addPendingToDeleteEntry(String originalKey, BatchedTempWriter writer) throws IOException {
+      writer.put(originalKey);
     }
 
     /**

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -578,19 +578,24 @@ public class FSORepairTool extends RepairTool {
       }
 
       private void flush() throws IOException {
-        tempDB.commitBatchOperation(batch);
-        batch.close();
+        commitPending();
         batch = tempDB.initBatchOperation();
-        pending = 0;
       }
 
       @Override
       public void close() throws IOException {
-        if (pending > 0) {
-          tempDB.commitBatchOperation(batch);
+        commitPending();
+      }
+
+      private void commitPending() throws IOException {
+        try {
+          if (pending > 0) {
+            tempDB.commitBatchOperation(batch);
+          }
+        } finally {
           pending = 0;
+          batch.close();
         }
-        batch.close();
       }
     }
 

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -114,6 +114,9 @@ public class FSORepairTool extends RepairTool {
 
   @Override
   public void execute() throws Exception {
+    if (tempDbBatchSize < 1) {
+      throw new IllegalArgumentException("--batch-size must be at least 1, but was " + tempDbBatchSize);
+    }
     try {
       Impl repairTool = new Impl();
       repairTool.run();

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -585,6 +585,7 @@ public class FSORepairTool extends RepairTool {
       public void close() throws IOException {
         if (pending > 0) {
           tempDB.commitBatchOperation(batch);
+          pending = 0;
         }
         batch.close();
       }

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/FSORepairTool.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.repair.om;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 
-import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
@@ -89,18 +88,6 @@ public class FSORepairTool extends RepairTool {
   private static final String REACHABLE_TABLE = "reachable";
   private static final String PENDING_TO_DELETE_TABLE = "pendingToDelete";
 
-  private static int tempDbBatchSize = 10_000;
-
-  @VisibleForTesting
-  static void setTempDbBatchSize(int batchSize) {
-    tempDbBatchSize = batchSize;
-  }
-
-  @VisibleForTesting
-  static int getTempDbBatchSize() {
-    return tempDbBatchSize;
-  }
-
   @CommandLine.Option(names = {"--db"},
       required = true,
       description = "Path to OM RocksDB")
@@ -113,6 +100,11 @@ public class FSORepairTool extends RepairTool {
   @CommandLine.Option(names = {"-b", "--bucket"},
       description = "Filter by bucket name")
   private String bucketFilter;
+
+  @CommandLine.Option(names = {"--batch-size"},
+      defaultValue = "10000",
+      description = "Number of entries to buffer before flushing a batch of writes to temp.db.")
+  private int tempDbBatchSize;
 
   @Nonnull
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -200,6 +200,28 @@ public class TestFSORepairTool {
   }
 
   /**
+   * Flush temp.db writes after every entry so the batch commit/reset path runs for both the
+   * reachable and pendingToDelete tables across all trees, and verify the report is unchanged.
+   */
+  @Order(ORDER_DRY_RUN)
+  @Test
+  public void testBatchedTempWrites() {
+    int originalBatchSize = FSORepairTool.tempDbBatchSize;
+    FSORepairTool.tempDbBatchSize = 1;
+    try {
+      String expectedOutput = serializeReport(fullReport);
+
+      int exitCode = dryRun();
+      assertEquals(0, exitCode, err.getOutput());
+
+      String reportOutput = extractRelevantSection(out.getOutput());
+      assertEquals(expectedOutput, reportOutput);
+    } finally {
+      FSORepairTool.tempDbBatchSize = originalBatchSize;
+    }
+  }
+
+  /**
    * Test to verify the file size of the tree.
    */
   @Order(ORDER_DRY_RUN)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -206,19 +206,13 @@ public class TestFSORepairTool {
   @Order(ORDER_DRY_RUN)
   @Test
   public void testBatchedTempWrites() {
-    int originalBatchSize = FSORepairTool.getTempDbBatchSize();
-    FSORepairTool.setTempDbBatchSize(1);
-    try {
-      String expectedOutput = serializeReport(fullReport);
+    String expectedOutput = serializeReport(fullReport);
 
-      int exitCode = dryRun();
-      assertEquals(0, exitCode, err.getOutput());
+    int exitCode = dryRun("--batch-size", "1");
+    assertEquals(0, exitCode, err.getOutput());
 
-      String reportOutput = extractRelevantSection(out.getOutput());
-      assertEquals(expectedOutput, reportOutput);
-    } finally {
-      FSORepairTool.setTempDbBatchSize(originalBatchSize);
-    }
+    String reportOutput = extractRelevantSection(out.getOutput());
+    assertEquals(expectedOutput, reportOutput);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -206,8 +206,8 @@ public class TestFSORepairTool {
   @Order(ORDER_DRY_RUN)
   @Test
   public void testBatchedTempWrites() {
-    int originalBatchSize = FSORepairTool.tempDbBatchSize;
-    FSORepairTool.tempDbBatchSize = 1;
+    int originalBatchSize = FSORepairTool.getTempDbBatchSize();
+    FSORepairTool.setTempDbBatchSize(1);
     try {
       String expectedOutput = serializeReport(fullReport);
 
@@ -217,7 +217,7 @@ public class TestFSORepairTool {
       String reportOutput = extractRelevantSection(out.getOutput());
       assertEquals(expectedOutput, reportOutput);
     } finally {
-      FSORepairTool.tempDbBatchSize = originalBatchSize;
+      FSORepairTool.setTempDbBatchSize(originalBatchSize);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/repair/om/TestFSORepairTool.java
@@ -25,6 +25,7 @@ import static org.apache.ozone.test.IntLambda.withTextFromSystemIn;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -213,6 +214,14 @@ public class TestFSORepairTool {
 
     String reportOutput = extractRelevantSection(out.getOutput());
     assertEquals(expectedOutput, reportOutput);
+  }
+
+  @Order(ORDER_DRY_RUN)
+  @Test
+  public void testInvalidBatchSize() {
+    int exitCode = dryRun("--batch-size", "0");
+    assertNotEquals(0, exitCode);
+    assertThat(err.getOutput()).contains("--batch-size must be at least 1");
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Problem.** When `FSORepairTool` marks the temporary `reachable` and `pendingToDelete` tables in `temp.db`, it writes each entry with an individual `Table.put`. Every put is a separate RocksDB write (WAL + fsync). For FSO buckets with thousands or millions of files and directories, this per-entry fsync overhead dominates the run.

**Fix.** Buffer the temp-table writes in a bounded RocksDB `BatchOperation` instead of one `put` per entry. A small `BatchedTempWriter` helper accumulates `putWithBatch` calls, flushes every `--batch-size` entries to cap memory, and commits the remainder on close; each marking phase wraps its directory walk in one writer. The already-batched repair-mode move logic is unchanged.

The batch size is exposed as a `--batch-size` CLI option (default 10000) so operators can tune it without a rebuild. Values below 1 are rejected.

This is safe because the temp tables are only written during the marking phases and only read back in the later classification phase, so every bucket's writes are committed before it is classified.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14187

## How was this patch tested?

- The existing `TestFSORepairTool` suite (connected / disconnected / empty / unreachable trees, dry-run, volume and bucket filters, repair mode, and post-repair OM restart validation) passes unchanged, confirming the batched writes produce identical reports.
- Added `testBatchedTempWrites`, which runs a full dry-run with `--batch-size 1` so the batch commit/reset path is exercised for both the `reachable` and `pendingToDelete` tables across all tree shapes, and asserts the report is identical to the default-batch run.
- Added `testInvalidBatchSize`, which asserts `--batch-size 0` fails with a non-zero exit and a clear error message.
- `checkstyle.sh` is clean on the changed modules.

Generated-by: Claude Code (claude-opus-4-8)
