### PR TITLE
HDDS-15587. [Recon] Show 0 for offline DN pending deletion instead of -1

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -95,6 +95,50 @@ describe('Capacity Page', () => {
     expect(datanodeCard).toHaveTextContent(/FREE SPACE\s*3\s*KB/i);
   });
 
+  test('clamps pendingBlockSize to 0 when selected datanode reports -1 (offline/unreachable)', async () => {
+    capacityServer.use(
+      rest.get('api/v1/pendingDeletion', (req, res, ctx) => {
+        const component = req.url.searchParams.get('component');
+        if (component === 'dn') {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              ...mockResponses.DnPendingDeletion,
+              pendingDeletionPerDataNode: [
+                { hostName: 'dn-1', datanodeUuid: 'uuid-1', pendingBlockSize: -1 },
+                { hostName: 'dn-2', datanodeUuid: 'uuid-2', pendingBlockSize: 2048 }
+              ]
+            })
+          );
+        }
+        const map: Record<string, object> = {
+          scm: mockResponses.ScmPendingDeletion,
+          om: mockResponses.OmPendingDeletion
+        };
+        const body = component ? map[component] : undefined;
+        return body
+          ? res(ctx.status(200), ctx.json(body))
+          : res(ctx.status(400), ctx.json({ message: 'Unsupported pending deletion component.' }));
+      })
+    );
+
+    render(<Capacity />);
+
+    const downloadLink = await screen.findByText('Download Insights');
+    const datanodeCard = downloadLink.closest('.ant-card');
+    expect(datanodeCard).not.toBeNull();
+    if (!datanodeCard) {
+      return;
+    }
+    // dn-1 is selected by default; its pendingBlockSize is -1 (offline sentinel).
+    // PENDING DELETION should show 0 B, not a negative value.
+    await waitFor(() =>
+      expect(datanodeCard).toHaveTextContent(/PENDING DELETION\s*0\s*B/i)
+    );
+    // USED SPACE = used (4096) + clamped pendingBlockSize (0) = 4 KB
+    expect(datanodeCard).toHaveTextContent(/USED SPACE\s*4\s*KB/i);
+  });
+
   test('shows scm-only error state when SCM pending deletion returns sentinel failure values', async () => {
     capacityServer.use(
       rest.get('api/v1/pendingDeletion', (req, res, ctx) => {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -127,6 +127,9 @@ const Capacity: React.FC<object> = () => {
   const selectedDNDetails: DataNodeUsage & { pendingBlockSize: number } = React.useMemo(() => {
     const selected = storageDistribution.data.dataNodeUsage.find(datanode => datanode.hostName === selectedDatanode)
       ?? storageDistribution.data.dataNodeUsage[0];
+    const dnPendingEntry = dnPendingDeletes.data.pendingDeletionPerDataNode?.find(
+      dn => dn.hostName === (selected?.hostName ?? selectedDatanode)
+    ) ?? { hostName: "unknown-host", datanodeUuid: "unknown-uuid", pendingBlockSize: 0 };
     return {
       ...(selected ?? {
         datanodeUuid: "unknown-uuid",
@@ -138,11 +141,8 @@ const Capacity: React.FC<object> = () => {
         minimumFreeSpace: 0,
         reserved: 0
       }),
-      ...dnPendingDeletes.data.pendingDeletionPerDataNode?.find(dn => dn.hostName === (selected?.hostName ?? selectedDatanode)) ?? {
-        hostName: "unknown-host",
-        datanodeUuid: "unknown-uuid",
-        pendingBlockSize: 0
-      }
+      ...dnPendingEntry,
+      pendingBlockSize: Math.max(0, dnPendingEntry.pendingBlockSize)
     }
   }, [selectedDatanode, storageDistribution.data.dataNodeUsage, dnPendingDeletes.data.pendingDeletionPerDataNode]);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the Capacity Distribution → Datanode Details section of Recon, if a datanode is selected and later goes offline, the node becomes disabled for new selection. However, if it was already selected, some metrics such as Pending Deletion are displayed as -1, which can be confusing to users.

To provide a better user experience, Recon should display 0 (or an appropriate default value) for these metrics when the selected datanode is offline or unavailable, instead of showing -1.

## What is the link to the Apache JIRA
HDDS-15587
## How was this patch tested?

Tested using unit test and manually.
<img width="3014" height="1622" alt="image" src="https://github.com/user-attachments/assets/8d145ddb-913a-43bd-862d-a4d1c314d108" />