### PR TITLE
HDDS-15618. Fix ListObjects to include single whitespace-only S3 object keys

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/S3SDKTestUtils.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/S3SDKTestUtils.java
@@ -25,6 +25,8 @@ import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -37,6 +39,13 @@ import org.apache.ozone.test.InputSubstream;
  * Utilities for S3 SDK tests.
  */
 public final class S3SDKTestUtils {
+
+  /**
+   * Key names from ceph s3-tests {@code test_bucket_create_special_key_names}.
+   */
+  public static final List<String> S3_SPECIAL_KEY_NAMES = Collections.unmodifiableList(
+      Arrays.asList(" ", "\"",
+          "$", "%", "&", "'", "<", ">", "_", "_ ", "_ _", "__"));
 
   public static final Pattern UPLOAD_ID_PATTERN = Pattern.compile("<UploadId>(.+?)</UploadId>");
 

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -1235,6 +1235,28 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     testListObjectsMany(true);
   }
 
+  @Test
+  public void testListObjectsSpecialKeyNames() throws Exception {
+    final String bucketName = getBucketName("special-keys");
+    final String content = "x";
+    s3Client.createBucket(bucketName);
+
+    for (String keyName : S3SDKTestUtils.S3_SPECIAL_KEY_NAMES) {
+      InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+      s3Client.putObject(bucketName, keyName, is, new ObjectMetadata());
+      try (S3Object object = s3Client.getObject(bucketName, keyName)) {
+        assertEquals(content, IOUtils.toString(object.getObjectContent(), StandardCharsets.UTF_8));
+      }
+    }
+
+    ObjectListing listObjectsResponse = s3Client.listObjects(
+        new ListObjectsRequest().withBucketName(bucketName));
+    List<String> listedKeys = listObjectsResponse.getObjectSummaries().stream()
+        .map(S3ObjectSummary::getKey)
+        .collect(Collectors.toList());
+    assertEquals(S3SDKTestUtils.S3_SPECIAL_KEY_NAMES, listedKeys);
+  }
+
   private void testListObjectsMany(boolean isListV2) throws Exception {
     final String bucketName = getBucketName();
     s3Client.createBucket(bucketName);

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -926,6 +926,28 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     testListObjectsMany(true);
   }
 
+  @Test
+  public void testListObjectsSpecialKeyNamesV2() throws Exception {
+    final String bucketName = getBucketName("special-keys");
+    final String content = "x";
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    for (String keyName : S3SDKTestUtils.S3_SPECIAL_KEY_NAMES) {
+      s3Client.putObject(b -> b.bucket(bucketName).key(keyName),
+          RequestBody.fromString(content));
+      ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(
+          b -> b.bucket(bucketName).key(keyName));
+      assertEquals(content, objectBytes.asUtf8String());
+    }
+
+    ListObjectsV2Response listObjectsResponse = s3Client.listObjectsV2(
+        ListObjectsV2Request.builder().bucket(bucketName).build());
+    List<String> listedKeys = listObjectsResponse.contents().stream()
+        .map(S3Object::key)
+        .collect(Collectors.toList());
+    assertEquals(S3SDKTestUtils.S3_SPECIAL_KEY_NAMES, listedKeys);
+  }
+
   private void testListObjectsMany(boolean isListV2) throws Exception {
     final String bucketName = getBucketName();
     s3Client.createBucket(b -> b.bucket(bucketName));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -640,7 +640,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     StringBuilder builder = new StringBuilder()
         .append(OM_KEY_PREFIX).append(volume)
         .append(OM_KEY_PREFIX).append(bucket); // TODO : Throw if the Bucket is null?
-    if (StringUtils.isNotBlank(key)) {
+    if (StringUtils.isNotEmpty(key)) {
       builder.append(OM_KEY_PREFIX);
       if (!key.equals(OM_KEY_PREFIX)) {
         builder.append(key);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -1294,4 +1294,29 @@ public class TestOmMetadataManager {
 
     assertEquals(25, noPagination.size());
   }
+
+  @Test
+  public void testListKeysSpecialKeyNames() throws Exception {
+    List<String> keyNames = Arrays.asList(" ", "\"",
+        "$", "%", "&", "'", "<", ">", "_", "_ ", "_ _", "__");
+
+    String volumeName = "volumeA";
+    String bucketName = "bucketA";
+    OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
+    addBucketsToCache(volumeName, bucketName);
+
+    assertEquals("/volumeA/bucketA/ ",
+        omMetadataManager.getOzoneKey(volumeName, bucketName, " "));
+
+    for (int i = 0; i < keyNames.size(); i++) {
+      addKeysToOM(volumeName, bucketName, keyNames.get(i), i);
+    }
+
+    List<String> listedKeys = omMetadataManager.listKeys(volumeName, bucketName,
+        null, null, 100).getKeys().stream()
+        .map(OmKeyInfo::getKeyName)
+        .collect(Collectors.toList());
+
+    assertEquals(keyNames, listedKeys);
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
s3-tests `test_bucket_create_special_key_names` fails because a key named      `   **' '**` is created but not returned by ListObjects. `OmMetadataManagerImpl.getOzoneKey()` uses `StringUtils.isNotBlank()`, which treats whitespace-only keys as absent, so the object is stored under /volume/bucket instead of /volume/bucket/.
List object uses prefix `/volume/bucket/`, so the key is omitted. Fix key encoding to allow whitespace-only names

```
Expected: [' ', '"', '$', '%', '&', "'", '<', '>', '_', '_ ', '_ _', '__']
Actual:   ['"', '$', '%', '&', "'", '<', '>', '_', '_ ', '_ _'] 

  # missing leading ' '

At index 0: ' ' != '"' 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15618

## How was this patch tested?

Added unit test.
