### PR TITLE
HDDS-15492. Support OM follower read for gRPC client

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/GrpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/GrpcOMFailoverProxyProvider.java
@@ -128,6 +128,10 @@ public class GrpcOMFailoverProxyProvider<T> extends
     return super.shouldFailover(ex);
   }
 
+  public synchronized boolean shouldFailoverForFollowerRead(Exception ex) {
+    return shouldFailover(ex);
+  }
+
   @Override
   public synchronized void close() throws IOException { }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
@@ -221,10 +221,6 @@ public class GrpcOmTransport implements OmTransport {
     for (int i = 0; useFollowerRead &&
         i < omFailoverProxyProvider.getOMProxyMap().getNodeIds().size(); i++) {
       String nodeId = getCurrentFollowerReadNodeId();
-      if (isCurrentLeaderNode(nodeId)) {
-        changeFollowerReadProxy(nodeId);
-        continue;
-      }
       String followerHost = omFailoverProxyProvider.getGrpcProxyAddress(nodeId);
       try {
         OMResponse response = submitRequestToHost(followerPayload, followerHost);
@@ -267,7 +263,6 @@ public class GrpcOmTransport implements OmTransport {
 
   private OMResponse submitRequestToLeader(OMRequest payload)
       throws IOException {
-    AtomicReference<OMResponse> resp = new AtomicReference<>();
     int requestFailoverCount = 0;
     boolean tryOtherHost = true;
     int expectedFailoverCount = 0;
@@ -276,7 +271,7 @@ public class GrpcOmTransport implements OmTransport {
       tryOtherHost = false;
       expectedFailoverCount = globalFailoverCount.get();
       try {
-        resp.set(submitRequestToHost(payload, host.get()));
+        return submitRequestToHost(payload, host.get());
       } catch (StatusRuntimeException e) {
         LOG.error("Failed to submit request", e);
         if (e.getStatus().getCode() == Status.Code.UNAVAILABLE) {
@@ -294,7 +289,7 @@ public class GrpcOmTransport implements OmTransport {
         }
       }
     }
-    return resp.get();
+    throw new OMException(resultCode);
   }
 
   private OMResponse submitRequestToHost(OMRequest payload, String targetHost)
@@ -335,10 +330,6 @@ public class GrpcOmTransport implements OmTransport {
       currentFollowerReadIndex = (currentFollowerReadIndex + 1) %
           omFailoverProxyProvider.getOMProxyMap().getNodeIds().size();
     }
-  }
-
-  private boolean isCurrentLeaderNode(String nodeId) {
-    return nodeId.equals(omFailoverProxyProvider.getCurrentProxyOMNodeId());
   }
 
   private Exception unwrapException(Exception ex) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
@@ -51,16 +51,23 @@ import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.ipc_.RemoteException;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.ha.GrpcOMFailoverProxyProvider;
+import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProviderBase;
+import org.apache.hadoop.ozone.om.helpers.ReadConsistency;
 import org.apache.hadoop.ozone.om.protocolPB.grpc.ClientAddressClientInterceptor;
 import org.apache.hadoop.ozone.om.protocolPB.grpc.GrpcClientConstants;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ReadConsistencyHint;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerServiceGrpc;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ratis.protocol.exceptions.ReadException;
+import org.apache.ratis.protocol.exceptions.ReadIndexException;
+import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +99,10 @@ public class GrpcOmTransport implements OmTransport {
   private RetryPolicy retryPolicy;
   private final GrpcOMFailoverProxyProvider<OzoneManagerProtocolPB>
       omFailoverProxyProvider;
+  private volatile boolean useFollowerRead;
+  private final ReadConsistencyHint followerReadConsistency;
+  private final ReadConsistencyHint leaderReadConsistency;
+  private int currentFollowerReadIndex = -1;
 
   public static void setCaCerts(List<X509Certificate> x509Certificates) {
     caCerts = x509Certificates;
@@ -116,6 +127,27 @@ public class GrpcOmTransport implements OmTransport {
         ugi,
         omServiceId,
         OzoneManagerProtocolPB.class);
+
+    this.useFollowerRead = conf.getBoolean(
+        OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_DEFAULT);
+    String defaultFollowerReadConsistencyStr = conf.get(
+        OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_DEFAULT_CONSISTENCY_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_DEFAULT_CONSISTENCY_DEFAULT
+    );
+    ReadConsistency defaultFollowerReadConsistency =
+        ReadConsistency.valueOf(defaultFollowerReadConsistencyStr);
+    String defaultLeaderReadConsistencyStr = conf.get(
+        OzoneConfigKeys.OZONE_CLIENT_LEADER_READ_DEFAULT_CONSISTENCY_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_LEADER_READ_DEFAULT_CONSISTENCY_DEFAULT);
+    ReadConsistency defaultLeaderReadConsistency =
+        ReadConsistency.valueOf(defaultLeaderReadConsistencyStr);
+    Preconditions.assertTrue(defaultFollowerReadConsistency.allowFollowerRead(),
+        "Invalid follower read consistency " + defaultFollowerReadConsistency);
+    Preconditions.assertTrue(!defaultLeaderReadConsistency.allowFollowerRead(),
+        "Invalid leader read consistency " + defaultLeaderReadConsistency);
+    this.followerReadConsistency = defaultFollowerReadConsistency.getHint();
+    this.leaderReadConsistency = defaultLeaderReadConsistency.getHint();
 
     start();
   }
@@ -174,6 +206,67 @@ public class GrpcOmTransport implements OmTransport {
 
   @Override
   public OMResponse submitRequest(OMRequest payload) throws IOException {
+    if (useFollowerRead && OmUtils.shouldSendToFollower(payload)) {
+      return submitRequestWithFollowerRead(payload);
+    }
+    return submitRequestToLeader(addReadConsistencyHint(payload,
+        leaderReadConsistency));
+  }
+
+  private OMResponse submitRequestWithFollowerRead(OMRequest payload)
+      throws IOException {
+    OMRequest followerPayload = addReadConsistencyHint(payload,
+        followerReadConsistency);
+    int failedCount = 0;
+    for (int i = 0; useFollowerRead &&
+        i < omFailoverProxyProvider.getOMProxyMap().getNodeIds().size(); i++) {
+      String nodeId = getCurrentFollowerReadNodeId();
+      if (isCurrentLeaderNode(nodeId)) {
+        changeFollowerReadProxy(nodeId);
+        continue;
+      }
+      String followerHost = omFailoverProxyProvider.getGrpcProxyAddress(nodeId);
+      try {
+        OMResponse response = submitRequestToHost(followerPayload, followerHost);
+        LOG.debug("Invocation with cmdType {} using follower read host {} was successful",
+            followerPayload.getCmdType(), followerHost);
+        return response;
+      } catch (StatusRuntimeException e) {
+        LOG.debug("Invocation with cmdType {} using follower read host {} failed",
+            followerPayload.getCmdType(), followerHost, e);
+        Exception unwrapped = unwrapException(new Exception(e));
+        if (OMFailoverProxyProviderBase.getNotLeaderException(unwrapped) != null) {
+          LOG.debug("Encountered OMNotLeaderException from {}. Disable OM follower read and retry OM leader directly.",
+              followerHost);
+          useFollowerRead = false;
+          break;
+        }
+        if (OMFailoverProxyProviderBase.getLeaderNotReadyException(unwrapped) != null) {
+          break;
+        }
+        ReadIndexException readIndexException =
+            OMFailoverProxyProviderBase.getReadIndexException(unwrapped);
+        ReadException readException =
+            OMFailoverProxyProviderBase.getReadException(unwrapped);
+        if (readIndexException != null || readException != null ||
+            omFailoverProxyProvider.shouldFailoverForFollowerRead(unwrapped)) {
+          failedCount++;
+          changeFollowerReadProxy(nodeId);
+        } else {
+          throw e;
+        }
+      }
+    }
+    if (failedCount > 0) {
+      LOG.warn("{} nodes have failed for read request with cmdType {}. Falling back to leader.",
+          failedCount, payload.getCmdType());
+    }
+    return submitRequestToLeader(addReadConsistencyHint(payload,
+        leaderReadConsistency));
+  }
+
+  private OMResponse submitRequestToLeader(OMRequest payload)
+      throws IOException {
     AtomicReference<OMResponse> resp = new AtomicReference<>();
     int requestFailoverCount = 0;
     boolean tryOtherHost = true;
@@ -183,14 +276,7 @@ public class GrpcOmTransport implements OmTransport {
       tryOtherHost = false;
       expectedFailoverCount = globalFailoverCount.get();
       try {
-        InetAddress inetAddress = InetAddress.getLocalHost();
-        Context.current()
-            .withValue(GrpcClientConstants.CLIENT_IP_ADDRESS_CTX_KEY,
-                inetAddress.getHostAddress())
-            .withValue(GrpcClientConstants.CLIENT_HOSTNAME_CTX_KEY,
-                inetAddress.getHostName())
-            .run(() -> resp.set(clients.get(host.get())
-                .submitRequest(payload)));
+        resp.set(submitRequestToHost(payload, host.get()));
       } catch (StatusRuntimeException e) {
         LOG.error("Failed to submit request", e);
         if (e.getStatus().getCode() == Status.Code.UNAVAILABLE) {
@@ -209,6 +295,50 @@ public class GrpcOmTransport implements OmTransport {
       }
     }
     return resp.get();
+  }
+
+  private OMResponse submitRequestToHost(OMRequest payload, String targetHost)
+      throws IOException {
+    AtomicReference<OMResponse> resp = new AtomicReference<>();
+    InetAddress inetAddress = InetAddress.getLocalHost();
+    Context.current()
+        .withValue(GrpcClientConstants.CLIENT_IP_ADDRESS_CTX_KEY,
+            inetAddress.getHostAddress())
+        .withValue(GrpcClientConstants.CLIENT_HOSTNAME_CTX_KEY,
+            inetAddress.getHostName())
+        .run(() -> resp.set(clients.get(targetHost)
+            .submitRequest(payload)));
+    return resp.get();
+  }
+
+  private OMRequest addReadConsistencyHint(OMRequest payload,
+      ReadConsistencyHint readConsistencyHint) {
+    if (!payload.hasReadConsistencyHint() && readConsistencyHint != null) {
+      return payload.toBuilder()
+          .setReadConsistencyHint(readConsistencyHint)
+          .build();
+    }
+    return payload;
+  }
+
+  private synchronized String getCurrentFollowerReadNodeId() {
+    if (currentFollowerReadIndex < 0) {
+      currentFollowerReadIndex = 0;
+    }
+    return new ArrayList<>(omFailoverProxyProvider.getOMProxyMap().getNodeIds())
+        .get(currentFollowerReadIndex);
+  }
+
+  private synchronized void changeFollowerReadProxy(String currentNodeId) {
+    String currentFollowerReadNodeId = getCurrentFollowerReadNodeId();
+    if (currentFollowerReadNodeId.equals(currentNodeId)) {
+      currentFollowerReadIndex = (currentFollowerReadIndex + 1) %
+          omFailoverProxyProvider.getOMProxyMap().getNodeIds().size();
+    }
+  }
+
+  private boolean isCurrentLeaderNode(String nodeId) {
+    return nodeId.equals(omFailoverProxyProvider.getCurrentProxyOMNodeId());
   }
 
   private Exception unwrapException(Exception ex) {
@@ -230,11 +360,10 @@ public class GrpcOmTransport implements OmTransport {
         grpcException = cn.newInstance(status.getDescription());
         IOException remote = null;
         try {
-          String cause = status.getDescription();
-          int colonIndex = cause.indexOf(':');
-          cause = cause.substring(colonIndex + 2);
-          remote = new RemoteException(cause.substring(0, colonIndex),
-              cause.substring(colonIndex + 1));
+          String description = status.getDescription();
+          int colonIndex = description.indexOf(':');
+          remote = new RemoteException(description.substring(0, colonIndex),
+              description.substring(colonIndex + 2));
           grpcException.initCause(remote);
         } catch (Exception e) {
           LOG.error("cannot get cause for remote exception");
@@ -369,6 +498,34 @@ public class GrpcOmTransport implements OmTransport {
               .newBlockingStub(testChannel));
     }
     LOG.info("{}: started", CLIENT_NAME);
+  }
+
+  @VisibleForTesting
+  public void startClient(String nodeId, ManagedChannel testChannel) throws IOException {
+    String hostaddr = omFailoverProxyProvider.getGrpcProxyAddress(nodeId);
+    clients.put(hostaddr,
+        OzoneManagerServiceGrpc
+            .newBlockingStub(testChannel));
+    LOG.info("{}: started test client for {}", CLIENT_NAME, nodeId);
+  }
+
+  @VisibleForTesting
+  public synchronized void changeFollowerReadInitialProxy(String nodeId) {
+    List<String> nodeIds = new ArrayList<>(
+        omFailoverProxyProvider.getOMProxyMap().getNodeIds());
+    for (int i = 0; i < nodeIds.size(); i++) {
+      if (nodeIds.get(i).equals(nodeId)) {
+        currentFollowerReadIndex = i;
+        return;
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public void changeLeaderProxyForTest(String nodeId) throws IOException {
+    omFailoverProxyProvider.setNextOmProxy(nodeId);
+    omFailoverProxyProvider.performFailover(null);
+    host.set(omFailoverProxyProvider.getGrpcProxyAddress(nodeId));
   }
 
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/TestS3GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/TestS3GrpcOmTransport.java
@@ -283,20 +283,21 @@ public class TestS3GrpcOmTransport {
   }
 
   @Test
-  public void testFollowerReadSkipsKnownLeader() throws Exception {
+  public void testFollowerReadDoesNotFailoverFromKnownLeader() throws Exception {
     conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
     configureHaOmService("om0", "om1");
 
     AtomicInteger leaderRequestCount = new AtomicInteger();
     AtomicInteger followerRequestCount = new AtomicInteger();
-    AtomicReference<OMRequest> followerRequest = new AtomicReference<>();
+    AtomicReference<OMRequest> leaderRequest = new AtomicReference<>();
 
     client = new GrpcOmTransport(conf, ugi, omServiceId);
     client.startClient("om0", createNodeChannel("om0",
-        leaderRequestCount, new AtomicReference<>()));
+        leaderRequestCount, leaderRequest));
     client.startClient("om1", createNodeChannel("om1",
-        followerRequestCount, followerRequest));
+        followerRequestCount, new AtomicReference<>()));
     client.changeLeaderProxyForTest("om0");
+    client.changeFollowerReadInitialProxy("om0");
 
     OMRequest request = OMRequest.newBuilder()
         .setCmdType(Type.ListVolume)
@@ -306,10 +307,10 @@ public class TestS3GrpcOmTransport {
 
     client.submitRequest(request);
 
-    assertEquals(0, leaderRequestCount.get());
-    assertEquals(1, followerRequestCount.get());
+    assertEquals(1, leaderRequestCount.get());
+    assertEquals(0, followerRequestCount.get());
     assertEquals(ReadConsistencyProto.LINEARIZABLE_ALLOW_FOLLOWER,
-        followerRequest.get().getReadConsistencyHint().getReadConsistency());
+        leaderRequest.get().getReadConsistencyHint().getReadConsistency());
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/TestS3GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/TestS3GrpcOmTransport.java
@@ -18,8 +18,12 @@
 package org.apache.hadoop.ozone.om.protocolPB;
 
 import static org.apache.hadoop.ozone.ClientVersion.CURRENT_VERSION;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_GRPC_MAXIMUM_RESPONSE_LENGTH;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_GRPC_MAXIMUM_RESPONSE_LENGTH_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_GRPC_PORT_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -29,13 +33,19 @@ import com.google.protobuf.ServiceException;
 import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ReadConsistencyHint;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ReadConsistencyProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerServiceGrpc;
@@ -270,6 +280,214 @@ public class TestS3GrpcOmTransport {
     // This exception should cause failover to NOT retry,
     // rather to fail.
     assertThrows(Exception.class, () -> client.submitRequest(omRequest));
+  }
+
+  @Test
+  public void testFollowerReadSkipsKnownLeader() throws Exception {
+    conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
+    configureHaOmService("om0", "om1");
+
+    AtomicInteger leaderRequestCount = new AtomicInteger();
+    AtomicInteger followerRequestCount = new AtomicInteger();
+    AtomicReference<OMRequest> followerRequest = new AtomicReference<>();
+
+    client = new GrpcOmTransport(conf, ugi, omServiceId);
+    client.startClient("om0", createNodeChannel("om0",
+        leaderRequestCount, new AtomicReference<>()));
+    client.startClient("om1", createNodeChannel("om1",
+        followerRequestCount, followerRequest));
+    client.changeLeaderProxyForTest("om0");
+
+    OMRequest request = OMRequest.newBuilder()
+        .setCmdType(Type.ListVolume)
+        .setVersion(CURRENT_VERSION)
+        .setClientId("test")
+        .build();
+
+    client.submitRequest(request);
+
+    assertEquals(0, leaderRequestCount.get());
+    assertEquals(1, followerRequestCount.get());
+    assertEquals(ReadConsistencyProto.LINEARIZABLE_ALLOW_FOLLOWER,
+        followerRequest.get().getReadConsistencyHint().getReadConsistency());
+  }
+
+  @Test
+  public void testFollowerReadDoesNotRouteWriteRequestToFollower() throws Exception {
+    conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
+    configureHaOmService("om0", "om1");
+
+    AtomicInteger leaderRequestCount = new AtomicInteger();
+    AtomicInteger followerRequestCount = new AtomicInteger();
+    AtomicReference<OMRequest> leaderRequest = new AtomicReference<>();
+
+    client = new GrpcOmTransport(conf, ugi, omServiceId);
+    client.startClient("om0", createNodeChannel("om0",
+        leaderRequestCount, leaderRequest));
+    client.startClient("om1", createNodeChannel("om1",
+        followerRequestCount, new AtomicReference<>()));
+    client.changeLeaderProxyForTest("om0");
+    client.changeFollowerReadInitialProxy("om1");
+
+    client.submitRequest(OMRequest.newBuilder()
+        .setCmdType(Type.CreateVolume)
+        .setVersion(CURRENT_VERSION)
+        .setClientId("test")
+        .build());
+
+    assertEquals(1, leaderRequestCount.get());
+    assertEquals(0, followerRequestCount.get());
+    assertEquals(ReadConsistencyProto.DEFAULT,
+        leaderRequest.get().getReadConsistencyHint().getReadConsistency());
+  }
+
+  @Test
+  public void testFollowerReadKeepsExistingConsistencyHint() throws Exception {
+    conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
+    configureHaOmService("om0", "om1");
+
+    AtomicInteger followerRequestCount = new AtomicInteger();
+    AtomicReference<OMRequest> followerRequest = new AtomicReference<>();
+
+    client = new GrpcOmTransport(conf, ugi, omServiceId);
+    client.startClient("om0", createNodeChannel("om0",
+        new AtomicInteger(), new AtomicReference<>()));
+    client.startClient("om1", createNodeChannel("om1",
+        followerRequestCount, followerRequest));
+    client.changeLeaderProxyForTest("om0");
+    client.changeFollowerReadInitialProxy("om1");
+
+    client.submitRequest(OMRequest.newBuilder()
+        .setCmdType(Type.ListVolume)
+        .setVersion(CURRENT_VERSION)
+        .setClientId("test")
+        .setReadConsistencyHint(ReadConsistencyHint.newBuilder()
+            .setReadConsistency(ReadConsistencyProto.LOCAL_LEASE)
+            .build())
+        .build());
+
+    assertEquals(1, followerRequestCount.get());
+    assertEquals(ReadConsistencyProto.LOCAL_LEASE,
+        followerRequest.get().getReadConsistencyHint().getReadConsistency());
+  }
+
+  @Test
+  public void testFollowerReadFallsBackToLeaderOnNotLeaderException() throws Exception {
+    conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
+    configureHaOmService("om0", "om1");
+
+    AtomicInteger leaderRequestCount = new AtomicInteger();
+    AtomicInteger followerRequestCount = new AtomicInteger();
+    AtomicReference<OMRequest> leaderRequest = new AtomicReference<>();
+
+    client = new GrpcOmTransport(conf, ugi, omServiceId);
+    client.startClient("om0", createNodeChannel("om0",
+        leaderRequestCount, leaderRequest));
+    client.startClient("om1", createNotLeaderNodeChannel(followerRequestCount));
+    client.changeLeaderProxyForTest("om0");
+    client.changeFollowerReadInitialProxy("om1");
+
+    client.submitRequest(OMRequest.newBuilder()
+        .setCmdType(Type.ListVolume)
+        .setVersion(CURRENT_VERSION)
+        .setClientId("test")
+        .build());
+
+    assertEquals(1, followerRequestCount.get());
+    assertEquals(1, leaderRequestCount.get());
+    assertEquals(ReadConsistencyProto.DEFAULT,
+        leaderRequest.get().getReadConsistencyHint().getReadConsistency());
+  }
+
+  @Test
+  public void testFollowerReadRejectsInvalidFollowerReadConsistency() {
+    conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
+    conf.set(OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_DEFAULT_CONSISTENCY_KEY, "DEFAULT");
+    configureHaOmService("om0", "om1");
+
+    assertThrows(IllegalStateException.class,
+        () -> new GrpcOmTransport(conf, ugi, omServiceId));
+  }
+
+  @Test
+  public void testFollowerReadRejectsInvalidLeaderReadConsistency() {
+    conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
+    conf.set(OzoneConfigKeys.OZONE_CLIENT_LEADER_READ_DEFAULT_CONSISTENCY_KEY,
+        "LINEARIZABLE_ALLOW_FOLLOWER");
+    configureHaOmService("om0", "om1");
+
+    assertThrows(IllegalStateException.class,
+        () -> new GrpcOmTransport(conf, ugi, omServiceId));
+  }
+
+  private void configureHaOmService(String... nodeIds) {
+    omServiceId = "om-service-test";
+    conf.set(OZONE_OM_SERVICE_IDS_KEY, omServiceId);
+    conf.set(ConfUtils.addKeySuffixes(OZONE_OM_NODES_KEY, omServiceId),
+        String.join(",", nodeIds));
+    for (int i = 0; i < nodeIds.length; i++) {
+      conf.set(ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, omServiceId,
+          nodeIds[i]), "localhost");
+      conf.setInt(ConfUtils.addKeySuffixes(OZONE_OM_GRPC_PORT_KEY, omServiceId,
+          nodeIds[i]), 19880 + i);
+    }
+  }
+
+  private ManagedChannel createNodeChannel(String nodeId,
+      AtomicInteger requestCount, AtomicReference<OMRequest> lastRequest)
+      throws IOException {
+    String nodeServerName = InProcessServerBuilder.generateName();
+    grpcCleanup.register(InProcessServerBuilder
+        .forName(nodeServerName)
+        .directExecutor()
+        .addService(new OzoneManagerServiceGrpc.OzoneManagerServiceImplBase() {
+          @Override
+          public void submitRequest(OMRequest request,
+              StreamObserver<OMResponse> responseObserver) {
+            requestCount.incrementAndGet();
+            lastRequest.set(request);
+            responseObserver.onNext(OMResponse.newBuilder()
+                .setSuccess(true)
+                .setStatus(org.apache.hadoop.ozone.protocol
+                    .proto.OzoneManagerProtocolProtos.Status.OK)
+                .setLeaderOMNodeId(nodeId)
+                .setCmdType(request.getCmdType())
+                .build());
+            responseObserver.onCompleted();
+          }
+        })
+        .build()
+        .start());
+    return grpcCleanup.register(
+        InProcessChannelBuilder.forName(nodeServerName).directExecutor().build());
+  }
+
+  private ManagedChannel createNotLeaderNodeChannel(AtomicInteger requestCount)
+      throws IOException {
+    String nodeServerName = InProcessServerBuilder.generateName();
+    grpcCleanup.register(InProcessServerBuilder
+        .forName(nodeServerName)
+        .directExecutor()
+        .addService(new OzoneManagerServiceGrpc.OzoneManagerServiceImplBase() {
+          @Override
+          public void submitRequest(OMRequest request,
+              StreamObserver<OMResponse> responseObserver) {
+            requestCount.incrementAndGet();
+            try {
+              throw createNotLeaderException();
+            } catch (Throwable e) {
+              IOException ex = new IOException(e.getCause());
+              responseObserver.onError(io.grpc.Status
+                  .INTERNAL
+                  .withDescription(ex.getMessage())
+                  .asRuntimeException());
+            }
+          }
+        })
+        .build()
+        .start());
+    return grpcCleanup.register(
+        InProcessChannelBuilder.forName(nodeServerName).directExecutor().build());
   }
 
   private static OMRequest arbitraryOmRequest() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/AbstractOzoneManagerHATest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/AbstractOzoneManagerHATest.java
@@ -29,6 +29,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_S3_GPRC_SERVER_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -158,6 +159,7 @@ public abstract class AbstractOzoneManagerHATest {
       // Enable the OM follower read.
       omHAConfig.setReadOption("LINEARIZABLE");
       omHAConfig.setReadLeaderLeaseEnabled(true);
+      conf.setBoolean(OZONE_OM_S3_GPRC_SERVER_ENABLED, true);
     }
 
     conf.setFromObject(omHAConfig);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OmTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OmTestUtil.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFollowerReadFailoverProxyProvider;
+import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
@@ -43,6 +44,13 @@ public interface OmTestUtil {
     Hadoop3OmTransport transport =
         (Hadoop3OmTransport) ozoneManagerClient.getTransport();
     return transport.getOmFollowerReadFailoverProxyProvider();
+  }
+
+  static GrpcOmTransport getGrpcOmTransport(ObjectStore store) {
+    OzoneManagerProtocolClientSideTranslatorPB ozoneManagerClient =
+        (OzoneManagerProtocolClientSideTranslatorPB) store.getClientProxy().getOzoneManagerClient();
+
+    return (GrpcOmTransport) ozoneManagerClient.getTransport();
   }
 
   static String getCurrentOmProxyNodeId(ObjectStore store) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithAllRunning.java
@@ -41,6 +41,7 @@ import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
@@ -62,7 +63,9 @@ import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFollowerReadFailoverProxyProvide
 import org.apache.hadoop.ozone.om.ha.OMProxyInfo;
 import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory;
+import org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
+import org.apache.hadoop.ozone.om.protocolPB.OmTransportFactory;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
@@ -76,6 +79,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeI
 import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Ozone Manager HA follower read tests where all OMs are running throughout all tests.
@@ -108,29 +113,63 @@ public class TestOzoneManagerHAFollowerReadWithAllRunning extends TestOzoneManag
     }
   }
 
-  @Test
-  void testFollowerReadTargetsFollower() throws Exception {
-    ObjectStore objectStore = getObjectStore();
-    HadoopRpcOMFollowerReadFailoverProxyProvider followerReadFailoverProxyProvider =
-        OmTestUtil.getFollowerReadFailoverProxyProvider(objectStore);
+  private static Stream<Class<? extends OmTransportFactory>> followerReadTransportClasses() {
+    return Stream.<Class<? extends OmTransportFactory>>of(
+        Hadoop3OmTransportFactory.class,
+        GrpcOmTransportFactory.class);
+  }
 
+  @ParameterizedTest
+  @MethodSource("followerReadTransportClasses")
+  void testFollowerReadTargetsFollower(Class<? extends OmTransportFactory> omTransportClass) throws Exception {
+    OzoneConfiguration clientConf = new OzoneConfiguration(getConf());
+    clientConf.setBoolean(OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
+    clientConf.set(OZONE_CLIENT_FOLLOWER_READ_DEFAULT_CONSISTENCY_KEY, "LOCAL_LEASE");
+    clientConf.set(OZONE_OM_TRANSPORT_CLASS, omTransportClass.getName());
     String leaderOMNodeId = getCluster().getOMLeader().getOMNodeId();
-    String followerOMNodeId = null;
+    OzoneManager followerOM = null;
     for (OzoneManager om : getCluster().getOzoneManagersList()) {
       if (!om.getOMNodeId().equals(leaderOMNodeId)) {
-        followerOMNodeId = om.getOMNodeId();
+        followerOM = om;
         break;
       }
     }
-    assertNotNull(followerOMNodeId);
+    assertNotNull(followerOM);
 
-    followerReadFailoverProxyProvider.changeInitialProxyForTest(followerOMNodeId);
-    objectStore.getClientProxy().listVolumes(null, null, 10);
+    OzoneClient ozoneClient = null;
+    try {
+      ozoneClient = OzoneClientFactory.getRpcClient(getOmServiceId(), clientConf);
+      ObjectStore objectStore = ozoneClient.getObjectStore();
+      changeFollowerReadInitialProxy(objectStore, omTransportClass, leaderOMNodeId, followerOM.getOMNodeId());
+      long previousLocalLeaseSuccess = followerOM.getMetrics().getNumFollowerReadLocalLeaseSuccess();
 
-    OMProxyInfo<OzoneManagerProtocolPB> lastProxy =
-        (OMProxyInfo<OzoneManagerProtocolPB>) followerReadFailoverProxyProvider.getLastProxy();
-    assertNotNull(lastProxy);
-    assertEquals(followerOMNodeId, lastProxy.getNodeId());
+      objectStore.listVolumes("");
+
+      long currentLocalLeaseSuccess = followerOM.getMetrics().getNumFollowerReadLocalLeaseSuccess();
+      assertThat(currentLocalLeaseSuccess).isGreaterThan(previousLocalLeaseSuccess);
+    } finally {
+      IOUtils.closeQuietly(ozoneClient);
+    }
+  }
+
+  private void changeFollowerReadInitialProxy(ObjectStore objectStore,
+      Class<? extends OmTransportFactory> omTransportClass, String leaderOMNodeId, String followerOMNodeId)
+      throws Exception {
+    if (Hadoop3OmTransportFactory.class.equals(omTransportClass)) {
+      HadoopRpcOMFollowerReadFailoverProxyProvider followerReadFailoverProxyProvider =
+          OmTestUtil.getFollowerReadFailoverProxyProvider(objectStore);
+      followerReadFailoverProxyProvider.changeInitialProxyForTest(followerOMNodeId);
+      return;
+    }
+
+    if (GrpcOmTransportFactory.class.equals(omTransportClass)) {
+      GrpcOmTransport grpcOmTransport = OmTestUtil.getGrpcOmTransport(objectStore);
+      grpcOmTransport.changeLeaderProxyForTest(leaderOMNodeId);
+      grpcOmTransport.changeFollowerReadInitialProxy(followerOMNodeId);
+      return;
+    }
+
+    throw new IllegalArgumentException("Unsupported OM transport class " + omTransportClass);
   }
 
   /**
@@ -575,39 +614,4 @@ public class TestOzoneManagerHAFollowerReadWithAllRunning extends TestOzoneManag
     }
   }
 
-  @Test
-  void testGrpcClientFollowerReadTargetsFollower() throws Exception {
-    OzoneConfiguration clientConf = new OzoneConfiguration(getConf());
-    clientConf.setBoolean(OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
-    clientConf.set(OZONE_CLIENT_FOLLOWER_READ_DEFAULT_CONSISTENCY_KEY, "LOCAL_LEASE");
-    clientConf.set(OZONE_OM_TRANSPORT_CLASS, GrpcOmTransportFactory.class.getName());
-
-    OzoneClient ozoneClient = null;
-    try {
-      ozoneClient = OzoneClientFactory.getRpcClient(getOmServiceId(), clientConf);
-      ObjectStore objectStore = ozoneClient.getObjectStore();
-      GrpcOmTransport grpcOmTransport = OmTestUtil.getGrpcOmTransport(objectStore);
-
-      String leaderOMNodeId = getCluster().getOMLeader().getOMNodeId();
-      OzoneManager followerOM = null;
-      for (OzoneManager om : getCluster().getOzoneManagersList()) {
-        if (!om.getOMNodeId().equals(leaderOMNodeId)) {
-          followerOM = om;
-          break;
-        }
-      }
-      assertNotNull(followerOM);
-
-      grpcOmTransport.changeLeaderProxyForTest(leaderOMNodeId);
-      grpcOmTransport.changeFollowerReadInitialProxy(followerOM.getOMNodeId());
-      long previousLocalLeaseSuccess = followerOM.getMetrics().getNumFollowerReadLocalLeaseSuccess();
-
-      objectStore.listVolumes("");
-
-      long currentLocalLeaseSuccess = followerOM.getMetrics().getNumFollowerReadLocalLeaseSuccess();
-      assertThat(currentLocalLeaseSuccess).isGreaterThan(previousLocalLeaseSuccess);
-    } finally {
-      IOUtils.closeQuietly(ozoneClient);
-    }
-  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithAllRunning.java
@@ -21,6 +21,7 @@ import static java.util.UUID.randomUUID;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_DEFAULT_CONSISTENCY_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_LEADER_READ_DEFAULT_CONSISTENCY_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_TRANSPORT_CLASS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
@@ -59,6 +60,8 @@ import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFollowerReadFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ha.OMProxyInfo;
+import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransport;
+import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
@@ -566,6 +569,42 @@ public class TestOzoneManagerHAFollowerReadWithAllRunning extends TestOzoneManag
 
       objectStore.listVolumes("");
       long currentLocalLeaseSuccess = ozoneManager.getMetrics().getNumFollowerReadLocalLeaseSuccess();
+      assertThat(currentLocalLeaseSuccess).isGreaterThan(previousLocalLeaseSuccess);
+    } finally {
+      IOUtils.closeQuietly(ozoneClient);
+    }
+  }
+
+  @Test
+  void testGrpcClientFollowerReadTargetsFollower() throws Exception {
+    OzoneConfiguration clientConf = new OzoneConfiguration(getConf());
+    clientConf.setBoolean(OZONE_CLIENT_FOLLOWER_READ_ENABLED_KEY, true);
+    clientConf.set(OZONE_CLIENT_FOLLOWER_READ_DEFAULT_CONSISTENCY_KEY, "LOCAL_LEASE");
+    clientConf.set(OZONE_OM_TRANSPORT_CLASS, GrpcOmTransportFactory.class.getName());
+
+    OzoneClient ozoneClient = null;
+    try {
+      ozoneClient = OzoneClientFactory.getRpcClient(getOmServiceId(), clientConf);
+      ObjectStore objectStore = ozoneClient.getObjectStore();
+      GrpcOmTransport grpcOmTransport = OmTestUtil.getGrpcOmTransport(objectStore);
+
+      String leaderOMNodeId = getCluster().getOMLeader().getOMNodeId();
+      OzoneManager followerOM = null;
+      for (OzoneManager om : getCluster().getOzoneManagersList()) {
+        if (!om.getOMNodeId().equals(leaderOMNodeId)) {
+          followerOM = om;
+          break;
+        }
+      }
+      assertNotNull(followerOM);
+
+      grpcOmTransport.changeLeaderProxyForTest(leaderOMNodeId);
+      grpcOmTransport.changeFollowerReadInitialProxy(followerOM.getOMNodeId());
+      long previousLocalLeaseSuccess = followerOM.getMetrics().getNumFollowerReadLocalLeaseSuccess();
+
+      objectStore.listVolumes("");
+
+      long currentLocalLeaseSuccess = followerOM.getMetrics().getNumFollowerReadLocalLeaseSuccess();
       assertThat(currentLocalLeaseSuccess).isGreaterThan(previousLocalLeaseSuccess);
     } finally {
       IOUtils.closeQuietly(ozoneClient);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithStoppedNodes.java
@@ -312,6 +312,7 @@ public class TestOzoneManagerHAFollowerReadWithStoppedNodes extends TestOzoneMan
   }
 
   @Test
+  @Order(Integer.MAX_VALUE)
   void testOMRetryProxy() {
     int maxFailoverAttempts = getOzoneClientFailoverMaxAttempts();
     // Stop all the OMs.

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -376,12 +376,15 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
         OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, omServiceId, omNodeId);
     String omHttpsAddrKey = ConfUtils.addKeySuffixes(
         OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, omServiceId, omNodeId);
+    String omGrpcPortKey = ConfUtils.addKeySuffixes(
+        OMConfigKeys.OZONE_OM_GRPC_PORT_KEY, omServiceId, omNodeId);
     String omRatisPortKey = ConfUtils.addKeySuffixes(
         OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, omServiceId, omNodeId);
 
     conf.set(omAddrKey, localhostWithFreePort());
     conf.set(omHttpAddrKey, localhostWithFreePort());
     conf.set(omHttpsAddrKey, localhostWithFreePort());
+    conf.setInt(omGrpcPortKey, getFreePort());
     conf.setInt(omRatisPortKey, getFreePort());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds OM follower read support for the gRPC OM transport.

Before this change, OM follower read support was available through the Hadoop RPC transport path, but gRPC clients still used the leader-oriented path for OM requests. This PR extends `GrpcOmTransport` so follower-read eligible OM requests can be sent to follower OM nodes when follower read is enabled.

The change includes:

* Applying the configured default read consistency hint for gRPC OM requests.
* Routing follower-read eligible read requests to non-leader OM nodes.
* Falling back to the leader path when follower read cannot be served by a follower.
* Reusing OM failover exception handling for follower read failures.
* Configuring per-OM gRPC ports in the HA mini cluster.
* Adding unit and integration coverage for gRPC follower read behavior.

Generated-by: OpenAI Codex

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15492

## How was this patch tested?

Tested with:

```bash
mvn clean test -pl :ozone-common,:ozone-integration-test -am \
  -Dtest=TestS3GrpcOmTransport,TestOzoneManagerHAWithAllRunning,TestOzoneManagerHAWithStoppedNodes,TestOzoneManagerHAFollowerReadWithAllRunning,TestOzoneManagerHAFollowerReadWithStoppedNodes,TestOzoneManagerPrepare \
  -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/28155889076
