### PR TITLE
HDDS-15651. Test case for DiskBalancer when markContainerForDelete fails

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.diskbalancer;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
 import static org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerService.DISK_BALANCER_DIR;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -522,8 +523,9 @@ public class TestDiskBalancerTask {
     Path destDirPath = Paths.get(
         KeyValueContainerLocationUtil.getBaseContainerLocation(
             destVolume.getHddsRootDir().toString(), scmId, CONTAINER_ID));
-    assertFalse(Files.exists(destDirPath),
-        "Destination container should not exist before task execution");
+    assertThat(destDirPath.toFile())
+        .as("Destination container should not exist before task execution")
+        .doesNotExist();
 
     KeyValueContainer spyContainer = spy(container);
     containerSet.removeContainer(CONTAINER_ID);
@@ -535,10 +537,11 @@ public class TestDiskBalancerTask {
     DiskBalancerService.DiskBalancerTask task = getTask();
     task.call();
 
-    assertTrue(serviceLog.getOutput().contains("Failed to mark the old container " + CONTAINER_ID
-        + " for delete"));
-    assertFalse(serviceLog.getOutput().contains("Rolling back move"),
-        "move should not roll back when markContainerForDelete fails");
+    assertThat(serviceLog.getOutput())
+        .contains("Failed to mark the old container " + CONTAINER_ID + " for delete");
+    assertThat(serviceLog.getOutput())
+        .as("move should not roll back when markContainerForDelete fails")
+        .doesNotContain("Rolling back move");
 
     assertEquals(1, diskBalancerService.getMetrics().getSuccessCount());
     assertEquals(0, diskBalancerService.getMetrics().getFailureCount());
@@ -548,17 +551,19 @@ public class TestDiskBalancerTask {
     assertNotNull(activeReplica);
     assertNotEquals(spyContainer, activeReplica);
     assertEquals(destVolume, activeReplica.getContainerData().getVolume());
-    assertTrue(new File(activeReplica.getContainerData().getContainerPath()).exists());
-    assertTrue(oldContainerDir.exists(),
-        "Source replica should remain on disk until lazy deletion runs");
+    assertThat(new File(activeReplica.getContainerData().getContainerPath())).exists();
+    assertThat(oldContainerDir)
+        .as("Source replica should remain on disk until lazy deletion runs")
+        .exists();
     assertEquals(1, diskBalancerService.getPendingDeletionQueueSize(),
         "Source replica should be queued for lazy deletion after mark failure");
 
     clock.fastForward(delay);
     diskBalancerService.cleanupPendingDeletionContainers();
 
-    assertFalse(oldContainerDir.exists(),
-        "Source replica should be removed after lazy deletion delay");
+    assertThat(oldContainerDir)
+        .as("Source replica should be removed after lazy deletion delay")
+        .doesNotExist();
     assertEquals(0, diskBalancerService.getPendingDeletionQueueSize());
   }
 
@@ -581,7 +586,7 @@ public class TestDiskBalancerTask {
 
     assertEquals(1, diskBalancerService.getMetrics().getSuccessCount());
     assertEquals(1, diskBalancerService.getPendingDeletionQueueSize());
-    assertTrue(oldContainerDir.exists());
+    assertThat(oldContainerDir).exists();
 
     clock.fastForward(delay);
 
@@ -594,17 +599,20 @@ public class TestDiskBalancerTask {
 
       diskBalancerService.cleanupPendingDeletionContainers();
 
-      assertTrue(oldContainerDir.exists(),
-          "Source replica should remain when lazy deletion fails");
+      assertThat(oldContainerDir)
+          .as("Source replica should remain when lazy deletion fails")
+          .exists();
       assertEquals(0, diskBalancerService.getPendingDeletionQueueSize(),
           "Failed deletion should be removed from the pending queue");
-      assertTrue(serviceLog.getOutput().contains("Failed to delete old container " + CONTAINER_ID));
-      assertTrue(serviceLog.getOutput().contains("background scanners"));
+      assertThat(serviceLog.getOutput())
+          .contains("Failed to delete old container " + CONTAINER_ID);
+      assertThat(serviceLog.getOutput()).contains("background scanners");
     }
 
     diskBalancerService.cleanupPendingDeletionContainers();
-    assertTrue(oldContainerDir.exists(),
-        "Source replica should not be retried after lazy deletion failure");
+    assertThat(oldContainerDir)
+        .as("Source replica should not be retried after lazy deletion failure")
+        .exists();
   }
 
   @ContainerTestVersionInfo.ContainerTest

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -504,6 +504,109 @@ public class TestDiskBalancerTask {
     assertEquals(initialSourceDelta, diskBalancerService.getDeltaSizes().get(sourceVolume));
   }
 
+  /**
+   * HDDS-15651. When markContainerForDelete fails after import and ContainerSet update,
+   * the move is still reported as success, the destination replica is active, the source
+   * replica is queued for lazy deletion, and cleanup removes it after the delay.
+   */
+  @ContainerTestVersionInfo.ContainerTest
+  public void moveSucceedsWhenMarkContainerForDeleteFails(
+      ContainerTestVersionInfo versionInfo)
+      throws IOException, InterruptedException, TimeoutException {
+    setLayoutAndSchemaForTest(versionInfo);
+    long delay = 2_000L;
+    diskBalancerService.setReplicaDeletionDelay(delay);
+
+    KeyValueContainer container = createContainer(CONTAINER_ID, sourceVolume, State.CLOSED);
+    File oldContainerDir = new File(container.getContainerData().getContainerPath());
+    Path destDirPath = Paths.get(
+        KeyValueContainerLocationUtil.getBaseContainerLocation(
+            destVolume.getHddsRootDir().toString(), scmId, CONTAINER_ID));
+    assertFalse(Files.exists(destDirPath),
+        "Destination container should not exist before task execution");
+
+    KeyValueContainer spyContainer = spy(container);
+    containerSet.removeContainer(CONTAINER_ID);
+    containerSet.addContainer(spyContainer);
+    doThrow(new RuntimeException("simulated markContainerForDelete failure"))
+        .when(spyContainer).markContainerForDelete();
+
+    LogCapturer serviceLog = GenericTestUtils.LogCapturer.captureLogs(DiskBalancerService.class);
+    DiskBalancerService.DiskBalancerTask task = getTask();
+    task.call();
+
+    assertTrue(serviceLog.getOutput().contains("Failed to mark the old container " + CONTAINER_ID
+        + " for delete"));
+    assertFalse(serviceLog.getOutput().contains("Rolling back move"),
+        "move should not roll back when markContainerForDelete fails");
+
+    assertEquals(1, diskBalancerService.getMetrics().getSuccessCount());
+    assertEquals(0, diskBalancerService.getMetrics().getFailureCount());
+    assertEquals(CONTAINER_SIZE, diskBalancerService.getMetrics().getSuccessBytes());
+
+    Container activeReplica = containerSet.getContainer(CONTAINER_ID);
+    assertNotNull(activeReplica);
+    assertNotEquals(spyContainer, activeReplica);
+    assertEquals(destVolume, activeReplica.getContainerData().getVolume());
+    assertTrue(new File(activeReplica.getContainerData().getContainerPath()).exists());
+    assertTrue(oldContainerDir.exists(),
+        "Source replica should remain on disk until lazy deletion runs");
+    assertEquals(1, diskBalancerService.getPendingDeletionQueueSize(),
+        "Source replica should be queued for lazy deletion after mark failure");
+
+    clock.fastForward(delay);
+    diskBalancerService.cleanupPendingDeletionContainers();
+
+    assertFalse(oldContainerDir.exists(),
+        "Source replica should be removed after lazy deletion delay");
+    assertEquals(0, diskBalancerService.getPendingDeletionQueueSize());
+  }
+
+  /**
+   * HDDS-15651. When lazy deletion fails, the pending queue entry is dropped and
+   * the source replica is not retried for deletion.
+   */
+  @ContainerTestVersionInfo.ContainerTest
+  public void lazyDeletionFailureDoesNotRetry(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    setLayoutAndSchemaForTest(versionInfo);
+    long delay = 2_000L;
+    diskBalancerService.setReplicaDeletionDelay(delay);
+
+    Container container = createContainer(CONTAINER_ID, sourceVolume, State.CLOSED);
+    File oldContainerDir = new File(container.getContainerData().getContainerPath());
+
+    DiskBalancerService.DiskBalancerTask task = getTask();
+    task.call();
+
+    assertEquals(1, diskBalancerService.getMetrics().getSuccessCount());
+    assertEquals(1, diskBalancerService.getPendingDeletionQueueSize());
+    assertTrue(oldContainerDir.exists());
+
+    clock.fastForward(delay);
+
+    LogCapturer serviceLog = GenericTestUtils.LogCapturer.captureLogs(DiskBalancerService.class);
+    try (MockedStatic<KeyValueContainerUtil> mockedUtil =
+             mockStatic(KeyValueContainerUtil.class, Mockito.CALLS_REAL_METHODS)) {
+      mockedUtil.when(() -> KeyValueContainerUtil.removeContainer(
+              any(KeyValueContainerData.class), any(OzoneConfiguration.class)))
+          .thenThrow(new IOException("simulated lazy deletion failure"));
+
+      diskBalancerService.cleanupPendingDeletionContainers();
+
+      assertTrue(oldContainerDir.exists(),
+          "Source replica should remain when lazy deletion fails");
+      assertEquals(0, diskBalancerService.getPendingDeletionQueueSize(),
+          "Failed deletion should be removed from the pending queue");
+      assertTrue(serviceLog.getOutput().contains("Failed to delete old container " + CONTAINER_ID));
+      assertTrue(serviceLog.getOutput().contains("background scanners"));
+    }
+
+    diskBalancerService.cleanupPendingDeletionContainers();
+    assertTrue(oldContainerDir.exists(),
+        "Source replica should not be retried after lazy deletion failure");
+  }
+
   @ContainerTestVersionInfo.ContainerTest
   public void moveFailsDuringOldContainerRemove(ContainerTestVersionInfo versionInfo) throws IOException {
     setLayoutAndSchemaForTest(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -506,7 +506,7 @@ public class TestDiskBalancerTask {
   }
 
   /**
-   * HDDS-15651. When markContainerForDelete fails after import and ContainerSet update,
+   * When markContainerForDelete fails after import and ContainerSet update,
    * the move is still reported as success, the destination replica is active, the source
    * replica is queued for lazy deletion, and cleanup removes it after the delay.
    */
@@ -548,8 +548,7 @@ public class TestDiskBalancerTask {
     assertEquals(CONTAINER_SIZE, diskBalancerService.getMetrics().getSuccessBytes());
 
     Container activeReplica = containerSet.getContainer(CONTAINER_ID);
-    assertNotNull(activeReplica);
-    assertNotEquals(spyContainer, activeReplica);
+    assertThat(activeReplica).isNotSameAs(spyContainer);
     assertEquals(destVolume, activeReplica.getContainerData().getVolume());
     assertThat(new File(activeReplica.getContainerData().getContainerPath())).exists();
     assertThat(oldContainerDir)
@@ -568,7 +567,7 @@ public class TestDiskBalancerTask {
   }
 
   /**
-   * HDDS-15651. When lazy deletion fails, the pending queue entry is dropped and
+   * When lazy deletion fails, the pending queue entry is dropped and
    * the source replica is not retried for deletion.
    */
   @ContainerTestVersionInfo.ContainerTest


### PR DESCRIPTION
## What changes were proposed in this pull request?
Test-only PR for HDDS-15651. Adds two unit tests in TestDiskBalancerTask to document the intended DiskBalancer move/cleanup behavior when markContainerForDelete() fails or when lazy deletion fails.

Please describe your PR in detail:
DiskBalancer treats container move and source cleanup as separate phases. Once import and ContainerSet update succeed, the move is reported as success even if marking the old source replica fails. The old replica is queued in pendingDeletionContainers and removed after replica.deletion.delay.

This PR adds tests to lock in that behavior and document a known gap when lazy deletion fails.

Test 1: moveSucceedsWhenMarkContainerForDeleteFails

- Simulates markContainerForDelete() failure on the source replica after a successful move.
- Verifies the move is still reported as success (success metrics updated, no rollback).
- Verifies ContainerSet points to the destination replica.
- Verifies the source replica stays on disk temporarily and is queued for lazy deletion.
- After the delay, verifies the source replica is removed via cleanupPendingDeletionContainers().

Test 2: lazyDeletionFailureDoesNotRetry

- Runs a successful move and advances the clock past the deletion delay.
- Mocks KeyValueContainerUtil.removeContainer() to fail during lazy deletion.
- Verifies the source replica remains on disk, the pending queue entry is dropped, and deletion is not retried on a second cleanup attempt.
- Documents current behavior when lazy deletion fails (recovery depends on other paths such as DN restart for Ratis).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15651

## How was this patch tested?

mvn test -pl hadoop-hdds/container-service -am \
  -Dtest=TestDiskBalancerTask#moveSucceedsWhenMarkContainerForDeleteFails,TestDiskBalancerTask#lazyDeletionFailureDoesNotRetry \
  -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false

