### PR TITLE
HDDS-15653. RandomKeyGenerator should reject negative inputs

### DIFF
--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -293,24 +293,32 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
   private void validateCounts() {
     if (numOfVolumes <= 0) {
       throw new IllegalArgumentException(
-          "Invalid command, numOfVolumes must be a positive integer");
+          "Invalid command, --num-of-volumes must be a positive integer");
     }
     if (numOfBuckets <= 0) {
       throw new IllegalArgumentException(
-          "Invalid command, numOfBuckets must be a positive integer");
+          "Invalid command, --num-of-buckets must be a positive integer");
     }
     if (numOfKeys <= 0) {
       throw new IllegalArgumentException(
-          "Invalid command, numOfKeys must be a positive integer");
+          "Invalid command, --num-of-keys must be a positive integer");
+    }
+    if (numOfThreads <= 0) {
+      throw new IllegalArgumentException(
+          "Invalid command, --num-of-threads must be a positive integer");
+    }
+    if (validateWrites && numOfValidateThreads <= 0) {
+      throw new IllegalArgumentException(
+          "Invalid command, --num-of-validate-threads must be a positive integer");
     }
   }
+
 
   @Override
   public Void call() throws Exception {
     if (ozoneConfiguration == null) {
       ozoneConfiguration = freon.getOzoneConf();
     }
-    validateCounts();
     if (!ozoneConfiguration.getBoolean(
         HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA,
         HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA_DEFAULT)) {
@@ -318,6 +326,7 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
           + HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA + " is set to false.");
       validateWrites = false;
     }
+    validateCounts();
     init(ozoneConfiguration);
 
     replicationConfig = replication.fromParamsOrConfig(ozoneConfiguration);

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -313,7 +313,6 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
     }
   }
 
-
   @Override
   public Void call() throws Exception {
     if (ozoneConfiguration == null) {

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -290,11 +290,27 @@ public final class RandomKeyGenerator implements Callable<Void>, FreonSubcommand
     }
   }
 
+  private void validateCounts() {
+    if (numOfVolumes <= 0) {
+      throw new IllegalArgumentException(
+          "Invalid command, numOfVolumes must be a positive integer");
+    }
+    if (numOfBuckets <= 0) {
+      throw new IllegalArgumentException(
+          "Invalid command, numOfBuckets must be a positive integer");
+    }
+    if (numOfKeys <= 0) {
+      throw new IllegalArgumentException(
+          "Invalid command, numOfKeys must be a positive integer");
+    }
+  }
+
   @Override
   public Void call() throws Exception {
     if (ozoneConfiguration == null) {
       ozoneConfiguration = freon.getOzoneConf();
     }
+    validateCounts();
     if (!ozoneConfiguration.getBoolean(
         HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA,
         HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA_DEFAULT)) {

--- a/hadoop-ozone/freon/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/freon/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.freon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+/**
+ * Unit tests for RandomKeyGenerator command.
+ */
+public class TestRandomKeyGenerator {
+
+  @Test
+  void rejectsNegativeNumOfVolumes() {
+    assertValidationFails(
+        new String[] {"--num-of-volumes", "-1",
+            "--num-of-buckets", "1",
+            "--num-of-keys", "1"},
+        "numOfVolumes must be a positive integer");
+  }
+
+  @Test
+  void rejectsZeroNumOfBuckets() {
+    assertValidationFails(
+        new String[] {"--num-of-volumes", "1",
+            "--num-of-buckets", "0",
+            "--num-of-keys", "1"},
+        "numOfBuckets must be a positive integer");
+  }
+
+  @Test
+  void rejectsNegativeNumOfKeys() {
+    assertValidationFails(
+        new String[] {"--num-of-volumes", "1",
+            "--num-of-buckets", "1",
+            "--num-of-keys", "-1"},
+        "numOfKeys must be a positive integer");
+  }
+
+  private void assertValidationFails(String[] args, String expectedMessage) {
+    RandomKeyGenerator generator = new RandomKeyGenerator(new OzoneConfiguration());
+    CommandLine cmd = new CommandLine(generator);
+    cmd.parseArgs(args);
+
+    IllegalArgumentException ex = assertThrows(
+        IllegalArgumentException.class, generator::call);
+
+    assertThat(ex.getMessage()).contains(expectedMessage);
+  }
+}

--- a/hadoop-ozone/freon/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/freon/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -32,31 +32,52 @@ public class TestRandomKeyGenerator {
   @Test
   void rejectsNegativeNumOfVolumes() {
     assertValidationFails(
-        new String[] {"--num-of-volumes", "-1",
-            "--num-of-buckets", "1",
-            "--num-of-keys", "1"},
-        "numOfVolumes must be a positive integer");
+        "--num-of-volumes must be a positive integer",
+        "--num-of-volumes", "-1",
+        "--num-of-buckets", "1",
+        "--num-of-keys", "1");
   }
 
   @Test
   void rejectsZeroNumOfBuckets() {
     assertValidationFails(
-        new String[] {"--num-of-volumes", "1",
-            "--num-of-buckets", "0",
-            "--num-of-keys", "1"},
-        "numOfBuckets must be a positive integer");
+        "--num-of-buckets must be a positive integer",
+        "--num-of-volumes", "1",
+        "--num-of-buckets", "0",
+        "--num-of-keys", "1");
   }
 
   @Test
   void rejectsNegativeNumOfKeys() {
     assertValidationFails(
-        new String[] {"--num-of-volumes", "1",
-            "--num-of-buckets", "1",
-            "--num-of-keys", "-1"},
-        "numOfKeys must be a positive integer");
+        "--num-of-keys must be a positive integer",
+        "--num-of-volumes", "1",
+        "--num-of-buckets", "1",
+        "--num-of-keys", "-1");
   }
 
-  private void assertValidationFails(String[] args, String expectedMessage) {
+  @Test
+  void rejectsNegativeNumOfThreads() {
+    assertValidationFails(
+        "--num-of-threads must be a positive integer",
+        "--num-of-volumes", "1",
+        "--num-of-buckets", "1",
+        "--num-of-keys", "1",
+        "--num-of-threads", "-1");
+  }
+
+  @Test
+  void rejectsNegativeNumOfValidateThreadsWhenValidateWritesEnabled() {
+    assertValidationFails(
+        "--num-of-validate-threads must be a positive integer",
+        "--num-of-volumes", "1",
+        "--num-of-buckets", "1",
+        "--num-of-keys", "1",
+        "--validate-writes",
+        "--num-of-validate-threads", "-1");
+  }
+
+  private void assertValidationFails(String expectedMessage, String... args) {
     RandomKeyGenerator generator = new RandomKeyGenerator(new OzoneConfiguration());
     CommandLine cmd = new CommandLine(generator);
     cmd.parseArgs(args);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Running ozone freon rk with a negative value for  --numOfVolumes , --numOfBuckets or --numOfKeys does not fail with an error. Instead, the command prints a  progress bar with negative value and hangs. 

```
bash-5.1$ ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=-1 
2026-06-24 04:37:36,027 [main] INFO freon.RandomKeyGenerator: Number of Threads: 10
2026-06-24 04:37:36,035 [main] INFO freon.RandomKeyGenerator: Number of Volumes: 1.
2026-06-24 04:37:36,035 [main] INFO freon.RandomKeyGenerator: Number of Buckets per Volume: 1.
2026-06-24 04:37:36,035 [main] INFO freon.RandomKeyGenerator: Number of Keys per Bucket: -1.
2026-06-24 04:37:36,035 [main] INFO freon.RandomKeyGenerator: Key size: 10240 bytes
2026-06-24 04:37:36,036 [main] INFO freon.RandomKeyGenerator: Buffer size: 4096 bytes
2026-06-24 04:37:36,036 [main] INFO freon.RandomKeyGenerator: validateWrites : false
2026-06-24 04:37:36,036 [main] INFO freon.RandomKeyGenerator: Number of Validate Threads: 1
2026-06-24 04:37:36,036 [main] INFO freon.RandomKeyGenerator: cleanObjects : false
2026-06-24 04:37:36,038 [main] INFO freon.RandomKeyGenerator: Starting progress bar Thread.

 -0.00% |?                                                                                                    |  0/-1 Time: 0:00:00|  
2026-06-24 04:37:36,044 [pool-2-thread-1] INFO rpc.RpcClient: Creating Volume: vol-0-97512, with hadoop as owner and space quota set to -1 bytes, counts quota set to -1
2026-06-24 04:37:36,083 [pool-2-thread-2] INFO rpc.RpcClient: Creating Bucket: vol-0-97512/bucket-0-75850, with server-side default bucket layout, hadoop as owner, Versioning false, Storage Type set to DISK and Encryption set to false, Replication Type set to server-side default replication type, Namespace Quota set to -1, Space Quota set to -1 
^C
***************************************************
Status: Success
Git Base Revision: 9d50c6884666e794e45102260a4017bb31802e1b
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 0
Average Time spent in volume creation: 00:00:00,002
Average Time spent in bucket creation: 00:00:00,001
Average Time spent in key creation: 00:00:00,000
Average Time spent in key write: 00:00:00,000
Total bytes written: 0
Total Execution time: 00:00:26,117
***************************************************
```
#### For decimal input:
```
bash-5.1$ ozone freon rk --numOfVolumes=0.1 --numOfBuckets=1 --numOfKeys=1 
Invalid value for option '--num-of-volumes': '0.1' is not an int
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15653

## How was this patch tested?
Manual Test.

#### invalid inputs 
```
bash-5.1$ ozone freon rk --numOfVolumes=-1 --numOfBuckets=1 --numOfKeys=1
ozone freon rk --numOfVolumes=0 --numOfBuckets=1 --numOfKeys=1

Invalid command, --num-of-volumes must be a positive integer
Invalid command, --num-of-volumes must be a positive integer
```
```
bash-5.1$ ozone freon rk --numOfVolumes=1 --numOfBuckets=-1 --numOfKeys=1
ozone freon rk --numOfVolumes=1 --numOfBuckets=0 --numOfKeys=1

Invalid command, --num-of-buckets must be a positive integer
Invalid command, --num-of-buckets must be a positive integer
```
```
bash-5.1$ ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=-1
ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=0

Invalid command, --num-of-keys must be a positive integer
Invalid command, --num-of-keys must be a positive integer
```
```
bash-5.1$ ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 --num-of-threads=-1
ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 --num-of-threads=0

Invalid command, --num-of-threads must be a positive integer
Invalid command, --num-of-threads must be a positive integer
```
```
bash-5.1$ ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 \
  --validate-writes --num-of-validate-threads=-1

ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 \
  --validate-writes --num-of-validate-threads=0
  
Invalid command, --num-of-validate-threads must be a positive integer
Invalid command, --num-of-validate-threads must be a positive integer
```

#### Success when validate threads is not +ve but validation is off
```
bash-5.1$ ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 --numOfValidateThreads=-1
2026-06-25 06:19:22,836 [main] INFO freon.RandomKeyGenerator: Number of Threads: 10
2026-06-25 06:19:22,844 [main] INFO freon.RandomKeyGenerator: Number of Volumes: 1.
2026-06-25 06:19:22,844 [main] INFO freon.RandomKeyGenerator: Number of Buckets per Volume: 1.
2026-06-25 06:19:22,844 [main] INFO freon.RandomKeyGenerator: Number of Keys per Bucket: 1.
2026-06-25 06:19:22,844 [main] INFO freon.RandomKeyGenerator: Key size: 10240 bytes
2026-06-25 06:19:22,844 [main] INFO freon.RandomKeyGenerator: Buffer size: 4096 bytes
2026-06-25 06:19:22,844 [main] INFO freon.RandomKeyGenerator: validateWrites : false
2026-06-25 06:19:22,844 [main] INFO freon.RandomKeyGenerator: Number of Validate Threads: -1
2026-06-25 06:19:22,844 [main] INFO freon.RandomKeyGenerator: cleanObjects : false
2026-06-25 06:19:22,846 [main] INFO freon.RandomKeyGenerator: Starting progress bar Thread.

 0.00% |?                                                                                                    |  0/1 Time: 0:00:00|  2026-06-25 06:19:22,852 [pool-2-thread-1] INFO rpc.RpcClient: Creating Volume: vol-0-90782, with hadoop as owner and space quota set to -1 bytes, counts quota set to -1
2026-06-25 06:19:22,912 [pool-2-thread-2] INFO rpc.RpcClient: Creating Bucket: vol-0-90782/bucket-0-31430, with server-side default bucket layout, hadoop as owner, Versioning false, Storage Type set to DISK and Encryption set to false, Replication Type set to server-side default replication type, Namespace Quota set to -1, Space Quota set to -1 
2026-06-25 06:19:23,052 [pool-2-thread-3] WARN impl.MetricsSystemImpl: ozone-freon metrics system already initialized!
 100.00% |?????????????????????????????????????????????????????????????????????????????????????????????????????|  1/1 Time: 0:00:01|  

***************************************************
Status: Success
Git Base Revision: 9d50c6884666e794e45102260a4017bb31802e1b
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 1
Average Time spent in volume creation: 00:00:00,005
Average Time spent in bucket creation: 00:00:00,001
Average Time spent in key creation: 00:00:00,009
Average Time spent in key write: 00:00:00,012
Total bytes written: 10240
Total Execution time: 00:00:01,545
```

#### Normal i/p

```
bash-5.1$ ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1
2026-06-25 06:19:33,724 [main] INFO freon.RandomKeyGenerator: Number of Threads: 10
2026-06-25 06:19:33,732 [main] INFO freon.RandomKeyGenerator: Number of Volumes: 1.
2026-06-25 06:19:33,732 [main] INFO freon.RandomKeyGenerator: Number of Buckets per Volume: 1.
2026-06-25 06:19:33,732 [main] INFO freon.RandomKeyGenerator: Number of Keys per Bucket: 1.
2026-06-25 06:19:33,732 [main] INFO freon.RandomKeyGenerator: Key size: 10240 bytes
2026-06-25 06:19:33,732 [main] INFO freon.RandomKeyGenerator: Buffer size: 4096 bytes
2026-06-25 06:19:33,732 [main] INFO freon.RandomKeyGenerator: validateWrites : false
2026-06-25 06:19:33,732 [main] INFO freon.RandomKeyGenerator: Number of Validate Threads: 1
2026-06-25 06:19:33,732 [main] INFO freon.RandomKeyGenerator: cleanObjects : false
2026-06-25 06:19:33,740 [main] INFO freon.RandomKeyGenerator: Starting progress bar Thread.

 0.00% |?                                                                                                    |  0/1 Time: 0:00:00|  2026-06-25 06:19:33,744 [pool-2-thread-1] INFO rpc.RpcClient: Creating Volume: vol-0-58519, with hadoop as owner and space quota set to -1 bytes, counts quota set to -1
2026-06-25 06:19:33,768 [pool-2-thread-2] INFO rpc.RpcClient: Creating Bucket: vol-0-58519/bucket-0-79137, with server-side default bucket layout, hadoop as owner, Versioning false, Storage Type set to DISK and Encryption set to false, Replication Type set to server-side default replication type, Namespace Quota set to -1, Space Quota set to -1 
2026-06-25 06:19:33,855 [pool-2-thread-3] WARN impl.MetricsSystemImpl: ozone-freon metrics system already initialized!
 100.00% |?????????????????????????????????????????????????????????????????????????????????????????????????????|  1/1 Time: 0:00:01|  

***************************************************
Status: Success
Git Base Revision: 9d50c6884666e794e45102260a4017bb31802e1b
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 1
Average Time spent in volume creation: 00:00:00,002
Average Time spent in bucket creation: 00:00:00,000
Average Time spent in key creation: 00:00:00,004
Average Time spent in key write: 00:00:00,012
Total bytes written: 10240
Total Execution time: 00:00:01,553
***************************************************
```
```
bash-5.1$ ozone freon rk --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 \
  --num-of-threads=2 --validate-writes --num-of-validate-threads=1
2026-06-25 06:19:38,556 [main] INFO freon.RandomKeyGenerator: Number of Threads: 2
2026-06-25 06:19:38,566 [main] INFO freon.RandomKeyGenerator: Number of Volumes: 1.
2026-06-25 06:19:38,566 [main] INFO freon.RandomKeyGenerator: Number of Buckets per Volume: 1.
2026-06-25 06:19:38,566 [main] INFO freon.RandomKeyGenerator: Number of Keys per Bucket: 1.
2026-06-25 06:19:38,566 [main] INFO freon.RandomKeyGenerator: Key size: 10240 bytes
2026-06-25 06:19:38,566 [main] INFO freon.RandomKeyGenerator: Buffer size: 4096 bytes
2026-06-25 06:19:38,566 [main] INFO freon.RandomKeyGenerator: validateWrites : true
2026-06-25 06:19:38,566 [main] INFO freon.RandomKeyGenerator: Number of Validate Threads: 1
2026-06-25 06:19:38,566 [main] INFO freon.RandomKeyGenerator: cleanObjects : false
2026-06-25 06:19:38,568 [main] INFO freon.RandomKeyGenerator: Data validation is enabled.
2026-06-25 06:19:38,568 [main] INFO freon.RandomKeyGenerator: Starting progress bar Thread.

 0.00% |?                                                                                                    |  0/1 Time: 0:00:00|  2026-06-25 06:19:38,575 [pool-2-thread-1] INFO rpc.RpcClient: Creating Volume: vol-0-40404, with hadoop as owner and space quota set to -1 bytes, counts quota set to -1
2026-06-25 06:19:38,603 [pool-2-thread-2] INFO rpc.RpcClient: Creating Bucket: vol-0-40404/bucket-0-22248, with server-side default bucket layout, hadoop as owner, Versioning false, Storage Type set to DISK and Encryption set to false, Replication Type set to server-side default replication type, Namespace Quota set to -1, Space Quota set to -1 
2026-06-25 06:19:38,689 [pool-2-thread-1] WARN impl.MetricsSystemImpl: ozone-freon metrics system already initialized!
 100.00% |?????????????????????????????????????????????????????????????????????????????????????????????????????|  1/1 Time: 0:00:01|  

***************************************************
Status: Success
Git Base Revision: 9d50c6884666e794e45102260a4017bb31802e1b
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 1
Average Time spent in volume creation: 00:00:00,009
Average Time spent in bucket creation: 00:00:00,005
Average Time spent in key creation: 00:00:00,021
Average Time spent in key write: 00:00:00,061
Total bytes written: 10240
Total number of writes validated: 1
Writes validated: 100.0 %
Successful validation: 1
Unsuccessful validation: 0
Total Execution time: 00:00:01,748
***************************************************
```