### PR TITLE
HDDS-13434. Intermittent failure in TestOzoneDebugShell#testChunkInfoVerifyPathsAreDifferent

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -34,6 +34,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -208,27 +210,49 @@ public abstract class TestOzoneDebugShell implements NonHATests.TestCase {
 
   private int runChunkInfoAndVerifyPaths(String volumeName, String bucketName,
       String keyName) throws Exception {
-    int exitCode = 1;
-    try (GenericTestUtils.SystemOutCapturer capture = new GenericTestUtils
-        .SystemOutCapturer()) {
-      exitCode = runChunkInfoCommand(volumeName, bucketName, keyName);
-      Set<String> blockFilePaths = new HashSet<>();
-      String output = capture.getOutput();
-      ObjectMapper objectMapper = new ObjectMapper();
-      // Parse the JSON array string into a JsonNode
-      JsonNode jsonNode = objectMapper.readTree(output);
-      JsonNode keyLocations = jsonNode.get("keyLocations").get(0);
-      for (JsonNode element : keyLocations) {
-        String fileName =
-            element.get("file").toString();
-        blockFilePaths.add(fileName);
-      }
-      // DN storage directories are set differently for each DN
-      // in MiniOzoneCluster as datanode-0,datanode-1,datanode-2 which is why
-      // we expect 3 paths here in the set.
-      assertEquals(3, blockFilePaths.size());
+    AtomicInteger exitCode = new AtomicInteger(1);
+    AtomicInteger lastPathCount = new AtomicInteger(-1);
+    AtomicReference<Throwable> lastError = new AtomicReference<>();
+    ObjectMapper objectMapper = new ObjectMapper();
+    // A RATIS THREE write is acknowledged on a Ratis majority, so right after
+    // the key is written one replica may not have applied the write yet and
+    // chunk-info silently drops that datanode. Wait until all three datanodes
+    // report the block, giving three distinct paths.
+    // DN storage directories are set differently for each DN in
+    // MiniOzoneCluster as datanode-0,datanode-1,datanode-2 which is why
+    // we expect 3 paths here in the set.
+    try {
+      GenericTestUtils.waitFor(() -> {
+        Set<String> blockFilePaths = new HashSet<>();
+        try (GenericTestUtils.SystemOutCapturer capture = new GenericTestUtils
+            .SystemOutCapturer()) {
+          exitCode.set(runChunkInfoCommand(volumeName, bucketName, keyName));
+          String output = capture.getOutput();
+          // Parse the JSON array string into a JsonNode
+          JsonNode jsonNode = objectMapper.readTree(output);
+          JsonNode keyLocations = jsonNode.get("keyLocations").get(0);
+          for (JsonNode element : keyLocations) {
+            String fileName =
+                element.get("file").toString();
+            blockFilePaths.add(fileName);
+          }
+        } catch (Exception e) {
+          // Keep retrying in case the output is not ready yet, but remember the
+          // failure so a persistent error is reported instead of an opaque
+          // timeout.
+          lastError.set(e);
+          return false;
+        }
+        lastError.set(null);
+        lastPathCount.set(blockFilePaths.size());
+        return blockFilePaths.size() == 3;
+      }, 1000, 30000);
+    } catch (TimeoutException e) {
+      throw new AssertionError("Expected 3 distinct block file paths across "
+          + "datanodes, last chunk-info reported " + lastPathCount.get()
+          + " path(s)", lastError.get() != null ? lastError.get() : e);
     }
-    return exitCode;
+    return exitCode.get();
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test-only change.

`TestOzoneDebugShell.testChunkInfoVerifyPathsAreDifferent` intermittently failed with `expected: <3> but was: <2>`. A RATIS THREE write is acknowledged on a Ratis majority, so right after the key is written one replica may not have applied the write yet. When `ozone debug replicas chunk-info` runs in that window, `ReadContainer` on the lagging datanode fails, the datanode is dropped from the response, and the test sees only 2 distinct block file paths instead of 3.

**Fix.** Wait until all three datanodes report the block (three distinct paths) before asserting, using `GenericTestUtils.waitFor`, instead of asserting on a single read taken immediately after the write. A persistent error or an unexpected path count is reported via the wait's last observed state, so genuine regressions still surface with context rather than an opaque timeout.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13434

## How was this patch tested?

- Ran the previously-flaky test locally; passes for all `BucketLayout` values.
- Confirmed the wait is not vacuous: with the target temporarily set to an unreachable path count, the test times out as expected, proving the wait actually gates the assertion.
- `flaky-test-check` on the fork, `TestOzoneIntegrationNonHA` `ALL`, 10x10: the `OzoneDebugShell` cases (including this test) passed in all 100 iterations. https://github.com/chihsuan/ozone/actions/runs/28101143264
  - One unrelated pre-existing flake in `TestListKeysWithFSO` (`BUCKET_ALREADY_EXISTS` in test setup) appeared in a single split; it is not touched by this change.
