### PR TITLE
HDDS-13063. Support splitting json output to multiple valid json files in a directory

### DIFF
--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
@@ -17,12 +17,15 @@
 
 package org.apache.hadoop.ozone.debug.replicas;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -88,6 +91,18 @@ public class ReplicasVerify extends Handler {
           "Note: This option is ignored if '--container-state' option is not used.",
       defaultValue = "1000000")
   private long containerCacheSize;
+
+  @CommandLine.Option(names = {"--out", "-o"},
+      description = "Output directory to dump verification output.The directory is created if it does not exist, " +
+          "and files are named using the directory's name as the base, e.g. <dirName>.0, <dirName>.1, " +
+          "when splitting with --max-records-per-file (otherwise a single <dirName> file is written).")
+  private String outputDir;
+
+  @CommandLine.Option(names = {"--max-records-per-file"},
+      description = "Maximum number of keys to write per output file. When greater than zero (and --out is set), " +
+          "output is split into multiple valid JSON files named <out>.0, <out>.1, Requires --out.",
+      defaultValue = "0")
+  private long recordsPerFile;
 
   private List<ReplicaVerifier> replicaVerifiers;
 
@@ -197,8 +212,68 @@ public class ReplicasVerify extends Handler {
         checkVolume(ozoneClient, it.next(), keysArray, allKeysPassed);
       }
     }
-    root.put("pass", allKeysPassed.get());
-    System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(root));
+    if (outputDir == null) {
+      root.put("pass", allKeysPassed.get());
+      System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(root));
+    } else {
+      writeOutputToFiles(root, keysArray, allKeysPassed.get());
+    }
+  }
+
+  /**
+   * Writes verification output to file(s) instead of stdout.
+   * When recordsPerFile is greater than zero, the keys are split into multiple valid JSON files.
+   */
+  private void writeOutputToFiles(ObjectNode root, ArrayNode keysArray, boolean allKeysPassed) throws IOException {
+    String outputPrefix = resolveOutputPrefix();
+
+    if (recordsPerFile <= 0) {
+      root.put("pass", allKeysPassed);
+      writeJsonToFile(root, outputPrefix);
+      return;
+    }
+
+    int suffix = 0;
+    ObjectNode chunkNode = null;
+    ArrayNode chunkKeys = null;
+    for (int i = 0; i < keysArray.size(); i++) {
+      if (chunkNode == null) {
+        chunkNode = JsonUtils.createObjectNode(null);
+        chunkKeys = chunkNode.putArray("keys");
+      }
+      chunkKeys.add(keysArray.get(i));
+      if (chunkKeys.size() >= recordsPerFile) {
+        writeJsonToFile(chunkNode, outputPrefix + "." + suffix++);
+        chunkNode = null;
+      }
+    }
+    if (chunkNode != null) {
+      writeJsonToFile(chunkNode, outputPrefix + "." + suffix++);
+    }
+  }
+
+  /**
+   * Resolves the file name prefix used for output files from --out. The value of --out is always treated as a directory
+   * it is created when missing, and files are written inside it using the directory's own name as the base.
+   */
+  private String resolveOutputPrefix() throws IOException {
+    File outputDirectory = new File(outputDir);
+    if (outputDirectory.exists()) {
+      if (!outputDirectory.isDirectory()) {
+        throw new IOException("Output path already exists and is not a directory: " +
+            outputDirectory.getAbsolutePath());
+      }
+    } else if (!outputDirectory.mkdirs()) {
+      throw new IOException("An exception occurred while creating the directory. Directory: " +
+          outputDirectory.getAbsolutePath());
+    }
+    return new File(outputDirectory, outputDirectory.getName()).getPath();
+  }
+
+  private void writeJsonToFile(ObjectNode node, String targetFileName) throws IOException {
+    try (PrintWriter writer = new PrintWriter(targetFileName, UTF_8.name())) {
+      writer.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(node));
+    }
   }
 
   void checkVolume(OzoneClient ozoneClient, OzoneVolume volume, ArrayNode keysArray, AtomicBoolean allKeysPassed)

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -133,6 +134,11 @@ public class ReplicasVerify extends Handler {
   protected void execute(OzoneClient client, OzoneAddress address) throws IOException {
     startTime = System.nanoTime();
 
+    if (recordsPerFile > 0 && outputDir == null) {
+      throw new CommandLine.ParameterException(spec().commandLine(),
+          "--max-records-per-file requires --out / -o option to be set.");
+    }
+
     if (!address.getKeyName().isEmpty()) {
       verificationScope = "Key";
     } else if (!address.getBucketName().isEmpty()) {
@@ -226,6 +232,8 @@ public class ReplicasVerify extends Handler {
    */
   private void writeOutputToFiles(ObjectNode root, ArrayNode keysArray, boolean allKeysPassed) throws IOException {
     String outputPrefix = resolveOutputPrefix();
+    // Remove output files from any previous run.
+    deleteExistingOutputFiles(outputPrefix);
 
     if (recordsPerFile <= 0) {
       root.put("pass", allKeysPassed);
@@ -243,12 +251,34 @@ public class ReplicasVerify extends Handler {
       }
       chunkKeys.add(keysArray.get(i));
       if (chunkKeys.size() >= recordsPerFile) {
+        chunkNode.put("pass", allKeysPassed);
         writeJsonToFile(chunkNode, outputPrefix + "." + suffix++);
         chunkNode = null;
       }
     }
     if (chunkNode != null) {
+      chunkNode.put("pass", allKeysPassed);
       writeJsonToFile(chunkNode, outputPrefix + "." + suffix++);
+    }
+  }
+
+  /**
+   * Deletes output files written by a previous run in the output directory. Matches the single-file
+   * output <dirName> and split files <dirName>.<number> so a re-run does not leave
+   * stale higher-numbered files behind.
+   */
+  private void deleteExistingOutputFiles(String outputPrefix) throws IOException {
+    File prefixFile = new File(outputPrefix);
+    File dir = prefixFile.getParentFile();
+    String baseName = prefixFile.getName();
+    Pattern outputFilePattern = Pattern.compile(Pattern.quote(baseName) + "(\\.\\d+)?");
+    File[] existing = dir.listFiles((d, name) -> outputFilePattern.matcher(name).matches());
+    if (existing != null) {
+      for (File file : existing) {
+        if (!file.delete()) {
+          throw new IOException("Failed to delete stale output file: " + file.getAbsolutePath());
+        }
+      }
     }
   }
 

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
@@ -100,8 +100,11 @@ public class ReplicasVerify extends Handler {
   private String outputDir;
 
   @CommandLine.Option(names = {"--max-records-per-file"},
-      description = "Maximum number of keys to write per output file. When greater than zero (and --out is set), " +
-          "output is split into multiple valid JSON files named <out>.0, <out>.1, Requires --out.",
+      description = "Maximum number of keys to write per output file. When greater than zero, output is split " +
+          "into multiple valid JSON files named <dirName>.0, <dirName>.1, ... Requires --out. " +
+          "Split output files do not include a top-level 'pass' field, check each key's 'pass'. " +
+          "The single-file output keeps the top-level 'pass' for the whole run. JSON format example: " +
+          "single file: { 'pass': true/false, 'keys': [ ... ] }, split files: { 'keys': [ ... ] }.",
       defaultValue = "0")
   private long recordsPerFile;
 
@@ -229,6 +232,8 @@ public class ReplicasVerify extends Handler {
   /**
    * Writes verification output to file(s) instead of stdout.
    * When recordsPerFile is greater than zero, the keys are split into multiple valid JSON files.
+   * Split files contain only a "keys" array (no top-level "pass"); the per-key "pass" field reflects each
+   * key's result. The single-file output keeps the top-level "pass".
    */
   private void writeOutputToFiles(ObjectNode root, ArrayNode keysArray, boolean allKeysPassed) throws IOException {
     String outputPrefix = resolveOutputPrefix();
@@ -251,13 +256,11 @@ public class ReplicasVerify extends Handler {
       }
       chunkKeys.add(keysArray.get(i));
       if (chunkKeys.size() >= recordsPerFile) {
-        chunkNode.put("pass", allKeysPassed);
         writeJsonToFile(chunkNode, outputPrefix + "." + suffix++);
         chunkNode = null;
       }
     }
     if (chunkNode != null) {
-      chunkNode.put("pass", allKeysPassed);
       writeJsonToFile(chunkNode, outputPrefix + "." + suffix++);
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
@@ -24,10 +24,14 @@ import static org.apache.ozone.test.GenericTestUtils.setLogLevel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -57,6 +61,7 @@ import org.apache.ratis.util.JvmPauseMonitor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -71,6 +76,7 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
   private static final Logger LOG = LoggerFactory.getLogger(TestOzoneDebugReplicasVerify.class);
   private static final String CHUNKS_DIR_NAME = "chunks";
   private static final String BLOCK_FILE_EXTENSION = ".block";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private OzoneDebug ozoneDebugShell;
   private String ozoneAddress;
@@ -260,5 +266,67 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
     assertThat(out.get())
         .contains("Unexpected read size")
         .doesNotContain("Checksum mismatch");
+  }
+
+  @Test
+  void testSplitOutputToNewDirectory(@TempDir Path tempDir) throws IOException {
+    int maxRecordsPerFile = 2;
+    int expectedKeyFiles = (int) Math.ceil(keyInfoMap.size() / (maxRecordsPerFile * 1.0));
+    // Directory does not exist yet: it should be created and files written inside as <dirName>.0, <dirName>.1
+    String dirName = "verify-replica";
+    File outDir = new File(tempDir.toFile(), dirName);
+
+    runVerifyToDirectory(outDir.getAbsolutePath(), maxRecordsPerFile);
+
+    assertSplitFilesInDirectory(outDir, dirName, expectedKeyFiles, maxRecordsPerFile);
+  }
+
+  @Test
+  void testSplitOutputToExistingDirectory(@TempDir Path tempDir) throws IOException {
+    int maxRecordsPerFile = 2;
+    int expectedKeyFiles = (int) Math.ceil(keyInfoMap.size() / (maxRecordsPerFile * 1.0));
+    // Directory already exists: files are written inside it using the directory's name as the base.
+    String dirName = "verify-output";
+    File outDir = new File(tempDir.toFile(), dirName);
+    assertTrue(outDir.mkdirs(), "Failed to create output directory: " + outDir.getAbsolutePath());
+
+    runVerifyToDirectory(outDir.getAbsolutePath(), maxRecordsPerFile);
+
+    assertSplitFilesInDirectory(outDir, dirName, expectedKeyFiles, maxRecordsPerFile);
+  }
+
+  private void runVerifyToDirectory(String outputDir, int maxRecordsPerFile) {
+    List<String> parameters = new ArrayList<>();
+    parameters.add(0, getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY));
+    parameters.add(0, getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY));
+    parameters.add("replicas");
+    parameters.add("verify");
+    parameters.add("--checksums");
+    parameters.add("--all-results");
+    parameters.add("--out");
+    parameters.add(outputDir);
+    parameters.add("--max-records-per-file");
+    parameters.add(String.valueOf(maxRecordsPerFile));
+    parameters.add(ozoneAddress);
+
+    int exitCode = ozoneDebugShell.execute(parameters.toArray(new String[0]));
+    assertEquals(0, exitCode, err.get());
+  }
+
+  private void assertSplitFilesInDirectory(File outDir, String baseName, int expectedKeyFiles, int maxRecordsPerFile)
+      throws IOException {
+    assertTrue(outDir.isDirectory(), "Output directory should be created: " + outDir.getAbsolutePath());
+    int keysInFiles = 0;
+    for (int i = 0; i < expectedKeyFiles; i++) {
+      File keyFile = new File(outDir, baseName + "." + i);
+      assertTrue(keyFile.isFile(), "Expected key file: " + keyFile.getAbsolutePath());
+      JsonNode jsonNode = MAPPER.readTree(keyFile);
+      assertNotNull(jsonNode, "Output file must be valid JSON: " + keyFile.getAbsolutePath());
+      JsonNode keys = jsonNode.get("keys");
+      assertNotNull(keys, "Each split file must contain a 'keys' array");
+      assertThat(keys.size()).isLessThanOrEqualTo(maxRecordsPerFile);
+      keysInFiles += keys.size();
+    }
+    assertEquals(keyInfoMap.size(), keysInFiles, "All keys should be written across the split files");
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
@@ -24,6 +24,7 @@ import static org.apache.ozone.test.GenericTestUtils.setLogLevel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -295,6 +296,73 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
     assertSplitFilesInDirectory(outDir, dirName, expectedKeyFiles, maxRecordsPerFile);
   }
 
+  @Test
+  void testRerunRemovesStaleOutputFiles(@TempDir Path tempDir) throws IOException {
+    String dirName = "verify-rerun";
+    File outDir = new File(tempDir.toFile(), dirName);
+
+    // First run: 2 keys per file over 10 keys produces 5 files (verify-rerun.0 ... verify-rerun.4)
+    runVerifyToDirectory(outDir.getAbsolutePath(), 2);
+    int firstRunFiles = (int) Math.ceil(keyInfoMap.size() / (2 * 1.0));
+    assertTrue(new File(outDir, dirName + "." + (firstRunFiles - 1)).isFile(),
+        "First run should create " + firstRunFiles + " split files");
+
+    // Second run: all keys in a single file produces only verify-rerun.0
+    runVerifyToDirectory(outDir.getAbsolutePath(), keyInfoMap.size());
+    for (int i = 1; i < firstRunFiles; i++) {
+      File staleFile = new File(outDir, dirName + "." + i);
+      assertFalse(staleFile.exists(), "Stale output file should be removed on re-run: " + staleFile.getAbsolutePath());
+    }
+  }
+
+  @Test
+  void testSingleFileOutputWithoutSplitting(@TempDir Path tempDir) throws IOException {
+    // Without --max-records-per-file, all keys are written to a single <dirName> file inside the directory.
+    String dirName = "verify-single";
+    File outDir = new File(tempDir.toFile(), dirName);
+
+    List<String> parameters = new ArrayList<>();
+    parameters.add(0, getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY));
+    parameters.add(0, getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY));
+    parameters.add("replicas");
+    parameters.add("verify");
+    parameters.add("--checksums");
+    parameters.add("--all-results");
+    parameters.add("--out");
+    parameters.add(outDir.getAbsolutePath());
+    parameters.add(ozoneAddress);
+
+    int exitCode = ozoneDebugShell.execute(parameters.toArray(new String[0]));
+    assertEquals(0, exitCode, err.get());
+
+    assertTrue(outDir.isDirectory(), "Output directory should be created: " + outDir.getAbsolutePath());
+    File outFile = new File(outDir, dirName);
+    assertTrue(outFile.isFile(), "Expected single output file: " + outFile.getAbsolutePath());
+    JsonNode jsonNode = MAPPER.readTree(outFile);
+    assertNotNull(jsonNode, "Output file must be valid JSON: " + outFile.getAbsolutePath());
+    assertTrue(jsonNode.get("pass").asBoolean(), "Single output file must have a top-level 'pass' field");
+    JsonNode keys = jsonNode.get("keys");
+    assertNotNull(keys, "Output file must contain a 'keys' array");
+    assertEquals(keyInfoMap.size(), keys.size(), "All keys should be written to the single output file");
+  }
+
+  @Test
+  void testMaxRecordsPerFileRequiresOut() {
+    // --max-records-per-file without --out should fail with a usage error (exit code 2).
+    List<String> parameters = new ArrayList<>();
+    parameters.add(0, getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY));
+    parameters.add(0, getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY));
+    parameters.add("replicas");
+    parameters.add("verify");
+    parameters.add("--checksums");
+    parameters.add("--max-records-per-file");
+    parameters.add("2");
+    parameters.add(ozoneAddress);
+
+    int exitCode = ozoneDebugShell.execute(parameters.toArray(new String[0]));
+    assertEquals(2, exitCode, "--max-records-per-file without --out should be rejected");
+  }
+
   private void runVerifyToDirectory(String outputDir, int maxRecordsPerFile) {
     List<String> parameters = new ArrayList<>();
     parameters.add(0, getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY));
@@ -322,6 +390,7 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
       assertTrue(keyFile.isFile(), "Expected key file: " + keyFile.getAbsolutePath());
       JsonNode jsonNode = MAPPER.readTree(keyFile);
       assertNotNull(jsonNode, "Output file must be valid JSON: " + keyFile.getAbsolutePath());
+      assertTrue(jsonNode.get("pass").asBoolean(), "Each split file must have a top-level 'pass' field");
       JsonNode keys = jsonNode.get("keys");
       assertNotNull(keys, "Each split file must contain a 'keys' array");
       assertThat(keys.size()).isLessThanOrEqualTo(maxRecordsPerFile);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
@@ -390,7 +390,6 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
       assertTrue(keyFile.isFile(), "Expected key file: " + keyFile.getAbsolutePath());
       JsonNode jsonNode = MAPPER.readTree(keyFile);
       assertNotNull(jsonNode, "Output file must be valid JSON: " + keyFile.getAbsolutePath());
-      assertTrue(jsonNode.get("pass").asBoolean(), "Each split file must have a top-level 'pass' field");
       JsonNode keys = jsonNode.get("keys");
       assertNotNull(keys, "Each split file must contain a 'keys' array");
       assertThat(keys.size()).isLessThanOrEqualTo(maxRecordsPerFile);


### PR DESCRIPTION
## What changes were proposed in this pull request?
ozone debug replicas verify currently prints all verification results as one large JSON to stdout. 
This PR adds support for writing output to a directory as multiple valid JSON files, similar to ozone debug ldb scan.

below options are added:
* --out / -o: output directory. If it does not exist, it is created. If it already exists, it is reused.
* --max-records-per-file: maximum number of keys per file. 
When set, output is split into files like dirName.0, dirName.1 etc. Each file is valid JSON with a keys array.

If --out is not used, the command still prints JSON to stdout as before. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13063


## How was this patch tested?
* Added integration tests in TestOzoneDebugReplicasVerify: 
    * testSplitOutputToNewDirectory — verifies the command creates a non-existent output directory and splits the output across the expected number of valid JSON files,  with each file respecting --max-records-per-file.
    * testSplitOutputToExistingDirectory — verifies the same behaviour when the output directory already exists. 
    
* Verified split files are valid JSON, respect --max-records-per-file, and contain all keys.
* Manually tested in local docker-compose Ozone cluster:  
```
ozone debug replicas verify <vol>/<bucket> --checksums --all-results -o <dir path> --max-records-per-file <no. of keys per file> 
```
confirmed the directory is created, the output is split into numbered valid JSON files, and the run summary is printed.
* CI success : https://github.com/prathmesh12-coder/ozone/actions/runs/28151057274 
