### PR TITLE
HDDS-15674. Bump protobuf to 3.25.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <properties.maven.plugin.version>1.3.0</properties.maven.plugin.version>
     <proto-backwards-compatibility.version>1.0.7</proto-backwards-compatibility.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-    <protobuf.version>3.25.8</protobuf.version>
+    <protobuf.version>3.25.9</protobuf.version>
     <ranger.version>2.8.0</ranger.version>
     <!-- versions included in ratis-thirdparty, update in sync -->
     <ratis-thirdparty.grpc.version>1.75.0</ratis-thirdparty.grpc.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `protobuf-java` to 3.25.9.

https://issues.apache.org/jira/browse/HDDS-15674

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/28172096997