### PR TITLE
HDDS-15675. Ranger test overrides custom OZONE_RUNNER_IMAGE

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-ranger.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-ranger.sh
@@ -21,7 +21,7 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
 if [[ -z "${RANGER_VERSION:-}" ]]; then
-  source "${COMPOSE_DIR}/.env"
+  export RANGER_VERSION="${ranger.version}"
 fi
 
 : "${DOWNLOAD_DIR:=${TEMP_DIR:-/tmp}}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

`.env` files define default values for variables in Docker Compose.  `test-ranger.sh` evaluates `.env` as a whole to get `RANGER_VERSION`, which it needs for downloading Ranger.  This overrides any custom value for other variables that appear in `.env` and are already defined (e.g. `OZONE_RUNNER_IMAGE`).

https://issues.apache.org/jira/browse/HDDS-15675

## How was this patch tested?

Added `set -x` and early exit, then ran `test-ranger.sh` without/with `RANGER_VERSION` being defined:

```bash
$ hadoop-ozone/dist/target/ozone-2.3.0-SNAPSHOT/compose/ozonesecure-ha/test-ranger.sh   
+ [[ -z '' ]]
+ export RANGER_VERSION=2.8.0
+ RANGER_VERSION=2.8.0
+ exit

$ RANGER_VERSION=2.9.0 hadoop-ozone/dist/target/ozone-2.3.0-SNAPSHOT/compose/ozonesecure-ha/test-ranger.sh   
+ [[ -z 2.9.0 ]]
+ exit
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/28175310084/job/83452870581