### PR TITLE
HDDS-15671. [JDK23] Allow using sun.misc.Unsafe

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1447,6 +1447,12 @@ function ozone_set_module_access_args
   fi
 
   # populate JVM args based on java version
+  if [[ "${JAVA_MAJOR_VERSION}" -ge 23 ]]; then
+    # allow sun.misc.Unsafe until protobuf-java moves away from it
+    # see: https://github.com/protocolbuffers/protobuf/issues/20760
+    # see: https://openjdk.org/jeps/471
+    OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --sun-misc-unsafe-memory-access=allow"
+  fi
   if [[ "${JAVA_MAJOR_VERSION}" -ge 17 ]]; then
     OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-opens java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED"
     OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-exports java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED"


### PR DESCRIPTION
## What changes were proposed in this pull request?

`protobuf-java` still uses `sun.misc.Unsafe`, which has been [deprecated](https://openjdk.org/jeps/471) in JDK 23.  Java warns on first usage, which breaks tests that rely on CLI output.

```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/opt/hadoop/share/ozone/lib/protobuf-java-3.25.8.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release
```

Allow `sun.misc.Unsafe`, at least until protobuf moves away from it.

https://issues.apache.org/jira/browse/HDDS-15671

## How was this patch tested?

Tested (together with HDDS-15668) on JDK 25.

CI (JDK 21):
https://github.com/adoroszlai/ozone/actions/runs/28184310364