### PR TITLE
HDDS-15664. ozone debug ldb display DeletedBlocksTransactionSummary info

### DIFF
--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/ldb/DBScanner.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/ldb/DBScanner.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -841,8 +840,6 @@ public class DBScanner extends AbstractSubcommand implements Callable<Void> {
         value instanceof ByteString) {
       try {
         return HddsProtos.DeletedBlocksTransactionSummary.parseFrom((ByteString) value);
-      } catch (InvalidProtocolBufferException e) {
-        LOG.error("Failed to parse {} for key {}", STATEFUL_SERVICE_CONFIG.getName(), SERVICE_NAME, e);
       } catch (IOException e) {
         LOG.error("Failed to parse {} for key {}", STATEFUL_SERVICE_CONFIG.getName(), SERVICE_NAME, e);
       }

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/ldb/DBScanner.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/ldb/DBScanner.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.ozone.debug.ldb;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.scm.block.DeletedBlockLogStateManagerImpl.SERVICE_NAME;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.STATEFUL_SERVICE_CONFIG;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -28,6 +30,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -54,6 +58,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -730,9 +735,9 @@ public class DBScanner extends AbstractSubcommand implements Callable<Void> {
             // one, to ensure valid JSON format.
             sb.append(", ");
           }
+          Object key = dbColumnFamilyDefinition.getKeyCodec()
+              .fromPersistedFormat(byteArrayKeyValue.getKey());
           if (withKey) {
-            Object key = dbColumnFamilyDefinition.getKeyCodec()
-                .fromPersistedFormat(byteArrayKeyValue.getKey());
             if (schemaV3) {
               int index =
                   DatanodeSchemaThreeDBDefinition.getContainerKeyPrefixLength();
@@ -758,9 +763,11 @@ public class DBScanner extends AbstractSubcommand implements Callable<Void> {
           Object o = dbColumnFamilyDefinition.getValueCodec()
               .fromPersistedFormat(byteArrayKeyValue.getValue());
 
+          o = parseStatefulServiceConfig(key, o, dbColumnFamilyDefinition);
+
           if (valueFields != null) {
             Map<String, Object> filteredValue = new HashMap<>();
-            filteredValue.putAll(getFieldsFilteredObject(o, dbColumnFamilyDefinition.getValueType(), fieldsSplitMap));
+            filteredValue.putAll(getFieldsFilteredObject(o, o.getClass(), fieldsSplitMap));
             sb.append(writer.writeValueAsString(filteredValue));
           } else {
             sb.append(writer.writeValueAsString(o));
@@ -827,6 +834,20 @@ public class DBScanner extends AbstractSubcommand implements Callable<Void> {
       }
       return subfieldObjectsList;
     }
+  }
+
+  private Object parseStatefulServiceConfig(Object key, Object value, DBColumnFamilyDefinition dbColumnFamily) {
+    if (dbColumnFamily.getName().equals(STATEFUL_SERVICE_CONFIG.getName()) && key.equals(SERVICE_NAME) &&
+        value instanceof ByteString) {
+      try {
+        return HddsProtos.DeletedBlocksTransactionSummary.parseFrom((ByteString) value);
+      } catch (InvalidProtocolBufferException e) {
+        LOG.error("Failed to parse {} for key {}", STATEFUL_SERVICE_CONFIG.getName(), SERVICE_NAME, e);
+      } catch (IOException e) {
+        LOG.error("Failed to parse {} for key {}", STATEFUL_SERVICE_CONFIG.getName(), SERVICE_NAME, e);
+      }
+    }
+    return value;
   }
 
   private static class ByteArrayKeyValue {


### PR DESCRIPTION
## What changes were proposed in this pull request?

add support in ldb scan command, to display DeletedBlocksTransactionSummary info. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15664

## How was this patch tested?

Manual test

```
root@vc1337:/var/log/hadoop-ozone# ozone admin scm deletedBlocksTxn summary
RemoteException: SCM Server, while invoking StorageContainerLocationProtocolPB over node1. Retrying in 2000ms after 0 failover attempt(s).
DeletedBlocksTransaction summary:
  Total number of transactions: 43
  Total number of blocks: 43
  Total size of blocks: 2709
  Total replicated size of blocks: 8127


root@vc1337:/var/log/hadoop-ozone# ozone debug ldb --db=/var/lib/hadoop-ozone/scm/data/scm.db/ scan --cf=statefulServiceConfig
{ "DeletedBlockLogStateManager": {
  "memoizedHashCode" : 0,
  "memoizedSize" : -1,
  "unknownFields" : {
    "fields" : { }
  },
  "bitField0_" : 15,
  "totalTransactionCount_" : 43,
  "totalBlockCount_" : 43,
  "totalBlockSize_" : 2709,
  "totalBlockReplicatedSize_" : 8127,
  "memoizedIsInitialized" : 1
}
 }
```