### PR TITLE
HDDS-15679. [Recon] Fix DN dropdown mismatch with pending deletion API

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -49,9 +49,9 @@ describe('Capacity Page', () => {
       return;
     }
     await waitFor(() =>
-      expect(ozoneCapacityCard).toHaveTextContent(/TOTAL\s*10\s*KB/i)
+      expect(ozoneCapacityCard).toHaveTextContent(/TOTAL CAPACITY\s*10\s*KB/i)
     );
-    expect(ozoneCapacityCard).toHaveTextContent(/OZONE USED SPACE\s*4\s*KB/i);
+    expect(ozoneCapacityCard).toHaveTextContent(/USED SPACE\s*4\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/OTHER USED SPACE\s*2\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/CONTAINER PRE-ALLOCATED\s*1\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/REMAINING SPACE\s*4\s*KB/i);
@@ -63,7 +63,7 @@ describe('Capacity Page', () => {
       return;
     }
     await waitFor(() =>
-      expect(ozoneUsedSpaceCard).toHaveTextContent(/PENDING DELETION\s*6\s*KB/i)
+      expect(ozoneUsedSpaceCard).toHaveTextContent(/PENDING DELETION\s*8\s*KB/i)
     );
   });
 
@@ -80,7 +80,7 @@ describe('Capacity Page', () => {
       expect(pendingDeletionCard).toHaveTextContent(/OZONE MANAGER\s*2\s*KB/i)
     );
     expect(pendingDeletionCard)
-      .toHaveTextContent(/STORAGE CONTAINER MANAGER\s*1\s*KB/i);
+      .toHaveTextContent(/STORAGE CONTAINER MANAGER\s*3\s*KB/i);
     expect(pendingDeletionCard).toHaveTextContent(/DATANODES\s*3\s*KB/i);
 
     const downloadLink = await screen.findByText('Download Insights');

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { rest } from 'msw';
 
 import Capacity from '@/v2/pages/capacity/capacity';
@@ -144,5 +144,123 @@ describe('Capacity Page', () => {
     expect(pendingDeletionCard).toHaveTextContent(/STORAGE CONTAINER MANAGER\s*N\/A/i);
     expect(await screen.findByTestId('pending-deletion-scm-error')).toBeInTheDocument();
     await waitFor(() => expect(screen.getAllByTestId('echart')).toHaveLength(4));
+  });
+
+  test('node selector dropdown only lists datanodes from pending deletion API when cluster has more than 15 DNs', async () => {
+    const totalDatanodes = 17;
+    const pendingDeletionLimit = 15;
+
+    const allDataNodeUsage = Array.from({ length: totalDatanodes }, (_, index) => {
+      const datanodeNumber = index + 1;
+      return {
+        datanodeUuid: `uuid-${datanodeNumber}`,
+        hostName: `dn-${datanodeNumber}`,
+        capacity: 8192,
+        used: 2048,
+        remaining: 2048,
+        committed: 1024,
+        minimumFreeSpace: 256,
+        reserved: 128
+      };
+    });
+
+    const pendingDeletionPerDataNode = Array.from({ length: pendingDeletionLimit }, (_, index) => {
+      const datanodeNumber = index + 1;
+      return {
+        hostName: `dn-${datanodeNumber}`,
+        datanodeUuid: `uuid-${datanodeNumber}`,
+        pendingBlockSize: 1024 * datanodeNumber
+      };
+    });
+    let pendingDeletionLimitParam: string | null = null;
+
+    capacityServer.use(
+      rest.get('api/v1/storageDistribution', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            ...mockResponses.StorageDistribution,
+            dataNodeUsage: allDataNodeUsage
+          })
+        );
+      }),
+      rest.get('api/v1/pendingDeletion', (req, res, ctx) => {
+        const component = req.url.searchParams.get('component');
+        switch (component) {
+        case 'scm':
+          return res(
+            ctx.status(200),
+            ctx.json(mockResponses.ScmPendingDeletion)
+          );
+        case 'om':
+          return res(
+            ctx.status(200),
+            ctx.json(mockResponses.OmPendingDeletion)
+          );
+        case 'dn':
+          pendingDeletionLimitParam = req.url.searchParams.get('limit');
+          return res(
+            ctx.status(200),
+            ctx.json({
+              status: 'FINISHED',
+              totalPendingDeletionSize: pendingDeletionPerDataNode.reduce(
+                (total, datanode) => total + datanode.pendingBlockSize,
+                0
+              ),
+              pendingDeletionPerDataNode,
+              totalNodesQueried: totalDatanodes,
+              totalNodeQueriesFailed: 0
+            })
+          );
+        default:
+          return res(
+            ctx.status(400),
+            ctx.json({ message: 'Unsupported pending deletion component.' })
+          );
+        }
+      })
+    );
+
+    render(<Capacity />);
+
+    await waitFor(() => expect(pendingDeletionLimitParam).toBe('15'));
+
+    const downloadLink = await screen.findByText('Download Insights');
+    const datanodeCard = downloadLink.closest('.ant-card');
+    expect(datanodeCard).not.toBeNull();
+    if (!datanodeCard) {
+      return;
+    }
+
+    await waitFor(() =>
+      expect(datanodeCard).toHaveTextContent(/PENDING DELETION\s*1\s*KB/i)
+    );
+    expect(datanodeCard).toHaveTextContent(/OZONE USED\s*2\s*KB/i);
+    expect(datanodeCard).toHaveTextContent(/USED SPACE\s*3\s*KB/i);
+
+    const nodeSelector = within(datanodeCard as HTMLElement).getByRole('combobox');
+    fireEvent.mouseDown(nodeSelector);
+
+    await waitFor(() => {
+      expect(document.querySelector('.ant-select-dropdown')).toBeInTheDocument();
+    });
+
+    const visibleDropdownHostNames = Array.from(
+      document.querySelectorAll('.ant-select-item-option-content span:first-child')
+    ).map(option => option.textContent);
+    expect(visibleDropdownHostNames.length).toBeGreaterThan(0);
+    expect(visibleDropdownHostNames.length).toBeLessThan(totalDatanodes);
+    expect(visibleDropdownHostNames).toContain('dn-1');
+    expect(visibleDropdownHostNames).not.toContain('dn-16');
+    expect(visibleDropdownHostNames).not.toContain('dn-17');
+
+    fireEvent.change(nodeSelector, { target: { value: 'dn-15' } });
+    expect(await screen.findByRole('option', { name: 'dn-15' })).toBeInTheDocument();
+
+    fireEvent.change(nodeSelector, { target: { value: 'dn-16' } });
+    await waitFor(() =>
+      expect(screen.queryByRole('option', { name: 'dn-16' })).not.toBeInTheDocument()
+    );
+    expect(screen.queryByRole('option', { name: 'dn-17' })).not.toBeInTheDocument();
   });
 });

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -49,9 +49,9 @@ describe('Capacity Page', () => {
       return;
     }
     await waitFor(() =>
-      expect(ozoneCapacityCard).toHaveTextContent(/TOTAL CAPACITY\s*10\s*KB/i)
+      expect(ozoneCapacityCard).toHaveTextContent(/TOTAL\s*10\s*KB/i)
     );
-    expect(ozoneCapacityCard).toHaveTextContent(/USED SPACE\s*4\s*KB/i);
+    expect(ozoneCapacityCard).toHaveTextContent(/OZONE USED SPACE\s*4\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/OTHER USED SPACE\s*2\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/CONTAINER PRE-ALLOCATED\s*1\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/REMAINING SPACE\s*4\s*KB/i);
@@ -63,7 +63,7 @@ describe('Capacity Page', () => {
       return;
     }
     await waitFor(() =>
-      expect(ozoneUsedSpaceCard).toHaveTextContent(/PENDING DELETION\s*8\s*KB/i)
+      expect(ozoneUsedSpaceCard).toHaveTextContent(/PENDING DELETION\s*6\s*KB/i)
     );
   });
 
@@ -80,7 +80,7 @@ describe('Capacity Page', () => {
       expect(pendingDeletionCard).toHaveTextContent(/OZONE MANAGER\s*2\s*KB/i)
     );
     expect(pendingDeletionCard)
-      .toHaveTextContent(/STORAGE CONTAINER MANAGER\s*3\s*KB/i);
+      .toHaveTextContent(/STORAGE CONTAINER MANAGER\s*1\s*KB/i);
     expect(pendingDeletionCard).toHaveTextContent(/DATANODES\s*3\s*KB/i);
 
     const downloadLink = await screen.findByText('Download Insights');

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/capacityMocks/capacityResponseMocks.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/capacityMocks/capacityResponseMocks.ts
@@ -63,7 +63,7 @@ export const StorageDistribution = {
 
 export const ScmPendingDeletion = {
   totalBlocksize: 1024,
-  totalReplicatedBlockSize: 2048,
+  totalReplicatedBlockSize: 3072,
   totalBlocksCount: 2
 };
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/capacityMocks/capacityResponseMocks.ts
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/mocks/capacityMocks/capacityResponseMocks.ts
@@ -63,7 +63,7 @@ export const StorageDistribution = {
 
 export const ScmPendingDeletion = {
   totalBlocksize: 1024,
-  totalReplicatedBlockSize: 3072,
+  totalReplicatedBlockSize: 2048,
   totalBlocksCount: 2
 };
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -90,15 +90,24 @@ const Capacity: React.FC<object> = () => {
     }
   );
 
-  const [selectedDatanode, setSelectedDatanode] = React.useState<string>(storageDistribution.data.dataNodeUsage[0]?.hostName ?? "");
+  const [selectedDatanode, setSelectedDatanode] = React.useState<string>("");
+
+  // Only show DNs that appear in the pending deletion response (max 15), so the
+  // dropdown and the pending-block-size values are always in sync.
+  const filteredDNs = React.useMemo(() => {
+    const pendingHostNames = new Set(
+      (dnPendingDeletes.data.pendingDeletionPerDataNode ?? []).map(dn => dn.hostName)
+    );
+    return storageDistribution.data.dataNodeUsage.filter(dn => pendingHostNames.has(dn.hostName));
+  }, [storageDistribution.data.dataNodeUsage, dnPendingDeletes.data.pendingDeletionPerDataNode]);
 
   // Seed selected datanode once data loads so dependent calculations work
   React.useEffect(() => {
-    const firstHost = storageDistribution.data.dataNodeUsage[0]?.hostName;
+    const firstHost = filteredDNs[0]?.hostName;
     if (!selectedDatanode && firstHost) {
       setSelectedDatanode(firstHost);
     }
-  }, [selectedDatanode, storageDistribution.data.dataNodeUsage]);
+  }, [selectedDatanode, filteredDNs]);
 
   const loadData = () => {
     storageDistribution.refetch();
@@ -194,17 +203,23 @@ const Capacity: React.FC<object> = () => {
   };
 
   // Adjust the polling interval based on DN scan status:
-  // fast (5s) while a scan is running, normal (60s) once finished.
-  // Honors the auto-reload toggle: if polling is OFF, do nothing.
+  // fast (5s) while a scan is running (regardless of auto-reload toggle, since
+  // the scan is async and must be tracked to completion), normal (60s) once
+  // finished — but only if the user has auto-reload enabled.
   React.useEffect(() => {
-    if (!autoReload.isPolling) {
-      return;
+    if (dnPendingDeletes.data.status !== "FINISHED") {
+      autoReload.startPolling(PENDING_POLL_INTERVAL);
+    } else if (autoReload.isPolling) {
+      // Scan just finished while fast-polling was active.
+      // Switch to normal interval only if the user still wants auto-reload;
+      // otherwise stop so we don't override the toggle.
+      const autoReloadEnabled = sessionStorage.getItem('autoReloadEnabled') !== 'false';
+      if (autoReloadEnabled) {
+        autoReload.startPolling(AUTO_RELOAD_INTERVAL_DEFAULT);
+      } else {
+        autoReload.stopPolling();
+      }
     }
-    autoReload.startPolling(
-      dnPendingDeletes.data.status === "FINISHED"
-        ? AUTO_RELOAD_INTERVAL_DEFAULT
-        : PENDING_POLL_INTERVAL
-    );
   }, [dnPendingDeletes.data.status, autoReload.isPolling]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const dnReportStatus = (
@@ -444,7 +459,7 @@ const Capacity: React.FC<object> = () => {
             downloadUrl={DN_CSV_DOWNLOAD_URL}
             onDownloadClick={() => downloadCsv(DN_CSV_DOWNLOAD_URL)}
             handleSelect={setSelectedDatanode}
-            dropdownItems={storageDistribution.data.dataNodeUsage.map(datanode => ({
+            dropdownItems={filteredDNs.map(datanode => ({
               label: (
                 <>
                   <span>{datanode.hostName}</span>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -203,23 +203,17 @@ const Capacity: React.FC<object> = () => {
   };
 
   // Adjust the polling interval based on DN scan status:
-  // fast (5s) while a scan is running (regardless of auto-reload toggle, since
-  // the scan is async and must be tracked to completion), normal (60s) once
-  // finished — but only if the user has auto-reload enabled.
+  // fast (5s) while a scan is running, normal (60s) once finished.
+  // Honors the auto-reload toggle: if polling is OFF, do nothing.
   React.useEffect(() => {
-    if (dnPendingDeletes.data.status !== "FINISHED") {
-      autoReload.startPolling(PENDING_POLL_INTERVAL);
-    } else if (autoReload.isPolling) {
-      // Scan just finished while fast-polling was active.
-      // Switch to normal interval only if the user still wants auto-reload;
-      // otherwise stop so we don't override the toggle.
-      const autoReloadEnabled = sessionStorage.getItem('autoReloadEnabled') !== 'false';
-      if (autoReloadEnabled) {
-        autoReload.startPolling(AUTO_RELOAD_INTERVAL_DEFAULT);
-      } else {
-        autoReload.stopPolling();
-      }
+    if (!autoReload.isPolling) {
+      return;
     }
+    autoReload.startPolling(
+      dnPendingDeletes.data.status === "FINISHED"
+        ? AUTO_RELOAD_INTERVAL_DEFAULT
+        : PENDING_POLL_INTERVAL
+    );
   }, [dnPendingDeletes.data.status, autoReload.isPolling]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const dnReportStatus = (

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -103,11 +103,11 @@ const Capacity: React.FC<object> = () => {
 
   // Seed selected datanode once data loads so dependent calculations work
   React.useEffect(() => {
-    const firstHost = filteredDNs[0]?.hostName;
-    if (!selectedDatanode && firstHost) {
-      setSelectedDatanode(firstHost);
+    const hostNames = filteredDNs.map(dn => dn.hostName);
+    if (!hostNames.includes(selectedDatanode)) {
+      setSelectedDatanode(hostNames[0] ?? "");
     }
-  }, [selectedDatanode, filteredDNs]);
+  }, [filteredDNs]);
 
   const loadData = () => {
     storageDistribution.refetch();


### PR DESCRIPTION
## What changes were proposed in this pull request?
The DN pending deletion API is fetched with limit=15, returning pending block size data for at most 15 datanodes. However, the node-selector dropdown on the Capacity page was populated from storageDistribution, which returns all datanodes in the cluster. This caused a mismatch: the dropdown could list nodes for which no pending deletion data existed, while the nodes actually covered by the API response might be missing from the dropdown. Selecting such a node would show a pending block size of zero regardless of the actual value.

## What is the link to the Apache JIRA

HDDS-15679

## How was this patch tested?

Tested manually and using newly added unit test (unit test is generated using AI)