### PR TITLE
HDDS-15668. [JDK24] Add --enable-native-access=ALL-UNNAMED JVM option

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1447,6 +1447,9 @@ function ozone_set_module_access_args
   fi
 
   # populate JVM args based on java version
+  if [[ "${JAVA_MAJOR_VERSION}" -ge 24 ]]; then
+    OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --enable-native-access=ALL-UNNAMED"
+  fi
   if [[ "${JAVA_MAJOR_VERSION}" -ge 23 ]]; then
     # allow sun.misc.Unsafe until protobuf-java moves away from it
     # see: https://github.com/protocolbuffers/protobuf/issues/20760


### PR DESCRIPTION
## What changes were proposed in this pull request?

Warning on JDK 24+ breaks tests that depend on CLI output:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by org.apache.hadoop.util.NativeCodeLoader in an unnamed module (file:/opt/hadoop/share/ozone/lib/hadoop-common-3.4.3.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

Enable native access as suggested in the warning.

(See also HADOOP-19530.)

https://issues.apache.org/jira/browse/HDDS-15668

## How was this patch tested?

Tested with JDK 25, acceptance tests passed (except `test-ranger.sh`, which is being fixed in HDDS-15675):
https://github.com/adoroszlai/ozone/actions/runs/28170184237

CI (with Java 21):
https://github.com/adoroszlai/ozone/actions/runs/28199512783