### PR TITLE
HDDS-14989. Delay follower SCM DN server start until Ratis log catch-up.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -252,7 +252,7 @@ abstract class AbstractContainerReportHandler {
       // If the state of a container is OPEN and a replica is in different state, finalize the container.
       if (replica.getState() != State.OPEN) {
         getLogger().info("FINALIZE (i.e. CLOSING) {}", detailsForLogging);
-        containerManager.updateContainerState(containerId, LifeCycleEvent.FINALIZE);
+        updateContainerState(containerId, LifeCycleEvent.FINALIZE);
       }
       return false;
     case CLOSING:
@@ -263,7 +263,7 @@ abstract class AbstractContainerReportHandler {
       // If the replica is in QUASI_CLOSED state, move the container to QUASI_CLOSED state.
       if (replica.getState() == State.QUASI_CLOSED) {
         getLogger().info("QUASI_CLOSE {}", detailsForLogging);
-        containerManager.updateContainerState(containerId, LifeCycleEvent.QUASI_CLOSE);
+        updateContainerState(containerId, LifeCycleEvent.QUASI_CLOSE);
         return false;
       }
 
@@ -287,7 +287,7 @@ abstract class AbstractContainerReportHandler {
           return true;
         }
         getLogger().info("CLOSE {}", detailsForLogging);
-        containerManager.updateContainerState(containerId, LifeCycleEvent.CLOSE);
+        updateContainerState(containerId, LifeCycleEvent.CLOSE);
       }
       return false;
     case QUASI_CLOSED:
@@ -300,7 +300,7 @@ abstract class AbstractContainerReportHandler {
           return true;
         }
         getLogger().info("FORCE_CLOSE for {}", detailsForLogging);
-        containerManager.updateContainerState(containerId, LifeCycleEvent.FORCE_CLOSE);
+        updateContainerState(containerId, LifeCycleEvent.FORCE_CLOSE);
       }
       return false;
     case CLOSED:
@@ -358,6 +358,24 @@ abstract class AbstractContainerReportHandler {
       getLogger().error("Replica not processed due to container state {}: {}",
           container.getState(), detailsForLogging);
       return false;
+    }
+  }
+
+  /**
+   * Apply a container lifecycle state transition, but only on the leader SCM.
+   * On a follower the underlying {@code containerManager.updateContainerState}
+   * is a Ratis write and would throw {@code NotLeaderException}, which would
+   * abort {@code processContainerReplica} and skip recording the replica
+   * location. Skipping the state change on a follower is safe: the leader
+   * drives the transition and it replicates back via the Ratis log.
+   */
+  private void updateContainerState(ContainerID containerID, LifeCycleEvent event)
+      throws InvalidStateTransitionException, IOException {
+    if (scmContext.isLeader()) {
+      containerManager.updateContainerState(containerID, event);
+    } else {
+      getLogger().debug("Skipping updateContainerState on non-leader SCM, container {} event {}",
+          containerID, event);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -370,7 +370,7 @@ abstract class AbstractContainerReportHandler {
    * drives the transition and it replicates back via the Ratis log.
    */
   private void updateContainerState(ContainerID containerID, LifeCycleEvent event)
-      throws InvalidStateTransitionException, IOException {
+      throws IOException {
     if (scmContext.isLeader()) {
       containerManager.updateContainerState(containerID, event);
     } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -32,7 +32,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLog;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
@@ -51,6 +50,7 @@ import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.DivisionInfo;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
@@ -86,7 +86,6 @@ public class SCMStateMachine extends BaseStateMachine {
   private DBCheckpoint installingDBCheckpoint = null;
   private List<ManagedSecretKey> installingSecretKeys = null;
 
-  private AtomicLong currentLeaderTerm = new AtomicLong(-1L);
   private AtomicBoolean isStateMachineReady = new AtomicBoolean();
 
   public SCMStateMachine(final StorageContainerManager scm,
@@ -278,18 +277,13 @@ public class SCMStateMachine extends BaseStateMachine {
       return;
     }
 
-    currentLeaderTerm.set(scm.getScmHAManager().getRatisServer().getDivision()
-        .getInfo().getCurrentTerm());
+    final boolean isLeader = groupMemberId.getPeerId().equals(newLeaderId);
 
-    if (isStateMachineReady.compareAndSet(false, true)) {
-      // refresh and validate safe mode rules if it can exit safe mode
-      // if being leader, all previous term transactions have been applied
-      // if other states, just refresh safe mode rules, and transaction keeps flushing from leader
-      // and does not depend on pending transactions.
-      scm.getScmSafeModeManager().refreshAndValidate();
-    }
-
-    if (!groupMemberId.getPeerId().equals(newLeaderId)) {
+    if (!isLeader) {
+      // Follower: start the datanode protocol server if we are already caught
+      // up with the leader's committed log; otherwise notifyTermIndexUpdated
+      // starts it as catch-up completes.
+      tryStartDNServerAndRefreshSafeMode();
       String message = "Leader changed to " + newLeaderId +
           ", current SCM " + scm.getScmId() + " is still follower.";
       LOG.info(message);
@@ -297,14 +291,19 @@ public class SCMStateMachine extends BaseStateMachine {
       return;
     }
 
+    long currentTerm = scm.getScmHAManager().getRatisServer().getDivision()
+        .getInfo().getCurrentTerm();
     String message = "current SCM " + scm.getScmId() +
-        " becomes leader of term " + currentLeaderTerm;
+        " becomes leader of term " + currentTerm;
     LOG.info(message);
     addRatisEvent(message);
 
-    scm.getScmContext().updateLeaderAndTerm(true,
-        currentLeaderTerm.get());
+    scm.getScmContext().updateLeaderAndTerm(true, currentTerm);
     scm.getSequenceIdGen().invalidateBatch();
+
+    // isLeader() is now true -> start the datanode protocol server for the new
+    // leader (a leader has applied all committed entries) and refresh safe mode.
+    tryStartDNServerAndRefreshSafeMode();
 
     try {
       transactionBuffer.flush();
@@ -380,13 +379,69 @@ public class SCMStateMachine extends BaseStateMachine {
       }
     }
 
-    if (currentLeaderTerm.get() == term) {
-      // This means after a restart, all pending transactions have been applied.
+    // As committed entries are applied (e.g. a restarted follower catching up),
+    // start the datanode protocol server once we are caught up with the leader's
+    // committed index. No-op once the server has already been started.
+    tryStartDNServerAndRefreshSafeMode();
+  }
+
+  /**
+   * Start the DatanodeProtocolServer and re-evaluate safe-mode rules, but only
+   * when this SCM is safe to accept datanode reports: it is the leader, or it
+   * is a follower whose state machine has caught up with the leader's committed
+   * log. Guarded by {@code isStateMachineReady} (CAS) so the non-idempotent
+   * {@code DatanodeProtocolServer.start()} runs exactly once.
+   *
+   * <p>In HA mode {@link StorageContainerManager#start()} deliberately does not
+   * start the datanode protocol server; it is deferred to here so datanode
+   * container reports are processed against the up-to-date container/pipeline
+   * state rather than a stale, mid-replay snapshot.
+   */
+  private void tryStartDNServerAndRefreshSafeMode() {
+    if (isStateMachineReady.get()) {
+      return;
+    }
+    if (scm.getScmContext().isLeader() || isFollowerCaughtUp()) {
       if (isStateMachineReady.compareAndSet(false, true)) {
-        // Refresh Safemode rules state if not already done.
+        scm.getDatanodeProtocolServer().start();
         scm.getScmSafeModeManager().refreshAndValidate();
       }
-      currentLeaderTerm.set(-1L);
+    }
+  }
+
+  /**
+   * @return true if this follower's last applied index has reached the leader's
+   * committed index, i.e. all committed transactions have been replayed.
+   */
+  private boolean isFollowerCaughtUp() {
+    try {
+      RaftServer.Division division = scm.getScmHAManager()
+          .getRatisServer().getDivision();
+      DivisionInfo divisionInfo = division.getInfo();
+      long lastAppliedIndex = divisionInfo.getLastAppliedIndex();
+
+      RaftPeerId leaderId = divisionInfo.getLeaderId();
+      if (leaderId != null) {
+        for (RaftProtos.CommitInfoProto info : division.getCommitInfos()) {
+          if (info.getServer().getId().equals(leaderId.toByteString())) {
+            long leaderCommit = info.getCommitIndex();
+            boolean caughtUp = lastAppliedIndex >= leaderCommit;
+            if (caughtUp) {
+              LOG.info("Follower caught up with leader: lastAppliedIndex={}, leaderCommit={}",
+                  lastAppliedIndex, leaderCommit);
+            } else {
+              LOG.debug("Follower not caught up: lastAppliedIndex={}, leaderCommit={}",
+                  lastAppliedIndex, leaderCommit);
+            }
+            return caughtUp;
+          }
+        }
+      }
+      LOG.warn("Leader commit index not available yet, leaderId={}", leaderId);
+      return false;
+    } catch (Exception e) {
+      LOG.warn("Failed to check follower catch-up status", e);
+      return false;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLog;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
@@ -87,10 +88,22 @@ public class SCMStateMachine extends BaseStateMachine {
 
   private AtomicBoolean isStateMachineReady = new AtomicBoolean();
 
+  // Separate guard for the deferred datanode protocol server start. Kept
+  // distinct from isStateMachineReady so that starting the server is decoupled
+  // from the StateMachineReadyRule safe-mode signal, which isStateMachineReady
+  // drives.
+  private AtomicBoolean dnServerStarted = new AtomicBoolean();
+
+  // The current leader's term, captured at each leader change. Used in
+  // notifyTermIndexUpdated to detect when a restarted SCM has replayed all of
+  // that term's pending transactions, so isStateMachineReady can be set.
+  private AtomicLong currentLeaderTerm = new AtomicLong(-1L);
+
   // The leader's committed index captured when this SCM (re)joins as a
-  // follower. Catch-up is measured against this fixed target rather than the
-  // leader's live commit index, which on a busy cluster keeps advancing and
-  // would never be reached. Set only while not yet ready; -1 means uncaptured.
+  // follower. Catch-up (for starting the datanode server) is measured against
+  // this fixed target rather than the leader's live commit index, which on a
+  // busy cluster keeps advancing and would never be reached. Set only until the
+  // datanode server has started; -1 means uncaptured.
   private volatile long leaderCommitIndexOnStart = -1L;
 
   public SCMStateMachine(final StorageContainerManager scm,
@@ -183,7 +196,7 @@ public class SCMStateMachine extends BaseStateMachine {
       // A restarted follower may catch up by applying data-carrying entries
       // here rather than through notifyTermIndexUpdated, so check for catch-up
       // in both places. No-op once the datanode protocol server has started.
-      tryStartDNServerAndRefreshSafeMode();
+      tryStartDatanodeProtocolServer();
     } catch (Exception ex) {
       applyTransactionFuture.completeExceptionally(ex);
       ExitUtils.terminate(1, ex.getMessage(), ex, StateMachine.LOG);
@@ -287,20 +300,32 @@ public class SCMStateMachine extends BaseStateMachine {
       return;
     }
 
+    currentLeaderTerm.set(scm.getScmHAManager().getRatisServer().getDivision()
+        .getInfo().getCurrentTerm());
+
+    if (isStateMachineReady.compareAndSet(false, true)) {
+      // refresh and validate safe mode rules if it can exit safe mode
+      // if being leader, all previous term transactions have been applied
+      // if other states, just refresh safe mode rules, and transaction keeps flushing from leader
+      // and does not depend on pending transactions.
+      scm.getScmSafeModeManager().refreshAndValidate();
+    }
+
     final boolean isLeader = groupMemberId.getPeerId().equals(newLeaderId);
 
     if (!isLeader) {
       // Follower: capture the leader's current committed index as the fixed
-      // catch-up target (only while not yet ready), then start the datanode
-      // protocol server if we are already caught up with it; otherwise
-      // applyTransaction / notifyTermIndexUpdated start it as catch-up completes.
-      if (!isStateMachineReady.get()) {
+      // catch-up target for starting the datanode protocol server (only until
+      // the server has started), then start it if we are already caught up;
+      // otherwise applyTransaction / notifyTermIndexUpdated start it as
+      // catch-up completes.
+      if (!dnServerStarted.get()) {
         long leaderCommit = getLeaderCommitIndex();
         if (leaderCommit >= 0) {
           leaderCommitIndexOnStart = leaderCommit;
         }
       }
-      tryStartDNServerAndRefreshSafeMode();
+      tryStartDatanodeProtocolServer();
       String message = "Leader changed to " + newLeaderId +
           ", current SCM " + scm.getScmId() + " is still follower.";
       LOG.info(message);
@@ -308,19 +333,17 @@ public class SCMStateMachine extends BaseStateMachine {
       return;
     }
 
-    long currentTerm = scm.getScmHAManager().getRatisServer().getDivision()
-        .getInfo().getCurrentTerm();
     String message = "current SCM " + scm.getScmId() +
-        " becomes leader of term " + currentTerm;
+        " becomes leader of term " + currentLeaderTerm;
     LOG.info(message);
     addRatisEvent(message);
 
-    scm.getScmContext().updateLeaderAndTerm(true, currentTerm);
+    scm.getScmContext().updateLeaderAndTerm(true, currentLeaderTerm.get());
     scm.getSequenceIdGen().invalidateBatch();
 
     // isLeader() is now true -> start the datanode protocol server for the new
-    // leader (a leader has applied all committed entries) and refresh safe mode.
-    tryStartDNServerAndRefreshSafeMode();
+    // leader (a leader has applied all committed entries).
+    tryStartDatanodeProtocolServer();
 
     try {
       transactionBuffer.flush();
@@ -396,32 +419,42 @@ public class SCMStateMachine extends BaseStateMachine {
       }
     }
 
+    if (currentLeaderTerm.get() == term) {
+      // This means after a restart, all pending transactions have been applied.
+      if (isStateMachineReady.compareAndSet(false, true)) {
+        // Refresh Safemode rules state if not already done.
+        scm.getScmSafeModeManager().refreshAndValidate();
+      }
+      currentLeaderTerm.set(-1L);
+    }
+
     // As committed entries are applied (e.g. a restarted follower catching up),
-    // start the datanode protocol server once we are caught up with the leader's
-    // committed index. No-op once the server has already been started.
-    tryStartDNServerAndRefreshSafeMode();
+    // start the datanode protocol server once caught up with the leader's
+    // committed index captured at (re)join. No-op once the server has started.
+    tryStartDatanodeProtocolServer();
   }
 
   /**
-   * Start the DatanodeProtocolServer and re-evaluate safe-mode rules, but only
-   * when this SCM is safe to accept datanode reports: it is the leader, or it
-   * is a follower whose state machine has caught up with the leader's committed
-   * log. Guarded by {@code isStateMachineReady} (CAS) so the non-idempotent
+   * Start the DatanodeProtocolServer exactly once, when this SCM is safe to
+   * accept datanode reports: it is the leader, or a follower whose state machine
+   * has caught up with the leader's committed index captured at (re)join.
+   * Guarded by {@code dnServerStarted} (CAS) so the non-idempotent
    * {@code DatanodeProtocolServer.start()} runs exactly once.
    *
    * <p>In HA mode {@link StorageContainerManager#start()} deliberately does not
    * start the datanode protocol server; it is deferred to here so datanode
    * container reports are processed against the up-to-date container/pipeline
-   * state rather than a stale, mid-replay snapshot.
+   * state rather than a stale, mid-replay snapshot. This is intentionally
+   * independent of {@code isStateMachineReady}, which drives the
+   * StateMachineReadyRule safe-mode rule.
    */
-  private void tryStartDNServerAndRefreshSafeMode() {
-    if (isStateMachineReady.get()) {
+  private void tryStartDatanodeProtocolServer() {
+    if (dnServerStarted.get()) {
       return;
     }
     if (scm.getScmContext().isLeader() || isFollowerCaughtUp()) {
-      if (isStateMachineReady.compareAndSet(false, true)) {
+      if (dnServerStarted.compareAndSet(false, true)) {
         scm.getDatanodeProtocolServer().start();
-        scm.getScmSafeModeManager().refreshAndValidate();
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -290,15 +290,14 @@ public class SCMStateMachine extends BaseStateMachine {
     final boolean isLeader = groupMemberId.getPeerId().equals(newLeaderId);
 
     if (!isLeader) {
-      // Follower: capture the leader's current committed index as the fixed
-      // catch-up target (only while not yet ready), then start the datanode
-      // protocol server if we are already caught up with it; otherwise
-      // applyTransaction / notifyTermIndexUpdated start it as catch-up completes.
+      // Follower: capture the (possibly new) leader's current committed index
+      // as the fixed catch-up target, then start the datanode protocol server
+      // if we are already caught up with it; otherwise applyTransaction /
+      // notifyTermIndexUpdated start it as catch-up completes. Set it always:
+      // getLeaderCommitIndex() returns -1 when the leader is not known yet,
+      // which isFollowerCaughtUp() treats as uncaptured and re-reads later.
       if (!isStateMachineReady.get()) {
-        long leaderCommit = getLeaderCommitIndex();
-        if (leaderCommit >= 0) {
-          leaderCommitIndexOnStart = leaderCommit;
-        }
+        leaderCommitIndexOnStart = getLeaderCommitIndex();
       }
       tryStartDNServerAndRefreshSafeMode();
       String message = "Leader changed to " + newLeaderId +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -439,7 +439,9 @@ public class SCMStateMachine extends BaseStateMachine {
         // commit index once here so we still compare against a fixed target.
         target = getLeaderCommitIndex();
         if (target < 0) {
-          LOG.warn("Leader commit index not available yet");
+          // Normal transient condition during startup/catch-up; this is polled
+          // from multiple callbacks, so keep it at DEBUG to avoid log flooding.
+          LOG.debug("Leader commit index not available yet");
           return false;
         }
         leaderCommitIndexOnStart = target;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -421,19 +421,20 @@ public class SCMStateMachine extends BaseStateMachine {
     if (isStateMachineReady.get() || dnServerStartExecutor != null) {
       return;
     }
-    dnServerStartExecutor = Executors.newSingleThreadScheduledExecutor(
+    final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder()
             .setNameFormat(scm.threadNamePrefix() + "SCMDNServerStartCheck-%d")
             .setDaemon(true)
             .build());
-    dnServerStartExecutor.scheduleWithFixedDelay(() -> {
+    dnServerStartExecutor = executor;
+    executor.scheduleWithFixedDelay(() -> {
       try {
         tryStartDNServerAndRefreshSafeMode();
       } catch (Throwable t) {
         LOG.warn("Error while checking catch-up for datanode server start", t);
       }
       if (isStateMachineReady.get()) {
-        dnServerStartExecutor.shutdown();
+        executor.shutdown();
       }
     }, 0, 1, TimeUnit.SECONDS);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -32,7 +32,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLog;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
@@ -88,22 +87,10 @@ public class SCMStateMachine extends BaseStateMachine {
 
   private AtomicBoolean isStateMachineReady = new AtomicBoolean();
 
-  // Separate guard for the deferred datanode protocol server start. Kept
-  // distinct from isStateMachineReady so that starting the server is decoupled
-  // from the StateMachineReadyRule safe-mode signal, which isStateMachineReady
-  // drives.
-  private AtomicBoolean dnServerStarted = new AtomicBoolean();
-
-  // The current leader's term, captured at each leader change. Used in
-  // notifyTermIndexUpdated to detect when a restarted SCM has replayed all of
-  // that term's pending transactions, so isStateMachineReady can be set.
-  private AtomicLong currentLeaderTerm = new AtomicLong(-1L);
-
   // The leader's committed index captured when this SCM (re)joins as a
-  // follower. Catch-up (for starting the datanode server) is measured against
-  // this fixed target rather than the leader's live commit index, which on a
-  // busy cluster keeps advancing and would never be reached. Set only until the
-  // datanode server has started; -1 means uncaptured.
+  // follower. Catch-up is measured against this fixed target rather than the
+  // leader's live commit index, which on a busy cluster keeps advancing and
+  // would never be reached. Set only while not yet ready; -1 means uncaptured.
   private volatile long leaderCommitIndexOnStart = -1L;
 
   public SCMStateMachine(final StorageContainerManager scm,
@@ -196,7 +183,7 @@ public class SCMStateMachine extends BaseStateMachine {
       // A restarted follower may catch up by applying data-carrying entries
       // here rather than through notifyTermIndexUpdated, so check for catch-up
       // in both places. No-op once the datanode protocol server has started.
-      tryStartDatanodeProtocolServer();
+      tryStartDNServerAndRefreshSafeMode();
     } catch (Exception ex) {
       applyTransactionFuture.completeExceptionally(ex);
       ExitUtils.terminate(1, ex.getMessage(), ex, StateMachine.LOG);
@@ -300,32 +287,20 @@ public class SCMStateMachine extends BaseStateMachine {
       return;
     }
 
-    currentLeaderTerm.set(scm.getScmHAManager().getRatisServer().getDivision()
-        .getInfo().getCurrentTerm());
-
-    if (isStateMachineReady.compareAndSet(false, true)) {
-      // refresh and validate safe mode rules if it can exit safe mode
-      // if being leader, all previous term transactions have been applied
-      // if other states, just refresh safe mode rules, and transaction keeps flushing from leader
-      // and does not depend on pending transactions.
-      scm.getScmSafeModeManager().refreshAndValidate();
-    }
-
     final boolean isLeader = groupMemberId.getPeerId().equals(newLeaderId);
 
     if (!isLeader) {
       // Follower: capture the leader's current committed index as the fixed
-      // catch-up target for starting the datanode protocol server (only until
-      // the server has started), then start it if we are already caught up;
-      // otherwise applyTransaction / notifyTermIndexUpdated start it as
-      // catch-up completes.
-      if (!dnServerStarted.get()) {
+      // catch-up target (only while not yet ready), then start the datanode
+      // protocol server if we are already caught up with it; otherwise
+      // applyTransaction / notifyTermIndexUpdated start it as catch-up completes.
+      if (!isStateMachineReady.get()) {
         long leaderCommit = getLeaderCommitIndex();
         if (leaderCommit >= 0) {
           leaderCommitIndexOnStart = leaderCommit;
         }
       }
-      tryStartDatanodeProtocolServer();
+      tryStartDNServerAndRefreshSafeMode();
       String message = "Leader changed to " + newLeaderId +
           ", current SCM " + scm.getScmId() + " is still follower.";
       LOG.info(message);
@@ -333,17 +308,19 @@ public class SCMStateMachine extends BaseStateMachine {
       return;
     }
 
+    long currentTerm = scm.getScmHAManager().getRatisServer().getDivision()
+        .getInfo().getCurrentTerm();
     String message = "current SCM " + scm.getScmId() +
-        " becomes leader of term " + currentLeaderTerm;
+        " becomes leader of term " + currentTerm;
     LOG.info(message);
     addRatisEvent(message);
 
-    scm.getScmContext().updateLeaderAndTerm(true, currentLeaderTerm.get());
+    scm.getScmContext().updateLeaderAndTerm(true, currentTerm);
     scm.getSequenceIdGen().invalidateBatch();
 
     // isLeader() is now true -> start the datanode protocol server for the new
-    // leader (a leader has applied all committed entries).
-    tryStartDatanodeProtocolServer();
+    // leader (a leader has applied all committed entries) and refresh safe mode.
+    tryStartDNServerAndRefreshSafeMode();
 
     try {
       transactionBuffer.flush();
@@ -419,42 +396,32 @@ public class SCMStateMachine extends BaseStateMachine {
       }
     }
 
-    if (currentLeaderTerm.get() == term) {
-      // This means after a restart, all pending transactions have been applied.
-      if (isStateMachineReady.compareAndSet(false, true)) {
-        // Refresh Safemode rules state if not already done.
-        scm.getScmSafeModeManager().refreshAndValidate();
-      }
-      currentLeaderTerm.set(-1L);
-    }
-
     // As committed entries are applied (e.g. a restarted follower catching up),
-    // start the datanode protocol server once caught up with the leader's
-    // committed index captured at (re)join. No-op once the server has started.
-    tryStartDatanodeProtocolServer();
+    // start the datanode protocol server once we are caught up with the leader's
+    // committed index. No-op once the server has already been started.
+    tryStartDNServerAndRefreshSafeMode();
   }
 
   /**
-   * Start the DatanodeProtocolServer exactly once, when this SCM is safe to
-   * accept datanode reports: it is the leader, or a follower whose state machine
-   * has caught up with the leader's committed index captured at (re)join.
-   * Guarded by {@code dnServerStarted} (CAS) so the non-idempotent
+   * Start the DatanodeProtocolServer and re-evaluate safe-mode rules, but only
+   * when this SCM is safe to accept datanode reports: it is the leader, or it
+   * is a follower whose state machine has caught up with the leader's committed
+   * log. Guarded by {@code isStateMachineReady} (CAS) so the non-idempotent
    * {@code DatanodeProtocolServer.start()} runs exactly once.
    *
    * <p>In HA mode {@link StorageContainerManager#start()} deliberately does not
    * start the datanode protocol server; it is deferred to here so datanode
    * container reports are processed against the up-to-date container/pipeline
-   * state rather than a stale, mid-replay snapshot. This is intentionally
-   * independent of {@code isStateMachineReady}, which drives the
-   * StateMachineReadyRule safe-mode rule.
+   * state rather than a stale, mid-replay snapshot.
    */
-  private void tryStartDatanodeProtocolServer() {
-    if (dnServerStarted.get()) {
+  private void tryStartDNServerAndRefreshSafeMode() {
+    if (isStateMachineReady.get()) {
       return;
     }
     if (scm.getScmContext().isLeader() || isFollowerCaughtUp()) {
-      if (dnServerStarted.compareAndSet(false, true)) {
+      if (isStateMachineReady.compareAndSet(false, true)) {
         scm.getDatanodeProtocolServer().start();
+        scm.getScmSafeModeManager().refreshAndValidate();
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
@@ -94,12 +92,6 @@ public class SCMStateMachine extends BaseStateMachine {
   // leader's live commit index, which on a busy cluster keeps advancing and
   // would never be reached. Set only while not yet ready; -1 means uncaptured.
   private volatile long leaderCommitIndexOnStart = -1L;
-
-  // Re-checks catch-up until the datanode protocol server is started, so a
-  // restarted follower on an otherwise idle cluster (no applyTransaction /
-  // notifyTermIndexUpdated callbacks to re-drive the check) still starts its DN
-  // server and exits safe mode. Self-terminates once the server has started.
-  private ScheduledExecutorService dnServerStartExecutor;
 
   public SCMStateMachine(final StorageContainerManager scm,
       SCMHADBTransactionBuffer buffer) {
@@ -183,6 +175,12 @@ public class SCMStateMachine extends BaseStateMachine {
         // Otherwise, it's considered as a logical rejection and is returned to
         // Ratis client, leaving SCM intact.
         applyTransactionFuture.completeExceptionally(ex);
+      }
+
+      // After previous term transactions are applied, still in safe mode,
+      // perform refreshAndValidate to update the safemode rule state.
+      if (scm.isInSafeMode() && isStateMachineReady.get()) {
+        scm.getScmSafeModeManager().refreshAndValidate();
       }
       final TermIndex appliedTermIndex = TermIndex.valueOf(trx.getLogEntry());
       transactionBuffer.updateLatestTrxInfo(TransactionInfo.valueOf(appliedTermIndex));
@@ -307,7 +305,7 @@ public class SCMStateMachine extends BaseStateMachine {
       if (!isStateMachineReady.get()) {
         leaderCommitIndexOnStart = getLeaderCommitIndex();
       }
-      scheduleDNServerStartCheck();
+      tryStartDNServerAndRefreshSafeMode();
       String message = "Leader changed to " + newLeaderId +
           ", current SCM " + scm.getScmId() + " is still follower.";
       LOG.info(message);
@@ -410,35 +408,17 @@ public class SCMStateMachine extends BaseStateMachine {
   }
 
   /**
-   * Periodically re-evaluate catch-up and start the datanode protocol server
-   * once ready. This is required because on an idle cluster a restarted follower
-   * may get no further applyTransaction / notifyTermIndexUpdated callbacks to
-   * re-drive {@link #tryStartDNServerAndRefreshSafeMode()} after the single
-   * notifyLeaderChanged, so without this it could stay in safe mode forever. The
-   * task stops itself once the server has been started.
+   * Start the DatanodeProtocolServer and re-evaluate safe-mode rules, but only
+   * when this SCM is safe to accept datanode reports: it is the leader, or it
+   * is a follower whose state machine has caught up with the leader's committed
+   * log. Guarded by {@code isStateMachineReady} (CAS) so the non-idempotent
+   * {@code DatanodeProtocolServer.start()} runs exactly once.
+   *
+   * <p>In HA mode {@link StorageContainerManager#start()} deliberately does not
+   * start the datanode protocol server; it is deferred to here so datanode
+   * container reports are processed against the up-to-date container/pipeline
+   * state rather than a stale, mid-replay snapshot.
    */
-  private synchronized void scheduleDNServerStartCheck() {
-    if (isStateMachineReady.get() || dnServerStartExecutor != null) {
-      return;
-    }
-    final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
-        new ThreadFactoryBuilder()
-            .setNameFormat(scm.threadNamePrefix() + "SCMDNServerStartCheck-%d")
-            .setDaemon(true)
-            .build());
-    dnServerStartExecutor = executor;
-    executor.scheduleWithFixedDelay(() -> {
-      try {
-        tryStartDNServerAndRefreshSafeMode();
-      } catch (Throwable t) {
-        LOG.warn("Error while checking catch-up for datanode server start", t);
-      }
-      if (isStateMachineReady.get()) {
-        executor.shutdown();
-      }
-    }, 0, 1, TimeUnit.SECONDS);
-  }
-
   private void tryStartDNServerAndRefreshSafeMode() {
     if (isStateMachineReady.get()) {
       return;
@@ -465,6 +445,8 @@ public class SCMStateMachine extends BaseStateMachine {
         // commit index once here so we still compare against a fixed target.
         target = getLeaderCommitIndex();
         if (target < 0) {
+          // Normal transient condition during startup/catch-up; this is polled
+          // from multiple callbacks, so keep it at DEBUG to avoid log flooding.
           LOG.debug("Leader commit index not available yet");
           return false;
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
@@ -92,6 +94,12 @@ public class SCMStateMachine extends BaseStateMachine {
   // leader's live commit index, which on a busy cluster keeps advancing and
   // would never be reached. Set only while not yet ready; -1 means uncaptured.
   private volatile long leaderCommitIndexOnStart = -1L;
+
+  // Re-checks catch-up until the datanode protocol server is started, so a
+  // restarted follower on an otherwise idle cluster (no applyTransaction /
+  // notifyTermIndexUpdated callbacks to re-drive the check) still starts its DN
+  // server and exits safe mode. Self-terminates once the server has started.
+  private ScheduledExecutorService dnServerStartExecutor;
 
   public SCMStateMachine(final StorageContainerManager scm,
       SCMHADBTransactionBuffer buffer) {
@@ -299,7 +307,7 @@ public class SCMStateMachine extends BaseStateMachine {
       if (!isStateMachineReady.get()) {
         leaderCommitIndexOnStart = getLeaderCommitIndex();
       }
-      tryStartDNServerAndRefreshSafeMode();
+      scheduleDNServerStartCheck();
       String message = "Leader changed to " + newLeaderId +
           ", current SCM " + scm.getScmId() + " is still follower.";
       LOG.info(message);
@@ -402,17 +410,34 @@ public class SCMStateMachine extends BaseStateMachine {
   }
 
   /**
-   * Start the DatanodeProtocolServer and re-evaluate safe-mode rules, but only
-   * when this SCM is safe to accept datanode reports: it is the leader, or it
-   * is a follower whose state machine has caught up with the leader's committed
-   * log. Guarded by {@code isStateMachineReady} (CAS) so the non-idempotent
-   * {@code DatanodeProtocolServer.start()} runs exactly once.
-   *
-   * <p>In HA mode {@link StorageContainerManager#start()} deliberately does not
-   * start the datanode protocol server; it is deferred to here so datanode
-   * container reports are processed against the up-to-date container/pipeline
-   * state rather than a stale, mid-replay snapshot.
+   * Periodically re-evaluate catch-up and start the datanode protocol server
+   * once ready. This is required because on an idle cluster a restarted follower
+   * may get no further applyTransaction / notifyTermIndexUpdated callbacks to
+   * re-drive {@link #tryStartDNServerAndRefreshSafeMode()} after the single
+   * notifyLeaderChanged, so without this it could stay in safe mode forever. The
+   * task stops itself once the server has been started.
    */
+  private synchronized void scheduleDNServerStartCheck() {
+    if (isStateMachineReady.get() || dnServerStartExecutor != null) {
+      return;
+    }
+    dnServerStartExecutor = Executors.newSingleThreadScheduledExecutor(
+        new ThreadFactoryBuilder()
+            .setNameFormat(scm.threadNamePrefix() + "SCMDNServerStartCheck-%d")
+            .setDaemon(true)
+            .build());
+    dnServerStartExecutor.scheduleWithFixedDelay(() -> {
+      try {
+        tryStartDNServerAndRefreshSafeMode();
+      } catch (Throwable t) {
+        LOG.warn("Error while checking catch-up for datanode server start", t);
+      }
+      if (isStateMachineReady.get()) {
+        dnServerStartExecutor.shutdown();
+      }
+    }, 0, 1, TimeUnit.SECONDS);
+  }
+
   private void tryStartDNServerAndRefreshSafeMode() {
     if (isStateMachineReady.get()) {
       return;
@@ -439,8 +464,6 @@ public class SCMStateMachine extends BaseStateMachine {
         // commit index once here so we still compare against a fixed target.
         target = getLeaderCommitIndex();
         if (target < 0) {
-          // Normal transient condition during startup/catch-up; this is polled
-          // from multiple callbacks, so keep it at DEBUG to avoid log flooding.
           LOG.debug("Leader commit index not available yet");
           return false;
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -50,7 +50,6 @@ import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
-import org.apache.ratis.server.DivisionInfo;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
@@ -87,6 +86,12 @@ public class SCMStateMachine extends BaseStateMachine {
   private List<ManagedSecretKey> installingSecretKeys = null;
 
   private AtomicBoolean isStateMachineReady = new AtomicBoolean();
+
+  // The leader's committed index captured when this SCM (re)joins as a
+  // follower. Catch-up is measured against this fixed target rather than the
+  // leader's live commit index, which on a busy cluster keeps advancing and
+  // would never be reached. Set only while not yet ready; -1 means uncaptured.
+  private volatile long leaderCommitIndexOnStart = -1L;
 
   public SCMStateMachine(final StorageContainerManager scm,
       SCMHADBTransactionBuffer buffer) {
@@ -174,6 +179,11 @@ public class SCMStateMachine extends BaseStateMachine {
       final TermIndex appliedTermIndex = TermIndex.valueOf(trx.getLogEntry());
       transactionBuffer.updateLatestTrxInfo(TransactionInfo.valueOf(appliedTermIndex));
       updateLastAppliedTermIndex(appliedTermIndex);
+
+      // A restarted follower may catch up by applying data-carrying entries
+      // here rather than through notifyTermIndexUpdated, so check for catch-up
+      // in both places. No-op once the datanode protocol server has started.
+      tryStartDNServerAndRefreshSafeMode();
     } catch (Exception ex) {
       applyTransactionFuture.completeExceptionally(ex);
       ExitUtils.terminate(1, ex.getMessage(), ex, StateMachine.LOG);
@@ -280,9 +290,16 @@ public class SCMStateMachine extends BaseStateMachine {
     final boolean isLeader = groupMemberId.getPeerId().equals(newLeaderId);
 
     if (!isLeader) {
-      // Follower: start the datanode protocol server if we are already caught
-      // up with the leader's committed log; otherwise notifyTermIndexUpdated
-      // starts it as catch-up completes.
+      // Follower: capture the leader's current committed index as the fixed
+      // catch-up target (only while not yet ready), then start the datanode
+      // protocol server if we are already caught up with it; otherwise
+      // applyTransaction / notifyTermIndexUpdated start it as catch-up completes.
+      if (!isStateMachineReady.get()) {
+        long leaderCommit = getLeaderCommitIndex();
+        if (leaderCommit >= 0) {
+          leaderCommitIndexOnStart = leaderCommit;
+        }
+      }
       tryStartDNServerAndRefreshSafeMode();
       String message = "Leader changed to " + newLeaderId +
           ", current SCM " + scm.getScmId() + " is still follower.";
@@ -411,38 +428,57 @@ public class SCMStateMachine extends BaseStateMachine {
 
   /**
    * @return true if this follower's last applied index has reached the leader's
-   * committed index, i.e. all committed transactions have been replayed.
+   * committed index captured when it (re)joined, i.e. all transactions the
+   * leader had committed at that point have been replayed. Comparing against a
+   * fixed target avoids chasing the leader's ever-advancing live commit index.
    */
   private boolean isFollowerCaughtUp() {
     try {
-      RaftServer.Division division = scm.getScmHAManager()
-          .getRatisServer().getDivision();
-      DivisionInfo divisionInfo = division.getInfo();
-      long lastAppliedIndex = divisionInfo.getLastAppliedIndex();
-
-      RaftPeerId leaderId = divisionInfo.getLeaderId();
-      if (leaderId != null) {
-        for (RaftProtos.CommitInfoProto info : division.getCommitInfos()) {
-          if (info.getServer().getId().equals(leaderId.toByteString())) {
-            long leaderCommit = info.getCommitIndex();
-            boolean caughtUp = lastAppliedIndex >= leaderCommit;
-            if (caughtUp) {
-              LOG.info("Follower caught up with leader: lastAppliedIndex={}, leaderCommit={}",
-                  lastAppliedIndex, leaderCommit);
-            } else {
-              LOG.debug("Follower not caught up: lastAppliedIndex={}, leaderCommit={}",
-                  lastAppliedIndex, leaderCommit);
-            }
-            return caughtUp;
-          }
+      long target = leaderCommitIndexOnStart;
+      if (target < 0) {
+        // Not captured at leader-change time yet; capture the leader's current
+        // commit index once here so we still compare against a fixed target.
+        target = getLeaderCommitIndex();
+        if (target < 0) {
+          LOG.warn("Leader commit index not available yet");
+          return false;
         }
+        leaderCommitIndexOnStart = target;
       }
-      LOG.warn("Leader commit index not available yet, leaderId={}", leaderId);
-      return false;
+
+      long lastAppliedIndex = scm.getScmHAManager().getRatisServer()
+          .getDivision().getInfo().getLastAppliedIndex();
+      boolean caughtUp = lastAppliedIndex >= target;
+      if (caughtUp) {
+        LOG.info("Follower caught up with leader: lastAppliedIndex={}, leaderCommitOnStart={}",
+            lastAppliedIndex, target);
+      } else {
+        LOG.debug("Follower not caught up: lastAppliedIndex={}, leaderCommitOnStart={}",
+            lastAppliedIndex, target);
+      }
+      return caughtUp;
     } catch (Exception e) {
       LOG.warn("Failed to check follower catch-up status", e);
       return false;
     }
+  }
+
+  /**
+   * @return the leader's current committed index as seen by this SCM, or -1 if
+   * the leader or its commit info is not available yet.
+   */
+  private long getLeaderCommitIndex() {
+    RaftServer.Division division = scm.getScmHAManager()
+        .getRatisServer().getDivision();
+    RaftPeerId leaderId = division.getInfo().getLeaderId();
+    if (leaderId != null) {
+      for (RaftProtos.CommitInfoProto info : division.getCommitInfos()) {
+        if (info.getServer().getId().equals(leaderId.toByteString())) {
+          return info.getCommitIndex();
+        }
+      }
+    }
+    return -1L;
   }
 
   public boolean getIsStateMachineReady() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -177,11 +177,6 @@ public class SCMStateMachine extends BaseStateMachine {
         applyTransactionFuture.completeExceptionally(ex);
       }
 
-      // After previous term transactions are applied, still in safe mode,
-      // perform refreshAndValidate to update the safemode rule state.
-      if (scm.isInSafeMode() && isStateMachineReady.get()) {
-        scm.getScmSafeModeManager().refreshAndValidate();
-      }
       final TermIndex appliedTermIndex = TermIndex.valueOf(trx.getLogEntry());
       transactionBuffer.updateLatestTrxInfo(TransactionInfo.valueOf(appliedTermIndex));
       updateLastAppliedTermIndex(appliedTermIndex);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1585,8 +1585,13 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     }
     getBlockProtocolServer().start();
 
-    // start datanode protocol server
-    getDatanodeProtocolServer().start();
+    // In HA mode, defer starting the datanode protocol server until the SCM
+    // state machine has caught up with the leader's committed log entries
+    // (see SCMStateMachine#tryStartDNServerAndRefreshSafeMode). In non-HA mode
+    // there is no Ratis state machine, so start it here as before.
+    if (!scmStorageConfig.isSCMHAEnabled()) {
+      getDatanodeProtocolServer().start();
+    }
     if (getSecurityProtocolServer() != null) {
       getSecurityProtocolServer().start();
       persistSCMCertificates();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMFollowerCatchupWithContainerReport.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMFollowerCatchupWithContainerReport.java
@@ -44,8 +44,8 @@ import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -81,19 +81,24 @@ public class TestSCMFollowerCatchupWithContainerReport {
   private static final int NUM_OF_SCMS = 3;
   private static final int NUM_OF_DNS = 3;
   private static final int NUM_KEYS = 5;
-  private static final String VOLUME = "testvol";
-  private static final String BUCKET = "testbucket";
 
-  private MiniOzoneHAClusterImpl cluster;
+  // One cluster is shared by all tests in this class (built once in @BeforeAll).
+  // Each test uses its own volume/bucket and re-discovers leader/follower, so the
+  // restart + leadership-transfer each test performs leaves the cluster healthy
+  // for the next one.
+  private static MiniOzoneHAClusterImpl cluster;
 
-  @BeforeEach
-  void init() throws Exception {
+  @BeforeAll
+  static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     // Keep the full container report interval long so a replica dropped during
     // catch-up is not silently re-reported within the test window. This makes
     // the regression deterministic: only the deferred-start path can repopulate
     // replicas in time.
     conf.setTimeDuration("hdds.container.report.interval", 5, TimeUnit.MINUTES);
+    // Fast datanode heartbeats so safe-mode exit at startup and replica
+    // re-reporting after the deferred DN-server start happen within ~1s.
+    conf.setTimeDuration("hdds.heartbeat.interval", 1, TimeUnit.SECONDS);
     cluster = MiniOzoneCluster.newHABuilder(conf)
         .setOMServiceId(OM_SERVICE_ID)
         .setSCMServiceId(SCM_SERVICE_ID)
@@ -104,8 +109,8 @@ public class TestSCMFollowerCatchupWithContainerReport {
     cluster.waitForClusterToBeReady();
   }
 
-  @AfterEach
-  void shutdown() {
+  @AfterAll
+  static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -118,8 +123,10 @@ public class TestSCMFollowerCatchupWithContainerReport {
    */
   @Test
   void testFollowerCatchupAfterContainerClose() throws Exception {
+    String vol = "vol-close";
+    String buck = "buck-close";
     byte[] keyData = "value-of-key".getBytes(UTF_8);
-    Set<Long> containerIds = createKeys(keyData);
+    Set<Long> containerIds = createKeys(vol, buck, keyData);
     assertFalse(containerIds.isEmpty(), "Should have created containers");
 
     StorageContainerManager followerScm = null;
@@ -142,11 +149,11 @@ public class TestSCMFollowerCatchupWithContainerReport {
 
     StorageContainerManager newFollower =
         cluster.restartStorageContainerManager(followerScm, false);
-    GenericTestUtils.waitFor(() -> !newFollower.isInSafeMode(), 1000, 120_000);
+    GenericTestUtils.waitFor(() -> !newFollower.isInSafeMode(), 250, 120_000);
 
     cluster.getStorageContainerLocationClient()
         .transferLeadership(newFollower.getScmId());
-    GenericTestUtils.waitFor(newFollower::checkLeader, 1000, 60_000);
+    GenericTestUtils.waitFor(newFollower::checkLeader, 250, 60_000);
 
     for (long cid : containerIds) {
       ContainerID id = ContainerID.valueOf(cid);
@@ -158,7 +165,7 @@ public class TestSCMFollowerCatchupWithContainerReport {
           newFollower.getContainerManager().getContainerReplicas(id).size(),
           "Container " + cid + " should have " + NUM_OF_DNS + " replicas");
     }
-    assertKeysReadable(keyData);
+    assertKeysReadable(vol, buck, keyData);
   }
 
   /**
@@ -183,20 +190,22 @@ public class TestSCMFollowerCatchupWithContainerReport {
     followerScm.join();
 
     // ---- Step 3: create keys -> new containers created while follower offline.
+    String vol = "vol-create";
+    String buck = "buck-create";
     byte[] keyData = "value-of-key".getBytes(UTF_8);
-    Set<Long> containerIds = createKeys(keyData);
+    Set<Long> containerIds = createKeys(vol, buck, keyData);
     assertFalse(containerIds.isEmpty(), "Should have created containers");
 
     // ---- Step 4: restart the follower and wait for safe-mode exit ----
     StorageContainerManager newFollower =
         cluster.restartStorageContainerManager(followerScm, false);
     BooleanSupplier safeModeExited = () -> !newFollower.isInSafeMode();
-    GenericTestUtils.waitFor(safeModeExited, 1000, 120_000);
+    GenericTestUtils.waitFor(safeModeExited, 250, 120_000);
 
     // ---- Step 5: transfer leadership to the restarted follower ----
     cluster.getStorageContainerLocationClient()
         .transferLeadership(newFollower.getScmId());
-    GenericTestUtils.waitFor(newFollower::checkLeader, 1000, 60_000);
+    GenericTestUtils.waitFor(newFollower::checkLeader, 250, 60_000);
     LOG.info("Leadership transferred to {}", newFollower.getScmId());
 
     // ---- Step 6: every container must have a full replica set on the new
@@ -210,7 +219,7 @@ public class TestSCMFollowerCatchupWithContainerReport {
     }
 
     // ---- Step 7: every key must still be readable ----
-    assertKeysReadable(keyData);
+    assertKeysReadable(vol, buck, keyData);
   }
 
   /**
@@ -221,8 +230,10 @@ public class TestSCMFollowerCatchupWithContainerReport {
    */
   @Test
   void testFollowerCatchupOnIdleCluster() throws Exception {
+    String vol = "vol-idle";
+    String buck = "buck-idle";
     byte[] keyData = "value-of-key".getBytes(UTF_8);
-    Set<Long> containerIds = createKeys(keyData);
+    Set<Long> containerIds = createKeys(vol, buck, keyData);
     assertFalse(containerIds.isEmpty(), "Should have created containers");
 
     StorageContainerManager followerScm = null;
@@ -241,11 +252,11 @@ public class TestSCMFollowerCatchupWithContainerReport {
         cluster.restartStorageContainerManager(followerScm, false);
     // Must still exit safe mode (i.e. the datanode server started) without any
     // new transactions to apply.
-    GenericTestUtils.waitFor(() -> !newFollower.isInSafeMode(), 1000, 120_000);
+    GenericTestUtils.waitFor(() -> !newFollower.isInSafeMode(), 250, 120_000);
 
     cluster.getStorageContainerLocationClient()
         .transferLeadership(newFollower.getScmId());
-    GenericTestUtils.waitFor(newFollower::checkLeader, 1000, 60_000);
+    GenericTestUtils.waitFor(newFollower::checkLeader, 250, 60_000);
 
     for (long cid : containerIds) {
       ContainerID id = ContainerID.valueOf(cid);
@@ -254,17 +265,18 @@ public class TestSCMFollowerCatchupWithContainerReport {
           newFollower.getContainerManager().getContainerReplicas(id).size(),
           "Container " + cid + " should have " + NUM_OF_DNS + " replicas");
     }
-    assertKeysReadable(keyData);
+    assertKeysReadable(vol, buck, keyData);
   }
 
-  private Set<Long> createKeys(byte[] keyData) throws IOException {
+  private Set<Long> createKeys(String volumeName, String bucketName, byte[] keyData)
+      throws IOException {
     Set<Long> containerIds = new LinkedHashSet<>();
     try (OzoneClient client = cluster.newClient()) {
       ObjectStore store = client.getObjectStore();
-      store.createVolume(VOLUME);
-      OzoneVolume volume = store.getVolume(VOLUME);
-      volume.createBucket(BUCKET);
-      OzoneBucket bucket = volume.getBucket(BUCKET);
+      store.createVolume(volumeName);
+      OzoneVolume volume = store.getVolume(volumeName);
+      volume.createBucket(bucketName);
+      OzoneBucket bucket = volume.getBucket(bucketName);
 
       for (int i = 0; i < NUM_KEYS; i++) {
         String keyName = "key-" + i;
@@ -278,10 +290,11 @@ public class TestSCMFollowerCatchupWithContainerReport {
     return containerIds;
   }
 
-  private void assertKeysReadable(byte[] keyData) throws IOException {
+  private void assertKeysReadable(String volumeName, String bucketName, byte[] keyData)
+      throws IOException {
     try (OzoneClient client = cluster.newClient()) {
       ObjectStore store = client.getObjectStore();
-      OzoneBucket bucket = store.getVolume(VOLUME).getBucket(BUCKET);
+      OzoneBucket bucket = store.getVolume(volumeName).getBucket(bucketName);
       for (int i = 0; i < NUM_KEYS; i++) {
         String keyName = "key-" + i;
         try (OzoneInputStream is = bucket.readKey(keyName)) {
@@ -304,7 +317,7 @@ public class TestSCMFollowerCatchupWithContainerReport {
       } catch (Exception e) {
         return false;
       }
-    }, 1000, 120_000);
+    }, 250, 120_000);
   }
 
   private static void waitForReplicaCount(
@@ -318,6 +331,6 @@ public class TestSCMFollowerCatchupWithContainerReport {
         return false;
       }
     };
-    GenericTestUtils.waitFor(check, 1000, 120_000);
+    GenericTestUtils.waitFor(check, 250, 120_000);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMFollowerCatchupWithContainerReport.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMFollowerCatchupWithContainerReport.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verifies that a follower SCM correctly rebuilds container replica locations
+ * for containers that were <em>created</em> while it was offline. After the
+ * follower restarts, catches up its Ratis log, and is promoted to leader, all
+ * such containers must still have the expected replica count and all keys must
+ * be readable.
+ *
+ * <p>This is the create-while-down counterpart of
+ * {@code TestSCMFollowerCatchupWithContainerClose} (HDDS-14989). It exercises
+ * the deferred datanode-server start: the restarted follower must finish Raft
+ * log replay <em>before</em> accepting datanode container reports, otherwise a
+ * report for a not-yet-replayed container is dropped with CONTAINER_NOT_FOUND
+ * and the replica location is lost until the next full container report.
+ *
+ * <p>The container report interval is set high so that, without the fix, the
+ * dropped replicas are not re-reported within the test window and the
+ * assertions fail; with the fix the datanode server is deferred until catch-up,
+ * datanodes (re)register against the up-to-date state, and replicas are
+ * recorded immediately.
+ */
+@Timeout(300)
+public class TestSCMFollowerCatchupWithContainerReport {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestSCMFollowerCatchupWithContainerReport.class);
+
+  private static final String OM_SERVICE_ID = "om-service-test1";
+  private static final String SCM_SERVICE_ID = "scm-service-test1";
+  private static final int NUM_OF_SCMS = 3;
+  private static final int NUM_OF_DNS = 3;
+  private static final int NUM_KEYS = 5;
+  private static final String VOLUME = "testvol";
+  private static final String BUCKET = "testbucket";
+
+  private MiniOzoneHAClusterImpl cluster;
+
+  @BeforeEach
+  void init() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    // Keep the full container report interval long so a replica dropped during
+    // catch-up is not silently re-reported within the test window. This makes
+    // the regression deterministic: only the deferred-start path can repopulate
+    // replicas in time.
+    conf.setTimeDuration("hdds.container.report.interval", 5, TimeUnit.MINUTES);
+    cluster = MiniOzoneCluster.newHABuilder(conf)
+        .setOMServiceId(OM_SERVICE_ID)
+        .setSCMServiceId(SCM_SERVICE_ID)
+        .setNumOfOzoneManagers(1)
+        .setNumOfStorageContainerManagers(NUM_OF_SCMS)
+        .setNumOfActiveSCMs(NUM_OF_SCMS)
+        .build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @AfterEach
+  void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  /**
+   * HDDS-14989 scenario: containers are closed while a follower SCM is offline.
+   * After the follower restarts and is promoted to leader, each container must
+   * be CLOSED with a full replica set and all keys must remain readable.
+   */
+  @Test
+  void testFollowerCatchupAfterContainerClose() throws Exception {
+    byte[] keyData = "value-of-key".getBytes(UTF_8);
+    Set<Long> containerIds = createKeys(keyData);
+    assertFalse(containerIds.isEmpty(), "Should have created containers");
+
+    StorageContainerManager followerScm = null;
+    for (StorageContainerManager scm : cluster.getStorageContainerManagers()) {
+      if (!scm.checkLeader() && followerScm == null) {
+        followerScm = scm;
+      }
+    }
+    assertFalse(followerScm == null, "Expected to find a follower SCM");
+
+    cluster.shutdownStorageContainerManager(followerScm);
+    followerScm.join();
+
+    for (long cid : containerIds) {
+      cluster.getStorageContainerLocationClient().closeContainer(cid);
+    }
+    for (long cid : containerIds) {
+      waitForContainerState(cluster.getActiveSCM(), ContainerID.valueOf(cid), CLOSED);
+    }
+
+    StorageContainerManager newFollower =
+        cluster.restartStorageContainerManager(followerScm, false);
+    GenericTestUtils.waitFor(() -> !newFollower.isInSafeMode(), 1000, 120_000);
+
+    cluster.getStorageContainerLocationClient()
+        .transferLeadership(newFollower.getScmId());
+    GenericTestUtils.waitFor(newFollower::checkLeader, 1000, 60_000);
+
+    for (long cid : containerIds) {
+      ContainerID id = ContainerID.valueOf(cid);
+      assertEquals(CLOSED,
+          newFollower.getContainerManager().getContainer(id).getState(),
+          "Container " + cid + " should be CLOSED");
+      waitForReplicaCount(newFollower, id, NUM_OF_DNS);
+      assertEquals(NUM_OF_DNS,
+          newFollower.getContainerManager().getContainerReplicas(id).size(),
+          "Container " + cid + " should have " + NUM_OF_DNS + " replicas");
+    }
+    assertKeysReadable(keyData);
+  }
+
+  /**
+   * Reproduces the production failure: containers are created while a follower
+   * SCM is offline. After the follower restarts and is promoted to leader, the
+   * containers must have full replica sets (not an empty replica list).
+   */
+  @Test
+  void testFollowerCatchupAfterContainerCreate() throws Exception {
+    // ---- Step 1: pick a leader and a follower ----
+    StorageContainerManager followerScm = null;
+    for (StorageContainerManager scm : cluster.getStorageContainerManagers()) {
+      if (!scm.checkLeader() && followerScm == null) {
+        followerScm = scm;
+      }
+    }
+    assertFalse(followerScm == null, "Expected to find a follower SCM");
+
+    // ---- Step 2: stop the follower BEFORE creating containers, so it misses
+    //              the container-create transactions entirely ----
+    cluster.shutdownStorageContainerManager(followerScm);
+    followerScm.join();
+
+    // ---- Step 3: create keys -> new containers created while follower offline.
+    byte[] keyData = "value-of-key".getBytes(UTF_8);
+    Set<Long> containerIds = createKeys(keyData);
+    assertFalse(containerIds.isEmpty(), "Should have created containers");
+
+    // ---- Step 4: restart the follower and wait for safe-mode exit ----
+    StorageContainerManager newFollower =
+        cluster.restartStorageContainerManager(followerScm, false);
+    BooleanSupplier safeModeExited = () -> !newFollower.isInSafeMode();
+    GenericTestUtils.waitFor(safeModeExited, 1000, 120_000);
+
+    // ---- Step 5: transfer leadership to the restarted follower ----
+    cluster.getStorageContainerLocationClient()
+        .transferLeadership(newFollower.getScmId());
+    GenericTestUtils.waitFor(newFollower::checkLeader, 1000, 60_000);
+    LOG.info("Leadership transferred to {}", newFollower.getScmId());
+
+    // ---- Step 6: every container must have a full replica set on the new
+    //              leader (the bug shows replicas == 0) ----
+    for (long cid : containerIds) {
+      ContainerID id = ContainerID.valueOf(cid);
+      waitForReplicaCount(newFollower, id, NUM_OF_DNS);
+      assertEquals(NUM_OF_DNS,
+          newFollower.getContainerManager().getContainerReplicas(id).size(),
+          "Container " + cid + " should have " + NUM_OF_DNS + " replicas");
+    }
+
+    // ---- Step 7: every key must still be readable ----
+    assertKeysReadable(keyData);
+  }
+
+  /**
+   * Edge case for removing the background polling loop: on an otherwise idle
+   * cluster a restarted follower must still start its datanode server (exit safe
+   * mode) and serve replicas after promotion, driven by Ratis heartbeats /
+   * notifyLeaderChanged rather than a steady stream of new transactions.
+   */
+  @Test
+  void testFollowerCatchupOnIdleCluster() throws Exception {
+    byte[] keyData = "value-of-key".getBytes(UTF_8);
+    Set<Long> containerIds = createKeys(keyData);
+    assertFalse(containerIds.isEmpty(), "Should have created containers");
+
+    StorageContainerManager followerScm = null;
+    for (StorageContainerManager scm : cluster.getStorageContainerManagers()) {
+      if (!scm.checkLeader() && followerScm == null) {
+        followerScm = scm;
+      }
+    }
+    assertFalse(followerScm == null, "Expected to find a follower SCM");
+
+    // Stop the follower, then do NO further writes (idle cluster).
+    cluster.shutdownStorageContainerManager(followerScm);
+    followerScm.join();
+
+    StorageContainerManager newFollower =
+        cluster.restartStorageContainerManager(followerScm, false);
+    // Must still exit safe mode (i.e. the datanode server started) without any
+    // new transactions to apply.
+    GenericTestUtils.waitFor(() -> !newFollower.isInSafeMode(), 1000, 120_000);
+
+    cluster.getStorageContainerLocationClient()
+        .transferLeadership(newFollower.getScmId());
+    GenericTestUtils.waitFor(newFollower::checkLeader, 1000, 60_000);
+
+    for (long cid : containerIds) {
+      ContainerID id = ContainerID.valueOf(cid);
+      waitForReplicaCount(newFollower, id, NUM_OF_DNS);
+      assertEquals(NUM_OF_DNS,
+          newFollower.getContainerManager().getContainerReplicas(id).size(),
+          "Container " + cid + " should have " + NUM_OF_DNS + " replicas");
+    }
+    assertKeysReadable(keyData);
+  }
+
+  private Set<Long> createKeys(byte[] keyData) throws IOException {
+    Set<Long> containerIds = new LinkedHashSet<>();
+    try (OzoneClient client = cluster.newClient()) {
+      ObjectStore store = client.getObjectStore();
+      store.createVolume(VOLUME);
+      OzoneVolume volume = store.getVolume(VOLUME);
+      volume.createBucket(BUCKET);
+      OzoneBucket bucket = volume.getBucket(BUCKET);
+
+      for (int i = 0; i < NUM_KEYS; i++) {
+        String keyName = "key-" + i;
+        TestDataUtil.createKey(bucket, keyName,
+            RatisReplicationConfig.getInstance(THREE), keyData);
+        OzoneKeyDetails keyDetails = bucket.getKey(keyName);
+        keyDetails.getOzoneKeyLocations()
+            .forEach(loc -> containerIds.add(loc.getContainerID()));
+      }
+    }
+    return containerIds;
+  }
+
+  private void assertKeysReadable(byte[] keyData) throws IOException {
+    try (OzoneClient client = cluster.newClient()) {
+      ObjectStore store = client.getObjectStore();
+      OzoneBucket bucket = store.getVolume(VOLUME).getBucket(BUCKET);
+      for (int i = 0; i < NUM_KEYS; i++) {
+        String keyName = "key-" + i;
+        try (OzoneInputStream is = bucket.readKey(keyName)) {
+          byte[] readData = new byte[keyData.length];
+          int bytesRead = is.read(readData);
+          assertEquals(keyData.length, bytesRead);
+          assertArrayEquals(keyData, readData);
+        }
+      }
+    }
+  }
+
+  private static void waitForContainerState(
+      StorageContainerManager scm, ContainerID id, LifeCycleState expectedState)
+      throws Exception {
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return scm.getContainerManager().getContainer(id).getState()
+            == expectedState;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 1000, 120_000);
+  }
+
+  private static void waitForReplicaCount(
+      StorageContainerManager scm, ContainerID id, int expectedCount)
+      throws Exception {
+    BooleanSupplier check = () -> {
+      try {
+        return scm.getContainerManager().getContainerReplicas(id).size()
+            == expectedCount;
+      } catch (Exception e) {
+        return false;
+      }
+    };
+    GenericTestUtils.waitFor(check, 1000, 120_000);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMFollowerCatchupWithContainerReport.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMFollowerCatchupWithContainerReport.java
@@ -58,8 +58,8 @@ import org.slf4j.LoggerFactory;
  * such containers must still have the expected replica count and all keys must
  * be readable.
  *
- * <p>This is the create-while-down counterpart of
- * {@code TestSCMFollowerCatchupWithContainerClose} (HDDS-14989). It exercises
+ * <p>This class covers the create-while-down, close-while-down, and
+ * idle-cluster scenarios for HDDS-14989. It exercises
  * the deferred datanode-server start: the restarted follower must finish Raft
  * log replay <em>before</em> accepting datanode container reports, otherwise a
  * report for a not-yet-replayed container is dropped with CONTAINER_NOT_FOUND

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSafeModeSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSafeModeSCMHA.java
@@ -91,9 +91,23 @@ public class TestSafeModeSCMHA {
     GenericTestUtils.waitFor(() -> leaderScmStateMachine.getLastAppliedTermIndex().getIndex()
         == followerScmStateMachine.getLastAppliedTermIndex().getIndex(), 1000, 60000);
 
-    // wait for follower to exit safe mode
+    // Wait for the restarted follower to exit safe mode. A live cluster has
+    // ongoing activity that advances the Ratis log and re-drives the follower's
+    // catch-up check (via applyTransaction / notifyTermIndexUpdated); a totally
+    // idle cluster provides no such trigger. Generate some SCM activity by
+    // allocating containers on the leader so the follower catches up, starts its
+    // datanode protocol server and exits safe mode.
     StorageContainerManager newFollowerScm = cluster.restartStorageContainerManager(followerScm, false);
-    GenericTestUtils.waitFor(() -> !newFollowerScm.isInSafeMode(), 1000, 60000);
+    final StorageContainerManager currentLeader = leaderScm;
+    GenericTestUtils.waitFor(() -> {
+      try {
+        currentLeader.getContainerManager().allocateContainer(
+            RatisReplicationConfig.getInstance(THREE), "safemode-test");
+      } catch (Exception e) {
+        // Ignore transient errors while the follower is catching up.
+      }
+      return !newFollowerScm.isInSafeMode();
+    }, 1000, 60000);
   }
 
   private void createTestData(OzoneClient client) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When an SCM follower restarts in an HA cluster, it used to start talking to datanodes **right away**, even while it was still catching up on the Ratis log.

That caused problems:

- Datanodes report containers the follower doesn’t know about yet → **`CONTAINER_NOT_FOUND`**
- Or the follower tries to update container state and fails → **`NotLeaderException`**
- In both cases, **replica info gets dropped**
- If that SCM later becomes leader, containers can show **missing or wrong replicas**

**The fix:**

1. **Don’t start the datanode server in HA mode** during normal SCM startup.
2. **Wait until catch-up is done**, then start it from `SCMStateMachine`.
3. **Don’t let followers write container state changes** during report handling — only the leader should.

**Why:** Replica locations are rebuilt from datanode reports. Those reports must only be processed **after** the SCM has replayed all committed Ratis entries.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14989

## How was this patch tested?
### **Integration tests**

TestSCMFollowerCatchupWithContainerReport - 

- `testFollowerCatchupAfterContainerClose` — close-while-down (HDDS-14989 scenario)
- `testFollowerCatchupAfterContainerCreate` — create-while-down (`CONTAINER_NOT_FOUND` scenario)
- `testFollowerCatchupOnIdleCluster` — idle cluster edge case

### **Manual test (docker-compose `ozone-ha`)**

Environment: `hadoop-ozone/dist/target/ozone-2.3.0-SNAPSHOT/compose/ozone-ha`

Config: RF=3, 3 datanodes, `hdds.container.report.interval=1h`, `ozone.scm.container.size=1GB`

**Procedure** (same for with/without fix):

1. Start cluster: `OZONE_REPLICATION_FACTOR=3 docker compose up -d --scale datanode=3`
2. Write 50 × 1MB keys to `vol1/buck1` (containers 1–3)
3. Stop follower **scm3**
4. Close containers 1, 2, 3
5. Write 50 × 1MB keys to `vol1/buck2` (creates containers 4, 5, 6 while scm3 is down)
6. Restart **scm3**
7. Transfer SCM leadership to scm3
8. Inspect scm3 logs and `ozone admin container info` for containers 4–6

**Without the fix:**
```
06:57:58.622  ScmDatanodeProtocol RPC server ... listening at /0.0.0.0:9861
06:57:58.837  CONTAINER_NOT_FOUND for Container #4
06:57:58.837  CONTAINER_NOT_FOUND for Container #5
06:57:58.837  CONTAINER_NOT_FOUND for Container #6
(6 errors total — 2 datanodes × 3 containers)
```
After leadership transfer, containers 4–6 had **1 replica each** (expected 3).

**With the fix:**
```
07:24:28.377  Follower caught up with leader: lastAppliedIndex=49, leaderCommit=49
07:24:28.378  ScmDatanodeProtocol RPC server ... listening at /0.0.0.0:9861
```
- `CONTAINER_NOT_FOUND` on scm3: **0**
- After leadership transfer, containers 4–6 each had **3 replicas** from all datanodes