### PR TITLE
HDDS-15689. Compare MD5Hash directly in ScmInvokerCodeGenerator

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java
@@ -41,6 +41,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -642,7 +643,7 @@ public final class ScmInvokerCodeGenerator {
 
     final MD5Hash javaMd5 = MD5FileUtil.computeMd5ForFile(java);
     final MD5Hash tmpMd5 = MD5FileUtil.computeMd5ForFile(tmp);
-    if (Arrays.equals(javaMd5.getDigest(), tmpMd5.getDigest())) {
+    if (Objects.equals(javaMd5, tmpMd5)) {
       Files.delete(tmp.toPath());
       return null;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/ozone/blob/29b2ad5fcd40642c77f771128e7f0f7c4fe88e42/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/invoker/ScmInvokerCodeGenerator.java#L643-L645

`getDigest()` returns `byte[]` in Ratis 3.2.1, but `ByteBuffer` in 3.2.2 (RATIS-2361), resulting in compile error:

```
ScmInvokerCodeGenerator.java:[645,15] no suitable method found for equals(java.nio.ByteBuffer,java.nio.ByteBuffer)
```

`MD5Hash#equals` is based on `digest` internally, so we can make `ScmInvokerCodeGenerator` work with both versions of Ratis by checking equality of `MD5Hash` itself.

https://issues.apache.org/jira/browse/HDDS-15689

## How was this patch tested?

Build, checkstyle, `TestScmInvokerCodeGenerator`

Build with Ratis 3.2.2:
https://github.com/adoroszlai/ozone/actions/runs/28229850840/job/83631071973