### PR TITLE
HDDS-14774. Intermittent timeout in TestContainerReportHandling

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -33,15 +33,18 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -110,8 +113,23 @@ public class TestContainerReportHandling {
         // also wait till the container is closed in SCM
         waitForContainerStateInSCM(cluster.getStorageContainerManager(), containerID, HddsProtos.LifeCycleState.CLOSED);
 
-        // move the container to DELETING
         ContainerManager containerManager = cluster.getStorageContainerManager().getContainerManager();
+        // Wait until SCM sees all replicas CLOSED before moving the container to DELETING. The container state above
+        // flips to CLOSED as soon as the first replica is reported CLOSED, so a lagging replica may still be CLOSING in
+        // SCM. Deleting then races with that lagging CLOSING report, which would resurrect the container out of
+        // DELETING/DELETED and the replicas would never be deleted.
+        int expectedReplicas = replicationInput.getNumDatanodes();
+        GenericTestUtils.waitFor(() -> {
+          try {
+            Set<ContainerReplica> replicas = containerManager.getContainerReplicas(containerID);
+            return replicas.size() == expectedReplicas
+                && replicas.stream().allMatch(replica -> replica.getState() == ContainerReplicaProto.State.CLOSED);
+          } catch (ContainerNotFoundException e) {
+            return false;
+          }
+        }, 100, 60000);
+
+        // move the container to DELETING
         assertFalse(containerManager.getContainerReplicas(containerID).isEmpty());
         containerManager.updateContainerState(containerID, HddsProtos.LifeCycleEvent.DELETE);
         assertEquals(HddsProtos.LifeCycleState.DELETING, containerManager.getContainer(containerID).getState());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
@@ -44,7 +43,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
-import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -118,16 +116,8 @@ public class TestContainerReportHandling {
         // flips to CLOSED as soon as the first replica is reported CLOSED, so a lagging replica may still be CLOSING in
         // SCM. Deleting then races with that lagging CLOSING report, which would resurrect the container out of
         // DELETING/DELETED and the replicas would never be deleted.
-        int expectedReplicas = replicationInput.getNumDatanodes();
-        GenericTestUtils.waitFor(() -> {
-          try {
-            Set<ContainerReplica> replicas = containerManager.getContainerReplicas(containerID);
-            return replicas.size() == expectedReplicas
-                && replicas.stream().allMatch(replica -> replica.getState() == ContainerReplicaProto.State.CLOSED);
-          } catch (ContainerNotFoundException e) {
-            return false;
-          }
-        }, 100, 60000);
+        TestHelper.waitForReplicaState(containerManager, containerID, replicationInput.getNumDatanodes(),
+            ContainerReplicaProto.State.CLOSED);
 
         // move the container to DELETING
         assertFalse(containerManager.getContainerReplicas(containerID).isEmpty());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -38,7 +38,6 @@ import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
@@ -79,8 +78,8 @@ public class TestContainerReportHandling {
    * Tests that a DELETING (or DELETED) container replica gets deleted when replica bcsid <= container bcsid
    * applicable to RATIS; EC ignores bcsid.
    * To do this, the test first creates a key and closes its corresponding container. Then it moves that container to
-   * DELETING (or DELETED) state using ContainerManager. Then it restarts a Datanode hosting that container,
-   * making it send a full container report.
+   * DELETING (or DELETED) state using ContainerManager. SCM then deletes the replicas when it processes a periodic
+   * container report for the CLOSED replicas.
    * Tests wait for a DELETING (or DELETED) container replica gets deleted based on the bcsid comparison.
    */
   @ParameterizedTest
@@ -123,14 +122,9 @@ public class TestContainerReportHandling {
           assertEquals(HddsProtos.LifeCycleState.DELETED, containerManager.getContainer(containerID).getState());
         }
 
-        // restart all the DNs
-        List<DatanodeDetails> dnlist = keyLocation.getPipeline().getNodes();
-        for (DatanodeDetails dn: dnlist) {
-          cluster.restartHddsDatanode(dn, false);
-        }
-
-        // Since replica state is CLOSED and container is DELETED/DELETING in SCM
-        // bcsid of replica and container is same, SCM will trigger delete replica for RATIS, while EC ignores bcsid
+        // Since replica state is CLOSED and container is DELETED/DELETING in SCM, and the bcsid of replica and
+        // container is same, SCM will trigger delete replica for RATIS (EC ignores bcsid) when it processes a
+        // periodic container report for the CLOSED replicas.
         // wait for all replica to be deleted
         GenericTestUtils.waitFor(() -> {
           try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
@@ -40,9 +41,11 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
@@ -113,8 +116,23 @@ public class TestContainerReportHandlingWithHA {
 
         waitForContainerStateInAllSCMs(cluster, containerID, HddsProtos.LifeCycleState.CLOSED);
 
-        // move the container to DELETING
         ContainerManager containerManager = cluster.getScmLeader().getContainerManager();
+        // Wait until SCM sees all replicas CLOSED before moving the container to DELETING. The container state above
+        // flips to CLOSED as soon as the first replica is reported CLOSED, so a lagging replica may still be CLOSING in
+        // SCM. Deleting then races with that lagging CLOSING report, which would resurrect the container out of
+        // DELETING/DELETED and the replicas would never be deleted.
+        int expectedReplicas = replicationInput.getNumDatanodes();
+        GenericTestUtils.waitFor(() -> {
+          try {
+            Set<ContainerReplica> replicas = containerManager.getContainerReplicas(containerID);
+            return replicas.size() == expectedReplicas
+                && replicas.stream().allMatch(replica -> replica.getState() == ContainerReplicaProto.State.CLOSED);
+          } catch (ContainerNotFoundException e) {
+            return false;
+          }
+        }, 100, 60000);
+
+        // move the container to DELETING
         assertFalse(containerManager.getContainerReplicas(containerID).isEmpty());
         containerManager.updateContainerState(containerID, HddsProtos.LifeCycleEvent.DELETE);
         assertEquals(HddsProtos.LifeCycleState.DELETING, containerManager.getContainer(containerID).getState());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
@@ -45,7 +44,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
-import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
@@ -121,16 +119,8 @@ public class TestContainerReportHandlingWithHA {
         // flips to CLOSED as soon as the first replica is reported CLOSED, so a lagging replica may still be CLOSING in
         // SCM. Deleting then races with that lagging CLOSING report, which would resurrect the container out of
         // DELETING/DELETED and the replicas would never be deleted.
-        int expectedReplicas = replicationInput.getNumDatanodes();
-        GenericTestUtils.waitFor(() -> {
-          try {
-            Set<ContainerReplica> replicas = containerManager.getContainerReplicas(containerID);
-            return replicas.size() == expectedReplicas
-                && replicas.stream().allMatch(replica -> replica.getState() == ContainerReplicaProto.State.CLOSED);
-          } catch (ContainerNotFoundException e) {
-            return false;
-          }
-        }, 100, 60000);
+        TestHelper.waitForReplicaState(containerManager, containerID, replicationInput.getNumDatanodes(),
+            ContainerReplicaProto.State.CLOSED);
 
         // move the container to DELETING
         assertFalse(containerManager.getContainerReplicas(containerID).isEmpty());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -39,7 +39,6 @@ import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
@@ -82,8 +81,8 @@ public class TestContainerReportHandlingWithHA {
    * Tests that a DELETING (or DELETED) container replica gets deleted when replica bcsid <= container bcsid
    * applicable to RATIS; EC ignores bcsid.
    * To do this, the test first creates a key and closes its corresponding container. Then it moves that container to
-   * DELETING (or DELETED) state using ContainerManager. Then it restarts Datanodes hosting that container,
-   * making it send a full container report.
+   * DELETING (or DELETED) state using ContainerManager. SCM then deletes the replicas when it processes a periodic
+   * container report for the CLOSED replicas.
    * Tests wait for a DELETING (or DELETED) container replica gets deleted based on the bcsid comparison.
    */
   @ParameterizedTest
@@ -126,14 +125,9 @@ public class TestContainerReportHandlingWithHA {
           assertEquals(HddsProtos.LifeCycleState.DELETED, containerManager.getContainer(containerID).getState());
         }
 
-        // restart all the DNs
-        List<DatanodeDetails> dnlist = keyLocation.getPipeline().getNodes();
-        for (DatanodeDetails dn: dnlist) {
-          cluster.restartHddsDatanode(dn, false);
-        }
-
-        // Since replica state is CLOSED and container is DELETED/DELETING in SCM
-        // bcsid of replica and container is same, SCM will trigger delete replica for RATIS, while EC ignores bcsid
+        // Since replica state is CLOSED and container is DELETED/DELETING in SCM, and the bcsid of replica and
+        // container is same, SCM will trigger delete replica for RATIS (EC ignores bcsid) when it processes a
+        // periodic container report for the CLOSED replicas.
         // wait for all replica to be deleted
         GenericTestUtils.waitFor(() -> {
           try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -462,6 +463,25 @@ public final class TestHelper {
       MiniOzoneCluster cluster) throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> countReplicas(containerID, cluster) == count,
         200, 30000);
+  }
+
+  /**
+   * Wait until SCM reports exactly {@code count} replicas for the container and every replica is in {@code state}.
+   * Unlike {@link #waitForContainerStateInSCM}, which checks the container's aggregate state (it flips as soon as the
+   * first replica reaches the state), this requires all replicas to have settled, so a lagging replica cannot trip
+   * later report handling.
+   */
+  public static void waitForReplicaState(ContainerManager containerManager, ContainerID containerID,
+      int count, ContainerReplicaProto.State state) throws TimeoutException, InterruptedException {
+    GenericTestUtils.waitFor(() -> {
+      try {
+        Set<ContainerReplica> replicas = containerManager.getContainerReplicas(containerID);
+        return replicas.size() == count
+            && replicas.stream().allMatch(replica -> replica.getState() == state);
+      } catch (ContainerNotFoundException e) {
+        return false;
+      }
+    }, 100, 60000);
   }
 
   /** Helper to set config even if {@code value} is null, which


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the earlier fix (#10535) set `hdds.container.report.interval` to 1s, `TestContainerReportHandling` (and its HA variant) still timed out intermittently on CI.

**Problem.** The test marks a freshly-closed, non-empty container DELETING/DELETED and waits for SCM to delete the replicas. It intermittently times out because the container is **resurrected** out of the deletable state: SCM's safety net (`AbstractContainerReportHandler`, the HDDS-11136 / HDDS-12421 path) treats a non-empty, non-CLOSED replica on a DELETING/DELETED container as a reason to move it back to QUASI_CLOSED/CLOSED, after which no delete command is issued and the 180s wait times out.

A transient **CLOSING** replica report can reach SCM after the container is already DELETING/DELETED in two ways:

1. **Datanode restart.** The test restarted all datanodes after deleting; during restart a replica is briefly reported CLOSING. The restart was only ever a workaround to force a full container report under the old 60-minute report interval (#6967); with the interval now at 1s, the periodic full report already delivers the CLOSED replicas, so the restart is obsolete.
2. **Close-vs-delete race.** `waitForContainerStateInSCM(CLOSED)` returns as soon as the *first* RATIS replica is reported CLOSED, but the other replicas may still be CLOSING in SCM. The test then immediately forces DELETING/DELETED, and a lagging replica's in-flight CLOSING report resurrects the container.

Evidence (from a repro with the flaky-test-check split-failure masking removed, so timeouts surface): the failing iteration logs `Resurrecting container #1 from DELETED to QUASI_CLOSED due to non-empty CLOSING replica` and issues **zero** delete commands for that container, while passing iterations issue several.

**Fix.**

1. Remove the datanode restart (obsolete now that the report interval is 1s).
2. Before moving the container to DELETING, wait until SCM reports **all** replicas CLOSED, not just the aggregate container state. Once every replica is CLOSED in SCM, no lagging CLOSING report can resurrect the container.

Both changes are applied to `TestContainerReportHandling` and `TestContainerReportHandlingWithHA`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14774

## How was this patch tested?

- flaky-test-check (10 splits x 15 iterations, both classes), all green, verified two ways:
  - [un-masked workflow run](https://github.com/chihsuan/ozone/actions/runs/28283678853): the split-failure masking is removed so a timeout actually fails the split (the default flaky-test-check currently reports green even when a split times out).
  - [on-branch run](https://github.com/chihsuan/ozone/actions/runs/28285542837): branch as-is; all 300 class executions pass, confirmed by parsing the split logs (its badge is green regardless due to the masking).
- Ran both test classes locally across several iterations; all parameters pass.
- `checkstyle` passes.
- Side effect: removing the restart also cuts CI `integration (container)` runtime (passing runs): `TestContainerReportHandling` ~153s to ~93s, `TestContainerReportHandlingWithHA` ~223s to ~176s.
