### PR TITLE
HDDS-15605. Fix flaky testContainerExclusionWithClosedContainerException

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -394,7 +394,12 @@ public class TestFailureHandlingByClient {
 
       assertThat(keyOutputStream.getExcludeList().getContainerIds())
           .contains(ContainerID.valueOf(containerId));
-      assertThat(keyOutputStream.getExcludeList().getDatanodes()).isEmpty();
+      // Datanodes are not asserted here. Under the default ALL_COMMITTED watch
+      // level a slow-but-healthy follower can be recorded in the exclude list, so
+      // an empty datanode set is not an invariant for this config (the watch
+      // level is configurable via RatisClientConfig watchType, HDDS-2887).
+      // Watch-level datanode exclusion is covered by
+      // testDatanodeExclusionWithMajorityCommit.
       assertThat(keyOutputStream.getExcludeList().getPipelineIds()).isEmpty();
 
       // The close will just write to the buffer


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testContainerExclusionWithClosedContainerException` intermittently fails at the datanode assertion (`Expecting empty but was: [<uuid>(null/null)]`).

The test asserts that after a `ClosedContainerException` only the closed container is excluded. But under the default `ALL_COMMITTED` watch level, a momentarily-slow follower whose watch-for-commit times out is recorded in the client exclude list — intended slow-node-avoidance behaviour of the configurable `watchType` (HDDS-2887). So an empty datanode set is not an invariant under `ALL_COMMITTED`; the assertion predates the `watchType` config and never accounted for it.

The test's subject is container exclusion, which is independent of the watch level. This removes the non-invariant `getDatanodes().isEmpty()` assertion (the container and pipeline assertions stay); watch-level datanode exclusion is already covered by `testDatanodeExclusionWithMajorityCommit`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15605

## How was this patch tested?

`intermittent-test-check` on the fork, `TestFailureHandlingByClient`, `test-name=ALL`, 100 runs each (10 splits x 10 iterations):

- This branch: the assertion did not recur (0/100). ([run](https://github.com/chihsuan/ozone/actions/runs/28273749692))
- `master` baseline, same harness: the assertion reproduced in ~5/100 runs (`Expecting empty but was: [...]`), matching the reported intermittency. ([run](https://github.com/chihsuan/ozone/actions/runs/28276995686))
- Remaining noise, unrelated to this change (present on `master` too):
  - A `TimeoutException` in `TestHelper.waitForContainerClose` (container state transition not completing under the harness's extreme parallel load of 10 concurrent splits); it occurs before the modified assertion and is a pre-existing load-sensitivity of the test.
  - `testDatanodeExclusionWithMajorityCommit` failures are the known HDDS-13972 (`@Flaky`).
