### PR TITLE
HDDS-15700. `flaky-test-check` green despite failing tests

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -188,7 +188,6 @@ jobs:
           name: ozone-repo
           path: |
             ~/.m2/repository/org/apache/ozone
-        continue-on-error: true
       - name: Setup java
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
@@ -213,7 +212,6 @@ jobs:
             set -x
             hadoop-ozone/dev-support/checks/junit.sh $args -Dtest="$TEST_CLASS#$TEST_METHOD,Abstract*Test*\$*"
           fi
-        continue-on-error: true
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           repo_path: ${{ steps.download-ozone-repo.outputs.download-path }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-15589 introduced a bug in `flaky-test-check` where splits are not marked as failed.  Workflow summary still shows splits exited with error code 1 (i.e. failure).  Example:

https://github.com/chihsuan/ozone/actions/runs/28250989222

The problem is that `Execute tests` passes due to `continue-on-error`, and `Summary of failures` only runs on `failure`.  To ensure that failure is properly reported, remove `continue-on-error`.

https://issues.apache.org/jira/browse/HDDS-15700

## How was this patch tested?

Passing `flaky-test-check` is green:
https://github.com/adoroszlai/ozone/actions/runs/28290160719

Failing `flaky-test-check` is red:
https://github.com/adoroszlai/ozone/actions/runs/28290150197