### PR TITLE
HDDS-15699. Check compilation targeting Java 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 8, 17, 25 ]
         include:
           - os: ubuntu-24.04
           - java: 21

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
@@ -78,7 +78,7 @@ abstract class StringCodecBase implements Codec<String> {
    * <p>
    * For a fixed-length {@link Codec},
    * each character is encoded to the same number of bytes and
-   * {@link #getSerializedSizeUpperBound(String)} equals to the serialized size.
+   * {@code getSerializedSizeUpperBound(String)} equals to the serialized size.
    */
   public boolean isFixedLength() {
     return fixedLength;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumByteBuffer.java
@@ -34,11 +34,9 @@ public interface ChecksumByteBuffer extends Checksum {
    * Upon return, the buffer's position will be equal to its limit.
    *
    * @param buffer the bytes to update the checksum with
-   *
-   * @apiNote {@link Override} annotation is missing since {@link Checksum#update(ByteBuffer)} introduced only in Java9.
-   * TODO: Remove when Java 1.8 support is dropped.
-   * TODO: <a href="https://issues.apache.org/jira/browse/HDDS-12366">HDDS-12366</a>
    */
+  // TODO HDDS-12366: Remove when Java 1.8 support is dropped.
+  // Cannot @Override, since introduced only in Java 9.
   @SuppressWarnings("PMD.MissingOverride")
   void update(ByteBuffer buffer);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/OMClientVersionValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/OMClientVersionValidator.java
@@ -96,7 +96,7 @@ public @interface OMClientVersionValidator {
   /**
    * The version before which the validator needs to run. The validator will run only for requests
    * having a version which precedes the specified version.
-   * @returns the exclusive upper bound of the request's version under which the validator is applicable.
+   * @return the exclusive upper bound of the request's version under which the validator is applicable.
    */
   ClientVersion applyBefore();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/OMLayoutVersionValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/OMLayoutVersionValidator.java
@@ -101,7 +101,7 @@ public @interface OMLayoutVersionValidator {
   /**
    * The version before which the validator needs to run. The validator will run only for requests
    * having a version which precedes the specified version.
-   * @returns the exclusive upper bound of the request's version under which the validator is applicable.
+   * @return the exclusive upper bound of the request's version under which the validator is applicable.
    */
   OMLayoutFeature applyBefore();
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,7 @@
     <aspectj.java11.version>1.9.20</aspectj.java11.version>
     <aspectj.java21.version>1.9.24</aspectj.java21.version>
     <aspectj.java25.version>1.9.25.1</aspectj.java25.version>
-    <!-- Default aspectj version for java8 -->
-    <aspectj.version>1.9.7</aspectj.version>
+    <aspectj.java8.version>1.9.7</aspectj.java8.version>
     <assertj.version>3.27.7</assertj.version>
     <aws-java-sdk.version>1.12.788</aws-java-sdk.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
@@ -2649,6 +2648,15 @@
       </build>
     </profile>
     <!-- Profiles for specific aspectj versions -->
+    <profile>
+      <id>aspectj-java8-10</id>
+      <activation>
+        <jdk>[1.8,10]</jdk>
+      </activation>
+      <properties>
+        <aspectj.version>${aspectj.java8.version}</aspectj.version>
+      </properties>
+    </profile>
     <profile>
       <id>aspectj-java11-20</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <aspectj-plugin.version>1.14.1</aspectj-plugin.version>
     <aspectj.java11.version>1.9.20</aspectj.java11.version>
     <aspectj.java21.version>1.9.24</aspectj.java21.version>
+    <aspectj.java25.version>1.9.25.1</aspectj.java25.version>
     <!-- Default aspectj version for java8 -->
     <aspectj.version>1.9.7</aspectj.version>
     <assertj.version>3.27.7</assertj.version>
@@ -2658,12 +2659,21 @@
       </properties>
     </profile>
     <profile>
-      <id>aspectj-java21-or-later</id>
+      <id>aspectj-java21-24</id>
       <activation>
-        <jdk>[21,]</jdk>
+        <jdk>[21,24]</jdk>
       </activation>
       <properties>
         <aspectj.version>${aspectj.java21.version}</aspectj.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>aspectj-java25-or-later</id>
+      <activation>
+        <jdk>[25,]</jdk>
+      </activation>
+      <properties>
+        <aspectj.version>${aspectj.java25.version}</aspectj.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test Ozone compilation targeting Java 25.

- Add Java 25 to `compile` check matrix.  (Remove Java 11 to keep number of splits.)
- Fix Javadoc warnings that were not flagged by earlier Java versions.
- Add new AspectJ version for Java 25.  Add profile for AspectJ version to be used with Java 8, to simplify future move to newer Java version (no need to edit `<aspectj.version>` property, just remove unsupported version-specific part).

https://issues.apache.org/jira/browse/HDDS-15699

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/28293410609