### PR TITLE
HDDS-13812. Fix Recon pnpm build failure when proxy is set

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -440,7 +440,7 @@
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <configuration>
-          <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
+          <pnpmInheritsProxyConfigFromMaven>false</pnpmInheritsProxyConfigFromMaven>
           <installDirectory>target</installDirectory>
           <workingDirectory>${basedir}/src/main/resources/webapps/recon/ozone-recon-web</workingDirectory>
           <nodeVersion>v${nodejs.version}</nodeVersion>


### PR DESCRIPTION
## What changes were proposed in this pull request?

With a proxy in Maven's `settings.xml`, the Recon build fails at the
frontend-maven-plugin `pnpm` goal, because the Maven proxy args get appended to the
pnpm command line:

    'pnpm config set store-dir ~/.pnpm-store --https-proxy=... --proxy=... --noproxy=...' failed.
    ERROR Unknown options: 'https-proxy', 'proxy', 'noproxy'

HDDS-3913 set `npmInheritsProxyConfigFromMaven=false` to prevent this, which was
correct while the build used the `npm`/`yarn` goals. HDDS-13620 later switched to the
`pnpm` goal, which reads `pnpmInheritsProxyConfigFromMaven` (default `true`) and
ignores the `npm`-named parameter. This patch uses the correct parameter name.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13812

## How was this patch tested?

Manually reproduced and verified with a proxy in a custom `settings.xml`:

```xml
<proxy>
  <id>repro-proxy</id>
  <active>true</active>
  <protocol>http</protocol>
  <host>localhost</host>
  <port>9876</port>
  <nonProxyHosts>*.com|*.org</nonProxyHosts>
</proxy>
```

Ran the failing execution directly (after `frontend:install-node-and-pnpm`):

    mvn -pl :ozone-recon -o -s settings.xml "frontend:pnpm@set pnpm@10.28.2 store path"

- Old `npmInheritsProxyConfigFromMaven` parameter: ran
  `pnpm config set store-dir ~/.pnpm-store --https-proxy=... --proxy=... --noproxy=...`
  and failed with `Unknown options` (exit 1).
- New `pnpmInheritsProxyConfigFromMaven` parameter: logged
  `pnpm not inheriting proxy config from Maven`, ran
  `pnpm config set store-dir ~/.pnpm-store` without proxy args, and succeeded.



Generated-by: Claude Code (Claude Opus 4.8)
