### PR TITLE
HDDS-15660. Skip prometheus container during stack collection

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -290,7 +290,7 @@ reorder_om_nodes() {
 ## @description Create stack dump of each java process in each container
 create_stack_dumps() {
   local c pid procname
-  for c in $(docker-compose ps | cut -f1 -d' ' | grep -e datanode -e om -e recon -e s3g -e scm); do
+  for c in $(docker-compose ps | cut -f1 -d' ' | grep -e datanode -e om -e recon -e s3g -e scm | grep -v -e prometheus); do
     while read -r pid procname; do
       echo "jstack $pid > ${RESULT_DIR}/${c}_${procname}.stack"
       docker exec "${c}" bash -c "jstack $pid" > "${RESULT_DIR}/${c}_${procname}.stack"


### PR DESCRIPTION
## What changes were proposed in this pull request?

On acceptance test failure, `create_stack_dumps()` iterates over the service containers and runs `jstack` in each one. The container filter `grep -e datanode -e om -e recon -e s3g -e scm` matches by substring, so `prometheus` (pr**om**etheus) is accidentally selected. The `prometheus` image has no `bash`, so the stack dump step fails with:

```
exec: "bash": executable file not found in $PATH
```

producing noise and a useless `.stack` file in the result directory.

**Fix.** Exclude the `prometheus` container from the stack collection loop by appending `grep -v -e prometheus` to the filter. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15660

## How was this patch tested?

- Verified the updated filter still matches `ozone-om1-1`, `ozone-scm2-1`, `ozone-recon-1` and no longer matches `ozone-prometheus-1` / `ozone-grafana-1`.
