### PR TITLE
HDDS-15648. Improve TestSnapshotDiffManager#testThreadPoolIsFull drain scenario

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -1195,28 +1195,31 @@ public class TestSnapshotDiffManager {
         eq(VOLUME_NAME), eq(BUCKET_NAME), anyString(), anyString(),
         eq(false), eq(false));
 
-    if (drainBetweenBatches) {
-      blockWorkers.countDown();
-    }
-
     try {
       List<SnapshotDiffResponse> responses = new ArrayList<>();
       int totalSubmitted = 0;
+      int fullThreadPoolSize = 2 * OZONE_OM_SNAPSHOT_DIFF_THREAD_POOL_SIZE_DEFAULT;
+      boolean latchOpened = false;
+
       for (int i = 0; i < snapshotInfos.size(); i++) {
         for (int j = i + 1; j < snapshotInfos.size(); j++) {
           String fromSnapshotName = snapshotInfos.get(i).getName();
           String toSnapshotName = snapshotInfos.get(j).getName();
+
+          if (drainBetweenBatches && !latchOpened &&
+              totalSubmitted >= fullThreadPoolSize) {
+            blockWorkers.countDown();
+            latchOpened = true;
+          }
+
+          if (drainBetweenBatches && latchOpened) {
+            while (totalSubmitted - completedJobs.get() >= fullThreadPoolSize) {
+              Thread.sleep(10);
+            }
+          }
+
           responses.add(submitJob(spy, fromSnapshotName, toSnapshotName));
           totalSubmitted++;
-        }
-        if (drainBetweenBatches) {
-          final int expected = totalSubmitted;
-          attempt(() -> {
-            if (completedJobs.get() < expected) {
-              throw new IllegalStateException("Waiting for jobs to complete");
-            }
-            return null;
-          }, 50, TimeDuration.valueOf(100, TimeUnit.MILLISECONDS), null, null);
         }
       }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -1213,9 +1213,13 @@ public class TestSnapshotDiffManager {
           }
 
           if (drainBetweenBatches && latchOpened) {
-            while (totalSubmitted - completedJobs.get() >= fullThreadPoolSize) {
-              Thread.sleep(10);
-            }
+            final int currentlySubmitted = totalSubmitted;
+            attempt(() -> {
+              if (currentlySubmitted - completedJobs.get() >= fullThreadPoolSize) {
+                throw new RuntimeException("Thread pool is still full");
+              }
+              return null;
+            }, 10000, TimeDuration.valueOf(1, TimeUnit.MILLISECONDS), null, null);
           }
 
           responses.add(submitJob(spy, fromSnapshotName, toSnapshotName));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve TestSnapshotDiffManager#testThreadPoolIsFull drai n scenario by filling the pool before releasing workers

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15648

## How was this patch tested?
Existing unit and integration tests