### PR TITLE
HDDS-15616. ListBuckets API ignores MaxBuckets parameter and returns all buckets

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/S3SDKTestUtils.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/S3SDKTestUtils.java
@@ -25,10 +25,12 @@ import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.io.IOUtils;
@@ -48,6 +50,49 @@ public final class S3SDKTestUtils {
           "$", "%", "&", "'", "<", ">", "_", "_ ", "_ _", "__"));
 
   public static final Pattern UPLOAD_ID_PATTERN = Pattern.compile("<UploadId>(.+?)</UploadId>");
+
+  /**
+   * One page of a paginated ListBuckets response.
+   */
+  public static final class BucketListPage {
+    private final List<String> bucketNames;
+    private final String continuationToken;
+
+    public BucketListPage(List<String> bucketNames, String continuationToken) {
+      this.bucketNames = bucketNames;
+      this.continuationToken = continuationToken;
+    }
+
+    public List<String> getBucketNames() {
+      return bucketNames;
+    }
+
+    public String getContinuationToken() {
+      return continuationToken;
+    }
+  }
+
+  /**
+   * Lists buckets one per page and returns all bucket names from the pages.
+   *
+   * @param listPage fetches one page; first arg is continuation token (nullable),
+   *                 second arg is max buckets per page
+   */
+  public static List<String> collectBucketsOnePerPage(
+      BiFunction<String, Integer, BucketListPage> listPage) {
+    List<String> found = new ArrayList<>();
+    String continuationToken = null;
+    do {
+      BucketListPage page = listPage.apply(continuationToken, 1);
+      if (page.getBucketNames().size() != 1) {
+        throw new AssertionError(
+            "Expected 1 bucket per page, got " + page.getBucketNames().size());
+      }
+      found.add(page.getBucketNames().get(0));
+      continuationToken = page.getContinuationToken();
+    } while (continuationToken != null);
+    return found;
+  }
 
   private S3SDKTestUtils() {
   }

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/S3SDKTestUtils.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/S3SDKTestUtils.java
@@ -28,11 +28,14 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.ozone.test.InputSubstream;
@@ -92,6 +95,17 @@ public final class S3SDKTestUtils {
       continuationToken = page.getContinuationToken();
     } while (continuationToken != null);
     return found;
+  }
+
+  /**
+   * Filters a paginated bucket list down to the buckets created by the test.
+   */
+  public static List<String> filterToExpectedBuckets(
+      List<String> paginatedBuckets, String... expectedBuckets) {
+    Set<String> expected = new HashSet<>(Arrays.asList(expectedBuckets));
+    return paginatedBuckets.stream()
+        .filter(expected::contains)
+        .collect(Collectors.toList());
   }
 
   private S3SDKTestUtils() {

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -52,6 +52,8 @@ import com.amazonaws.services.s3.model.GetObjectTaggingResult;
 import com.amazonaws.services.s3.model.Grantee;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ListBucketsPaginatedRequest;
+import com.amazonaws.services.s3.model.ListBucketsPaginatedResult;
 import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
@@ -284,6 +286,144 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
 
     assertThat(s3AccountOwner.getDisplayName()).isEqualTo(expectOwner);
     assertThat(s3AccountOwner.getId()).isEqualTo(S3Owner.DEFAULT_S3OWNER_ID);
+  }
+
+  /**
+   * Integration tests for paginated ListBuckets (GET / ListAllMyBuckets).
+   */
+  @Nested
+  class ListBucketsPaginationTests {
+
+    /**
+     * Verifies {@code maxBuckets=1} returns one bucket per page and a continuation token
+     * when more buckets exist.
+     */
+    @Test
+    public void testListBucketsPaginatedMaxBucketsOne() {
+      final String bucketA = uniqueObjectName("bucket-a");
+      final String bucketB = uniqueObjectName("bucket-b");
+      s3Client.createBucket(bucketA);
+      s3Client.createBucket(bucketB);
+      try {
+        List<String> found = new ArrayList<>();
+        String continuationToken = null;
+
+        do {
+          ListBucketsPaginatedRequest request = new ListBucketsPaginatedRequest()
+              .withMaxBuckets(1);
+          if (continuationToken != null) {
+            request.withContinuationToken(continuationToken);
+          }
+
+          ListBucketsPaginatedResult page = s3Client.listBuckets(request);
+          assertEquals(1, page.getBuckets().size());
+          found.add(page.getBuckets().get(0).getName());
+          continuationToken = page.getContinuationToken();
+        } while (continuationToken != null
+            && !(found.contains(bucketA) && found.contains(bucketB)));
+
+        assertThat(found).contains(bucketA, bucketB);
+      } finally {
+        s3Client.deleteBucket(bucketA);
+        s3Client.deleteBucket(bucketB);
+      }
+    }
+
+    /**
+     * Verifies pagination: listing buckets page-by-page using {@code maxBuckets}
+     * and the returned continuation token, until all buckets are retrieved.
+     */
+    @Test
+    public void testListBucketsPaginationReturnsAllBuckets() {
+      final int totalBuckets = 5;
+      final int pageSize = 2;
+      List<String> created = new ArrayList<>();
+
+      for (int i = 0; i < totalBuckets; i++) {
+        String name = uniqueObjectName("paginated-" + i);
+        s3Client.createBucket(name);
+        created.add(name);
+      }
+
+      try {
+        List<String> retrieved = new ArrayList<>();
+        String continuationToken = null;
+
+        do {
+          ListBucketsPaginatedRequest request = new ListBucketsPaginatedRequest()
+              .withMaxBuckets(pageSize);
+          if (continuationToken != null) {
+            request.withContinuationToken(continuationToken);
+          }
+
+          ListBucketsPaginatedResult response = s3Client.listBuckets(request);
+
+          response.getBuckets().stream()
+              .map(Bucket::getName)
+              .filter(created::contains)
+              .forEach(retrieved::add);
+
+          continuationToken = response.getContinuationToken();
+        } while (continuationToken != null);
+
+        assertThat(retrieved).containsExactlyInAnyOrderElementsOf(created);
+      } finally {
+        for (String name : created) {
+          s3Client.deleteBucket(name);
+        }
+      }
+    }
+
+    /**
+     * verifies that Page 1 uses maxBuckets=1;
+     * later pages send only continuationToken (no maxBuckets).
+     */
+    @Test
+    public void testListBucketsContinuationTokenWithoutMaxBuckets() {
+      List<String> created = new ArrayList<>();
+      for (int i = 0; i < 3; i++) {
+        String name = uniqueObjectName("token-only-" + i);
+        s3Client.createBucket(name);
+        created.add(name);
+      }
+
+      try {
+        List<String> retrieved = new ArrayList<>();
+        String continuationToken = null;
+        boolean firstPage = true;
+
+        do {
+          ListBucketsPaginatedRequest request = new ListBucketsPaginatedRequest();
+          if (firstPage) {
+            request.withMaxBuckets(1);
+            firstPage = false;
+          } else {
+            request.withContinuationToken(continuationToken);
+          }
+
+          ListBucketsPaginatedResult response = s3Client.listBuckets(request);
+          if (continuationToken == null) {
+            assertEquals(1, response.getBuckets().size());
+            assertNotNull(response.getContinuationToken());
+          } else {
+            assertFalse(response.getBuckets().isEmpty());
+          }
+
+          response.getBuckets().stream()
+              .map(Bucket::getName)
+              .filter(created::contains)
+              .forEach(retrieved::add);
+
+          continuationToken = response.getContinuationToken();
+        } while (continuationToken != null);
+
+        assertThat(retrieved).containsExactlyInAnyOrderElementsOf(created);
+      } finally {
+        for (String name : created) {
+          s3Client.deleteBucket(name);
+        }
+      }
+    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -264,35 +264,35 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     //assertEquals(aclList, s3Client.getBucketAcl(bucketName));
   }
 
-  @Test
-  public void testListBuckets() throws IOException {
-    List<String> bucketNames = new ArrayList<>();
-    for (int i = 0; i <= 5; i++) {
-      String bucketName = getBucketName(String.valueOf(i));
-      s3Client.createBucket(bucketName);
-      bucketNames.add(bucketName);
-    }
-
-    List<Bucket> bucketList = s3Client.listBuckets();
-    List<String> listBucketNames = bucketList.stream()
-        .map(Bucket::getName).collect(Collectors.toList());
-
-    assertThat(listBucketNames).containsAll(bucketNames);
-
-    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-    String expectOwner = ugi.getShortUserName();
-
-    Owner s3AccountOwner = s3Client.getS3AccountOwner();
-
-    assertThat(s3AccountOwner.getDisplayName()).isEqualTo(expectOwner);
-    assertThat(s3AccountOwner.getId()).isEqualTo(S3Owner.DEFAULT_S3OWNER_ID);
-  }
-
   /**
-   * Integration tests for paginated ListBuckets (GET / ListAllMyBuckets).
+   * Integration tests for ListBuckets (GET / ListAllMyBuckets).
    */
   @Nested
-  class ListBucketsPaginationTests {
+  class ListBucketsTests {
+
+    @Test
+    public void testListBuckets() throws IOException {
+      List<String> bucketNames = new ArrayList<>();
+      for (int i = 0; i <= 5; i++) {
+        String bucketName = getBucketName(String.valueOf(i));
+        s3Client.createBucket(bucketName);
+        bucketNames.add(bucketName);
+      }
+
+      List<Bucket> bucketList = s3Client.listBuckets();
+      List<String> listBucketNames = bucketList.stream()
+          .map(Bucket::getName).collect(Collectors.toList());
+
+      assertThat(listBucketNames).containsAll(bucketNames);
+
+      UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+      String expectOwner = ugi.getShortUserName();
+
+      Owner s3AccountOwner = s3Client.getS3AccountOwner();
+
+      assertThat(s3AccountOwner.getDisplayName()).isEqualTo(expectOwner);
+      assertThat(s3AccountOwner.getId()).isEqualTo(S3Owner.DEFAULT_S3OWNER_ID);
+    }
 
     /**
      * Verifies {@code maxBuckets=1} returns one bucket per page and a continuation token

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -305,24 +305,19 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
       s3Client.createBucket(bucketA);
       s3Client.createBucket(bucketB);
       try {
-        List<String> found = new ArrayList<>();
-        String continuationToken = null;
-
-        do {
+        List<String> found = S3SDKTestUtils.collectBucketsOnePerPage((token, max) -> {
           ListBucketsPaginatedRequest request = new ListBucketsPaginatedRequest()
-              .withMaxBuckets(1);
-          if (continuationToken != null) {
-            request.withContinuationToken(continuationToken);
+              .withMaxBuckets(max);
+          if (token != null) {
+            request.withContinuationToken(token);
           }
 
           ListBucketsPaginatedResult page = s3Client.listBuckets(request);
-          assertEquals(1, page.getBuckets().size());
-          found.add(page.getBuckets().get(0).getName());
-          continuationToken = page.getContinuationToken();
-        } while (continuationToken != null
-            && !(found.contains(bucketA) && found.contains(bucketB)));
-
-        assertThat(found).contains(bucketA, bucketB);
+          return new S3SDKTestUtils.BucketListPage(
+              page.getBuckets().stream().map(Bucket::getName).collect(Collectors.toList()),
+              page.getContinuationToken());
+        });
+        assertThat(found).containsExactlyInAnyOrder(bucketA, bucketB);
       } finally {
         s3Client.deleteBucket(bucketA);
         s3Client.deleteBucket(bucketB);

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -317,7 +317,9 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
               page.getBuckets().stream().map(Bucket::getName).collect(Collectors.toList()),
               page.getContinuationToken());
         });
-        assertThat(found).containsExactlyInAnyOrder(bucketA, bucketB);
+        List<String> foundTestBuckets = S3SDKTestUtils.filterToExpectedBuckets(
+            found, bucketA, bucketB);
+        assertThat(foundTestBuckets).containsExactlyInAnyOrder(bucketA, bucketB);
       } finally {
         s3Client.deleteBucket(bucketA);
         s3Client.deleteBucket(bucketB);

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -127,6 +127,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
 import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
 import software.amazon.awssdk.services.s3.model.ListDirectoryBucketsRequest;
 import software.amazon.awssdk.services.s3.model.ListDirectoryBucketsResponse;
@@ -2793,6 +2794,144 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
       S3Exception exception = assertThrows(S3Exception.class, function);
       assertEquals(403, exception.statusCode());
       assertEquals("Access Denied", exception.awsErrorDetails().errorCode());
+    }
+  }
+
+  /**
+   * Integration tests for paginated ListBuckets (GET / ListAllMyBuckets).
+   */
+  @Nested
+  class ListBucketsPaginationTests {
+
+    /**
+     * Verifies {@code maxBuckets=1} returns one bucket per page and a continuation token
+     * when more buckets exist.
+     */
+    @Test
+    public void testListBucketsPaginatedMaxBucketsOne() throws Exception {
+      final String bucketA = uniqueObjectName("bucket-a");
+      final String bucketB = uniqueObjectName("bucket-b");
+      s3Client.createBucket(b -> b.bucket(bucketA));
+      s3Client.createBucket(b -> b.bucket(bucketB));
+      try {
+        List<String> found = new ArrayList<>();
+        String continuationToken = null;
+
+        do {
+          ListBucketsRequest.Builder reqBuilder = ListBucketsRequest.builder()
+              .maxBuckets(1);
+          if (continuationToken != null) {
+            reqBuilder.continuationToken(continuationToken);
+          }
+
+          ListBucketsResponse page = s3Client.listBuckets(reqBuilder.build());
+          assertEquals(1, page.buckets().size());
+          found.add(page.buckets().get(0).name());
+          continuationToken = page.continuationToken();
+        } while (continuationToken != null
+            && !(found.contains(bucketA) && found.contains(bucketB)));
+
+        assertThat(found).contains(bucketA, bucketB);
+      } finally {
+        s3Client.deleteBucket(b -> b.bucket(bucketA));
+        s3Client.deleteBucket(b -> b.bucket(bucketB));
+      }
+    }
+
+    /**
+     * Verifies pagination: listing buckets page-by-page using {@code maxBuckets}
+     * and the returned continuation token, until all buckets are retrieved.
+     */
+    @Test
+    public void testListBucketsPaginationReturnsAllBuckets() throws Exception {
+      final int totalBuckets = 5;
+      final int pageSize = 2;
+      List<String> created = new ArrayList<>();
+
+      for (int i = 0; i < totalBuckets; i++) {
+        String name = uniqueObjectName("paginated-" + i);
+        s3Client.createBucket(b -> b.bucket(name));
+        created.add(name);
+      }
+
+      try {
+        List<String> retrieved = new ArrayList<>();
+        String continuationToken = null;
+
+        do {
+          ListBucketsRequest.Builder reqBuilder = ListBucketsRequest.builder()
+              .maxBuckets(pageSize);
+          if (continuationToken != null) {
+            reqBuilder.continuationToken(continuationToken);
+          }
+
+          ListBucketsResponse response = s3Client.listBuckets(reqBuilder.build());
+
+          response.buckets().stream()
+              .map(Bucket::name)
+              .filter(created::contains)
+              .forEach(retrieved::add);
+
+          continuationToken = response.continuationToken();
+        } while (continuationToken != null);
+
+        assertThat(retrieved).containsExactlyInAnyOrderElementsOf(created);
+      } finally {
+        for (String name : created) {
+          s3Client.deleteBucket(b -> b.bucket(name));
+        }
+      }
+    }
+
+    /**
+     * Verifies that page 2 can use only {@code continuationToken} without {@code maxBuckets}.
+     * The first page uses {@code maxBuckets=1}; subsequent pages send only the token.
+     */
+    @Test
+    public void testListBucketsContinuationTokenWithoutMaxBuckets() throws Exception {
+      List<String> created = new ArrayList<>();
+      for (int i = 0; i < 3; i++) {
+        String name = uniqueObjectName("token-only-" + i);
+        s3Client.createBucket(b -> b.bucket(name));
+        created.add(name);
+      }
+
+      try {
+        List<String> retrieved = new ArrayList<>();
+        String continuationToken = null;
+        boolean firstPage = true;
+
+        do {
+          ListBucketsRequest.Builder reqBuilder = ListBucketsRequest.builder();
+          if (firstPage) {
+            reqBuilder.maxBuckets(1);
+            firstPage = false;
+          } else {
+            reqBuilder.continuationToken(continuationToken);
+          }
+
+          ListBucketsResponse response = s3Client.listBuckets(reqBuilder.build());
+          if (continuationToken == null) {
+            assertEquals(1, response.buckets().size());
+            assertNotNull(response.continuationToken());
+          } else {
+            assertFalse(response.buckets().isEmpty());
+          }
+
+          response.buckets().stream()
+              .map(Bucket::name)
+              .filter(created::contains)
+              .forEach(retrieved::add);
+
+          continuationToken = response.continuationToken();
+        } while (continuationToken != null);
+
+        assertThat(retrieved).containsExactlyInAnyOrderElementsOf(created);
+      } finally {
+        for (String name : created) {
+          s3Client.deleteBucket(b -> b.bucket(name));
+        }
+      }
     }
   }
 

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -2791,14 +2791,21 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
 
     @Test
     public void testListBuckets() throws Exception {
-      final String bucketName = getBucketName();
-      final String expectedOwner = UserGroupInformation.getCurrentUser().getUserName();
-
-      s3Client.createBucket(b -> b.bucket(bucketName));
+      List<String> bucketNames = new ArrayList<>();
+      for (int i = 0; i <= 5; i++) {
+        String bucketName = getBucketName(String.valueOf(i));
+        s3Client.createBucket(b -> b.bucket(bucketName));
+        bucketNames.add(bucketName);
+      }
 
       ListBucketsResponse syncResponse = s3Client.listBuckets();
-      assertEquals(1, syncResponse.buckets().size());
-      assertEquals(bucketName, syncResponse.buckets().get(0).name());
+      List<String> listBucketNames = syncResponse.buckets().stream()
+          .map(Bucket::name)
+          .collect(Collectors.toList());
+
+      assertThat(listBucketNames).containsAll(bucketNames);
+
+      String expectedOwner = UserGroupInformation.getCurrentUser().getShortUserName();
       assertEquals(expectedOwner, syncResponse.owner().displayName());
       assertEquals(S3Owner.DEFAULT_S3OWNER_ID, syncResponse.owner().id());
     }

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -2825,7 +2825,9 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
               page.buckets().stream().map(Bucket::name).collect(Collectors.toList()),
               page.continuationToken());
         });
-        assertThat(found).containsExactlyInAnyOrder(bucketA, bucketB);
+        List<String> foundTestBuckets = S3SDKTestUtils.filterToExpectedBuckets(
+            found, bucketA, bucketB);
+        assertThat(foundTestBuckets).containsExactlyInAnyOrder(bucketA, bucketB);
       } finally {
         s3Client.deleteBucket(b -> b.bucket(bucketA));
         s3Client.deleteBucket(b -> b.bucket(bucketB));

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -2814,24 +2814,18 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
       s3Client.createBucket(b -> b.bucket(bucketA));
       s3Client.createBucket(b -> b.bucket(bucketB));
       try {
-        List<String> found = new ArrayList<>();
-        String continuationToken = null;
-
-        do {
+        List<String> found = S3SDKTestUtils.collectBucketsOnePerPage((token, max) -> {
           ListBucketsRequest.Builder reqBuilder = ListBucketsRequest.builder()
-              .maxBuckets(1);
-          if (continuationToken != null) {
-            reqBuilder.continuationToken(continuationToken);
+              .maxBuckets(max);
+          if (token != null) {
+            reqBuilder.continuationToken(token);
           }
-
           ListBucketsResponse page = s3Client.listBuckets(reqBuilder.build());
-          assertEquals(1, page.buckets().size());
-          found.add(page.buckets().get(0).name());
-          continuationToken = page.continuationToken();
-        } while (continuationToken != null
-            && !(found.contains(bucketA) && found.contains(bucketB)));
-
-        assertThat(found).contains(bucketA, bucketB);
+          return new S3SDKTestUtils.BucketListPage(
+              page.buckets().stream().map(Bucket::name).collect(Collectors.toList()),
+              page.continuationToken());
+        });
+        assertThat(found).containsExactlyInAnyOrder(bucketA, bucketB);
       } finally {
         s3Client.deleteBucket(b -> b.bucket(bucketA));
         s3Client.deleteBucket(b -> b.bucket(bucketB));

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -214,20 +214,6 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
   }
 
   @Test
-  public void listBuckets() throws Exception {
-    final String bucketName = getBucketName();
-    final String expectedOwner = UserGroupInformation.getCurrentUser().getUserName();
-
-    s3Client.createBucket(b -> b.bucket(bucketName));
-
-    ListBucketsResponse syncResponse = s3Client.listBuckets();
-    assertEquals(1, syncResponse.buckets().size());
-    assertEquals(bucketName, syncResponse.buckets().get(0).name());
-    assertEquals(expectedOwner, syncResponse.owner().displayName());
-    assertEquals(S3Owner.DEFAULT_S3OWNER_ID, syncResponse.owner().id());
-  }
-
-  @Test
   public void testPutObject() {
     final String bucketName = getBucketName();
     final String keyName = getKeyName();
@@ -2798,10 +2784,24 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
   }
 
   /**
-   * Integration tests for paginated ListBuckets (GET / ListAllMyBuckets).
+   * Integration tests for ListBuckets (GET / ListAllMyBuckets).
    */
   @Nested
-  class ListBucketsPaginationTests {
+  class ListBucketsTests {
+
+    @Test
+    public void testListBuckets() throws Exception {
+      final String bucketName = getBucketName();
+      final String expectedOwner = UserGroupInformation.getCurrentUser().getUserName();
+
+      s3Client.createBucket(b -> b.bucket(bucketName));
+
+      ListBucketsResponse syncResponse = s3Client.listBuckets();
+      assertEquals(1, syncResponse.buckets().size());
+      assertEquals(bucketName, syncResponse.buckets().get(0).name());
+      assertEquals(expectedOwner, syncResponse.owner().displayName());
+      assertEquals(S3Owner.DEFAULT_S3OWNER_ID, syncResponse.owner().id());
+    }
 
     /**
      * Verifies {@code maxBuckets=1} returns one bucket per page and a continuation token

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListBucketResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListBucketResponse.java
@@ -41,7 +41,10 @@ public class ListBucketResponse {
 
   @XmlElement(name = "Owner")
   private S3Owner owner;
-  
+
+  @XmlElement(name = "ContinuationToken")
+  private String continuationToken;
+
   public List<BucketMetadata> getBuckets() {
     return buckets;
   }
@@ -65,5 +68,13 @@ public class ListBucketResponse {
 
   public void setOwner(S3Owner owner) {
     this.owner = owner;
+  }
+
+  public String getContinuationToken() {
+    return continuationToken;
+  }
+
+  public void setContinuationToken(String continuationToken) {
+    this.continuationToken = continuationToken;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
@@ -153,22 +153,49 @@ public class RootEndpoint extends EndpointBase {
     long startNanos = Time.monotonicNowNanos();
     boolean auditSuccess = true;
     try {
+      final String continueToken = queryParams().get(QueryParams.CONTINUATION_TOKEN);
+      final String maxBucketsParam = queryParams().get(QueryParams.MAX_BUCKETS);
+      final boolean paginated = maxBucketsParam != null || continueToken != null;
+      final int maxBuckets = paginated
+          ? validateMaxBuckets(queryParams().getInt(QueryParams.MAX_BUCKETS,
+              S3Consts.MAX_BUCKETS_LIMIT))
+          : Integer.MAX_VALUE;
+
       ListBucketResponse response = new ListBucketResponse();
+      String previousBucket = null;
+      if (continueToken != null) {
+        previousBucket = ContinueToken.decodeFromString(continueToken).getLastKey();
+      }
+
       Iterator<? extends OzoneBucket> bucketIterator;
       try {
-        bucketIterator =
-            listS3Buckets(null, volume -> response.setOwner(S3Owner.of(volume.getOwner())));
+        if (previousBucket == null) {
+          bucketIterator = listS3Buckets(null,
+              volume -> response.setOwner(S3Owner.of(volume.getOwner())));
+        } else {
+          bucketIterator = listS3Buckets(null, previousBucket,
+              volume -> response.setOwner(S3Owner.of(volume.getOwner())));
+        }
       } catch (Exception e) {
         getMetrics().updateListS3BucketsFailureStats(startNanos);
         throw e;
       }
 
-      while (bucketIterator.hasNext()) {
+      int count = 0;
+      String lastBucketName = null;
+      while (bucketIterator.hasNext() && count < maxBuckets) {
         OzoneBucket next = bucketIterator.next();
         BucketMetadata bucketMetadata = new BucketMetadata();
         bucketMetadata.setName(next.getName());
         bucketMetadata.setCreationDate(next.getCreationTime());
         response.addBucket(bucketMetadata);
+        lastBucketName = next.getName();
+        count++;
+      }
+
+      if (paginated && lastBucketName != null && bucketIterator.hasNext()) {
+        response.setContinuationToken(
+            new ContinueToken(lastBucketName, null).encodeToString());
       }
 
       getMetrics().updateListS3BucketsSuccessStats(startNanos);
@@ -182,6 +209,13 @@ public class RootEndpoint extends EndpointBase {
         auditReadSuccess(S3GAction.LIST_S3_BUCKETS);
       }
     }
+  }
+
+  private int validateMaxBuckets(int maxBuckets) throws OS3Exception {
+    if (maxBuckets < 1) {
+      throw newError(INVALID_ARGUMENT, "max-buckets must be >= 1");
+    }
+    return Math.min(maxBuckets, S3Consts.MAX_BUCKETS_LIMIT);
   }
 
   private int validateMaxDirectoryBuckets(int maxDirectoryBuckets) throws OS3Exception {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
@@ -156,10 +156,8 @@ public class RootEndpoint extends EndpointBase {
       final String continueToken = queryParams().get(QueryParams.CONTINUATION_TOKEN);
       final String maxBucketsParam = queryParams().get(QueryParams.MAX_BUCKETS);
       final boolean paginated = maxBucketsParam != null || continueToken != null;
-      final int maxBuckets = paginated
-          ? validateMaxBuckets(queryParams().getInt(QueryParams.MAX_BUCKETS,
-              S3Consts.MAX_BUCKETS_LIMIT))
-          : Integer.MAX_VALUE;
+      final int maxBuckets = getMaxBuckets(paginated,
+          queryParams().getInt(QueryParams.MAX_BUCKETS, S3Consts.MAX_BUCKETS_LIMIT));
 
       ListBucketResponse response = new ListBucketResponse();
       String previousBucket = null;
@@ -211,11 +209,14 @@ public class RootEndpoint extends EndpointBase {
     }
   }
 
-  private int validateMaxBuckets(int maxBuckets) throws OS3Exception {
-    if (maxBuckets < 1) {
+  private int getMaxBuckets(boolean paginated, int requestedMaxBuckets) throws OS3Exception {
+    if (!paginated) {
+      return Integer.MAX_VALUE;
+    }
+    if (requestedMaxBuckets < 1) {
       throw newError(INVALID_ARGUMENT, "max-buckets must be >= 1");
     }
-    return Math.min(maxBuckets, S3Consts.MAX_BUCKETS_LIMIT);
+    return Math.min(requestedMaxBuckets, S3Consts.MAX_BUCKETS_LIMIT);
   }
 
   private int validateMaxDirectoryBuckets(int maxDirectoryBuckets) throws OS3Exception {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
@@ -114,6 +114,8 @@ public final class S3Consts {
 
   // Constants related to S3 Express / ListDirectoryBuckets
   public static final int MAX_DIRECTORY_BUCKETS_LIMIT = 1000;
+  // Maximum number of buckets per ListBuckets response page.
+  public static final int MAX_BUCKETS_LIMIT = 10000;
   public static final String DEFAULT_S3_REGION = "us-east-1";
   public static final String S3_EXPRESS_SERVICE = "s3express";
 
@@ -142,6 +144,7 @@ public final class S3Consts {
     public static final String LOCATION = "location";
     public static final String MARKER = "marker";
     public static final String MAX_DIRECTORY_BUCKETS = "max-directory-buckets";
+    public static final String MAX_BUCKETS = "max-buckets";
     public static final String MAX_KEYS = "max-keys";
     public static final String MAX_PARTS = "max-parts";
     public static final String MAX_UPLOADS = "max-uploads";

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
@@ -18,10 +18,15 @@
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.util.S3Consts.QueryParams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -66,6 +71,97 @@ public class TestRootList {
     assertEquals(10, response.getBucketsNum());
     assertEquals("root", response.getOwner().getDisplayName());
     assertEquals(S3Owner.DEFAULT_S3OWNER_ID, response.getOwner().getId());
+  }
+
+  @Test
+  public void testListAllBucketsPaginated() throws Exception {
+    ListBucketResponse response = listWithMaxBuckets(1);
+    assertEquals(0, response.getBucketsNum());
+    assertNull(response.getContinuationToken());
+
+    clientStub.getObjectStore().createS3Bucket("bucket-a");
+    response = listWithMaxBuckets(1);
+    assertEquals(1, response.getBucketsNum());
+    assertEquals("bucket-a", response.getBuckets().get(0).getName());
+    assertNull(response.getContinuationToken());
+
+    clientStub.getObjectStore().createS3Bucket("bucket-b");
+    response = listWithMaxBuckets(1);
+    assertEquals(1, response.getBucketsNum());
+    assertEquals("bucket-a", response.getBuckets().get(0).getName());
+    assertNotNull(response.getContinuationToken());
+
+    rootEndpoint.queryParamsForTest().set(QueryParams.CONTINUATION_TOKEN,
+        response.getContinuationToken());
+    rootEndpoint.queryParamsForTest().setInt(QueryParams.MAX_BUCKETS, 1);
+    response = (ListBucketResponse) rootEndpoint.get().getEntity();
+    assertEquals(1, response.getBucketsNum());
+    assertEquals("bucket-b", response.getBuckets().get(0).getName());
+    assertNull(response.getContinuationToken());
+  }
+
+  @Test
+  public void testListAllBucketsPaginationMultiplePages() throws Exception {
+    String bucketBaseName = "bucket-" + getClass().getName();
+    for (int i = 0; i < 5; i++) {
+      clientStub.getObjectStore().createS3Bucket(bucketBaseName + i);
+    }
+
+    rootEndpoint.queryParamsForTest().setInt(QueryParams.MAX_BUCKETS, 2);
+    ListBucketResponse response =
+        (ListBucketResponse) rootEndpoint.get().getEntity();
+
+    assertEquals(2, response.getBucketsNum());
+    assertEquals(bucketBaseName + 0, response.getBuckets().get(0).getName());
+    assertEquals(bucketBaseName + 1, response.getBuckets().get(1).getName());
+    assertNotNull(response.getContinuationToken());
+
+    rootEndpoint.queryParamsForTest().set(QueryParams.CONTINUATION_TOKEN,
+        response.getContinuationToken());
+    response = (ListBucketResponse) rootEndpoint.get().getEntity();
+
+    assertEquals(2, response.getBucketsNum());
+    assertEquals(bucketBaseName + 2, response.getBuckets().get(0).getName());
+    assertEquals(bucketBaseName + 3, response.getBuckets().get(1).getName());
+    assertNotNull(response.getContinuationToken());
+
+    rootEndpoint.queryParamsForTest().set(QueryParams.CONTINUATION_TOKEN,
+        response.getContinuationToken());
+    response = (ListBucketResponse) rootEndpoint.get().getEntity();
+
+    assertEquals(1, response.getBucketsNum());
+    assertEquals(bucketBaseName + 4, response.getBuckets().get(0).getName());
+    assertNull(response.getContinuationToken());
+  }
+
+  @Test
+  public void testListAllBucketsInvalidMaxBuckets() {
+    rootEndpoint.queryParamsForTest().setInt(QueryParams.MAX_BUCKETS, 0);
+    assertThrows(OS3Exception.class, () -> rootEndpoint.get());
+
+    rootEndpoint.queryParamsForTest().setInt(QueryParams.MAX_BUCKETS, -1);
+    assertThrows(OS3Exception.class, () -> rootEndpoint.get());
+  }
+
+  @Test
+  public void testListAllBucketsUnpaginatedReturnsAll() throws Exception {
+    for (int i = 0; i < 3; i++) {
+      clientStub.getObjectStore().createS3Bucket("unpaginated-bucket-" + i);
+    }
+
+    rootEndpoint.queryParamsForTest().unset(QueryParams.MAX_BUCKETS);
+    rootEndpoint.queryParamsForTest().unset(QueryParams.CONTINUATION_TOKEN);
+    ListBucketResponse response =
+        (ListBucketResponse) rootEndpoint.get().getEntity();
+
+    assertEquals(3, response.getBucketsNum());
+    assertNull(response.getContinuationToken());
+  }
+
+  private ListBucketResponse listWithMaxBuckets(int maxBuckets) throws Exception {
+    rootEndpoint.queryParamsForTest().unset(QueryParams.CONTINUATION_TOKEN);
+    rootEndpoint.queryParamsForTest().setInt(QueryParams.MAX_BUCKETS, maxBuckets);
+    return (ListBucketResponse) rootEndpoint.get().getEntity();
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
@@ -107,9 +107,7 @@ public class TestRootList {
       clientStub.getObjectStore().createS3Bucket(bucketBaseName + i);
     }
 
-    rootEndpoint.queryParamsForTest().setInt(QueryParams.MAX_BUCKETS, 2);
-    ListBucketResponse response =
-        (ListBucketResponse) rootEndpoint.get().getEntity();
+    ListBucketResponse response = listWithMaxBuckets(2);
 
     assertEquals(2, response.getBucketsNum());
     assertEquals(bucketBaseName + 0, response.getBuckets().get(0).getName());


### PR DESCRIPTION
## What changes were proposed in this pull request?
S3 test test_list_buckets_paginated is failing today as ListBuckets pagination using MaxBuckets and ContinuationToken on GET / (ListAllMyBuckets) is not supported. 

creates 2 buckets and calls list_buckets(MaxBuckets=1).

**Expected:** 1 bucket per page + ContinuationToken when more exist.
**Ozone:** Ignores MaxBuckets and returns both buckets → assert len == 1 fails with 2.

Simple example:
 
 ```
 Buckets: [bucket-A, bucket-B]
 Client: list_buckets(MaxBuckets=1) 

 AWS: { Buckets: [bucket-A], ContinuationToken: "..." }
 Ozone: { Buckets: [bucket-A, bucket-B] } ← 2 items, no token 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15616

## How was this patch tested?

Added UT and IT.
Also tested manually.
**Before Fix:**
```
// no continuation token is given and send all the buckets stored.
bash-5.1$ aws s3api list-buckets --max-buckets 1 --endpoint-url http://s3g:9878 --output json
{
    "Buckets": [
        {
            "Name": "buck1",
            "CreationDate": "2026-06-30T07:04:27.544Z"
        },
        {
            "Name": "buck2",              -----------------------------> wrong behaviour
            "CreationDate": "2026-06-30T07:04:30.460Z"
        },
        {
            "Name": "buck3",       -----------------------------> wrong behaviour
            "CreationDate": "2026-06-30T07:04:35.556Z"
        },
        {
            "Name": "buck4",           -----------------------------> wrong behaviour
            "CreationDate": "2026-06-30T07:04:40.205Z"
        },
        {
            "Name": "buck5",        -----------------------------> wrong behaviour
            "CreationDate": "2026-06-30T07:04:43.890Z"
        }
    ],
    "Owner": {
        "DisplayName": "om",
        "ID": "bb2bd7ca4a327f84e6cd3979f8fa3828a50a08893c1b68f9d6715352c8d07b93"
    }
}
```

**After Fix:**
```
bash-5.1$ aws s3api list-buckets --max-buckets 1 --endpoint-url http://s3g:9878/ --output json
{
    "Buckets": [
        {
            "Name": "buck1",
            "CreationDate": "2026-06-23T08:51:13.848Z"
        }
    ],
    "Owner": {
        "DisplayName": "om",
        "ID": "bb2bd7ca4a327f84e6cd3979f8fa3828a50a08893c1b68f9d6715352c8d07b93"
    },
    "ContinuationToken": "000000056275636b31-f239795a4c8be1e364face563bdc554b5559cbc1978becf3086b5079c2c44850"
}

bash-5.1$ aws s3api list-buckets --max-buckets 2 --endpoint-url http://s3g:9878/ --output json
{
    "Buckets": [
        {
            "Name": "buck1",
            "CreationDate": "2026-06-23T08:51:13.848Z"
        },
        {
            "Name": "buck2",
            "CreationDate": "2026-06-23T08:51:16.495Z"
        }
    ],
    "Owner": {
        "DisplayName": "om",
        "ID": "bb2bd7ca4a327f84e6cd3979f8fa3828a50a08893c1b68f9d6715352c8d07b93"
    }
}

bash-5.1$ ozone sh bucket create /s3v/buck3
bash-5.1$ aws s3api list-buckets --max-buckets 2 --endpoint-url http://s3g:9878/ --output json
{
    "Buckets": [
        {
            "Name": "buck1",
            "CreationDate": "2026-06-23T08:51:13.848Z"
        },
        {
            "Name": "buck2",
            "CreationDate": "2026-06-23T08:51:16.495Z"
        }
    ],
    "Owner": {
        "DisplayName": "om",
        "ID": "bb2bd7ca4a327f84e6cd3979f8fa3828a50a08893c1b68f9d6715352c8d07b93"
    },
    "ContinuationToken": "000000056275636b32-0880ee15253ee89c74cbc13b73c026a3ecd9529d0682e4d61e85dde392eb3ed3"
}

bash-5.1$ aws s3api list-buckets --max-buckets 1 --continuation-token 000000056275636b32-0880ee15253ee89c74cbc13b73c026a3ecd9529d0682e4d61e85dde392eb3ed3 \
    --endpoint-url http://s3g:9878/ --output json
{
    "Buckets": [
        {
            "Name": "buck3",
            "CreationDate": "2026-06-23T08:52:25.003Z"
        }
    ],
    "Owner": {
        "DisplayName": "om",
        "ID": "bb2bd7ca4a327f84e6cd3979f8fa3828a50a08893c1b68f9d6715352c8d07b93"
    }
}
bash-5.1$ aws s3api list-buckets --max-buckets 2 --endpoint-url http://s3g:9878/
{
    "Buckets": [
        {
            "Name": "buck1",
            "CreationDate": "2026-06-23T08:51:13.848Z"
        },
        {
            "Name": "buck2",
            "CreationDate": "2026-06-23T08:51:16.495Z"
        }
    ],
    "Owner": {
        "DisplayName": "om",
        "ID": "bb2bd7ca4a327f84e6cd3979f8fa3828a50a08893c1b68f9d6715352c8d07b93"
    },
    "ContinuationToken": "000000056275636b32-0880ee15253ee89c74cbc13b73c026a3ecd9529d0682e4d61e85dde392eb3ed3"
}
```
