### PR TITLE
HDDS-15719. Add check for allowed action usage in workflows

### DIFF
--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "ASF Allowlist Check"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check actions
+        uses: apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3 # main

--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -45,3 +45,5 @@ jobs:
           persist-credentials: false
       - name: Check actions
         uses: apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3
+        with:
+          scan-glob: ".github/workflows/*.y*ml"

--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -21,11 +21,19 @@ on:
     paths:
       - ".github/workflows/**"
   push:
+    branches-ignore:
+      - 'dependabot/**'
+    tags:
+      - '**'
     paths:
       - ".github/workflows/**"
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
 
 jobs:
   asf-allowlist-check:

--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -44,4 +44,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Check actions
-        uses: apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3 # main
+        uses: apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub workflows may fail silently when using any actions not allowed by ASF Infra.  See https://github.com/apache/infrastructure-actions/issues/574 for details.

This change add a new check that verifies action usage in workflows.  See https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md

https://issues.apache.org/jira/browse/HDDS-15719

## How was this patch tested?

asf-allowlist-check: https://github.com/apache/ozone/actions/runs/28676520867/job/85051000513#step:3:30

```
Checking 11 unique action ref(s) against the ASF allowlist:

  ✅ actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 — trusted owner (actions)  (.github/workflows/check.yml, .github/workflows/ci.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/populate-cache.yml, .github/workflows/repeat-acceptance.yml)
  ✅ actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 — trusted owner (actions)  (.github/workflows/populate-cache.yml)
  ✅ actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 — trusted owner (actions)  (.github/workflows/build-ratis.yml, .github/workflows/check.yml, .github/workflows/populate-cache.yml, .github/workflows/repeat-acceptance.yml)
  ✅ actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 — trusted owner (actions)  (.github/workflows/asf-allowlist-check.yaml, .github/workflows/build-ratis.yml, .github/workflows/build-ratis.yml, .github/workflows/check.yml, .github/workflows/ci.yml, .github/workflows/ci.yml, .github/workflows/ci.yml, .github/workflows/ci.yml, .github/workflows/generate-config-doc.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/label-pr.yml, .github/workflows/populate-cache.yml, .github/workflows/pull-request.yml, .github/workflows/repeat-acceptance.yml, .github/workflows/repeat-acceptance.yml, .github/workflows/repeat-acceptance.yml, .github/workflows/update-ozone-site-config-doc.yml, .github/workflows/zizmor.yml)
  ✅ actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c — trusted owner (actions)  (.github/workflows/check.yml, .github/workflows/check.yml, .github/workflows/check.yml, .github/workflows/check.yml, .github/workflows/ci.yml, .github/workflows/generate-config-doc.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/repeat-acceptance.yml, .github/workflows/update-ozone-site-config-doc.yml)
  ✅ actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 — trusted owner (actions)  (.github/workflows/build-ratis.yml, .github/workflows/check.yml, .github/workflows/ci.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/populate-cache.yml, .github/workflows/populate-cache.yml, .github/workflows/repeat-acceptance.yml)
  ✅ actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 — trusted owner (actions)  (.github/workflows/generate-config-doc.yml)
  ✅ actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 — trusted owner (actions)  (.github/workflows/close-stale-prs.yaml)
  ✅ actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a — trusted owner (actions)  (.github/workflows/build-ratis.yml, .github/workflows/check.yml, .github/workflows/check.yml, .github/workflows/check.yml, .github/workflows/check.yml, .github/workflows/ci.yml, .github/workflows/generate-config-doc.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/intermittent-test-check.yml, .github/workflows/repeat-acceptance.yml, .github/workflows/repeat-acceptance.yml)
  ✅ apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3 — trusted owner (apache)  (.github/workflows/asf-allowlist-check.yaml)
  ✅ zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa — matches allowlist  (.github/workflows/zizmor.yml)
All 11 unique action refs are on the ASF allowlist
```

zizmor: https://github.com/apache/ozone/actions/runs/28676520903/job/85051000643#step:3:116