### PR TITLE
HDDS-12563. Cache and reuse ContainerID object.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerID.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.ratis.util.MemoizedSupplier;
+import org.apache.ratis.util.WeakValueCache;
 
 /**
  * Container ID is an integer that is a value between 1..MAX_CONTAINER ID.
@@ -42,7 +43,9 @@ public final class ContainerID implements Comparable<ContainerID> {
       LongCodec.get(), ContainerID::valueOf, c -> c.id,
       ContainerID.class, DelegatedCodec.CopyType.SHALLOW);
 
-  public static final ContainerID MIN = ContainerID.valueOf(0);
+  public static final ContainerID MIN = new ContainerID(0);
+  private static final WeakValueCache<Long, ContainerID> CACHE
+      = new WeakValueCache<>("containerId", ContainerID::new);
 
   private final long id;
   private final Supplier<HddsProtos.ContainerID> proto;
@@ -71,7 +74,11 @@ public final class ContainerID implements Comparable<ContainerID> {
    * @return ContainerID.
    */
   public static ContainerID valueOf(final long containerID) {
-    return new ContainerID(containerID);
+    return CACHE.getOrCreate(containerID);
+  }
+
+  static WeakValueCache<Long, ContainerID> getCacheForTesting() {
+    return CACHE;
   }
 
   /**
@@ -84,6 +91,10 @@ public final class ContainerID implements Comparable<ContainerID> {
    * Don't expose the int value.
    */
   public long getId() {
+    return id;
+  }
+
+  public long getIdForTesting() {
     return id;
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerID.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerID.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container;
+
+import static org.apache.hadoop.hdds.utils.db.CodecTestUtil.gc;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.RatisUtilTestUtil;
+import org.apache.ratis.util.TimeDuration;
+import org.apache.ratis.util.WeakValueCache;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Test {@link ContainerID}. */
+public final class TestContainerID {
+  private static final Logger LOG = LoggerFactory.getLogger(TestContainerID.class);
+
+  private static final WeakValueCache<Long, ContainerID> CACHE = ContainerID.getCacheForTesting();
+
+  static String dumpCache() {
+    final List<ContainerID> values = RatisUtilTestUtil.getValues(CACHE);
+    values.sort(Comparator.comparing(ContainerID::getIdForTesting));
+    String header = CACHE + ": " + values.size();
+    System.out.println(header);
+    System.out.println("  " + values);
+    return header;
+  }
+
+  static void assertCache(IDs expectedIDs) {
+    final List<ContainerID> computed = RatisUtilTestUtil.getValues(CACHE);
+    computed.sort(Comparator.comparing(ContainerID::getIdForTesting));
+
+    final List<ContainerID> expected = expectedIDs.getIds();
+    expected.sort(Comparator.comparing(ContainerID::getIdForTesting));
+
+    assertEquals(expected, computed, TestContainerID::dumpCache);
+  }
+
+  void assertCacheSizeWithGC(IDs expectedIDs) throws Exception {
+    JavaUtils.attempt(() -> {
+      gc();
+      assertCache(expectedIDs);
+    }, 5, TimeDuration.valueOf(100, TimeUnit.MILLISECONDS), "assertCacheSizeWithGC", LOG);
+  }
+
+  static class IDs {
+    private final List<ContainerID> ids = new LinkedList<>();
+
+    List<ContainerID> getIds() {
+      return new ArrayList<>(ids);
+    }
+
+    int size() {
+      return ids.size();
+    }
+
+    ContainerID allocate() {
+      final ContainerID id = ContainerID.valueOf(ThreadLocalRandom.current().nextLong(Long.MAX_VALUE));
+      LOG.info("allocate {}", id);
+      ids.add(id);
+      return id;
+    }
+
+    void release() {
+      final int r = ThreadLocalRandom.current().nextInt(size());
+      final ContainerID removed = ids.remove(r);
+      LOG.info("release {}", removed);
+    }
+  }
+
+  @Test
+  public void testCaching() throws Exception {
+    final int n = 100;
+    final IDs ids = new IDs();
+    assertEquals(0, ids.size());
+    assertCache(ids);
+
+    for (int i = 0; i < n; i++) {
+      final ContainerID id = ids.allocate();
+      assertSame(id, ContainerID.valueOf(id.getIdForTesting()));
+      assertCache(ids);
+    }
+
+    for (int i = 0; i < n / 2; i++) {
+      ids.release();
+      if (ThreadLocalRandom.current().nextInt(10) == 0) {
+        assertCacheSizeWithGC(ids);
+      }
+    }
+    assertCacheSizeWithGC(ids);
+
+    for (int i = 0; i < n / 2; i++) {
+      final ContainerID id = ids.allocate();
+      assertSame(id, ContainerID.valueOf(id.getIdForTesting()));
+      assertCache(ids);
+    }
+
+
+    for (int i = 0; i < n; i++) {
+      ids.release();
+      if (ThreadLocalRandom.current().nextInt(10) == 0) {
+        assertCacheSizeWithGC(ids);
+      }
+    }
+    assertCacheSizeWithGC(ids);
+
+    assertEquals(0, ids.size());
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/ratis/util/RatisUtilTestUtil.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/ratis/util/RatisUtilTestUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ratis.util;
+
+import java.util.List;
+
+/** Test util for the {@link org.apache.ratis.util} package. */
+public final class RatisUtilTestUtil {
+
+  private RatisUtilTestUtil() { }
+
+  public static <K, V> List<V> getValues(WeakValueCache<K, V> cache) {
+    return cache.getValues();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since ContainerID is immutable and all the Container IDs are kept in SCM's memory, we can cache and reuse the ContainerID object

This will avoid re-calculation of hash and proto conversion and also help (though very little) with SCM's memory consumption.

## What is the link to the Apache JIRA

HDDS-12563

## How was this patch tested?

Added a new test, which is mostly copied from [TestRaftIdCache](https://github.com/apache/ratis/blob/master/ratis-test/src/test/java/org/apache/ratis/util/TestRaftIdCache.java).