### PR TITLE
HDDS-15722. Bump netty to 4.1.135

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <metainf-services.version>1.11</metainf-services.version>
     <mockito.version>4.11.0</mockito.version>
     <native.lib.tmp.dir />
-    <netty.version>4.1.133.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <!-- Node.js version number (without the v prefix required by frontend-maven-plugin) -->
     <nodejs.version>20.18.2</nodejs.version>
     <okhttp3.version>4.12.0</okhttp3.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Bump netty version to 4.1.135.Final

This solves multiple CVEs:
1. https://nvd.nist.gov/vuln/detail/CVE-2026-48043
2. https://nvd.nist.gov/vuln/detail/CVE-2026-45674
3. https://nvd.nist.gov/vuln/detail/CVE-2026-47691

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15722

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
