### PR TITLE
HDDS-15727. Bump ratis-thirdparty to 1.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,10 +185,10 @@
     <protobuf.version>3.25.9</protobuf.version>
     <ranger.version>2.8.0</ranger.version>
     <!-- versions included in ratis-thirdparty, update in sync -->
-    <ratis-thirdparty.grpc.version>1.75.0</ratis-thirdparty.grpc.version>
-    <ratis-thirdparty.netty.version>4.1.127.Final</ratis-thirdparty.netty.version>
+    <ratis-thirdparty.grpc.version>1.77.1</ratis-thirdparty.grpc.version>
+    <ratis-thirdparty.netty.version>4.1.130.Final</ratis-thirdparty.netty.version>
     <ratis-thirdparty.protobuf.version>3.25.8</ratis-thirdparty.protobuf.version>
-    <ratis.thirdparty.version>1.0.10</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.11</ratis.thirdparty.version>
     <ratis.version>3.2.1</ratis.version>
     <re2j.version>1.7</re2j.version>
     <reflections.version>0.10.2</reflections.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Provide a one-liner summary of the changes in the PR **Title** field above.
It should be in the form of `HDDS-1234. Short summary of the change`.

Bump ratis thirdparty version to 1.0.11

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15727

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)

https://github.com/krvikash/ozone/actions/runs/28568611003