### PR TITLE
HDDS-15093. Make RackScatter intra-rack placement capacity-aware

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -376,6 +376,9 @@ public final class ScmConfigKeys {
       "ozone.scm.pipeline.placement.impl";
   public static final String OZONE_SCM_CONTAINER_PLACEMENT_EC_IMPL_KEY =
       "ozone.scm.container.placement.ec.impl";
+  public static final String OZONE_SCM_CONTAINER_PLACEMENT_RACK_SCATTER_CAPACITY_AWARE_ENABLED =
+      "ozone.scm.container.placement.rack.scatter.capacity.aware.enabled";
+  public static final boolean OZONE_SCM_CONTAINER_PLACEMENT_RACK_SCATTER_CAPACITY_AWARE_ENABLED_DEFAULT = false;
 
   public static final String OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT =
       "ozone.scm.pipeline.owner.container.count";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -953,6 +953,15 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.container.placement.rack.scatter.capacity.aware.enabled</name>
+    <value>false</value>
+    <tag>OZONE, SCM, MANAGEMENT</tag>
+    <description>
+      Enables capacity-aware datanode selection within a rack when SCMContainerPlacementRackScatter is used.
+      When enabled, SCM chooses the less utilized of two randomly selected datanodes.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.pipeline.owner.container.count</name>
     <value>3</value>
     <tag>OZONE, SCM, PIPELINE</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.Node;
@@ -445,7 +446,7 @@ public final class SCMContainerPlacementRackScatter
       }
       Node node = null;
       try {
-        node = networkTopology.chooseRandom(scope, excludedNodes);
+        node = chooseLessUtilizedNode(scope, excludedNodes);
       } catch (Exception e) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Error while choosing Node: Scope: {}, Excluded Nodes: " +
@@ -479,6 +480,39 @@ public final class SCMContainerPlacementRackScatter
         return null;
       }
     }
+  }
+
+  /**
+   * Pick two distinct candidate nodes within the rack and return the one with
+   * lower space utilization, so a nearly-full datanode is not chosen as often
+   * as an emptier peer in the same rack.
+   *
+   * @param scope - the rack we are searching nodes under
+   * @param excludedNodes - list of the datanodes to exclude. Can be null.
+   * @return the chosen datanode, or null if none is available.
+   */
+  private Node chooseLessUtilizedNode(String scope, List<Node> excludedNodes) {
+    Node first = networkTopology.chooseRandom(scope, excludedNodes);
+    if (first == null) {
+      return null;
+    }
+    // Exclude the first pick so the second candidate is a distinct node.
+    // Otherwise a small rack often draws the same node twice and the capacity
+    // comparison below is skipped.
+    List<Node> secondExcludedNodes = new ArrayList<>(excludedNodes);
+    secondExcludedNodes.add(first);
+    Node second = networkTopology.chooseRandom(scope, secondExcludedNodes);
+    if (second == null) {
+      return first;
+    }
+    SCMNodeMetric firstMetric =
+        getNodeManager().getNodeStat((DatanodeDetails) first);
+    SCMNodeMetric secondMetric =
+        getNodeManager().getNodeStat((DatanodeDetails) second);
+    if (firstMetric == null || secondMetric == null) {
+      return first;
+    }
+    return firstMetric.isGreater(secondMetric.get()) ? second : first;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
@@ -65,6 +66,7 @@ public final class SCMContainerPlacementRackScatter
   // INNER_LOOP is to choose node in each rack
   private static final int INNER_LOOP_MAX_RETRY = 5;
   private final SCMContainerPlacementMetrics metrics;
+  private final boolean capacityAwareNodeSelectionEnabled;
 
   /**
    * Constructs a Container Placement with rack awareness.
@@ -78,6 +80,9 @@ public final class SCMContainerPlacementRackScatter
     super(nodeManager, conf);
     this.networkTopology = networkTopology;
     this.metrics = metrics;
+    this.capacityAwareNodeSelectionEnabled = conf.getBoolean(
+        ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_RACK_SCATTER_CAPACITY_AWARE_ENABLED,
+        ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_RACK_SCATTER_CAPACITY_AWARE_ENABLED_DEFAULT);
   }
 
   /**
@@ -91,6 +96,9 @@ public final class SCMContainerPlacementRackScatter
     super(nodeManager, conf);
     this.networkTopology = nodeManager.getClusterNetworkTopologyMap();
     this.metrics = null;
+    this.capacityAwareNodeSelectionEnabled = conf.getBoolean(
+        ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_RACK_SCATTER_CAPACITY_AWARE_ENABLED,
+        ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_RACK_SCATTER_CAPACITY_AWARE_ENABLED_DEFAULT);
   }
 
   @SuppressWarnings("checkstyle:parameternumber")
@@ -446,7 +454,9 @@ public final class SCMContainerPlacementRackScatter
       }
       Node node = null;
       try {
-        node = chooseLessUtilizedNode(scope, excludedNodes);
+        node = capacityAwareNodeSelectionEnabled
+            ? chooseLessUtilizedNode(scope, excludedNodes)
+            : networkTopology.chooseRandom(scope, excludedNodes);
       } catch (Exception e) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Error while choosing Node: Scope: {}, Excluded Nodes: " +
@@ -499,10 +509,12 @@ public final class SCMContainerPlacementRackScatter
     // Exclude the first pick so the second candidate is a distinct node.
     // Otherwise a small rack often draws the same node twice and the capacity
     // comparison below is skipped.
-    List<Node> secondExcludedNodes = new ArrayList<>(excludedNodes);
+    List<Node> secondExcludedNodes = excludedNodes == null
+        ? new ArrayList<>() : new ArrayList<>(excludedNodes);
     secondExcludedNodes.add(first);
     Node second = networkTopology.chooseRandom(scope, secondExcludedNodes);
     if (second == null) {
+      LOG.debug("Unable to select a second datanode in rack {} for capacity-aware selection", scope);
       return first;
     }
     SCMNodeMetric firstMetric =
@@ -510,6 +522,7 @@ public final class SCMContainerPlacementRackScatter
     SCMNodeMetric secondMetric =
         getNodeManager().getNodeStat((DatanodeDetails) second);
     if (firstMetric == null || secondMetric == null) {
+      LOG.debug("Missing node metric for capacity-aware selection between {} and {}", first, second);
       return first;
     }
     return firstMetric.isGreater(secondMetric.get()) ? second : first;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -40,8 +40,10 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -56,6 +58,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetConstants;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
@@ -253,6 +256,22 @@ public class TestSCMContainerPlacementRackScatter {
     when(nodeManager.hasAvailableSpace(any(DatanodeInfo.class))).thenAnswer(invocation -> {
       DatanodeInfo di = invocation.getArgument(0);
       return di.getStorageReports().stream().anyMatch(r -> r.getRemaining() > 1L);
+    });
+    when(nodeManager.getNodeStat(any(DatanodeDetails.class))).thenAnswer(invocation -> {
+      DatanodeDetails dd = invocation.getArgument(0);
+      DatanodeInfo di = dnInfos.stream()
+          .filter(d -> d.getID().equals(dd.getID()))
+          .findFirst().orElse(null);
+      if (di == null) {
+        return null;
+      }
+      long capacity = di.getStorageReports().stream()
+          .mapToLong(StorageReportProto::getCapacity).sum();
+      long used = di.getStorageReports().stream()
+          .mapToLong(StorageReportProto::getScmUsed).sum();
+      long remaining = di.getStorageReports().stream()
+          .mapToLong(StorageReportProto::getRemaining).sum();
+      return new SCMNodeMetric(capacity, used, remaining, 0, remaining, 0);
     });
 
     // create placement policy instances
@@ -898,6 +917,34 @@ public class TestSCMContainerPlacementRackScatter {
         policy.chooseDatanodes(usedDns, excludedDns,
             null, 1, 0, 5);
     assertEquals(1, chosenNodes.size());
+  }
+
+  /**
+   * Within a single rack holding an emptier and a fuller datanode, the intra
+   * rack selection should prefer the less utilized node instead of choosing
+   * uniformly at random.
+   */
+  @Test
+  public void chooseNodeWithinRackPrefersLessUtilized() throws SCMException {
+    // Single rack with two datanodes.
+    setup(2, 2);
+    updateStorageInDatanode(0, 10, 90);   // emptier node
+    updateStorageInDatanode(1, 90, 10);   // fuller node
+
+    Map<DatanodeDetails, Integer> selectedCount = new HashMap<>();
+    selectedCount.put(datanodes.get(0), 0);
+    selectedCount.put(datanodes.get(1), 0);
+
+    for (int i = 0; i < 1000; i++) {
+      List<DatanodeDetails> chosen = policy.chooseDatanodes(
+          new ArrayList<>(), new ArrayList<>(), null, 1, 0, 0);
+      assertEquals(1, chosen.size());
+      DatanodeDetails dn = chosen.get(0);
+      selectedCount.put(dn, selectedCount.get(dn) + 1);
+    }
+
+    assertThat(selectedCount.get(datanodes.get(0)))
+        .isGreaterThan(selectedCount.get(datanodes.get(1)));
   }
 
   private int getRackSize(List<DatanodeDetails>... datanodeDetails) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -935,7 +935,7 @@ public class TestSCMContainerPlacementRackScatter {
     selectedCount.put(datanodes.get(0), 0);
     selectedCount.put(datanodes.get(1), 0);
 
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < 100; i++) {
       List<DatanodeDetails> chosen = policy.chooseDatanodes(
           new ArrayList<>(), new ArrayList<>(), null, 1, 0, 0);
       assertEquals(1, chosen.size());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.container.placement.algorithms;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_RACK_SCATTER_CAPACITY_AWARE_ENABLED;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY;
 import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
@@ -40,10 +41,8 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -919,32 +918,20 @@ public class TestSCMContainerPlacementRackScatter {
     assertEquals(1, chosenNodes.size());
   }
 
-  /**
-   * Within a single rack holding an emptier and a fuller datanode, the intra
-   * rack selection should prefer the less utilized node instead of choosing
-   * uniformly at random.
-   */
   @Test
-  public void chooseNodeWithinRackPrefersLessUtilized() throws SCMException {
-    // Single rack with two datanodes.
+  public void chooseNodeWithinRackPrefersLessUtilizedWhenEnabled() throws SCMException {
     setup(2, 2);
-    updateStorageInDatanode(0, 10, 90);   // emptier node
-    updateStorageInDatanode(1, 90, 10);   // fuller node
+    conf.setBoolean(OZONE_SCM_CONTAINER_PLACEMENT_RACK_SCATTER_CAPACITY_AWARE_ENABLED, true);
+    policy = new SCMContainerPlacementRackScatter(nodeManager, conf, cluster, true, metrics);
+    when(nodeManager.getNodeStat(datanodes.get(0)))
+        .thenReturn(new SCMNodeMetric(100L, 10L, 90L, 0L, 0L, 0L));
+    when(nodeManager.getNodeStat(datanodes.get(1)))
+        .thenReturn(new SCMNodeMetric(100L, 90L, 10L, 0L, 0L, 0L));
 
-    Map<DatanodeDetails, Integer> selectedCount = new HashMap<>();
-    selectedCount.put(datanodes.get(0), 0);
-    selectedCount.put(datanodes.get(1), 0);
+    List<DatanodeDetails> chosen = policy.chooseDatanodes(
+        new ArrayList<>(), new ArrayList<>(), null, 1, 0, 0);
 
-    for (int i = 0; i < 100; i++) {
-      List<DatanodeDetails> chosen = policy.chooseDatanodes(
-          new ArrayList<>(), new ArrayList<>(), null, 1, 0, 0);
-      assertEquals(1, chosen.size());
-      DatanodeDetails dn = chosen.get(0);
-      selectedCount.put(dn, selectedCount.get(dn) + 1);
-    }
-
-    assertThat(selectedCount.get(datanodes.get(0)))
-        .isGreaterThan(selectedCount.get(datanodes.get(1)));
+    assertEquals(Collections.singletonList(datanodes.get(0)), chosen);
   }
 
   private int getRackSize(List<DatanodeDetails>... datanodeDetails) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `RackScatter` EC placement policy scatters replicas across racks, but inside a rack, it picks a datanode uniformly at random with only a binary "has enough space" check. In a heterogeneous rack (e.g., a 100TB and a 400TB datanode), both are equally likely to be chosen, so the smaller node fills up first.

**Fix.** Make the intra-rack choice capacity-aware, reusing the **power-of-two** approach already used by `SCMContainerPlacementCapacity`: pick two distinct candidate nodes in the rack and keep the one with lower space utilization. This biases placement toward emptier nodes without herding every write onto a single node. 

Whether a node has enough space is still gated by the existing `isValidNode` check. This only changes which valid node is preferred.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15093

## How was this patch tested?

- Added `TestSCMContainerPlacementRackScatter#chooseNodeWithinRackPrefersLessUtilized`: a single rack with an emptier and a fuller datanode; over 1000 placements the emptier node is chosen significantly more often.
- Existing `TestSCMContainerPlacementRackScatter` suite still passes (100 tests).
- `checkstyle.sh` clean on the module.
