### PR TITLE
HDDS-15725. zizmor check should reflect failure in fork

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -30,8 +30,8 @@ on:
 permissions: { }
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository == 'apache/ozone', github.sha, github.ref_name) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'apache/ozone' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -42,3 +42,5 @@ jobs:
 
     - name: Run zizmor
       uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      with:
+        advanced-security: ${{ github.repository_owner == 'apache' }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,11 @@ on:
       - 'dependabot/**'
     tags:
       - '**'
+    paths:
+      - '.github/workflows/**'
   pull_request:
+    paths:
+      - '.github/workflows/**'
 
 permissions: { }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

zizmor workflow added in HDDS-14920 provides feedback via "Code scanning results".  The workflow itself passes even if it finds issues to be fixed.  This does not work well in forks where code scanning is disabled.

Example (with intentional violation):
https://github.com/adoroszlai/ozone/actions/runs/28570405264/job/84706670204#step:3:1058

To provide better feedback, the workflow should reflect scan results in forks.

Two additional minor tweaks:
- run zizmor check only for workflow changes
- make repository owner condition more portable

https://issues.apache.org/jira/browse/HDDS-15725

## How was this patch tested?

Same violation with the patch fails:
https://github.com/adoroszlai/ozone/actions/runs/28570585965/job/84707233189#step:3:208

The patch without intentional violation passes:
https://github.com/adoroszlai/ozone/actions/runs/28570809169/job/84707932173#step:3:107