### PR TITLE
HDDS-15726. Improve SCM block deletion summary error handling

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -330,8 +330,8 @@ public class DeletedBlockLogImpl
   private void addTxToTxSizeMap(DeletedBlocksTransaction tx) {
     if (tx.hasTotalBlockReplicatedSize()) {
       transactionStatusManager.getTxSizeMap().put(tx.getTxID(),
-          new SCMDeletedBlockTransactionStatusManager.TxBlockInfo(tx.getLocalIDCount(),
-              tx.getTotalBlockSize(), tx.getTotalBlockReplicatedSize()));
+          new SCMDeletedBlockTransactionStatusManager.TxBlockInfo(tx.getTxID(), tx.getContainerID(),
+              tx.getLocalIDCount(), tx.getTotalBlockSize(), tx.getTotalBlockReplicatedSize()));
     }
   }
 
@@ -504,6 +504,11 @@ public class DeletedBlockLogImpl
       DeleteBlockStatus deleteBlockStatus, EventPublisher publisher) {
     if (!scmContext.isLeader()) {
       LOG.info("Skip commit transactions since current SCM is not leader.");
+      return;
+    }
+
+    if (!scmContext.isLeaderReady()) {
+      LOG.warn("SCM is not ready to commit transactions.");
       return;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -508,7 +508,7 @@ public class DeletedBlockLogImpl
     }
 
     if (!scmContext.isLeaderReady()) {
-      LOG.warn("SCM is not ready to commit transactions.");
+      LOG.debug("SCM is not ready to commit transactions.");
       return;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
@@ -471,7 +471,7 @@ public class SCMDeletedBlockTransactionStatusManager {
         // Revert the in-memory changes if the DB update fails
         for (DeletedBlocksTransaction tx: txList) {
           if (tx.hasTotalBlockSize()) {
-            descDeletedBlocksSummary(tx);
+            rollbackDeletedBlocksSummary(tx);
             LOG.warn("{} is decreased from summary due to DB update failure", transactionToString(tx));
           }
         }
@@ -482,7 +482,7 @@ public class SCMDeletedBlockTransactionStatusManager {
     deletedBlockLogStateManager.addTransactionsToDB(txList);
   }
 
-  private void incrDeletedBlocksSummary(TxBlockInfo txBlockInfo) {
+  private void rollbackDeletedBlocksSummary(TxBlockInfo txBlockInfo) {
     totalTxCount.addAndGet(1);
     totalBlockCount.addAndGet(txBlockInfo.getTotalBlockCount());
     totalBlocksSize.addAndGet(txBlockInfo.getTotalBlockSize());
@@ -519,7 +519,7 @@ public class SCMDeletedBlockTransactionStatusManager {
         // Revert the in-memory changes if the DB update fails
         for (TxBlockInfo txBlockInfo : removedTxBlockInfos) {
           txSizeMap.put(txBlockInfo.getTxId(), txBlockInfo);
-          incrDeletedBlocksSummary(txBlockInfo);
+          rollbackDeletedBlocksSummary(txBlockInfo);
           LOG.warn("{} is added back to txSizeMap and increased to summary due to DB update failure", txBlockInfo);
         }
         throw e;
@@ -623,7 +623,7 @@ public class SCMDeletedBlockTransactionStatusManager {
     LOG.debug("Decrease summary for {} to {}", txBlockInfo, summaryToString(getSummary()));
   }
 
-  private void descDeletedBlocksSummary(DeletedBlocksTransaction tx) {
+  private void rollbackDeletedBlocksSummary(DeletedBlocksTransaction tx) {
     totalTxCount.addAndGet(-1);
     totalBlockCount.addAndGet(-tx.getLocalIDCount());
     totalBlocksSize.addAndGet(-tx.getTotalBlockSize());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
@@ -427,10 +427,8 @@ public class SCMDeletedBlockTransactionStatusManager {
     try {
       initDataDistributionData();
     } catch (IOException e) {
-      LOG.warn("Failed to initialize Storage space distribution data. The feature will continue with current " +
-              "totalTxCount {}, totalBlockCount {}, totalBlocksSize {} and totalReplicatedBlocksSize {}. " +
-              "There is a high chance that the real data and current data has a gap.",
-          totalTxCount.get(), totalBlockCount.get(), totalBlocksSize.get(), totalReplicatedBlocksSize.get());
+      LOG.warn("Failed to initialize Storage space distribution data. The feature will continue with current {}." +
+          " There is a high chance that the real data and current data has a gap.", summaryToString(getSummary()));
     }
   }
 
@@ -467,10 +465,29 @@ public class SCMDeletedBlockTransactionStatusManager {
           incrDeletedBlocksSummary(tx);
         }
       }
-      deletedBlockLogStateManager.addTransactionsToDB(txList, getSummary());
+      try {
+        deletedBlockLogStateManager.addTransactionsToDB(txList, getSummary());
+      } catch (IOException e) {
+        // Revert the in-memory changes if the DB update fails
+        for (DeletedBlocksTransaction tx: txList) {
+          if (tx.hasTotalBlockSize()) {
+            descDeletedBlocksSummary(tx);
+            LOG.warn("{} is decreased from summary due to DB update failure", transactionToString(tx));
+          }
+        }
+        throw e;
+      }
       return;
     }
     deletedBlockLogStateManager.addTransactionsToDB(txList);
+  }
+
+  private void incrDeletedBlocksSummary(TxBlockInfo txBlockInfo) {
+    totalTxCount.addAndGet(1);
+    totalBlockCount.addAndGet(txBlockInfo.getTotalBlockCount());
+    totalBlocksSize.addAndGet(txBlockInfo.getTotalBlockSize());
+    totalReplicatedBlocksSize.addAndGet(txBlockInfo.getTotalReplicatedBlockSize());
+    LOG.debug("Increase summary for {} to {}", txBlockInfo, summaryToString(getSummary()));
   }
 
   private void incrDeletedBlocksSummary(DeletedBlocksTransaction tx) {
@@ -478,6 +495,7 @@ public class SCMDeletedBlockTransactionStatusManager {
     totalBlockCount.addAndGet(tx.getLocalIDCount());
     totalBlocksSize.addAndGet(tx.getTotalBlockSize());
     totalReplicatedBlocksSize.addAndGet(tx.getTotalBlockReplicatedSize());
+    LOG.debug("Increase summary for {} to {}", transactionToString(tx), summaryToString(getSummary()));
   }
 
   @VisibleForTesting
@@ -487,13 +505,25 @@ public class SCMDeletedBlockTransactionStatusManager {
     }
     if (VersionedDatanodeFeatures.isFinalized(HDDSLayoutFeature.STORAGE_SPACE_DISTRIBUTION) &&
         !disableDataDistributionForTest) {
+      List<TxBlockInfo> removedTxBlockInfos = new ArrayList<>();
       for (Long txID: txIDs) {
         TxBlockInfo txBlockInfo = txSizeMap.remove(txID);
         if (txBlockInfo != null) {
           descDeletedBlocksSummary(txBlockInfo);
+          removedTxBlockInfos.add(txBlockInfo);
         }
       }
-      deletedBlockLogStateManager.removeTransactionsFromDB(txIDs, getSummary());
+      try {
+        deletedBlockLogStateManager.removeTransactionsFromDB(txIDs, getSummary());
+      } catch (IOException e) {
+        // Revert the in-memory changes if the DB update fails
+        for (TxBlockInfo txBlockInfo : removedTxBlockInfos) {
+          txSizeMap.put(txBlockInfo.getTxId(), txBlockInfo);
+          incrDeletedBlocksSummary(txBlockInfo);
+          LOG.warn("{} is added back to txSizeMap and increased to summary due to DB update failure", txBlockInfo);
+        }
+        throw e;
+      }
       return;
     }
 
@@ -590,6 +620,15 @@ public class SCMDeletedBlockTransactionStatusManager {
     totalBlockCount.addAndGet(-txBlockInfo.getTotalBlockCount());
     totalBlocksSize.addAndGet(-txBlockInfo.getTotalBlockSize());
     totalReplicatedBlocksSize.addAndGet(-txBlockInfo.getTotalReplicatedBlockSize());
+    LOG.debug("Decrease summary for {} to {}", txBlockInfo, summaryToString(getSummary()));
+  }
+
+  private void descDeletedBlocksSummary(DeletedBlocksTransaction tx) {
+    totalTxCount.addAndGet(-1);
+    totalBlockCount.addAndGet(-tx.getLocalIDCount());
+    totalBlocksSize.addAndGet(-tx.getTotalBlockSize());
+    totalReplicatedBlocksSize.addAndGet(-tx.getTotalBlockReplicatedSize());
+    LOG.debug("Decrease summary for {} to {}", transactionToString(tx), summaryToString(getSummary()));
   }
 
   @VisibleForTesting
@@ -674,16 +713,18 @@ public class SCMDeletedBlockTransactionStatusManager {
   }
 
   private void initDataDistributionData() throws IOException {
-    DeletedBlocksTransactionSummary summary = loadDeletedBlocksSummary();
-    if (summary != null) {
-      totalTxCount.set(summary.getTotalTransactionCount());
-      totalBlockCount.set(summary.getTotalBlockCount());
-      totalBlocksSize.set(summary.getTotalBlockSize());
-      totalReplicatedBlocksSize.set(summary.getTotalBlockReplicatedSize());
-      LOG.info("Storage space distribution is initialized with totalTxCount {}, totalBlockCount {}, " +
-              "totalBlocksSize {} and totalReplicatedBlocksSize {}", totalTxCount.get(),
-          totalBlockCount.get(), totalBlocksSize.get(), totalReplicatedBlocksSize.get());
+    DeletedBlocksTransactionSummary newSummary = loadDeletedBlocksSummary();
+    if (newSummary != null) {
+      DeletedBlocksTransactionSummary currentSummary = getSummary();
+      totalTxCount.set(newSummary.getTotalTransactionCount());
+      totalBlockCount.set(newSummary.getTotalBlockCount());
+      totalBlocksSize.set(newSummary.getTotalBlockSize());
+      totalReplicatedBlocksSize.set(newSummary.getTotalBlockReplicatedSize());
+      if (!isSummaryEqual(currentSummary, newSummary)) {
+        LOG.info("Old summary {} is replaced.", summaryToString(currentSummary));
+      }
     }
+    LOG.info("Storage space distribution is initialized with {}", summaryToString(getSummary()));
   }
 
   private DeletedBlocksTransactionSummary loadDeletedBlocksSummary() throws IOException {
@@ -702,15 +743,38 @@ public class SCMDeletedBlockTransactionStatusManager {
     }
   }
 
+  private String summaryToString(DeletedBlocksTransactionSummary summary) {
+    return String.format("Summary {TotalTransactionCount: %d, TotalBlockCount: %d, " +
+            "TotalBlockSize: %d, TotalBlockReplicatedSize: %d}", summary.getTotalTransactionCount(),
+        summary.getTotalBlockCount(), summary.getTotalBlockSize(), summary.getTotalBlockReplicatedSize());
+  }
+
+  private String transactionToString(DeletedBlocksTransaction tx) {
+    return String.format("Tx {TxId: %d, ContainerId: %d, TotalBlockCount: %d, TotalBlockSize: %d, " +
+            "TotalBlockReplicatedSize: %d}", tx.getTxID(), tx.getContainerID(), tx.getLocalIDCount(),
+        tx.getTotalBlockSize(), tx.getTotalBlockReplicatedSize());
+  }
+
+  private boolean isSummaryEqual(DeletedBlocksTransactionSummary summaryA, DeletedBlocksTransactionSummary summaryB) {
+    return summaryA.getTotalTransactionCount() == summaryB.getTotalTransactionCount() &&
+        summaryA.getTotalBlockCount() == summaryB.getTotalBlockCount() &&
+        summaryA.getTotalBlockSize() == summaryB.getTotalBlockSize() &&
+        summaryA.getTotalBlockReplicatedSize() == summaryB.getTotalBlockReplicatedSize();
+  }
+
   /**
    * Block size information of a transaction.
    */
   public static class TxBlockInfo {
-    private long totalBlockCount;
-    private long totalBlockSize;
-    private long totalReplicatedBlockSize;
+    private final long txId;
+    private final long containerId;
+    private final long totalBlockCount;
+    private final long totalBlockSize;
+    private final long totalReplicatedBlockSize;
 
-    public TxBlockInfo(long blockCount, long blockSize, long replicatedSize) {
+    public TxBlockInfo(long txId, long containerId, long blockCount, long blockSize, long replicatedSize) {
+      this.txId = txId;
+      this.containerId = containerId;
       this.totalBlockCount = blockCount;
       this.totalBlockSize = blockSize;
       this.totalReplicatedBlockSize = replicatedSize;
@@ -726,6 +790,25 @@ public class SCMDeletedBlockTransactionStatusManager {
 
     public long getTotalReplicatedBlockSize() {
       return totalReplicatedBlockSize;
+    }
+
+    public long getTxId() {
+      return txId;
+    }
+
+    public long getContainerId() {
+      return containerId;
+    }
+
+    @Override
+    public String toString() {
+      return "TxBlockInfo{" +
+          "txId=" + txId +
+          ", containerId=" + containerId +
+          ", totalBlockCount=" + totalBlockCount +
+          ", totalBlockSize=" + totalBlockSize +
+          ", totalReplicatedBlockSize=" + totalReplicatedBlockSize +
+          '}';
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -899,7 +899,7 @@ public class TestDeletedBlockLog {
       Map<Long, TxBlockInfo> txSizeMap = statusManager.getTxSizeMap();
       for (Map.Entry<Long, List<DeletedBlock>> entry : data.entrySet()) {
         List<DeletedBlock> deletedBlockList = entry.getValue();
-        TxBlockInfo txBlockInfo = new TxBlockInfo(deletedBlockList.size(),
+        TxBlockInfo txBlockInfo = new TxBlockInfo(entry.getKey(), 0, deletedBlockList.size(),
             deletedBlockList.stream().map(DeletedBlock::getSize).reduce(0L, Long::sum),
             deletedBlockList.stream().map(DeletedBlock::getReplicatedSize).reduce(0L, Long::sum));
         txSizeMap.put(entry.getKey(), txBlockInfo);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improve the block deletion summary error handing
1. check leader ready in onMessage()
2. adjust summary if db persist fails
3. add debug log info for summary change, for further debug purpose 

## What is the link to the Apache JIRA

[HDDS-15726](https://issues.apache.org/jira/browse/HDDS-15726)

## How was this patch tested?

existing unit tests. 
