### PR TITLE
HDDS-765. Configure shorter node failure detection timeouts in TestNodeFailure

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
@@ -62,6 +62,8 @@ public class TestNodeFailure {
     conf.set(HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL, "2s");
     conf.setTimeDuration(HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL, 1000, MILLISECONDS);
     conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL, 1000, MILLISECONDS);
+    conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL, 10 * 1000, MILLISECONDS);
+    conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL, 20 * 1000, MILLISECONDS);
 
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(6)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Configure shorter node failure detection timeouts in TestNodeFailure

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-765

## How was this patch tested?
Existing unit and integration tests