### PR TITLE
HDDS-15732. Some ozone commands ignore OZONE_MODULE_ACCESS_ARGS

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -252,7 +252,7 @@ function ozonecmd_case
     repair)
       check_running_ozone_services
       OZONE_CLASSNAME=org.apache.hadoop.ozone.repair.OzoneRepair
-      OZONE_DEBUG_OPTS="${OZONE_DEBUG_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
+      OZONE_REPAIR_OPTS="${OZONE_REPAIR_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-cli-repair"
     ;;
     ratis)

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -162,7 +162,7 @@ function ozonecmd_case
       OZONE_OM_OPTS="${OZONE_OM_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-manager"
     ;;
-    sh | shell)
+    sh)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.OzoneShell
       ozone_deprecate_envvar HDFS_OM_SH_OPTS OZONE_SH_OPTS
       OZONE_SH_OPTS="${OZONE_SH_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
@@ -354,6 +354,10 @@ else
   shift
 fi
 
+# needed for accepting `ozone shell` but still picking up OZONE_SH_OPTS
+if [[ "${OZONE_SUBCMD}" == "shell" ]]; then
+  OZONE_SUBCMD=sh
+fi
 
 if ozone_need_reexec ozone "${OZONE_SUBCMD}"; then
   ozone_uservar_su ozone "${OZONE_SUBCMD}" \

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -97,6 +97,8 @@ function ozonecmd_case
   # Corresponding Ratis issue https://issues.apache.org/jira/browse/RATIS-534.
   RATIS_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false ${RATIS_OPTS}"
 
+  OZONE_OPTS="${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS} ${OZONE_OPTS}"
+
   case ${subcmd} in
     classpath)
       if [[ "$#" -gt 0 ]]; then
@@ -121,9 +123,7 @@ function ozonecmd_case
     datanode)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       ozone_deprecate_envvar HDDS_DN_OPTS OZONE_DATANODE_OPTS
-      OZONE_DATANODE_OPTS="${RATIS_OPTS} ${OZONE_DATANODE_OPTS}"
       OZONE_DATANODE_OPTS="-Dlog4j.configurationFile=${OZONE_CONF_DIR}/dn-audit-log4j2.properties,${OZONE_CONF_DIR}/dn-container-log4j2.properties -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties ${OZONE_DATANODE_OPTS}"
-      OZONE_DATANODE_OPTS="${OZONE_DATANODE_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_CLASSNAME=org.apache.hadoop.ozone.HddsDatanodeService
       OZONE_RUN_ARTIFACT_NAME="ozone-datanode"
     ;;
@@ -141,7 +141,6 @@ function ozonecmd_case
     ;;
     freon)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.freon.Freon
-      OZONE_FREON_OPTS="${OZONE_FREON_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-freon"
       if ozone_is_freon_command_moved_to_vapor; then
         # backward compatibility
@@ -157,15 +156,12 @@ function ozonecmd_case
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME=org.apache.hadoop.ozone.om.OzoneManagerStarter
       ozone_deprecate_envvar HDFS_OM_OPTS OZONE_OM_OPTS
-      OZONE_OM_OPTS="${RATIS_OPTS} ${OZONE_OM_OPTS}"
       OZONE_OM_OPTS="${OZONE_OM_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/om-audit-log4j2.properties -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties"
-      OZONE_OM_OPTS="${OZONE_OM_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-manager"
     ;;
     sh)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.OzoneShell
       ozone_deprecate_envvar HDFS_OM_SH_OPTS OZONE_SH_OPTS
-      OZONE_SH_OPTS="${OZONE_SH_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-cli-shell"
     ;;
     s3)
@@ -176,20 +172,18 @@ function ozonecmd_case
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter'
       ozone_deprecate_envvar HDFS_STORAGECONTAINERMANAGER_OPTS OZONE_SCM_OPTS
-      OZONE_SCM_OPTS="${RATIS_OPTS} ${OZONE_SCM_OPTS}"
       OZONE_SCM_OPTS="${OZONE_SCM_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/scm-audit-log4j2.properties -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties"
-      OZONE_SCM_OPTS="${OZONE_SCM_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="hdds-server-scm"
     ;;
     s3g)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.ozone.s3.Gateway'
-      OZONE_S3G_OPTS="${OZONE_S3G_OPTS} ${RATIS_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/s3g-audit-log4j2.properties -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties ${OZONE_MODULE_ACCESS_ARGS}"
+      OZONE_S3G_OPTS="${OZONE_S3G_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/s3g-audit-log4j2.properties -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties"
       OZONE_RUN_ARTIFACT_NAME="ozone-s3gateway"
     ;;
     httpfs)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
-      OZONE_HTTPFS_OPTS="${OZONE_HTTPFS_OPTS} ${RATIS_OPTS} -Dhttpfs.home.dir=${OZONE_HOME} -Dhttpfs.config.dir=${OZONE_CONF_DIR} -Dhttpfs.log.dir=${OZONE_HOME}/log -Dhttpfs.temp.dir=${OZONE_HOME}/temp -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties ${OZONE_MODULE_ACCESS_ARGS}"
+      OZONE_HTTPFS_OPTS="${OZONE_HTTPFS_OPTS} -Dhttpfs.home.dir=${OZONE_HOME} -Dhttpfs.config.dir=${OZONE_CONF_DIR} -Dhttpfs.log.dir=${OZONE_HOME}/log -Dhttpfs.temp.dir=${OZONE_HOME}/temp -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties"
       OZONE_CLASSNAME='org.apache.ozone.fs.http.server.HttpFSServerWebServer'
       OZONE_RUN_ARTIFACT_NAME="ozone-httpfsgateway"
     ;;
@@ -206,12 +200,11 @@ function ozonecmd_case
     recon)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.ozone.recon.ReconServer'
-      OZONE_RECON_OPTS="${OZONE_RECON_OPTS} ${RATIS_OPTS} -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties ${OZONE_MODULE_ACCESS_ARGS}"
+      OZONE_RECON_OPTS="${OZONE_RECON_OPTS} -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties"
       OZONE_RUN_ARTIFACT_NAME="ozone-recon"
     ;;
     fs)
       OZONE_CLASSNAME=org.apache.hadoop.fs.ozone.OzoneFsShell
-      OZONE_FS_OPTS="${OZONE_FS_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-tools"
     ;;
     daemonlog)
@@ -237,22 +230,18 @@ function ozonecmd_case
     interactive)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.OzoneInteractiveShell
       OZONE_RUN_ARTIFACT_NAME="ozone-cli-interactive"
-      OZONE_OPTS="${OZONE_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
     ;;
     admin)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.admin.OzoneAdmin
-      OZONE_ADMIN_OPTS="${OZONE_ADMIN_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-cli-admin"
     ;;
     debug)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.debug.OzoneDebug
-      OZONE_DEBUG_OPTS="${OZONE_DEBUG_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-cli-debug"
     ;;
     repair)
       check_running_ozone_services
       OZONE_CLASSNAME=org.apache.hadoop.ozone.repair.OzoneRepair
-      OZONE_REPAIR_OPTS="${OZONE_REPAIR_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-cli-repair"
     ;;
     ratis)
@@ -261,7 +250,6 @@ function ozonecmd_case
     ;;
     vapor)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.freon.Vapor
-      OZONE_VAPOR_OPTS="${OZONE_VAPOR_OPTS} ${RATIS_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-vapor"
     ;;
     iceberg)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Java 24/25 deprecation warnings are shown for several commands even after HDDS-15668.

```bash
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by org.apache.hadoop.util.NativeCodeLoader in an unnamed module (file:/opt/hadoop/share/ozone/lib/hadoop-common-3.4.3.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/opt/hadoop/share/ozone/lib/protobuf-java-3.25.9.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release
```

Examples:

```bash
ozone insight logs om.protocol.client
ozone repair om compact --column-family fileTable
ozone s3 getsecret
ozone shell volume list
ozone tenant list
```

Problems:
- several commands completely ignore `OZONE_MODULE_ACCESS_ARGS`
- `ozone repair` sets `OZONE_DEBUG_OPTS` instead of `OZONE_REPAIR_OPTS`
- `ozone shell` is an alias for `ozone sh`, but only in the subcommand switch, so `ozone_subcommand_opts` looks for `OZONE_SHELL_OPTS`

Fix:
- Apply `RATIS_OPTS` and `OZONE_MODULE_ACCESS_ARGS` to `OZONE_OPTS` globally.  Setting these for commands that do not need them is harmless.
- Update `OZONE_SUBCMD` upon `shell -> sh` conversion.

https://issues.apache.org/jira/browse/HDDS-15732

## How was this patch tested?

```bash
$ ozone repair om compact --column-family fileTable
Compaction request issued for om.db of om node: null, column-family: fileTable with bottommost level compaction: kSkip.
Please check role logs of null for completion status.

$ export OZONE_SHELL_SCRIPT_DEBUG=true

$ ozone repair --help 2>&1 | grep -o '[^ ]*enable-native-access[^ ]*'
--enable-native-access=ALL-UNNAMED

$ ozone s3 getsecret --help 2>&1 | grep -o '[^ ]*enable-native-access[^ ]*'
--enable-native-access=ALL-UNNAMED

$ ozone tenant list --help 2>&1 | grep -o '[^ ]*enable-native-access[^ ]*'
--enable-native-access=ALL-UNNAMED

$ ozone shell volume list --help 2>&1 | grep -o '[^ ]*enable-native-access[^ ]*'
--enable-native-access=ALL-UNNAMED
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/28657320150
