### PR TITLE
HDDS-15736. Change tests to use ContainerID.getIdForTesting().

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestReconcileContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestReconcileContainerCommandHandler.java
@@ -177,7 +177,7 @@ public class TestReconcileContainerCommandHandler {
 
     for (Map.Entry<ContainerID, ContainerReplicaProto> entry: reportsSent.entrySet()) {
       ContainerID id = entry.getKey();
-      assertNotNull(containerSet.getContainer(id.getId()));
+      assertNotNull(containerSet.getContainer(id.getIdForTesting()));
 
       long sentDataChecksum = entry.getValue().getDataChecksum();
       // Current implementation is incomplete, and uses a mocked checksum.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -849,7 +849,7 @@ public final class HddsTestUtils {
           int replicaIndex) {
 
     return ContainerReplicaProto.newBuilder()
-                    .setContainerID(containerId.getId())
+                    .setContainerID(containerId.getIdForTesting())
                     .setState(state)
                     .setOriginNodeId(originNodeId)
                     .setFinalhash("e16cc9d6024365750ed8dbd194ea46d2")

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -1481,7 +1481,7 @@ public class TestContainerReportHandler {
         ContainerReportsProto.newBuilder();
     final ContainerReplicaProto replicaProto =
         ContainerReplicaProto.newBuilder()
-            .setContainerID(containerId.getId())
+            .setContainerID(containerId.getIdForTesting())
             .setState(state)
             .setOriginNodeId(originNodeId)
             .setSize(5368709120L)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -366,7 +366,7 @@ public class TestContainerStateManager {
   private void verifyForceDeleteCommand(DeleteContainerCommand deleteCmd,
       ContainerID expectedContainerId, boolean expectedForce, String message) {
     assertEquals(expectedForce, deleteCmd.isForce(), message);
-    assertEquals(expectedContainerId.getId(), deleteCmd.getContainerID());
+    assertEquals(expectedContainerId.getIdForTesting(), deleteCmd.getContainerID());
   }
 
   /**
@@ -413,7 +413,7 @@ public class TestContainerStateManager {
       throws Exception {
     ContainerID containerID = ContainerID.valueOf(3L);
     ContainerInfo openContainerInfo = new ContainerInfo.Builder()
-        .setContainerID(containerID.getId())
+        .setContainerID(containerID.getIdForTesting())
         .setState(HddsProtos.LifeCycleState.OPEN)
         .setSequenceId(100L)
         .setOwner("scm")
@@ -439,7 +439,7 @@ public class TestContainerStateManager {
     long sequenceId = 100L;
 
     ContainerInfo containerInfo = new ContainerInfo.Builder()
-        .setContainerID(containerID.getId())
+        .setContainerID(containerID.getIdForTesting())
         .setState(HddsProtos.LifeCycleState.OPEN)
         .setSequenceId(sequenceId)
         .setOwner("scm")

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -779,7 +779,7 @@ public class TestIncrementalContainerReportHandler {
           final long bcsId) {
     final ContainerReplicaProto.Builder replicaProto =
             ContainerReplicaProto.newBuilder()
-                    .setContainerID(containerId.getId())
+                    .setContainerID(containerId.getIdForTesting())
                     .setState(state)
                     .setOriginNodeId(originNodeId)
                     .setSize(5368709120L)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestUnknownContainerReport.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestUnknownContainerReport.java
@@ -133,7 +133,7 @@ public class TestUnknownContainerReport {
         ContainerReportsProto.newBuilder();
     final ContainerReplicaProto replicaProto =
         ContainerReplicaProto.newBuilder()
-            .setContainerID(containerId.getId())
+            .setContainerID(containerId.getIdForTesting())
             .setState(state)
             .setOriginNodeId(originNodeId)
             .setFinalhash("e16cc9d6024365750ed8dbd194ea46d2")

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/reconciliation/TestReconcileContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/reconciliation/TestReconcileContainerEventHandler.java
@@ -281,7 +281,7 @@ public class TestReconcileContainerEventHandler {
 
   private ContainerInfo addContainer(ReplicationConfig repConfig, LifeCycleState state) throws Exception {
     ContainerInfo container = new ContainerInfo.Builder()
-        .setContainerID(CONTAINER_ID.getId())
+        .setContainerID(CONTAINER_ID.getIdForTesting())
         .setReplicationConfig(repConfig)
         .setState(state)
         .build();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
@@ -101,7 +101,7 @@ public final class DatanodeAdminMonitorTestUtil {
           MockDatanodeDetails.randomDatanodeDetails()));
     }
     ContainerInfo container = new ContainerInfo.Builder()
-        .setContainerID(containerID.getId())
+        .setContainerID(containerID.getIdForTesting())
         .setState(containerState)
         .build();
 
@@ -132,7 +132,7 @@ public final class DatanodeAdminMonitorTestUtil {
           t.getRight(), t.getMiddle()));
     }
     ContainerInfo container = new ContainerInfo.Builder()
-        .setContainerID(containerID.getId())
+        .setContainerID(containerID.getIdForTesting())
         .setState(containerState)
         .setReplicationConfig(repConfig)
         .build();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -247,7 +247,7 @@ public class TestDatanodeAdminMonitor {
     // the container's sequence id is greater than the healthy replicas'
     ContainerInfo container = ReplicationTestUtil.createContainerInfo(
         RatisReplicationConfig.getInstance(
-            HddsProtos.ReplicationFactor.THREE), containerID.getId(),
+            HddsProtos.ReplicationFactor.THREE), containerID.getIdForTesting(),
         HddsProtos.LifeCycleState.QUASI_CLOSED,
         replicas.iterator().next().getSequenceId() + 1);
     // UNHEALTHY replica is on a unique origin and has same sequence id as
@@ -311,7 +311,7 @@ public class TestDatanodeAdminMonitor {
     // create a container and 3 QUASI_CLOSED replicas with containerID 1 and same origin ID
     ContainerID containerID = ContainerID.valueOf(1);
     ContainerInfo container = ReplicationTestUtil.createContainerInfo(RatisReplicationConfig.getInstance(
-        HddsProtos.ReplicationFactor.THREE), containerID.getId(), HddsProtos.LifeCycleState.QUASI_CLOSED);
+        HddsProtos.ReplicationFactor.THREE), containerID.getIdForTesting(), HddsProtos.LifeCycleState.QUASI_CLOSED);
     Set<ContainerReplica> replicas =
         ReplicationTestUtil.createReplicasWithSameOrigin(containerID, State.QUASI_CLOSED, 0, 0, 0);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -104,7 +104,7 @@ public class TestNodeDecommissionManager {
   private ContainerInfo getMockContainer(ReplicationConfig rep, ContainerID conId) {
     ContainerInfo.Builder builder = new ContainerInfo.Builder()
         .setReplicationConfig(rep)
-        .setContainerID(conId.getId())
+        .setContainerID(conId.getIdForTesting())
         .setPipelineID(PipelineID.randomId())
         .setState(OPEN)
         .setOwner("admin");

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -382,7 +382,7 @@ class TestReconAndAdminContainerCLI {
     List<ContainerID> rmContainerIDs = rmReport.getSample(rmState);
     List<Long> rmIDsToLong = new ArrayList<>();
     for (ContainerID id : rmContainerIDs) {
-      rmIDsToLong.add(id.getId());
+      rmIDsToLong.add(id.getIdForTesting());
     }
     List<Long> reconContainerIDs =
         reconResponse.getContainers()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -1036,7 +1036,7 @@ public class TestContainerCommandsEC {
                     .map(ContainerInfo::containerID)
                     .collect(Collectors.toList());
     assertEquals(1, containerIDs.size());
-    containerID = containerIDs.get(0).getId();
+    containerID = containerIDs.get(0).getIdForTesting();
     List<Pipeline> pipelines = scm.getPipelineManager().getPipelines(repConfig);
     assertEquals(1, pipelines.size());
     pipeline = pipelines.get(0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -154,7 +154,7 @@ public class TestContainerReportHandling {
         assertThat(keyLocations).isNotEmpty();
         OmKeyLocationInfo keyLocation = keyLocations.get(0);
         ContainerID containerID = ContainerID.valueOf(keyLocation.getContainerID());
-        waitForContainerClose(cluster, containerID.getId());
+        waitForContainerClose(cluster, containerID.getIdForTesting());
 
         // also wait till the container is closed in SCM
         waitForContainerClosedInSCM(containerID);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -508,14 +508,14 @@ public class TestBlockDeletion {
         containerInfos.get(0).getContainerID());
     // Before restart container state is non-empty
     assertFalse(getContainerFromDN(
-        cluster.getHddsDatanodes().get(0), containerId.getId())
+        cluster.getHddsDatanodes().get(0), containerId.getIdForTesting())
         .getContainerData().isEmpty());
     // Restart DataNode
     cluster.restartHddsDatanode(0, true);
 
     // After restart also container state remains non-empty.
     assertFalse(getContainerFromDN(
-        cluster.getHddsDatanodes().get(0), containerId.getId())
+        cluster.getHddsDatanodes().get(0), containerId.getIdForTesting())
         .getContainerData().isEmpty());
 
     // Delete key
@@ -535,14 +535,14 @@ public class TestBlockDeletion {
 
     // Container state should be empty now as key got deleted
     assertTrue(getContainerFromDN(
-        cluster.getHddsDatanodes().get(0), containerId.getId())
+        cluster.getHddsDatanodes().get(0), containerId.getIdForTesting())
         .getContainerData().isEmpty());
 
     // Restart DataNode
     cluster.restartHddsDatanode(0, true);
     // Container state should be empty even after restart
     assertTrue(getContainerFromDN(
-        cluster.getHddsDatanodes().get(0), containerId.getId())
+        cluster.getHddsDatanodes().get(0), containerId.getIdForTesting())
         .getContainerData().isEmpty());
 
     GenericTestUtils.waitFor(() -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -113,25 +113,25 @@ public class TestCloseContainerHandler {
     Pipeline pipeline = cluster.getStorageContainerManager()
         .getPipelineManager().getPipeline(container.getPipelineID());
 
-    assertFalse(isContainerClosed(cluster, containerId.getId()));
+    assertFalse(isContainerClosed(cluster, containerId.getIdForTesting()));
 
     DatanodeDetails datanodeDetails =
         cluster.getHddsDatanodes().get(0).getDatanodeDetails();
     //send the order to close the container
     SCMCommand<?> command = new CloseContainerCommand(
-        containerId.getId(), pipeline.getId());
+        containerId.getIdForTesting(), pipeline.getId());
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     cluster.getStorageContainerManager().getScmNodeManager()
         .addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
-            isContainerClosed(cluster, containerId.getId()),
+            isContainerClosed(cluster, containerId.getIdForTesting()),
             500,
             5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    assertTrue(isContainerClosed(cluster, containerId.getId()));
+    assertTrue(isContainerClosed(cluster, containerId.getIdForTesting()));
   }
 
   private static Boolean isContainerClosed(MiniOzoneCluster cluster,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -164,12 +164,12 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
 
     KeyValueContainer kv = (KeyValueContainer) getContainerfromDN(
-        hddsDatanodeService, containerId.getId());
+        hddsDatanodeService, containerId.getIdForTesting());
     kv.setCheckChunksFilePath(true);
 
     NodeManager nodeManager =
@@ -183,11 +183,11 @@ public class TestDeleteContainerHandler {
             .getDatanodeStateMachine().getContainer().getMetrics();
     long beforeDeleteFailedCount = metrics.getContainerDeleteFailedNonEmpty();
     GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
+            isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    assertTrue(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertTrue(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     // Delete key, which will make isEmpty flag to true in containerData
     objectStore.getVolume(volumeName)
@@ -197,7 +197,7 @@ public class TestDeleteContainerHandler {
 
     // Ensure isEmpty flag is true when key is deleted and container is empty
     GenericTestUtils.waitFor(() -> getContainerfromDN(
-        hddsDatanodeService, containerId.getId())
+        hddsDatanodeService, containerId.getIdForTesting())
         .getContainerData().isEmpty(),
         500,
         5 * 2000);
@@ -205,7 +205,7 @@ public class TestDeleteContainerHandler {
     Container containerInternalObj =
         hddsDatanodeService.
             getDatanodeStateMachine().
-            getContainer().getContainerSet().getContainer(containerId.getId());
+            getContainer().getContainerSet().getContainer(containerId.getIdForTesting());
 
     // Write a file to the container chunks directory indicating that there
     // might be a discrepancy between block count as recorded in RocksDB and
@@ -216,14 +216,14 @@ public class TestDeleteContainerHandler {
     FileUtils.touch(lingeringBlock);
 
     // Check container exists before sending delete container command
-    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
 
     // Set container blockCount to 0 to mock that it is empty as per RocksDB
-    getContainerfromDN(hddsDatanodeService, containerId.getId())
+    getContainerfromDN(hddsDatanodeService, containerId.getIdForTesting())
         .getContainerData().getStatistics().setBlockCountForTesting(0);
 
     // send delete container to the datanode
-    SCMCommand<?> command = new DeleteContainerCommand(containerId.getId(),
+    SCMCommand<?> command = new DeleteContainerCommand(containerId.getIdForTesting(),
         false);
 
     // Send the delete command. It should fail as even though block count
@@ -240,22 +240,22 @@ public class TestDeleteContainerHandler {
         500,
         5 * 2000);
 
-    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
     assertThat(beforeDeleteFailedCount).isLessThan(metrics.getContainerDeleteFailedNonEmpty());
     // Send the delete command. It should pass with force flag.
     // Deleting a non-empty container should pass on the DN when the force flag
     // is true
     long beforeForceCount = metrics.getContainerForceDelete();
-    command = new DeleteContainerCommand(containerId.getId(), true);
+    command = new DeleteContainerCommand(containerId.getIdForTesting(), true);
 
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
+            isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
-    assertTrue(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertTrue(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
     assertThat(beforeForceCount).isLessThan(metrics.getContainerForceDelete());
 
     kv.setCheckChunksFilePath(false);
@@ -290,7 +290,7 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
 
@@ -301,11 +301,11 @@ public class TestDeleteContainerHandler {
         .getEventQueue(), cluster.getStorageContainerManager());
 
     GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
+            isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    assertTrue(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertTrue(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     // Delete key, which will make isEmpty flag to true in containerData
     objectStore.getVolume(volumeName)
@@ -315,7 +315,7 @@ public class TestDeleteContainerHandler {
 
     // Ensure isEmpty flag is true when key is deleted and container is empty
     GenericTestUtils.waitFor(() -> getContainerfromDN(
-            hddsDatanodeService, containerId.getId())
+            hddsDatanodeService, containerId.getIdForTesting())
             .getContainerData().isEmpty(),
         500,
         5 * 2000);
@@ -323,7 +323,7 @@ public class TestDeleteContainerHandler {
     Container containerInternalObj =
         hddsDatanodeService.
             getDatanodeStateMachine().
-            getContainer().getContainerSet().getContainer(containerId.getId());
+            getContainer().getContainerSet().getContainer(containerId.getIdForTesting());
 
     // Write a file to the container chunks directory indicating that there
     // might be a discrepancy between block count as recorded in RocksDB and
@@ -334,10 +334,10 @@ public class TestDeleteContainerHandler {
     FileUtils.touch(lingeringBlock);
 
     // Check container exists before sending delete container command
-    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
 
     // send delete container to the datanode
-    SCMCommand<?> command = new DeleteContainerCommand(containerId.getId(),
+    SCMCommand<?> command = new DeleteContainerCommand(containerId.getIdForTesting(),
         false);
 
     // Send the delete command. It should succeed as even though
@@ -347,9 +347,9 @@ public class TestDeleteContainerHandler {
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
+            isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
-    assertTrue(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertTrue(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
   }
 
   @Test
@@ -375,7 +375,7 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
 
@@ -383,7 +383,7 @@ public class TestDeleteContainerHandler {
         cluster.getStorageContainerManager().getScmNodeManager();
     //send the order to close the container
     SCMCommand<?> command = new CloseContainerCommand(
-        containerId.getId(), pipeline.getId());
+        containerId.getIdForTesting(), pipeline.getId());
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
@@ -391,7 +391,7 @@ public class TestDeleteContainerHandler {
     Container containerInternalObj =
         hddsDatanodeService.
             getDatanodeStateMachine().
-            getContainer().getContainerSet().getContainer(containerId.getId());
+            getContainer().getContainerSet().getContainer(containerId.getIdForTesting());
 
     // Write a file to the container chunks directory indicating that there
     // might be a discrepancy between block count as recorded in RocksDB and
@@ -404,21 +404,21 @@ public class TestDeleteContainerHandler {
         hddsDatanodeService
             .getDatanodeStateMachine().getContainer().getMetrics();
     GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
+            isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
     assertTrue(isContainerClosed(hddsDatanodeService,
-        containerId.getId()));
+        containerId.getIdForTesting()));
 
     // Check container exists before sending delete container command
     assertFalse(isContainerDeleted(hddsDatanodeService,
-        containerId.getId()));
+        containerId.getIdForTesting()));
 
     long containerDeleteFailedNonEmptyBlockDB =
         metrics.getContainerDeleteFailedNonEmpty();
     // send delete container to the datanode
-    command = new DeleteContainerCommand(containerId.getId(), false);
+    command = new DeleteContainerCommand(containerId.getIdForTesting(), false);
 
     // Send the delete command. It should fail as even though isEmpty
     // flag is true, there is a lingering block on disk.
@@ -434,13 +434,13 @@ public class TestDeleteContainerHandler {
         500,
         5 * 2000);
 
-    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
     assertThat(containerDeleteFailedNonEmptyBlockDB)
         .isLessThan(metrics.getContainerDeleteFailedNonEmpty());
 
     // Now empty the container Dir and try with a non-empty block table
     Container containerToDelete = getContainerfromDN(
-        hddsDatanodeService, containerId.getId());
+        hddsDatanodeService, containerId.getIdForTesting());
     File chunkDir = new File(containerToDelete.
         getContainerData().getChunksPath());
     File[] files = chunkDir.listFiles();
@@ -450,27 +450,27 @@ public class TestDeleteContainerHandler {
       }
     }
 
-    command = new DeleteContainerCommand(containerId.getId(), false);
+    command = new DeleteContainerCommand(containerId.getIdForTesting(), false);
 
     // Send the delete command.It should fail as still block table is non-empty
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
     Thread.sleep(5000);
-    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
     // Send the delete command. It should pass with force flag.
     long beforeForceCount = metrics.getContainerForceDelete();
-    command = new DeleteContainerCommand(containerId.getId(), true);
+    command = new DeleteContainerCommand(containerId.getIdForTesting(), true);
 
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
+            isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
     assertTrue(isContainerDeleted(hddsDatanodeService,
-        containerId.getId()));
+        containerId.getIdForTesting()));
     assertThat(beforeForceCount).isLessThan(metrics.getContainerForceDelete());
   }
 
@@ -492,36 +492,36 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
     NodeManager nodeManager =
         cluster.getStorageContainerManager().getScmNodeManager();
     //send the order to close the container
     SCMCommand<?> command = new CloseContainerCommand(
-        containerId.getId(), pipeline.getId());
+        containerId.getIdForTesting(), pipeline.getId());
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
+            isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    assertTrue(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertTrue(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     // Check container exists before sending delete container command
-    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
 
     // Clear block table
     clearBlocksTable(getContainerfromDN(hddsDatanodeService,
-        containerId.getId()));
+        containerId.getIdForTesting()));
 
 
     // Now empty the container Dir
     Container containerToDelete = getContainerfromDN(
-        hddsDatanodeService, containerId.getId());
+        hddsDatanodeService, containerId.getIdForTesting());
     File chunkDir = new File(containerToDelete.
         getContainerData().getChunksPath());
     File[] files = chunkDir.listFiles();
@@ -532,7 +532,7 @@ public class TestDeleteContainerHandler {
     }
 
     // send delete container to the datanode, blockCount is still 1(Invalid)
-    command = new DeleteContainerCommand(containerId.getId(), false);
+    command = new DeleteContainerCommand(containerId.getIdForTesting(), false);
 
     // Send the delete command. It should succeed as even though blockCount
     // is non-zero(Invalid).
@@ -541,9 +541,9 @@ public class TestDeleteContainerHandler {
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
+            isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
-    assertTrue(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertTrue(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
 
   }
 
@@ -601,7 +601,7 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
 
@@ -614,17 +614,17 @@ public class TestDeleteContainerHandler {
         .getEventQueue(), cluster.getStorageContainerManager());
 
     GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
+            isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    assertTrue(isContainerClosed(hddsDatanodeService, containerId.getId()));
+    assertTrue(isContainerClosed(hddsDatanodeService, containerId.getIdForTesting()));
 
     // Check container exists before sending delete container command
-    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getId()));
+    assertFalse(isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()));
 
     // send delete container to the datanode
-    SCMCommand<?> command = new DeleteContainerCommand(containerId.getId(),
+    SCMCommand<?> command = new DeleteContainerCommand(containerId.getIdForTesting(),
         false);
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
@@ -650,7 +650,7 @@ public class TestDeleteContainerHandler {
 
     // Ensure isEmpty flag is true when key is deleted
     GenericTestUtils.waitFor(() -> getContainerfromDN(
-            hddsDatanodeService, containerId.getId())
+            hddsDatanodeService, containerId.getIdForTesting())
             .getContainerData().isEmpty(),
         500, 5 * 2000);
 
@@ -660,11 +660,11 @@ public class TestDeleteContainerHandler {
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
+            isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
 
     assertTrue(isContainerDeleted(hddsDatanodeService,
-        containerId.getId()));
+        containerId.getIdForTesting()));
   }
 
   @Test
@@ -690,7 +690,7 @@ public class TestDeleteContainerHandler {
 
     // Send delete container command with force flag set to false.
     SCMCommand<?> command = new DeleteContainerCommand(
-        containerId.getId(), false);
+        containerId.getIdForTesting(), false);
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
@@ -700,7 +700,7 @@ public class TestDeleteContainerHandler {
     int count = 1;
     // Checking for 5 seconds, whether it is containerSet, as after command
     // is issued, giving some time for it to process.
-    while (!isContainerDeleted(hddsDatanodeService, containerId.getId())) {
+    while (!isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting())) {
       Thread.sleep(1000);
       count++;
       if (count == 5) {
@@ -709,22 +709,22 @@ public class TestDeleteContainerHandler {
     }
 
     assertFalse(isContainerDeleted(hddsDatanodeService,
-        containerId.getId()));
+        containerId.getIdForTesting()));
 
 
     // Now delete container with force flag set to true. now it should delete
     // container
-    command = new DeleteContainerCommand(containerId.getId(), true);
+    command = new DeleteContainerCommand(containerId.getIdForTesting(), true);
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getID(), command);
 
     GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
+            isContainerDeleted(hddsDatanodeService, containerId.getIdForTesting()),
         500, 5 * 1000);
 
     assertTrue(isContainerDeleted(hddsDatanodeService,
-        containerId.getId()));
+        containerId.getIdForTesting()));
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestFinalizeBlock.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestFinalizeBlock.java
@@ -159,7 +159,7 @@ public class TestFinalizeBlock {
     // Before finalize block WRITE chunk on the same block should pass through
     ContainerProtos.ContainerCommandRequestProto request =
         ContainerTestHelper.getWriteChunkRequest(pipeline, (
-            new BlockID(containerId.getId(), omKeyLocationInfoGroupList.get(0)
+            new BlockID(containerId.getIdForTesting(), omKeyLocationInfoGroupList.get(0)
                 .getLocationList().get(0).getLocalID())), 100);
     xceiverClient.sendCommand(request);
 
@@ -176,7 +176,7 @@ public class TestFinalizeBlock {
         omKeyLocationInfoGroupList.get(0).getLocationList().get(0).getLocalID());
 
     assertEquals(1, ((KeyValueContainerData)getContainerfromDN(cluster.getHddsDatanodes().get(0),
-        containerId.getId()).getContainerData()).getFinalizedBlockSet().size());
+        containerId.getIdForTesting()).getContainerData()).getFinalizedBlockSet().size());
 
     testRejectPutAndWriteChunkAfterFinalizeBlock(containerId, pipeline, xceiverClient, omKeyLocationInfoGroupList);
     testFinalizeBlockReloadAfterDNRestart(containerId);
@@ -192,7 +192,7 @@ public class TestFinalizeBlock {
 
     // After restart DN, finalizeBlock should be loaded into memory
     assertEquals(1, ((KeyValueContainerData)getContainerfromDN(cluster.getHddsDatanodes().get(0),
-            containerId.getId()).getContainerData()).getFinalizedBlockSet().size());
+            containerId.getIdForTesting()).getContainerData()).getFinalizedBlockSet().size());
   }
 
   private void testFinalizeBlockClearAfterCloseContainer(ContainerID containerId)
@@ -203,7 +203,7 @@ public class TestFinalizeBlock {
     // Finalize Block should be cleared from container data.
     GenericTestUtils.waitFor(() -> (
             (KeyValueContainerData)getContainerfromDN(cluster.getHddsDatanodes().get(0),
-                containerId.getId()).getContainerData()).getFinalizedBlockSet().isEmpty(),
+                containerId.getIdForTesting()).getContainerData()).getFinalizedBlockSet().isEmpty(),
         100, 10 * 1000);
     try {
       // Restart DataNode
@@ -215,7 +215,7 @@ public class TestFinalizeBlock {
     // After DN restart also there should not be any finalizeBlock
     assertTrue(((KeyValueContainerData)getContainerfromDN(
         cluster.getHddsDatanodes().get(0),
-        containerId.getId()).getContainerData())
+        containerId.getIdForTesting()).getContainerData())
         .getFinalizedBlockSet().isEmpty());
   }
 
@@ -225,7 +225,7 @@ public class TestFinalizeBlock {
     // Try doing WRITE chunk on the already finalized block
     ContainerProtos.ContainerCommandRequestProto request =
         ContainerTestHelper.getWriteChunkRequest(pipeline,
-            (new BlockID(containerId.getId(), omKeyLocationInfoGroupList.get(0)
+            (new BlockID(containerId.getIdForTesting(), omKeyLocationInfoGroupList.get(0)
                 .getLocationList().get(0).getLocalID())), 100);
 
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestSecureOzoneContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestSecureOzoneContainer.java
@@ -165,7 +165,7 @@ class TestSecureOzoneContainer {
           }
 
           ContainerCommandRequestProto request =
-              getCreateContainerSecureRequest(containerID.getId(),
+              getCreateContainerSecureRequest(containerID.getIdForTesting(),
                   client.getPipeline(), token);
           ContainerCommandResponseProto response = client.sendCommand(request);
           assertNotNull(response);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
@@ -268,7 +268,7 @@ public class TestBlocksEndPoint {
     reconPipelineManager.addPipeline(localPipeline);
     ContainerInfo containerInfo =
         new ContainerInfo.Builder()
-            .setContainerID(localContainerID.getId())
+            .setContainerID(localContainerID.getIdForTesting())
             .setNumberOfKeys(10)
             .setPipelineID(localPipeline.getId())
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -798,7 +798,7 @@ public class TestContainerEndpoint {
         responseObject.getContainers().stream().findFirst().orElse(null);
     assertNotNull(container);
 
-    assertEquals(containerID.getId(), container.getContainerID());
+    assertEquals(containerID.getIdForTesting(), container.getContainerID());
     assertEquals(keyCount, container.getKeys());
     assertEquals(pipelineID.getId(), container.getPipelineID());
     assertEquals(3, container.getReplicas().size());
@@ -1185,7 +1185,7 @@ public class TestContainerEndpoint {
     reconPipelineManager.addPipeline(localPipeline);
     ContainerInfo containerInfo =
         new ContainerInfo.Builder()
-            .setContainerID(localContainerID.getId())
+            .setContainerID(localContainerID.getIdForTesting())
             .setNumberOfKeys(10)
             .setPipelineID(localPipeline.getId())
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
@@ -145,7 +145,7 @@ public class AbstractReconContainerManagerTest {
     ContainerID containerID = ContainerID.valueOf(100L);
     ContainerInfo containerInfo =
         new ContainerInfo.Builder()
-            .setContainerID(containerID.getId())
+            .setContainerID(containerID.getIdForTesting())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
@@ -189,7 +189,7 @@ public class AbstractReconContainerManagerTest {
       ContainerID cID = ContainerID.valueOf(i);
       ContainerInfo cInfo =
           new ContainerInfo.Builder()
-              .setContainerID(cID.getId())
+              .setContainerID(cID.getIdForTesting())
               .setNumberOfKeys(10)
               .setPipelineID(pipeline.getId())
               .setReplicationConfig(
@@ -228,7 +228,7 @@ public class AbstractReconContainerManagerTest {
     pipelineManager.addPipeline(pipeline);
     ContainerInfo containerInfo =
         new ContainerInfo.Builder()
-            .setContainerID(containerID.getId())
+            .setContainerID(containerID.getIdForTesting())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
@@ -246,7 +246,7 @@ public class AbstractReconContainerManagerTest {
     pipelineManager.addPipeline(pipeline);
     ContainerInfo containerInfo =
         new ContainerInfo.Builder()
-            .setContainerID(containerID.getId())
+            .setContainerID(containerID.getIdForTesting())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
@@ -205,7 +205,7 @@ public class TestReconContainerManager
     assertFalse(getContainerManager().getPipelineToOpenContainer()
         .containsKey(openContainer.getPipeline().getId()));
     verify(getContainerManager().getScmClient(), never())
-        .getContainerWithPipeline(containerID.getId());
+        .getContainerWithPipeline(containerID.getIdForTesting());
   }
 
   @Test
@@ -275,7 +275,7 @@ public class TestReconContainerManager
     assertEquals(CLOSED,
         getContainerManager().getContainer(containerID).getState());
     verify(getContainerManager().getScmClient(), never())
-        .getContainerWithPipeline(containerID.getId());
+        .getContainerWithPipeline(containerID.getIdForTesting());
   }
 
   ContainerInfo newContainerInfo(long containerId, Pipeline pipeline) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -79,7 +79,7 @@ public class TestReconIncrementalContainerReportHandler
     when(reportMock.getDatanodeDetails()).thenReturn(datanodeDetails);
 
     ContainerWithPipeline containerWithPipeline = getTestContainer(
-        containerID.getId(), OPEN);
+        containerID.getIdForTesting(), OPEN);
     List<ContainerWithPipeline> containerWithPipelineList = new ArrayList<>();
     containerWithPipelineList.add(containerWithPipeline);
     ReconContainerManager containerManager = getContainerManager();
@@ -167,7 +167,7 @@ public class TestReconIncrementalContainerReportHandler
           String.format("Expecting %s in container state for replica state %s",
               expectedState, state));
       verify(containerManager.getScmClient(), never())
-          .getContainerWithPipeline(containerID.getId());
+          .getContainerWithPipeline(containerID.getIdForTesting());
     }
   }
 
@@ -200,7 +200,7 @@ public class TestReconIncrementalContainerReportHandler
           String.format("Expecting %s in container state for replica state %s",
               expectedState, state));
       verify(containerManager.getScmClient(), never())
-          .getContainerWithPipeline(containerID.getId());
+          .getContainerWithPipeline(containerID.getIdForTesting());
     }
   }
 
@@ -269,7 +269,7 @@ public class TestReconIncrementalContainerReportHandler
         IncrementalContainerReportProto.newBuilder();
     final ContainerReplicaProto replicaProto =
         ContainerReplicaProto.newBuilder()
-            .setContainerID(containerId.getId())
+            .setContainerID(containerId.getIdForTesting())
             .setState(state)
             .setOriginNodeId(originNodeId)
             .build();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconSCMContainerSyncIntegration.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconSCMContainerSyncIntegration.java
@@ -1106,7 +1106,7 @@ public class TestReconSCMContainerSyncIntegration
           any(ContainerID.class), eq(1), eq(DELETED)))
           .thenAnswer(inv -> {
             ContainerID id = inv.getArgument(0);
-            return Collections.singletonList(containerInfo(id.getId(), DELETED));
+            return Collections.singletonList(containerInfo(id.getIdForTesting(), DELETED));
           });
 
       assertTrue(syncHelper.syncWithSCMContainerInfo());


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-12563](https://issues.apache.org/jira/browse/HDDS-12563) added a getIdForTesting() to ContainerID. In this PR, we change all the tests to use it, instead of the deprecated getId() method. Later on, it will be easier to remove getId().

## What is the link to the Apache JIRA

HDDS-15736

## How was this patch tested?

This is a test only change.