### PR TITLE
HDDS-11093. Fix intermittent failure in TestContainerBalancerDatanodeNodeLimit#testMetrics

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -246,7 +246,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
 
   @ParameterizedTest(name = "MockedSCM #{index}: {0}")
   @MethodSource("createMockedSCMs")
-  @Flaky("HDDS-11093")
   public void testMetrics(@Nonnull MockedSCM mockedSCM) throws IOException, NodeNotFoundException {
     OzoneConfiguration ozoneConfig = new OzoneConfiguration();
     ozoneConfig.set("hdds.datanode.du.refresh.period", "1ms");
@@ -265,7 +264,10 @@ public class TestContainerBalancerDatanodeNodeLimit {
     assertEquals(mockedSCM.getCluster().getUnBalancedNodes(config.getThreshold()).size(),
         metrics.getNumDatanodesUnbalanced());
     assertThat(metrics.getDataSizeMovedGBInLatestIteration()).isLessThanOrEqualTo(6);
-    assertThat(metrics.getDataSizeMovedGB()).isGreaterThan(0);
+    // On small clusters the random layout may allow only one move, which is the mocked failure, so data
+    // moved cannot be asserted to be positive. Each container is a whole number of GB, so the size moved
+    // must be at least 1 GB per completed move.
+    assertThat(metrics.getDataSizeMovedGB()).isGreaterThanOrEqualTo(metrics.getNumContainerMovesCompleted());
     assertEquals(1, metrics.getNumIterations());
     assertThat(metrics.getNumContainerMovesScheduledInLatestIteration()).isGreaterThan(0);
     assertEquals(metrics.getNumContainerMovesScheduled(), metrics.getNumContainerMovesScheduledInLatestIteration());


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testMetrics` intermittently fails with `Expecting actual: 0L to be greater than: 0L` at `assertThat(metrics.getDataSizeMovedGB()).isGreaterThan(0)`, always on the 4-node cluster parameter. The test mocks the first move to fail and the rest to succeed. Since HDDS-10699 parameterized the test over cluster sizes 4-30, a small cluster's random layout can allow only a single schedulable move; that move is the mocked failure, so no move completes and the metric is legitimately 0.

Replace the assertion with an invariant that holds for any layout: `dataSizeMovedGB >= numContainerMovesCompleted`. Every test container is a whole number of GB, so each completed move adds at least 1 GB, and a regression where the metric stops accumulating still fails the assertion whenever any move completes. Also removes the `@Flaky("HDDS-11093")` annotation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11093

## How was this patch tested?

- Reproduced the reported failure deterministically by mocking all moves to fail, then re-injected the same fault on the fixed test: the changed assertion no longer fires.
- flaky-test-check, `testMetrics` 10x10 = 100 runs, all green: https://github.com/chihsuan/ozone/actions/runs/28692288330
- flaky-test-check, whole class 10x10 = 100 runs: `testMetrics` failed 0 times; the only failures are unrelated flaky siblings HDDS-11855 and HDDS-15737: https://github.com/chihsuan/ozone/actions/runs/28691674922
