### PR TITLE
HDDS-15737. Fix intermittent failure in balancerShouldOnlySelectConfiguredIncludeContainers

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -463,9 +463,16 @@ public class TestContainerBalancerDatanodeNodeLimit {
   @MethodSource("createMockedSCMs")
   public void balancerShouldOnlySelectConfiguredIncludeContainers(@Nonnull MockedSCM mockedSCM) {
     ContainerBalancerConfiguration config = new ContainerBalancerConfigBuilder(mockedSCM.getNodeCount()).build();
-    config.setIncludeContainers("1, 4, 5");
 
+    // The cluster layout is random, so a hardcoded include list may contain no movable container.
+    // Run the balancer once without restrictions to find a container that is movable in this layout;
+    // including it guarantees the restricted run below selects at least one container.
     ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
+    Set<ContainerID> movedContainers = task.getContainerToSourceMap().keySet();
+    assertThat(movedContainers).isNotEmpty();
+    config.setIncludeContainers(String.valueOf(movedContainers.iterator().next().getId()));
+
+    task = mockedSCM.startBalancerTask(config);
 
     Set<ContainerID> includeContainers = config.getIncludeContainers();
     assertThat(task.getContainerToSourceMap()).isNotEmpty();


### PR DESCRIPTION
## What changes were proposed in this pull request?

`balancerShouldOnlySelectConfiguredIncludeContainers` intermittently fails with `Expecting actual not to be empty` at the `getContainerToSourceMap()` assertion. The test hardcodes include containers "1, 4, 5", but the mocked cluster layout is generated with `ThreadLocalRandom` (`TestableCluster`) and these containers originate on low-utilization datanodes, so occasionally none of them is eligible for a move and the map is legitimately empty. Same family as HDDS-11093 and HDDS-11855.

Derive the include list from the layout instead of hardcoding it: run the balancer once without restrictions, pick a container that was actually moved, and use it as the include list for the restricted run. A container proven movable from the identical initial state is selectable again, so the non-emptiness assertion holds by construction for any layout, and the test still verifies that only included containers are selected.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15737

## How was this patch tested?

- Reproduced the reported failure deterministically by setting an include list containing no movable container: all 16 parameterized runs fail with the exact reported assertion. With the fix, that window cannot open by construction.
- flaky-test-check, `balancerShouldOnlySelectConfiguredIncludeContainers` 10x10 = 100 runs, all green: https://github.com/chihsuan/ozone/actions/runs/28693965833
- flaky-test-check, whole class 10x10 = 100 runs: the fixed test failed 0 times; the only failures are the unrelated flaky sibling HDDS-11855: https://github.com/chihsuan/ozone/actions/runs/28693662198
