### PR TITLE
HDDS-11855. Fix flaky TestContainerBalancerDatanodeNodeLimit#checkIterationResultException

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -562,10 +561,8 @@ public class TestContainerBalancerDatanodeNodeLimit {
 
   @ParameterizedTest(name = "MockedSCM #{index}: {0}")
   @MethodSource("createMockedSCMs")
-  @Flaky("HDDS-11855")
   public void checkIterationResultException(@Nonnull MockedSCM mockedSCM)
       throws NodeNotFoundException, ContainerNotFoundException, TimeoutException, ContainerReplicaNotFoundException {
-    int nodeCount = mockedSCM.getNodeCount();
     ContainerBalancerConfiguration config = new ContainerBalancerConfigBuilder(mockedSCM.getNodeCount()).build();
     config.setMaxSizeEnteringTarget(10 * STORAGE_UNIT);
     config.setMaxSizeToMovePerIteration(100 * STORAGE_UNIT);
@@ -574,7 +571,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
     CompletableFuture<MoveManager.MoveResult> future = new CompletableFuture<>();
     future.completeExceptionally(new RuntimeException("Runtime Exception"));
 
-    int expectedMovesFailed = (nodeCount > 6) ? 3 : 1;
     // Try the same test but with MoveManager instead of ReplicationManager.
     when(mockedSCM.getMoveManager()
         .move(any(ContainerID.class), any(DatanodeDetails.class), any(DatanodeDetails.class)))
@@ -584,7 +580,17 @@ public class TestContainerBalancerDatanodeNodeLimit {
 
     ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
     assertEquals(ContainerBalancerTask.IterationResult.ITERATION_COMPLETED, task.getIterationResult());
-    assertThat(task.getMetrics().getNumContainerMovesFailed()).isGreaterThanOrEqualTo(expectedMovesFailed);
+
+    // The random cluster layout decides how many moves get scheduled, so the exact number of failed moves
+    // cannot be asserted. Instead assert invariants that hold for any layout: every move is mocked to fail,
+    // so none can be counted as completed, and if any move was attempted it must be accounted as a failure
+    // or a timeout rather than silently dropped.
+    ContainerBalancerMetrics metrics = task.getMetrics();
+    assertEquals(0, metrics.getNumContainerMovesCompletedInLatestIteration());
+    if (!task.getContainerToSourceMap().isEmpty()) {
+      assertThat(metrics.getNumContainerMovesFailedInLatestIteration()
+          + metrics.getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(0);
+    }
   }
 
   public static List<DatanodeUsageInfo> getUnBalancedNodes(@Nonnull ContainerBalancerTask task) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`checkIterationResultException` failed intermittently (12/100 in CI) with `actual 0L >= 3L`. The test asserts that at least 3 container moves fail, but the number of moves the balancer schedules depends on the cluster layout, which `TestableCluster` builds from an unseeded random generator. On some layouts, fewer than 3 moves are scheduled, so the fixed count of 3 is not something the test can rely on.

**Fix:** Assert what is true for every layout instead of a fixed number. All moves are mocked to fail, so none can be counted as completed (`completed == 0`); and whenever a move is scheduled, it must be recorded as either a failure or a timeout. The `@Flaky` marker is removed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11855

## How was this patch tested?

- Ran the full `TestContainerBalancerDatanodeNodeLimit` class locally: 336 tests, 0 failures; checkstyle clean.
- flaky-test-check on the fork, whole class, 100 runs (10×10): all green. https://github.com/chihsuan/ozone/actions/runs/28726374356
