### PR TITLE
HDDS-15739. Fix ListObjectsV2 continuation-token: wrong XML element name and empty-token handling

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -114,7 +114,11 @@ public class BucketEndpoint extends BucketOperationHandler {
     String startAfter = queryParams().get(QueryParams.START_AFTER);
 
     Iterator<? extends OzoneKey> ozoneKeyIterator = null;
-    ContinueToken decodedToken = ContinueToken.decodeFromString(continueToken);
+    // AWS S3 treats an empty continuation-token as no token: list from the
+    // start and echo the empty token back (see setContinueToken below).
+    ContinueToken decodedToken =
+        (continueToken == null || continueToken.isEmpty())
+            ? null : ContinueToken.decodeFromString(continueToken);
     OzoneBucket bucket = null;
 
     try {
@@ -127,7 +131,7 @@ public class BucketEndpoint extends BucketOperationHandler {
 
       // If continuation token and start after both are provided, then we
       // ignore start After
-      String prevKey = continueToken != null ? decodedToken.getLastKey()
+      String prevKey = decodedToken != null ? decodedToken.getLastKey()
           : startAfter;
 
       // If shallow is true, only list immediate children
@@ -175,7 +179,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     response.setContinueToken(continueToken);
     response.setStartAfter(EncodingTypeObject.createNullable(startAfter, encodingType));
 
-    String prevDir = continueToken != null ? decodedToken.getLastDir() : null;
+    String prevDir = decodedToken != null ? decodedToken.getLastDir() : null;
     String lastKey = null;
     int count = 0;
     if (maxKeys > 0) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListObjectResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListObjectResponse.java
@@ -69,7 +69,7 @@ public class ListObjectResponse {
   @XmlElement(name = "NextMarker")
   private String nextMarker;
 
-  @XmlElement(name = "continueToken")
+  @XmlElement(name = "ContinuationToken")
   private String continueToken;
 
   @XmlElement(name = "Contents")

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -28,7 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.stream.IntStream;
+import javax.xml.bind.JAXB;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -570,6 +572,98 @@ public class TestBucketList {
       String exceptName, String exceptEncodingType, EncodingTypeObject object) {
     assertEquals(exceptName, object.getName());
     assertEquals(exceptEncodingType, object.getEncodingType());
+  }
+
+  /**
+   * An empty continuation token must be treated as no token: list from the
+   * start, not truncated, and echo the empty token back (AWS S3 semantics).
+   */
+  @Test
+  public void listWithEmptyContinuationToken() throws OS3Exception, IOException {
+    OzoneClient ozoneClient = createClientWithKeys("bar", "baz", "foo", "quxx");
+    BucketEndpoint endpoint = newBucketEndpointBuilder().setClient(ozoneClient).build();
+
+    endpoint.queryParamsForTest().set(QueryParams.PREFIX, "");
+    endpoint.queryParamsForTest().set(QueryParams.CONTINUATION_TOKEN, "");
+    ListObjectResponse response = (ListObjectResponse) endpoint.get("b1").getEntity();
+
+    assertFalse(response.isTruncated());
+    assertEquals(4, response.getContents().size());
+    // Echoed back verbatim (empty), so botocore populates ContinuationToken=''.
+    assertEquals("", response.getContinueToken());
+  }
+
+  /**
+   * A supplied continuation token must be echoed back in the response so that
+   * clients can read response['ContinuationToken'].
+   */
+  @Test
+  public void listEchoesContinuationToken() throws OS3Exception, IOException {
+    OzoneClient ozoneClient = createClientWithKeys("bar", "baz", "foo", "quxx");
+    BucketEndpoint endpoint = newBucketEndpointBuilder().setClient(ozoneClient).build();
+
+    endpoint.queryParamsForTest().set(QueryParams.PREFIX, "");
+    endpoint.queryParamsForTest().setInt(QueryParams.MAX_KEYS, 1);
+    ListObjectResponse first = (ListObjectResponse) endpoint.get("b1").getEntity();
+    assertTrue(first.isTruncated());
+    String token = first.getNextToken();
+    assertNotNull(token);
+
+    endpoint.queryParamsForTest().unset(QueryParams.MAX_KEYS);
+    endpoint.queryParamsForTest().set(QueryParams.CONTINUATION_TOKEN, token);
+    ListObjectResponse second = (ListObjectResponse) endpoint.get("b1").getEntity();
+
+    assertFalse(second.isTruncated());
+    // The request continuation token is echoed back verbatim.
+    assertEquals(token, second.getContinueToken());
+    assertEquals(3, second.getContents().size());
+  }
+
+  /**
+   * With both StartAfter and a continuation token, the token drives the
+   * listing position while both StartAfter and ContinuationToken are echoed.
+   */
+  @Test
+  public void listContinuationTokenWithStartAfter()
+      throws OS3Exception, IOException {
+    OzoneClient ozoneClient = createClientWithKeys("bar", "baz", "foo", "quxx");
+    BucketEndpoint endpoint = newBucketEndpointBuilder().setClient(ozoneClient).build();
+
+    endpoint.queryParamsForTest().set(QueryParams.PREFIX, "");
+    endpoint.queryParamsForTest().set(QueryParams.START_AFTER, "bar");
+    endpoint.queryParamsForTest().setInt(QueryParams.MAX_KEYS, 1);
+    ListObjectResponse first = (ListObjectResponse) endpoint.get("b1").getEntity();
+    assertTrue(first.isTruncated());
+    String token = first.getNextToken();
+    assertNotNull(token);
+
+    endpoint.queryParamsForTest().unset(QueryParams.MAX_KEYS);
+    endpoint.queryParamsForTest().set(QueryParams.CONTINUATION_TOKEN, token);
+    ListObjectResponse second = (ListObjectResponse) endpoint.get("b1").getEntity();
+
+    assertFalse(second.isTruncated());
+    assertEquals(token, second.getContinueToken());
+    assertEquals("bar", second.getStartAfter().getName());
+    assertEquals(2, second.getContents().size());
+  }
+
+  /**
+   * The echoed request continuation token must be serialized as the AWS S3
+   * element name {@code ContinuationToken} (not {@code continueToken}).
+   */
+  @Test
+  public void continuationTokenXmlElementName() throws Exception {
+    ListObjectResponse response = new ListObjectResponse();
+    response.setContinueToken("token-value");
+
+    StringWriter writer = new StringWriter();
+    JAXB.marshal(response, writer);
+    String xml = writer.toString();
+
+    assertTrue(xml.contains("<ContinuationToken>token-value</ContinuationToken>"),
+        "expected <ContinuationToken> element, got: " + xml);
+    assertFalse(xml.contains("continueToken"),
+        "response must not use the non-AWS <continueToken> element");
   }
 
   private OzoneClient createClientWithKeys(String... keys) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?
ListObjectsV2 has two server-side bugs around the continuation token that make S3 SDK clients fail:

1. **Wrong response element name.** The echoed request continuation token was serialized as
   `<continueToken>` instead of AWS's `<ContinuationToken>`. botocore maps response fields by
   element name, so `response['ContinuationToken']` was never populated and clients that read it
   back hit a `KeyError`.
2. **Empty token not treated as "no token".** An empty `ContinuationToken=''` was passed
   (non-null) into `ContinueToken.decodeFromString()`, which found no separator and threw
   `InvalidArgument`. AWS treats an empty continuation token as *no token* — return all keys,
   `IsTruncated=false`, and echo `''` back.

To align with AWS S3:
- Serialize the response continuation token as `ContinuationToken` (`ListObjectResponse`
  `@XmlElement`).
- In `BucketEndpoint`, treat a null/empty `continuation-token` query param as absent (list from
  the start, keyed off the decoded token) while still echoing the request value back.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15739

## How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/28727345055
