### PR TITLE
HDDS-15749. Run specific JUnit tests if possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
       acceptance-suites: ${{ steps.acceptance-suites.outputs.suites }}
+      test-classes: ${{ steps.selective-checks.outputs.test-classes }}
       integration-suites: ${{ steps.integration-suites.outputs.suites }}
       needs-basic-check: ${{ steps.categorize-basic-checks.outputs.needs-basic-check }}
       basic-checks: ${{ steps.categorize-basic-checks.outputs.basic-checks }}
@@ -349,6 +350,31 @@ jobs:
       matrix:
         profile: ${{ fromJson(needs.build-info.outputs.integration-suites) }}
       fail-fast: false
+
+  # same as integration, but runs specific tests instead of profiles
+  specific-tests:
+    name: integration
+    needs:
+      - build-info
+      - build
+      - basic
+      - dependency
+      - license
+    if: |
+      needs.build-info.outputs.test-classes != '' &&
+      needs.build-info.outputs.needs-integration-tests != 'true'
+    uses: ./.github/workflows/check.yml
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+    with:
+      java-version: ${{ needs.build-info.outputs.java-version }}
+      pre-script: sudo hostname localhost
+      ratis-args: ${{ inputs.ratis_args }}
+      script: integration
+      script-args: -Drocks_tools_native -DskipShade -Dtest=${{ needs.build-info.outputs.test-classes }}
+      sha: ${{ needs.build-info.outputs.sha }}
+      timeout-minutes: 90
+      with-coverage: ${{ fromJSON(needs.build-info.outputs.with-coverage) }}
 
   coverage:
     runs-on: ubuntu-24.04

--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -120,7 +120,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
-  assert_output -p test-classes=org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java,org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java,org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+  assert_output -p test-classes=org/apache/ozone/test/Test*,org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java,org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java,org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
 }
 
 @test "integration and unit: script change" {
@@ -144,7 +144,19 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
-  assert_output -p test-classes=org/apache/hadoop/ozone/container/TestContainerReportHandling.java,org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java,org/apache/hadoop/ozone/container/TestHelper.java
+  assert_output -p test-classes=org/apache/ozone/test/Test*,org/apache/hadoop/ozone/container/TestContainerReportHandling.java,org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java,org/apache/hadoop/ozone/container/TestHelper.java
+}
+
+@test "contract test" {
+  run dev-support/ci/selective_ci_checks.sh c0a6ffd6dda7432f57e38bcf3f5ababdd7999e26
+
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
+  assert_output -p needs-build=true
+  assert_output -p needs-compile=true
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-integration-tests=false
+  assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=org/apache/ozone/test/Test*,org/apache/hadoop/fs/ozone/contract/Test*
 }
 
 @test "script change including javadoc.sh" {
@@ -179,7 +191,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
-  assert_output -p test-classes=org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java,org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
+  assert_output -p test-classes=org/apache/ozone/test/Test*,org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java,org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
 }
 
 @test "unit helper" {
@@ -203,7 +215,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
-  assert_output -p test-classes=org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+  assert_output -p test-classes=org/apache/ozone/test/Test*,org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
 }
 
 @test "mini-cluster" {
@@ -250,7 +262,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
-  assert_output -p test-classes=org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithNativeLib.java
+  assert_output -p test-classes=org/apache/ozone/test/Test*,org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithNativeLib.java
 }
 
 @test "kubernetes only" {

--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -108,6 +108,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=
 }
 
 @test "integration and unit: java change" {
@@ -117,8 +118,9 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-integration-tests=true
+  assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java,org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java,org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
 }
 
 @test "integration and unit: script change" {
@@ -130,6 +132,19 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=
+}
+
+@test "integration and unit: test-only change" {
+  run dev-support/ci/selective_ci_checks.sh bf59f31a7e5fcad1acc85e1228d77c22ee7f036c
+
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","pmd"]'
+  assert_output -p needs-build=true
+  assert_output -p needs-compile=true
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-integration-tests=false
+  assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=org/apache/hadoop/ozone/container/TestContainerReportHandling.java,org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java,org/apache/hadoop/ozone/container/TestHelper.java
 }
 
 @test "script change including javadoc.sh" {
@@ -152,6 +167,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=
 }
 
 @test "unit only" {
@@ -161,8 +177,9 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-integration-tests=true
+  assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java,org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
 }
 
 @test "unit helper" {
@@ -174,6 +191,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=
 }
 
 @test "integration only" {
@@ -183,8 +201,9 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-integration-tests=true
+  assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
 }
 
 @test "mini-cluster" {
@@ -196,6 +215,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=
 }
 
 @test "test-utils" {
@@ -207,6 +227,7 @@ load bats-assert/load.bash
   assert_output -p needs-compose-tests=false
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=
 }
 
 @test "native only" {
@@ -227,8 +248,9 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-integration-tests=true
+  assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
+  assert_output -p test-classes=org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithNativeLib.java
 }
 
 @test "kubernetes only" {

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -267,9 +267,29 @@ function get_changed_test_classes() {
     start_end::group_start "List changed test classes"
     local pattern_array=(
         "src/test/java/.*/Test.*\.java"
+        "src/test/java/org/apache/hadoop/fs/contract"
+        "src/test/java/org/apache/hadoop/fs/ozone/contract"
     )
     filter_changed_files true
-    CHANGED_TEST_CLASSES=$(echo "${new_matched_files}" | sed -e 's@.*/src/test/java/@@' | xargs | sed -e 's/ /,/g')
+
+    local test_classes=""
+
+    if [[ -n "${new_matched_files}" ]]; then
+      # always run grouped integration tests
+      test_classes="org/apache/ozone/test/Test*"
+
+      local f
+      for f in ${new_matched_files}; do
+        if echo "$f" | grep -q -e '/fs/contract/' -e '/fs/ozone/contract/'; then
+          # run all contract tests
+          test_classes="${test_classes},org/apache/hadoop/fs/ozone/contract/Test*"
+        else
+          test_classes="${test_classes},${f}"
+        fi
+      done
+    fi
+
+    CHANGED_TEST_CLASSES=$(echo "${test_classes}" | sed -e 's@[^,]*/src/test/java/@@g')
     readonly CHANGED_TEST_CLASSES
     start_end::group_end
 }
@@ -289,6 +309,8 @@ function get_count_integration_files() {
     )
     local ignore_array=(
         "src/test/java/.*/Test.*\.java"
+        "src/test/java/org/apache/hadoop/fs/contract"
+        "src/test/java/org/apache/hadoop/fs/ozone/contract"
     )
     filter_changed_files true
     COUNT_INTEGRATION_CHANGED_FILES=${match_count}

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -38,7 +38,9 @@
 #
 declare -a pattern_array ignore_array
 
+declare -i match_count
 matched_files=""
+CHANGED_TEST_CLASSES=""
 ignore_array=(
     "^[^/]*.md" # exclude root docs
 )
@@ -136,7 +138,8 @@ function get_regexp_from_patterns() {
 #    ignore_array - array storing regexp patterns to be ignored
 # Output:
 #    match_count - number of matched files
-#    matched_files (appended) - list of matched files
+#    new_matched_files - list of matched files
+#    matched_files (appended) - cumulative list of all files matched so far
 function filter_changed_files() {
     local add_to_list="${1:-}"
 
@@ -146,17 +149,20 @@ function filter_changed_files() {
 
     verbosity::store_exit_on_error_status
 
-    match_count=$(echo "${CHANGED_FILES}" | grep -E "${match}" | grep -cEv "${ignore}")
+    new_matched_files=$(echo "${CHANGED_FILES}" | grep -E "${match}" | grep -Ev "${ignore}")
+    match_count=0
+    if [[ -n "${new_matched_files}" ]]; then
+        match_count=$(echo "${new_matched_files}" | wc -l)
+    fi
 
     if [[ "${add_to_list}" == "true" ]]; then
-        local additional=$(echo "${CHANGED_FILES}" | grep -E "${match}" | grep -Ev "${ignore}")
-        matched_files="${matched_files}$(echo -e "\n${additional}")"
+        matched_files="${matched_files}$(echo -e "\n${new_matched_files}")"
     fi
 
     echo
     echo "${match_count} changed files matching the '${match}' pattern, but ignoring '${ignore}':"
     echo
-    echo "${CHANGED_FILES}" | grep -E "${match}" | grep -Ev "${ignore}"
+    echo "${new_matched_files}"
     echo
 
     verbosity::restore_exit_on_error_status
@@ -257,6 +263,17 @@ function get_count_doc_files() {
     start_end::group_end
 }
 
+function get_changed_test_classes() {
+    start_end::group_start "List changed test classes"
+    local pattern_array=(
+        "src/test/java/.*/Test.*\.java"
+    )
+    filter_changed_files true
+    CHANGED_TEST_CLASSES=$(echo "${new_matched_files}" | sed -e 's@.*/src/test/java/@@' | xargs | sed -e 's/ /,/g')
+    readonly CHANGED_TEST_CLASSES
+    start_end::group_end
+}
+
 function get_count_integration_files() {
     start_end::group_start "Count integration test files"
     local pattern_array=(
@@ -269,6 +286,9 @@ function get_count_integration_files() {
         "^hadoop-ozone/fault-injection-test/mini-chaos-tests"
         "src/test/java"
         "src/test/resources"
+    )
+    local ignore_array=(
+        "src/test/java/.*/Test.*\.java"
     )
     filter_changed_files true
     COUNT_INTEGRATION_CHANGED_FILES=${match_count}
@@ -539,6 +559,12 @@ function set_outputs() {
     initialization::ga_output needs-compose-tests "${compose_tests_needed}"
     initialization::ga_output needs-integration-tests "${integration_tests_needed}"
     initialization::ga_output needs-kubernetes-tests "${kubernetes_tests_needed}"
+
+    if [[ "${integration_tests_needed}" == "true" ]]; then
+        initialization::ga_output test-classes ""
+    else
+        initialization::ga_output test-classes "${CHANGED_TEST_CLASSES}"
+    fi
 }
 
 check_for_full_tests_needed_label
@@ -567,6 +593,7 @@ run_all_tests_if_environment_files_changed
 get_count_all_files
 get_count_compose_files
 get_count_doc_files
+get_changed_test_classes
 get_count_integration_files
 get_count_kubernetes_files
 get_count_robot_files


### PR DESCRIPTION
## What changes were proposed in this pull request?

If only JUnit test classes have changed, limit tests run in pull request CI to that set.  This adds a new check `specific-tests` (with display name `integration`), which is the same as `integration`, but only runs specific tests instead of profiles in a matrix.

Example: f5a5f0fe681cf1c55e86f2ebc8830273b6c132ab only changed `TestContainerBalancerDatanodeNodeLimit`, no need to run all other integration tests.

Counterexample: 10a9437bf3a67f0451b5272795b04914a85b724c changed test helper code (`AbstractOzoneManagerHATest` and `MiniOzoneHAClusterImpl`), need to run all integration tests.

Note: there are many test helpers and parent classes that do not follow naming convention.  We'll need to rename these to ensure proper coverage.  Creating as draft until we address that.

https://issues.apache.org/jira/browse/HDDS-15749

## How was this patch tested?

Updated `bats` test.  Also tested in fork:

### Push [build](https://github.com/adoroszlai/ozone/actions/runs/28740631244) ###
- :x: `integration` with specific tests ([skipped](https://github.com/adoroszlai/ozone/actions/runs/28740631244/job/85223448648))
- :heavy_check_mark: profile-based `integration`

### Pull requests ###
1. test-only change: https://github.com/adoroszlai/ozone/pull/62
    - :heavy_check_mark: `integration` with specific tests ([run](https://github.com/adoroszlai/ozone/actions/runs/28741645927/job/85226940482))
      ```
      [INFO] Tests run: 336, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.89 s -- in org.apache.hadoop.hdds.scm.container.balancer.TestContainerBalancerDatanodeNodeLimit
      [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.719 s -- in org.apache.hadoop.ozone.om.TestAuthorizerLockImpl:w
      [INFO] Total time:  03:49 min
      ```
    - :x: profile-based `integration`
2. non-test change: https://github.com/adoroszlai/ozone/pull/63
    - :x: `integration` with specific tests ([skipped](https://github.com/adoroszlai/ozone/actions/runs/28741658176/job/85227089981))
    - :heavy_check_mark: profile-based `integration`