### PR TITLE
HDDS-15752. Rename base tests and helpers for naming convention in OM

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/BucketRequestTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/BucketRequestTests.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Base test class for Bucket request.
  */
 @SuppressWarnings("visibilityModifier")
-public class TestBucketRequest {
+public class BucketRequestTests {
   @TempDir
   private Path folder;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests OMBucketCreateRequest class, which handles CreateBucket request.
  */
-public class TestOMBucketCreateRequest extends TestBucketRequest {
+public class TestOMBucketCreateRequest extends BucketRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests OMBucketDeleteRequest class which handles DeleteBucket request.
  */
-public class TestOMBucketDeleteRequest extends TestBucketRequest {
+public class TestOMBucketDeleteRequest extends BucketRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
  * Tests OMBucketSetPropertyRequest class which handles OMSetBucketProperty
  * request.
  */
-public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
+public class TestOMBucketSetPropertyRequest extends BucketRequestTests {
 
   private static final String TEST_KEY = "key1";
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.bucket.TestBucketRequest;
+import org.apache.hadoop.ozone.om.request.bucket.BucketRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests bucket addAcl request.
  */
-public class TestOMBucketAddAclRequest extends TestBucketRequest {
+public class TestOMBucketAddAclRequest extends BucketRequestTests {
   @Test
   public void testPreExecute() throws Exception {
     String volumeName = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.bucket.TestBucketRequest;
+import org.apache.hadoop.ozone.om.request.bucket.BucketRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests bucket removeAcl request.
  */
-public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
+public class TestOMBucketRemoveAclRequest extends BucketRequestTests {
   @Test
   public void testPreExecute() throws Exception {
     String volumeName = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.bucket.TestBucketRequest;
+import org.apache.hadoop.ozone.om.request.bucket.BucketRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests bucket setAcl request.
  */
-public class TestOMBucketSetAclRequest extends TestBucketRequest {
+public class TestOMBucketSetAclRequest extends BucketRequestTests {
   @Test
   public void testPreExecute() throws Exception {
     String volumeName = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -67,7 +67,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.lock.OzoneLockProvider;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateFileRequest;
@@ -82,7 +82,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests OMFileCreateRequest.
  */
-public class TestOMFileCreateRequest extends TestOMKeyRequest {
+public class TestOMFileCreateRequest extends OMKeyRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.key.OMAllocateBlockRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequestWithFSO;
-import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockRequest;
@@ -63,7 +63,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests OMRecoverLeaseRequest.
  */
-public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
+public class TestOMRecoverLeaseRequest extends OMKeyRequestTests {
 
   private long parentId;
   private boolean forceRecovery = false;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequestTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequestTests.java
@@ -101,7 +101,7 @@ import org.slf4j.event.Level;
  * Base test class for key request.
  */
 @SuppressWarnings("visibilitymodifier")
-public class TestOMKeyRequest {
+public class OMKeyRequestTests {
   @TempDir
   private Path folder;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests OMAllocateBlockRequest class.
  */
-public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
+public class TestOMAllocateBlockRequest extends OMKeyRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -84,7 +84,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * Tests {@link OMKeyPurgeRequest} and {@link OMKeyPurgeResponse}.
  */
-public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
+public class TestOMDirectoriesPurgeRequestAndResponse extends OMKeyRequestTests {
 
   private int numKeys = 10;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test Key ACL requests.
  */
-public class TestOMKeyAclRequest extends TestOMKeyRequest {
+public class TestOMKeyAclRequest extends OMKeyRequestTests {
 
   @Test
   public void testKeyAddAclRequest() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -71,7 +71,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * Class tests OMKeyCommitRequest class.
  */
-public class TestOMKeyCommitRequest extends TestOMKeyRequest {
+public class TestOMKeyCommitRequest extends OMKeyRequestTests {
 
   private static final int DEFAULT_COMMIT_BLOCK_SIZE = 5;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -97,7 +97,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * This class tests the OM Key Create Request.
  */
-public class TestOMKeyCreateRequest extends TestOMKeyRequest {
+public class TestOMKeyCreateRequest extends OMKeyRequestTests {
 
   public static Collection<Object[]> data() {
     return Arrays.asList(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests OmKeyDelete request.
  */
-public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
+public class TestOMKeyDeleteRequest extends OMKeyRequestTests {
 
   @ParameterizedTest
   @ValueSource(strings = {"keyName", "a/b/keyName", "a/.snapshot/keyName", "a.snapshot/b/keyName"})

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests {@link OMKeyPurgeRequest} and {@link OMKeyPurgeResponse}.
  */
-public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
+public class TestOMKeyPurgeRequestAndResponse extends OMKeyRequestTests {
 
   private int numKeys = 10;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
  * Tests RenameKey request.
  */
 @SuppressWarnings("checkstyle:VisibilityModifier")
-public class TestOMKeyRenameRequest extends TestOMKeyRequest {
+public class TestOMKeyRenameRequest extends OMKeyRequestTests {
   protected OmKeyInfo fromKeyInfo;
   protected String fromKeyName;
   protected String toKeyName;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Class tests OMKeysDeleteRequest.
  */
-public class TestOMKeysDeleteRequest extends TestOMKeyRequest {
+public class TestOMKeysDeleteRequest extends OMKeyRequestTests {
 
   private List<String> deleteKeyList;
   private OMRequest omRequest;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysRenameRequest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests RenameKey request.
  */
-public class TestOMKeysRenameRequest extends TestOMKeyRequest {
+public class TestOMKeysRenameRequest extends OMKeyRequestTests {
 
   private int count = 10;
   private String parentDir = "/test";

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
@@ -62,7 +62,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 /**
  * This class tests the OM Open Keys Delete Request.
  */
-public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
+public class TestOMOpenKeysDeleteRequest extends OMKeyRequestTests {
 
   private BucketLayout bucketLayout;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMPrefixAclRequest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests Prefix ACL requests.
  */
-public class TestOMPrefixAclRequest extends TestOMKeyRequest {
+public class TestOMPrefixAclRequest extends OMKeyRequestTests {
 
   @Test
   public void testAddAclRequest() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test cases for OMSetTimesRequest.
  */
-public class TestOMSetTimesRequest extends TestOMKeyRequest {
+public class TestOMSetTimesRequest extends OMKeyRequestTests {
 
   /**
    * Verify that setTimes() on key works as expected.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartRequestTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartRequestTests.java
@@ -65,7 +65,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Base test class for S3 Multipart upload request.
  */
 @SuppressWarnings("visibilitymodifier")
-public class TestS3MultipartRequest {
+public class S3MultipartRequestTests {
   @TempDir
   private Path folder;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -64,7 +64,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Tests S3ExpiredMultipartUploadsAbortRequest.
  */
 public class TestS3ExpiredMultipartUploadsAbortRequest
-    extends TestS3MultipartRequest {
+    extends S3MultipartRequestTests {
 
   private BucketLayout bucketLayout;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
  * Tests S3 Initiate Multipart Upload request.
  */
 public class TestS3InitiateMultipartUploadRequest
-    extends TestS3MultipartRequest {
+    extends S3MultipartRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test Multipart upload abort request.
  */
-public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
+public class TestS3MultipartUploadAbortRequest extends S3MultipartRequestTests {
 
   @Test
   public void testPreExecute() throws IOException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Test;
  * Tests S3 Multipart upload commit part request.
  */
 public class TestS3MultipartUploadCommitPartRequest
-    extends TestS3MultipartRequest {
+    extends S3MultipartRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
  * Tests S3 Multipart Upload Complete request.
  */
 public class TestS3MultipartUploadCompleteRequest
-    extends TestS3MultipartRequest {
+    extends S3MultipartRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3DeleteBucketTaggingRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3DeleteBucketTaggingRequest.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.bucket.TestBucketRequest;
+import org.apache.hadoop.ozone.om.request.bucket.BucketRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link S3DeleteBucketTaggingRequest}.
  */
-public class TestS3DeleteBucketTaggingRequest extends TestBucketRequest {
+public class TestS3DeleteBucketTaggingRequest extends BucketRequestTests {
 
   private String volumeName;
   private String bucketName;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3DeleteObjectTaggingRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3DeleteObjectTaggingRequest.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteObjectTaggingRequest;
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test delete object tagging request.
  */
-public class TestS3DeleteObjectTaggingRequest extends TestOMKeyRequest {
+public class TestS3DeleteObjectTaggingRequest extends OMKeyRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3PutBucketTaggingRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3PutBucketTaggingRequest.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.bucket.TestBucketRequest;
+import org.apache.hadoop.ozone.om.request.bucket.BucketRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link S3PutBucketTaggingRequest}.
  */
-public class TestS3PutBucketTaggingRequest extends TestBucketRequest {
+public class TestS3PutBucketTaggingRequest extends BucketRequestTests {
 
   private String volumeName;
   private String bucketName;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3PutObjectTaggingRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tagging/TestS3PutObjectTaggingRequest.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test put object tagging request.
  */
-public class TestS3PutObjectTaggingRequest extends TestOMKeyRequest {
+public class TestS3PutObjectTaggingRequest extends OMKeyRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/OMDelegationTokenRequestTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/OMDelegationTokenRequestTests.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Base class for testing OM delegation token request.
  */
 @SuppressWarnings("visibilitymodifier")
-public class TestOMDelegationTokenRequest {
+public class OMDelegationTokenRequestTests {
 
   @TempDir
   private Path folder;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Test;
  * The class tests OMGetDelegationTokenRequest.
  */
 public class TestOMGetDelegationTokenRequest extends
-    TestOMDelegationTokenRequest {
+    OMDelegationTokenRequestTests {
 
   private OzoneDelegationTokenSecretManager secretManager;
   private OzoneTokenIdentifier identifier;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -54,7 +54,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyRenameResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyRenameResponseWithFSO;
-import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotRequestAndResponseTests;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -68,7 +68,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests OMSnapshotCreateRequest class, which handles CreateSnapshot request.
  */
-public class TestOMSnapshotCreateRequest extends TestSnapshotRequestAndResponse {
+public class TestOMSnapshotCreateRequest extends SnapshotRequestAndResponseTests {
   private String snapshotName1;
   private String snapshotName2;
   private String snapshotName3;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotRequestAndResponseTests;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
@@ -58,7 +58,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Mostly mirrors TestOMSnapshotCreateRequest.
  * testEntryNotExist() and testEntryExists() are unique.
  */
-public class TestOMSnapshotDeleteRequest extends TestSnapshotRequestAndResponse {
+public class TestOMSnapshotDeleteRequest extends SnapshotRequestAndResponseTests {
 
   private String snapshotName;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotMoveTableKeysRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotMoveTableKeysRequest.java
@@ -34,8 +34,8 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotRequestAndResponseTests;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
-import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Class to test OmSnapshotMoveTableKeyRequest.
  */
-public class TestOMSnapshotMoveTableKeysRequest extends TestSnapshotRequestAndResponse {
+public class TestOMSnapshotMoveTableKeysRequest extends SnapshotRequestAndResponseTests {
 
   private String snapshotName1;
   private String snapshotName2;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
@@ -54,7 +54,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotPurgeResponse;
 import org.apache.hadoop.ozone.om.snapshot.OmSnapshotLocalDataManager;
 import org.apache.hadoop.ozone.om.snapshot.OmSnapshotLocalDataManager.ReadableOmSnapshotLocalDataProvider;
-import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotRequestAndResponseTests;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotPurgeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
@@ -69,7 +69,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests OMSnapshotPurgeRequest class.
  */
-public class TestOMSnapshotPurgeRequestAndResponse extends TestSnapshotRequestAndResponse {
+public class TestOMSnapshotPurgeRequestAndResponse extends SnapshotRequestAndResponseTests {
   private final List<Path> checkpointPaths = new ArrayList<>();
   private String keyName;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotRenameRequest.java
@@ -51,7 +51,7 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotRequestAndResponseTests;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +62,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests OMSnapshotRenameRequest class, which handles RenameSnapshot request.
  */
-public class TestOMSnapshotRenameRequest extends TestSnapshotRequestAndResponse {
+public class TestOMSnapshotRenameRequest extends SnapshotRequestAndResponseTests {
   private String snapshotName1;
   private String snapshotName2;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotSetPropertyRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotSetPropertyRequestAndResponse.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotSetPropertyResponse;
-import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotRequestAndResponseTests;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetSnapshotPropertyRequest;
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
  * Tests TestOMSnapshotSetPropertyRequest
  * TestOMSnapshotSetPropertyResponse class.
  */
-public class TestOMSnapshotSetPropertyRequestAndResponse extends TestSnapshotRequestAndResponse {
+public class TestOMSnapshotSetPropertyRequestAndResponse extends SnapshotRequestAndResponseTests {
   private String snapName;
   private long exclusiveSize;
   private long exclusiveSizeAfterRepl;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
@@ -24,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequestTests;
 import org.apache.hadoop.ozone.om.request.key.OMOpenKeysDeleteRequest;
-import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
  * Unit testing of cancel prepare request. Cancel prepare response does not
  * perform an action, so it has no unit testing.
  */
-public class TestOMCancelPrepareRequest extends TestOMKeyRequest {
+public class TestOMCancelPrepareRequest extends OMKeyRequestTests {
   private static final long LOG_INDEX = 1;
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeRequestTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeRequestTests.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Base test class for Volume request.
  */
 @SuppressWarnings("visibilitymodifier")
-public class TestOMVolumeRequest {
+public class OMVolumeRequestTests {
 
   @TempDir
   private Path folder;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests create volume request.
  */
-public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
+public class TestOMVolumeCreateRequest extends OMVolumeRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeDeleteRequest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests delete volume request.
  */
-public class TestOMVolumeDeleteRequest extends TestOMVolumeRequest {
+public class TestOMVolumeDeleteRequest extends OMVolumeRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests set volume property request.
  */
-public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
+public class TestOMVolumeSetOwnerRequest extends OMVolumeRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests set volume property request.
  */
-public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
+public class TestOMVolumeSetQuotaRequest extends OMVolumeRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeAddAclRequest.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.volume.TestOMVolumeRequest;
+import org.apache.hadoop.ozone.om.request.volume.OMVolumeRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests volume addAcl request.
  */
-public class TestOMVolumeAddAclRequest extends TestOMVolumeRequest {
+public class TestOMVolumeAddAclRequest extends OMVolumeRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.volume.TestOMVolumeRequest;
+import org.apache.hadoop.ozone.om.request.volume.OMVolumeRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests volume removeAcl request.
  */
-public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
+public class TestOMVolumeRemoveAclRequest extends OMVolumeRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeSetAclRequest.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.volume.TestOMVolumeRequest;
+import org.apache.hadoop.ozone.om.request.volume.OMVolumeRequestTests;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests volume setAcl request.
  */
-public class TestOMVolumeSetAclRequest extends TestOMVolumeRequest {
+public class TestOMVolumeSetAclRequest extends OMVolumeRequestTests {
 
   @Test
   public void testPreExecute() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/OMResponseTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/OMResponseTestUtils.java
@@ -25,10 +25,10 @@ import org.apache.hadoop.util.Time;
 /**
  * Helper class to test OMClientResponse classes.
  */
-public final class TestOMResponseUtils {
+public final class OMResponseTestUtils {
 
   // No one can instantiate, this is just utility class with all static methods.
-  private TestOMResponseUtils() {
+  private OMResponseTestUtils() {
   }
 
   public static OmBucketInfo createBucket(String volume, String bucket) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketCreateResponse.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
+import org.apache.hadoop.ozone.om.response.OMResponseTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateBucketResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -68,7 +68,7 @@ public class TestOMBucketCreateResponse {
   public void testAddToDBBatch() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
+    OmBucketInfo omBucketInfo = OMResponseTestUtils.createBucket(
         volumeName, bucketName);
     assertEquals(0,
         omMetadataManager.countRowsInTable(omMetadataManager.getBucketTable()));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketDeleteResponse.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
+import org.apache.hadoop.ozone.om.response.OMResponseTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateBucketResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteBucketResponse;
@@ -68,7 +68,7 @@ public class TestOMBucketDeleteResponse {
   public void testAddToDBBatch() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
+    OmBucketInfo omBucketInfo = OMResponseTestUtils.createBucket(
         volumeName, bucketName);
     OMBucketCreateResponse omBucketCreateResponse =
         new OMBucketCreateResponse(OMResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketSetPropertyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketSetPropertyResponse.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
+import org.apache.hadoop.ozone.om.response.OMResponseTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateBucketResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -69,7 +69,7 @@ public class TestOMBucketSetPropertyResponse {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
+    OmBucketInfo omBucketInfo = OMResponseTestUtils.createBucket(
         volumeName, bucketName);
     OMBucketSetPropertyResponse omBucketCreateResponse =
         new OMBucketSetPropertyResponse(OMResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequest.Result;
-import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
+import org.apache.hadoop.ozone.om.response.OMResponseTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -85,7 +85,7 @@ public class TestOMDirectoryCreateResponse {
 
     ThreadLocalRandom random = ThreadLocalRandom.current();
     long usedNamespace = Math.abs(random.nextLong(Long.MAX_VALUE));
-    OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
+    OmBucketInfo omBucketInfo = OMResponseTestUtils.createBucket(
         volumeName, bucketName);
     omBucketInfo = omBucketInfo.toBuilder()
         .setUsedNamespace(usedNamespace).build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequestWithFSO;
-import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
+import org.apache.hadoop.ozone.om.response.OMResponseTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,7 +90,7 @@ public class TestOMDirectoryCreateResponseWithFSO {
             .build();
     ThreadLocalRandom random = ThreadLocalRandom.current();
     long usedNamespace = Math.abs(random.nextLong(Long.MAX_VALUE));
-    OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
+    OmBucketInfo omBucketInfo = OMResponseTestUtils.createBucket(
         volumeName, bucketName);
     omBucketInfo = omBucketInfo.toBuilder()
         .setUsedNamespace(usedNamespace).build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/OMKeyResponseTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/OMKeyResponseTests.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Base test class for key response.
  */
 @SuppressWarnings("visibilitymodifier")
-public class TestOMKeyResponse {
+public class OMKeyResponseTests {
   @TempDir
   private Path folder;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests OMAllocateBlockResponse.
  */
-public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
+public class TestOMAllocateBlockResponse extends OMKeyResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
  * Tests OMKeyCommitResponse.
  */
 @SuppressWarnings("visibilitymodifier")
-public class TestOMKeyCommitResponse extends TestOMKeyResponse {
+public class TestOMKeyCommitResponse extends OMKeyResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests MKeyCreateResponse.
  */
-public class TestOMKeyCreateResponse extends TestOMKeyResponse {
+public class TestOMKeyCreateResponse extends OMKeyResponseTests {
 
   protected long getVolumeId() throws IOException {
     return omMetadataManager.getVolumeId(volumeName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests OMKeyDeleteResponse.
  */
-public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
+public class TestOMKeyDeleteResponse extends OMKeyResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
  * Tests OMKeyRenameResponse.
  */
 @SuppressWarnings("checkstyle:VisibilityModifier")
-public class TestOMKeyRenameResponse extends TestOMKeyResponse {
+public class TestOMKeyRenameResponse extends OMKeyResponseTests {
   protected OmKeyInfo fromKeyParent;
   protected OmKeyInfo toKeyParent;
   protected OmBucketInfo bucketInfo;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponseWithFSO.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
+import org.apache.hadoop.ozone.om.response.OMResponseTestUtils;
 
 /**
  * Tests TestOMKeyRenameResponseWithFSO.
@@ -90,7 +90,7 @@ public class TestOMKeyRenameResponseWithFSO extends TestOMKeyRenameResponse {
         .build();
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    bucketInfo = TestOMResponseUtils.createBucket(volumeName, bucketName);
+    bucketInfo = OMResponseTestUtils.createBucket(volumeName, bucketName);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Class to test OMKeysDeleteResponse.
  */
-public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
+public class TestOMKeysDeleteResponse extends OMKeyResponseTests {
 
   private List<OmKeyInfo> omKeyInfoList = new ArrayList<>();
   private List<String> ozoneKeys = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysRenameResponse.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests OMKeyRenameResponse.
  */
-public class TestOMKeysRenameResponse extends TestOMKeyResponse {
+public class TestOMKeysRenameResponse extends OMKeyResponseTests {
   private OmRenameKeys omRenameKeys;
   private int count = 10;
   private String parentDir = "/test";

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 /**
  * Tests the OM Response when open keys are deleted.
  */
-public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
+public class TestOMOpenKeysDeleteResponse extends OMKeyResponseTests {
   private static final long KEY_LENGTH = 100;
   private BucketLayout bucketLayout;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/acl/prefix/TestOMPrefixAclResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/acl/prefix/TestOMPrefixAclResponse.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.ozone.om.PrefixManagerImpl;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
-import org.apache.hadoop.ozone.om.response.key.TestOMKeyResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyResponseTests;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests TestOMPrefixAclResponse.
  */
-public class TestOMPrefixAclResponse extends TestOMKeyResponse {
+public class TestOMPrefixAclResponse extends OMKeyResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartResponseTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartResponseTests.java
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.io.TempDir;
  */
 
 @SuppressWarnings("VisibilityModifier")
-public class TestS3MultipartResponse {
+public class S3MultipartResponseTests {
 
   @TempDir
   private Path folder;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3ExpiredMultipartUploadsAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3ExpiredMultipartUploadsAbortResponse.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Tests S3 Expired Multipart Upload Abort Responses.
  */
 public class TestS3ExpiredMultipartUploadsAbortResponse
-    extends TestS3MultipartResponse {
+    extends S3MultipartResponseTests {
 
   private BucketLayout bucketLayout;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3InitiateMultipartUploadResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3InitiateMultipartUploadResponse.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
  * Class tests S3 Initiate MPU response.
  */
 public class TestS3InitiateMultipartUploadResponse
-    extends TestS3MultipartResponse {
+    extends S3MultipartResponseTests {
 
   @Test
   public void testAddDBToBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
  * Test multipart upload abort response.
  */
 public class TestS3MultipartUploadAbortResponse
-    extends TestS3MultipartResponse {
+    extends S3MultipartResponseTests {
 
   @Test
   public void testAddDBToBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCommitPartResponse.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
  * Test multipart upload commit part response.
  */
 public class TestS3MultipartUploadCommitPartResponse
-    extends TestS3MultipartResponse {
+    extends S3MultipartResponseTests {
 
   @Test
   public void testAddDBToBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponse.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
  * Test multipart upload complete response.
  */
 public class TestS3MultipartUploadCompleteResponse
-    extends TestS3MultipartResponse {
+    extends S3MultipartResponseTests {
 
   @Test
   public void testAddDBToBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/tagging/TestS3DeleteObjectTaggingResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/tagging/TestS3DeleteObjectTaggingResponse.java
@@ -29,14 +29,14 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.response.key.TestOMKeyResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyResponseTests;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test delete object tagging response.
  */
-public class TestS3DeleteObjectTaggingResponse extends TestOMKeyResponse {
+public class TestS3DeleteObjectTaggingResponse extends OMKeyResponseTests {
 
   @Test
   public void testAddToBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/tagging/TestS3PutObjectTaggingResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/tagging/TestS3PutObjectTaggingResponse.java
@@ -28,14 +28,14 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.response.key.TestOMKeyResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyResponseTests;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test put object tagging response.
  */
-public class TestS3PutObjectTaggingResponse extends TestOMKeyResponse {
+public class TestS3PutObjectTaggingResponse extends OMKeyResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/OMDelegationTokenResponseTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/OMDelegationTokenResponseTests.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /** Base test class for delegation token response. */
 @SuppressWarnings("visibilitymodifier")
-public class TestOMDelegationTokenResponse {
+public class OMDelegationTokenResponseTests {
 
   @TempDir
   private Path folder;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/TestOMGetDelegationTokenResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/TestOMGetDelegationTokenResponse.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 /** The class tests OMGetDelegationTokenResponse. */
 public class TestOMGetDelegationTokenResponse extends
-    TestOMDelegationTokenResponse {
+    OMDelegationTokenResponseTests {
 
   private OzoneTokenIdentifier identifier;
   private UpdateGetDelegationTokenRequest updateGetDelegationTokenRequest;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotMoveTableKeysResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotMoveTableKeysResponse.java
@@ -51,8 +51,8 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.lock.IOzoneManagerLock;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotRequestAndResponseTests;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
-import org.apache.hadoop.ozone.om.snapshot.TestSnapshotRequestAndResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 import org.junit.jupiter.api.Assertions;
@@ -63,7 +63,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Test class to test OMSnapshotMoveTableKeysResponse.
  */
-public class TestOMSnapshotMoveTableKeysResponse extends TestSnapshotRequestAndResponse {
+public class TestOMSnapshotMoveTableKeysResponse extends SnapshotRequestAndResponseTests {
 
   private String snapshotName1;
   private String snapshotName2;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeResponseTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeResponseTests.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Base test class for OM volume response.
  */
-public class TestOMVolumeResponse {
+public class OMVolumeResponseTests {
   @TempDir
   private Path folder;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 /**
  * This class tests OMVolumeCreateResponse.
  */
-public class TestOMVolumeCreateResponse extends TestOMVolumeResponse {
+public class TestOMVolumeCreateResponse extends OMVolumeResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 /**
  * This class tests OMVolumeCreateResponse.
  */
-public class TestOMVolumeDeleteResponse extends TestOMVolumeResponse {
+public class TestOMVolumeDeleteResponse extends OMVolumeResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 /**
  * This class tests OMVolumeCreateResponse.
  */
-public class TestOMVolumeSetOwnerResponse extends TestOMVolumeResponse {
+public class TestOMVolumeSetOwnerResponse extends OMVolumeResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 /**
  * This class tests OMVolumeCreateResponse.
  */
-public class TestOMVolumeSetQuotaResponse extends TestOMVolumeResponse {
+public class TestOMVolumeSetQuotaResponse extends OMVolumeResponseTests {
 
   @Test
   public void testAddToDBBatch() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequestTests;
 import org.apache.hadoop.ozone.om.request.volume.OMQuotaRepairRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.volume.OMQuotaRepairResponse;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Timeout;
  * Test class for quota repair.
  */
 @Timeout(120)
-public class TestQuotaRepairTask extends TestOMKeyRequest {
+public class TestQuotaRepairTask extends OMKeyRequestTests {
 
   /** Seconds; must match {@link Timeout} on this class. */
   private static final int REPAIR_TEST_TIMEOUT_SECONDS = 120;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/SnapshotRequestAndResponseTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/SnapshotRequestAndResponseTests.java
@@ -76,7 +76,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Base class to test snapshot functionalities.
  */
-public class TestSnapshotRequestAndResponse {
+public class SnapshotRequestAndResponseTests {
   @TempDir
   private File testDir;
 
@@ -131,11 +131,11 @@ public class TestSnapshotRequestAndResponse {
     return volumeName;
   }
 
-  protected TestSnapshotRequestAndResponse() {
+  protected SnapshotRequestAndResponseTests() {
     this.isAdmin = false;
   }
 
-  protected TestSnapshotRequestAndResponse(boolean isAdmin) {
+  protected SnapshotRequestAndResponseTests(boolean isAdmin) {
     this.isAdmin = isAdmin;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

For HDDS-15749 we need only actual tests to be named `Test...`.  Test utilities should be named `...TestUtils` or similar, base test classes `...Tests`.

This change renames such classes in `ozone-manager`.

(More PRs to follow for other modules.)

https://issues.apache.org/jira/browse/HDDS-15752

## How was this patch tested?

CI (build, checkstyle):
https://github.com/adoroszlai/ozone/actions/runs/28746254858
