### PR TITLE
HDDS-15755. Bump develocity-maven-extension to 2.5.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -24,7 +24,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>develocity-maven-extension</artifactId>
-    <version>1.22.2</version>
+    <version>2.5.0</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `develocity-maven-extension` from 1.22.2 to 2.5.0.  This should be upgraded by `dependabot`, but it does not handle major version changes (1.x -> 2.x).

"Compatible with ... Develocity 2026.2.0 or later" ([release notes](https://docs.develocity.ai/maven/2.5/release-history/#2-5-0)).  ASF's [Develocity](https://develocity.apache.org/) is on 2026.2.0.

https://issues.apache.org/jira/browse/HDDS-15755

## How was this patch tested?

Local build.

CI:
https://github.com/adoroszlai/ozone/actions/runs/28775111108
