### PR TITLE
HDDS-15756. Propose a structure for agentic tooling.

### DIFF
--- a/.agents/skills/ozone-build/SKILL.md
+++ b/.agents/skills/ozone-build/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: ozone-build
+description: Build, test, run, or set up a local Ozone cluster; run CI-aligned checks (checkstyle, rat, bats, unit, integration). Use when building, testing, or running anything.
+---
+Read `dev-support/agent/commands.md` and follow it for the requested build/test/run/check task.

--- a/.agents/skills/ozone-map/SKILL.md
+++ b/.agents/skills/ozone-map/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: ozone-map
+description: Locate code across Ozone modules; understand SCM/OM/datanode/Recon/S3G service boundaries and key paths. Use when finding where something lives or which module to change.
+---
+Read `dev-support/agent/project-map.md` for the module map, paths, and service boundaries.

--- a/.claude/agents/ozone-builder.md
+++ b/.claude/agents/ozone-builder.md
@@ -1,0 +1,17 @@
+---
+name: ozone-builder
+description: Run Ozone Maven builds, unit/integration tests, and CI-aligned checks (checkstyle.sh, rat.sh, pmd.sh, findbugs.sh, author.sh, bats.sh). Use proactively whenever a task needs the project built, a test run, or checks run before committing. Reports concise pass/fail with failures verbatim.
+tools: Bash, Read, Grep
+model: haiku
+---
+You run builds, tests, and checks for Apache Ozone and report results compactly.
+
+1. Read `dev-support/agent/commands.md` for exact commands, default flags, and the tiered
+   check catalog (quick / moderate / slow).
+2. Run what the delegating message asks (build / a specific test / a check script);
+   use the default local flags (-DskipShade -DskipRecon -DskipDocs) unless told otherwise.
+   Prefer the quick checks for pre-commit validation; before a slow run (unit/integration/
+   acceptance, ~1 hr+) confirm it is actually needed.
+3. Report: the command run, PASS/FAIL, and on failure the compiler errors, failing test
+   names, assertion messages, and stack traces VERBATIM — do not summarize them away.
+   One line for passing runs.

--- a/.claude/skills/ozone-map/SKILL.md
+++ b/.claude/skills/ozone-map/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: ozone-map
+description: Locate code across Ozone modules; understand SCM/OM/datanode/Recon/S3G service boundaries and key paths. Use when finding where something lives or which module to change.
+---
+Read `dev-support/agent/project-map.md` for the module map, paths, and service boundaries.

--- a/AGENTIC_TOOLING.md
+++ b/AGENTIC_TOOLING.md
@@ -1,0 +1,78 @@
+# Agentic Tooling in Apache Ozone
+
+This repository is set up to work with AI coding agents (Claude Code, OpenAI Codex,
+Gemini CLI, Cursor, and other tools that read `AGENTS.md`). This page explains how that
+setup is organized, why, and the rules to keep it healthy.
+
+## Goal
+
+- **One source of truth.** Project rules live once, in `AGENTS.md` — the cross-tool
+  standard ([agents.md](https://agents.md)) that most agents read directly.
+- **Small always-on context.** `AGENTS.md` stays a slim behavioral core; bulky reference
+  material (commands, module map) lives in separate files that agents open only when needed.
+- **Same knowledge for everyone; extra help where a tool supports it.** Every tool consumes
+  the same rules and reference docs. Claude Code additionally gets skills and a subagent;
+  those are conveniences layered on top, never a separate copy of the knowledge.
+
+## File layout
+
+```
+AGENTS.md                          # source of truth: slim behavioral rules (all tools)
+CLAUDE.md                          # Claude entry point  -> @AGENTS.md (+ Claude-only notes)
+GEMINI.md                          # Gemini entry point  -> @./AGENTS.md
+
+dev-support/agent/
+├── commands.md                    # build/test/lint commands + tiered CI-check catalog
+└── project-map.md                 # module map, key paths, service boundaries, test types
+
+.claude/                           # Claude Code only
+├── skills/ozone-map/SKILL.md      #   module/path lookup (auto-surfaces on demand)
+└── agents/ozone-builder.md        #   builds/tests/checks in an isolated context
+
+.agents/skills/                    # OpenAI Codex only (its skill discovery path)
+├── ozone-map/SKILL.md             #   copy of the map skill
+└── ozone-build/SKILL.md           #   build/test/lint commands (Codex has no subagent)
+```
+
+## What each piece does
+
+| Path | Role |
+| :--- | :--- |
+| `AGENTS.md` | The rules and restrictions every agent loads each session. Keep it short. |
+| `CLAUDE.md` | Claude Code reads this; it imports `AGENTS.md` and adds a few Claude-only lines. |
+| `GEMINI.md` | Gemini CLI reads this; it imports `AGENTS.md`. |
+| `dev-support/agent/commands.md` | Build, test, run, and the full tiered check catalog. Read on demand. |
+| `dev-support/agent/project-map.md` | Where things live, service boundaries, test taxonomy. Read on demand. |
+| `.claude/skills/ozone-map/` | Claude skill that surfaces the module/path lookup when relevant. |
+| `.claude/agents/ozone-builder.md` | Claude subagent that runs builds/tests/checks in its own context and returns a concise pass/fail, keeping large logs out of the main conversation. |
+| `.agents/skills/ozone-map/` | Byte-identical copy of the map skill for Codex. |
+| `.agents/skills/ozone-build/` | Codex build/test/lint skill (Codex has no subagent equivalent). |
+
+Build/test/lint by tool: **Claude** -> `ozone-builder` subagent; **Codex** -> `ozone-build`
+skill; **Cursor/Gemini/others** -> read `dev-support/agent/commands.md` via the `AGENTS.md`
+pointer.
+
+## Caveats and maintenance rules
+
+- **Edit knowledge once.** Behavioral rules go in `AGENTS.md`; reference material goes in
+  `dev-support/agent/*.md`. The wrappers and skills only *point* — never copy content into
+  them.
+- **Reference docs are cited by plain path, never with `@`.** An `@path` in `AGENTS.md` or
+  `CLAUDE.md` is eagerly pulled into context at launch, which defeats the point of keeping
+  reference material lazy. `@` is used *only* in `CLAUDE.md`/`GEMINI.md` to import
+  `AGENTS.md`.
+- **`CLAUDE.md`/`GEMINI.md` are small import files, not symlinks.** A committed symlink is
+  checked out as a plain text file on default Windows Git setups and breaks.
+- **`ozone-map` exists as two identical copies** (Claude and Codex discover skills from
+  different directories). Keep them in sync when you change one.
+- **These agent-config files carry no Apache license header** — they are listed in
+  `dev-support/rat/rat-exclusions.txt`.
+- **Per-module `AGENTS.md` files are intentionally avoided** for now. If a module ever needs
+  its own rules, add them sparingly; nested files load only when that module is touched.
+
+## AI-generated contributions
+
+When a contribution is authored in whole or in part with AI tooling, disclose it per the
+[ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html): add
+a `Generated-by: TOOL (MODEL)` line to the pull request description (and, where known, the
+commit message). See `AGENTS.md` for the full commit/PR conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,197 +1,86 @@
 # AGENTS instructions
 
+Apache Ozone is a multi-module Maven project (Java 8 bytecode, JDK 21 runtime). The root
+version lives in `pom.xml`. Two aggregators: `hadoop-hdds/` (storage layer) and
+`hadoop-ozone/` (services). This file is the source of truth read by all coding agents; see
+`AGENTIC_TOOLING.md` for how the agent setup is organized.
+
 ## Working Style
 
-- Prefer the smallest correct change. Do not add features, abstractions, refactors, or cleanup that were not asked for.
-- Keep diffs surgical. Every changed line should trace back to the task.
-  Do not reformat, rewrap, or rename adjacent code "while you are here".
-- Match the surrounding module before introducing a new pattern.
-  Reuse existing Ozone helpers, test scaffolding, and service abstractions where possible.
-- Reuse existing Ozone and Ratis utilities when the surrounding code already uses them.
-  Prefer extending an existing helper over duplicating logic or adding a new one-off abstraction.
-- If there are multiple reasonable interpretations, state the tradeoff and ask instead of guessing.
-- Do not wrap lines early just to make them look uniform. The project limit is 120 characters; use the space.
-- Use established Ozone vocabulary in code, docs, and PR text:
-  SCM, OM, datanode, container, pipeline, volume, bucket, key, snapshot,
-  Recon, FSO, OBS, and S3 Gateway.
-  Avoid inventing new architecture terms unless the repo already uses them.
-
-## Repository Snapshot
-
-Apache Ozone is a multi-module Maven project. The root coordinates and version live in [`pom.xml`](./pom.xml).
-
-Tech stack:
-
-- Java 8 bytecode with JDK 21 runtime compatibility (see the `[21,]` profile in `pom.xml`)
-- Maven build
-- Hadoop RPC and gRPC over Protobuf
-- RocksDB for persistent metadata
-- Apache Ratis for replicated state
-- JUnit 5 for tests
-
-Two top-level aggregators:
-
-- `hadoop-hdds/`: storage layer and shared infrastructure.
-  Key submodules include `server-scm`, `container-service`, `framework`,
-  `managed-rocksdb`, and `interface-{admin,client,server}`.
-- `hadoop-ozone/`: Ozone services and clients.
-  Key submodules include `ozone-manager`, `s3gateway`, `recon`, `datanode`,
-  `dist`, `integration-test*`, and `ozonefs*`.
-
-Service boundaries:
-
-1. SCM manages containers, pipelines, and replication metadata.
-2. OM manages namespace, keys, buckets, volumes, snapshots, and most user-visible metadata.
-3. Datanodes serve container data and participate in Ratis pipelines.
-4. Recon provides observability and derived metadata views.
-5. S3 Gateway and OzoneFS expose external APIs on top of OM and HDDS services.
-
-Cross-cutting changes often span multiple layers.
-A feature or bug fix may need updates in `hadoop-hdds/interface-*`,
-server-side handling, client translation code, and integration tests.
-
-## Local Environment
-
-- Use a JDK 21 runtime locally. Source and target compatibility remain Java 8.
-- Ozone formatting conventions are shared through `.editorconfig`.
-- If Maven behaves unexpectedly, check `java -version` and `mvn -version` first.
-
-## Commands
-
-Default local build flags:
-
-- Use `-DskipShade -DskipRecon -DskipDocs` for iterative local work.
-- Drop `-DskipShade` only when you need filesystem artifacts or tests that depend on the shaded Ozone FS jar.
-- Drop `-DskipRecon` only when you are changing Recon UI or server behavior that must be built locally.
-- Drop `-DskipDocs` only when you are changing docs or doc-generation logic.
-
-Primary commands:
-
-- Iterative full build: `mvn clean install -DskipTests -DskipShade -DskipRecon -DskipDocs`
-- Full compile/verify smoke check: `mvn clean verify -DskipTests -DskipShade -DskipRecon -DskipDocs`
-- Rebuild one module and its dependencies:
-  `mvn -pl :ozone-manager -am install -DskipTests -DskipShade -DskipRecon -DskipDocs`
-- Run one unit test class: `mvn -pl :ozone-manager test -Dtest=TestOzoneManagerLock -DskipShade -DskipRecon -DskipDocs`
-- Run one unit test method:
-  `mvn -pl :ozone-manager test -Dtest=TestOzoneManagerLock#testLockingOrder -DskipShade -DskipRecon -DskipDocs`
-- Run one integration test class:
-  `mvn -pl :ozone-integration-test test -Dtest=TestOmContainerLocationCache -DskipShade -DskipRecon`
-
-CI-aligned local checks live under
-[`hadoop-ozone/dev-support/checks/`](./hadoop-ozone/dev-support/checks/).
-Prefer these when validating a change because they match CI layout and reporting:
-
-- `./hadoop-ozone/dev-support/checks/unit.sh`
-- `./hadoop-ozone/dev-support/checks/integration.sh`
-- `./hadoop-ozone/dev-support/checks/checkstyle.sh`
-- `./hadoop-ozone/dev-support/checks/rat.sh`
-- `./hadoop-ozone/dev-support/checks/author.sh`
-
-Notes:
-
-- The check scripts write results under `target/<check-name>/` (or `$OUTPUT_DIR`).
-- `build.sh` honors `FAIL_FAST=true`, `ITERATIONS=N`, and `OZONE_WITH_COVERAGE=true`.
-
-### Local Cluster
-
-- Build a runnable distribution when you need compose assets or a local tarball: `mvn -Pdist -DskipTests package`
-- Start the default compose cluster from
-  `hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/ozone`:
-  `OZONE_REPLICATION_FACTOR=3 ./run.sh -d`
-- `.run/` contains IntelliJ run configurations for SCM, OM, Recon, datanodes, shells, S3 Gateway, and HA variants.
-
-## Repository Structure
-
-Key paths:
-
-- `hadoop-hdds/interface-*`: Protobuf definitions and protocol-facing interfaces
-- `hadoop-hdds/server-scm`: SCM server behavior
-- `hadoop-hdds/container-service`: datanode-side container handling
-- `hadoop-hdds/framework`: shared service infrastructure
-- `hadoop-hdds/managed-rocksdb`: RocksDB wrappers and helpers
-- `hadoop-ozone/ozone-manager`: OM request handling and namespace logic
-- `hadoop-ozone/s3gateway`: S3-compatible gateway
-- `hadoop-ozone/recon`: Recon backend and UI
-- `hadoop-ozone/datanode`: Ozone datanode service pieces outside HDDS container-service
-- `hadoop-ozone/integration-test*`: Mini-cluster and integration coverage
-- `hadoop-ozone/dist`: distribution assembly and compose definitions
-- `hadoop-ozone/dev-support/checks`: scripts that mirror CI checks
-- `.run/`: IDE launch configurations for local services and HA topologies
+- Prefer the smallest correct change. Do not add features, abstractions, refactors, or
+  cleanup that were not asked for.
+- Keep diffs surgical. Every changed line should trace to the task. Do not reformat, rewrap,
+  or rename adjacent code "while you are here".
+- Match the surrounding module before introducing a new pattern. Reuse existing Ozone and
+  Ratis helpers, test scaffolding, and service abstractions; extend an existing helper rather
+  than duplicating logic or adding a one-off abstraction.
+- If there are multiple reasonable interpretations, state the tradeoff and ask instead of
+  guessing.
+- Do not wrap lines early. The project limit is 120 characters; use the space.
+- Use established Ozone vocabulary (SCM, OM, datanode, container, pipeline, volume, bucket,
+  key, snapshot, Recon, FSO, OBS, S3 Gateway). Avoid inventing new architecture terms.
 
 ## Change Boundaries
 
-- Keep service responsibilities separated.
-  Do not move OM logic into SCM paths, bypass existing request/response layers,
-  or introduce cross-service shortcuts just because they are convenient.
-- When changing a wire type, expect to update the Protobuf definition,
-  translators, server-side logic, and relevant compatibility or integration tests.
+- Keep service responsibilities separate. Do not move OM logic into SCM paths, bypass existing
+  request/response layers, or add cross-service shortcuts for convenience.
+- When changing a wire type, update the Protobuf definition, translators, server-side logic,
+  and relevant compatibility/integration tests.
 - Prefer existing bucket-layout, snapshot, and upgrade abstractions over one-off conditionals.
-- Do not hand-edit generated sources or generated web artifacts when a source file or generation step exists.
-- For integration coverage, extend an existing suite, base class, or cluster provider
-  before creating a new `MiniOzoneCluster` lifecycle.
-  Reuse existing cluster utilities where practical.
+- Do not hand-edit generated sources or generated web artifacts when a source file or
+  generation step exists.
+- For integration coverage, extend an existing suite, base class, or cluster provider before
+  creating a new `MiniOzoneCluster` lifecycle.
 
 ## Coding Standards
 
-- Use 2-space indentation and stay within 120 characters.
-- Add the Apache license header to new files unless the surrounding area is explicitly exempted by RAT configuration.
+- 2-space indentation; stay within 120 characters.
+- Add the Apache license header to new files unless the area is RAT-exempt.
 - Do not add `@author` tags.
-- Keep comments concrete and local to the code. Avoid vague architecture prose or newly invented terminology.
-- Prefer existing helpers and utility methods over new abstractions for single-call-site use.
-- When touching code that already follows a specific local pattern,
-  stay consistent with that pattern instead of normalizing the whole file.
+- Keep comments concrete and local. Avoid vague architecture prose or invented terminology.
+- Prefer existing helpers over new abstractions for single-call-site use.
 
-## Testing Standards
+## Testing
 
-- New behavior and bug fixes should come with tests.
-- Start with the narrowest useful test:
-  - unit tests for local logic
-  - integration tests when the behavior depends on service boundaries, cluster lifecycle, storage, RPC, or upgrade flows
-- When adding integration coverage, prefer merging it into an existing suite
-  over creating a brand-new test class that spins up another cluster for similar coverage.
-- Before wrapping up a non-trivial change, run `./hadoop-ozone/dev-support/checks/checkstyle.sh`.
-- If you added files or changed license headers, run `./hadoop-ozone/dev-support/checks/rat.sh`.
-- If you touched shell tooling, run `./hadoop-ozone/dev-support/checks/bats.sh`.
-- Use `acceptance.sh` and `kubernetes.sh` only when the changed area actually depends on those environments.
+- New behavior and bug fixes come with tests.
+- Start with the narrowest useful test: unit tests for local logic; integration tests when
+  behavior depends on service boundaries, cluster lifecycle, storage, RPC, or upgrade flows.
+- Prefer merging integration coverage into an existing suite over a new cluster class.
+- Before wrapping up, run the quick checks (`checkstyle`, `rat`, `pmd`, `author`, `bats` as
+  applicable); full tiered check list in `dev-support/agent/commands.md`.
 
-## Commits and PRs
+## Commits & PRs
 
-- Every change should map to an Apache Jira in the HDDS project.
-- Branch names usually start with the Jira ID, for example `HDDS-1234`.
-- PR titles must be `HDDS-1234. Short summary of the change`.
-- Prefer commit subjects that also start with the Jira ID when it is known,
-  for example `HDDS-1234. Fix snapshot purge regression`.
-- For larger changes, use incremental commits so reviewers can inspect the delta.
-  Do not rewrite branch history unless explicitly asked.
-- To bring a branch up to date with `master`, merge instead of rebasing: `git merge --no-edit origin/master`
-- Avoid force-push when updating a PR unless a maintainer explicitly asks for rewritten history.
-- PR descriptions should include the Jira link, the problem statement,
-  the chosen approach, and how the patch was tested.
-- When non-trivial content is generated with AI tooling,
-  disclose it in the PR description as `Generated-by: TOOL (MODEL)`.
-  See the ASF generative tooling policy.
+- Every change maps to an Apache Jira in the HDDS project.
+- Branch, commit, and PR titles start with the Jira ID: `HDDS-1234. Short summary`.
+- Use incremental commits for review; the committer squashes on merge — do not self-squash or
+  rewrite history.
+- Bring a branch up to date with `master` by merge, not rebase:
+  `git merge --no-edit origin/master`. Avoid force-push unless a maintainer asks.
+- PR description = Jira link, problem statement, chosen approach, how it was tested.
+- Disclose AI tooling in the PR description: `Generated-by: TOOL (MODEL)` (ASF policy).
 
 ## Ask First
 
-- Large new features or design changes that may need an Ozone Enhancement Proposal
-- Large cross-module refactors that are not required for the task
-- New third-party dependencies
-- Protobuf or RPC changes with compatibility impact
-- RocksDB layout, metadata schema, or upgrade/finalization changes
-- Broad terminology or naming cleanups across many files
+- Large features or design changes that may need an Ozone Enhancement Proposal (OEP design
+  docs are Markdown-only).
+- Large cross-module refactors not required for the task.
+- New third-party dependencies.
+- Protobuf or RPC changes with compatibility impact.
+- RocksDB layout, metadata schema, or upgrade/finalization changes.
+- Broad terminology or naming cleanups across many files.
 
 ## Never
 
-- Commit secrets, credentials, or tokens
-- Use destructive git commands unless explicitly requested
-- Hand-edit generated files when the source or generation workflow exists
-- Add unrelated cleanup, formatting churn, or speculative abstractions to the same change
+- Commit secrets, credentials, or tokens.
+- Use destructive git commands unless explicitly requested.
+- Hand-edit generated files when the source or generation workflow exists.
+- Add unrelated cleanup, formatting churn, or speculative abstractions to the same change.
 
-## References
+## Build & reference (read on demand — do not @-import)
 
-- [`CONTRIBUTING.md`](./CONTRIBUTING.md)
-- [`.github/pull_request_template.md`](./.github/pull_request_template.md)
-- [`hadoop-ozone/dev-support/checks/README.md`](./hadoop-ozone/dev-support/checks/README.md)
-- [`hadoop-hdds/dev-support/checkstyle/checkstyle.xml`](./hadoop-hdds/dev-support/checkstyle/checkstyle.xml)
-- [`dev-support/rat/rat-exclusions.txt`](./dev-support/rat/rat-exclusions.txt)
-- [Ozone Enhancement Proposals](https://ozone.apache.org/docs/edge/design/ozone-enhancement-proposals.html)
+- Default local build flags: `-DskipShade -DskipRecon -DskipDocs` (full command reference and
+  tiered CI checks: `dev-support/agent/commands.md`).
+- Module map, key paths, service boundaries: `dev-support/agent/project-map.md`.
+- Contribution process (Jira, PR workflow), OEP: `CONTRIBUTING.md` and
+  `.github/pull_request_template.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,8 @@
-AGENTS.md
+@AGENTS.md
+
+## Claude Code
+- For builds, tests, and CI checks, delegate to the `ozone-builder` subagent (keeps Maven
+  logs out of the main context).
+- Module/path lookup auto-surfaces via the `ozone-map` skill.
+- For code/test review, prefer the pr-review-toolkit subagents over ad-hoc review.
+- Use plan mode for protobuf/RPC and RocksDB layout/upgrade changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,3 +223,9 @@ Usually this can be fixed by removing the class file (outside of the IDE), but s
 ## CI
 
 The Ozone project uses Github Actions for its CI system.  The configuration is described in detail [here](.github/ci.md).
+
+## AI coding agents
+
+This repository is configured for AI coding agents (Claude Code, OpenAI Codex, Gemini CLI, Cursor, and other tools that read `AGENTS.md`).  `AGENTS.md` is the source of truth; `CLAUDE.md` and `GEMINI.md` import it, and reference material lives under `dev-support/agent/`.  See [`AGENTIC_TOOLING.md`](./AGENTIC_TOOLING.md) for the full layout.
+
+When a contribution is authored in whole or in part with AI tooling, disclose it per the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html) by adding a `Generated-by: TOOL (MODEL)` line to the pull request description.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@./AGENTS.md

--- a/dev-support/agent/commands.md
+++ b/dev-support/agent/commands.md
@@ -1,0 +1,56 @@
+# Ozone build, test, and check commands
+
+Reference for building, testing, running, and checking Apache Ozone locally. Read on demand;
+this file is not loaded into agent context at startup.
+
+## Default local build flags
+
+- Use `-DskipShade -DskipRecon -DskipDocs` for iterative local work.
+- Drop `-DskipShade` only when you need filesystem artifacts or tests that depend on the
+  shaded Ozone FS jar.
+- Drop `-DskipRecon` only when changing Recon UI or server behavior that must be built locally.
+- Drop `-DskipDocs` only when changing docs or doc-generation logic.
+
+## Primary commands
+
+- Iterative full build: `mvn clean install -DskipTests -DskipShade -DskipRecon -DskipDocs`
+- Full compile/verify smoke check:
+  `mvn clean verify -DskipTests -DskipShade -DskipRecon -DskipDocs`
+- Rebuild one module and its dependencies:
+  `mvn -pl :ozone-manager -am install -DskipTests -DskipShade -DskipRecon -DskipDocs`
+- Run one unit test class:
+  `mvn -pl :ozone-manager test -Dtest=TestOzoneManagerLock -DskipShade -DskipRecon -DskipDocs`
+- Run one unit test method:
+  `mvn -pl :ozone-manager test -Dtest=TestOzoneManagerLock#testLockingOrder -DskipShade -DskipRecon -DskipDocs`
+- Run one integration test class:
+  `mvn -pl :ozone-integration-test test -Dtest=TestOmContainerLocationCache -DskipShade -DskipRecon`
+
+## CI-aligned checks
+
+Scripts live under `hadoop-ozone/dev-support/checks/`. Prefer them for validation — they
+match CI layout and reporting. Grouped by runtime so you can prefer cheap checks and avoid
+surprise long runs:
+
+- quick (< 2 min): `author.sh`, `bats.sh`, `rat.sh`, `docs.sh`, `dependency.sh`,
+  `checkstyle.sh`, `pmd.sh`
+- moderate (~10 min): `findbugs.sh` (SpotBugs), `kubernetes.sh`
+- slow (~1 hr+): `unit.sh`, `integration.sh`, `acceptance.sh`
+
+Notes:
+
+- `build.sh` compiles Ozone; it honors `FAIL_FAST=true`, `ITERATIONS=N`, and
+  `OZONE_WITH_COVERAGE=true`.
+- Most checks write results under `target/<check-name>/` (or `$OUTPUT_DIR`).
+- `integration` and `acceptance` accept arguments to limit the set of tests run.
+- Use `acceptance.sh` and `kubernetes.sh` only when the changed area depends on those
+  environments.
+
+## Local cluster
+
+- Build a runnable distribution when you need compose assets or a local tarball:
+  `mvn -Pdist -DskipTests package`
+- Start the default compose cluster from
+  `hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/ozone`:
+  `OZONE_REPLICATION_FACTOR=3 ./run.sh -d`
+- `.run/` contains IntelliJ run configurations for SCM, OM, Recon, datanodes, shells, S3
+  Gateway, and HA variants. Start order: SCM init → SCM → OM init → OM → Recon → datanodes.

--- a/dev-support/agent/project-map.md
+++ b/dev-support/agent/project-map.md
@@ -1,0 +1,71 @@
+# Ozone project map
+
+Where things live, service boundaries, and local environment for Apache Ozone. Read on
+demand; this file is not loaded into agent context at startup.
+
+## Tech stack
+
+- Java 8 bytecode with JDK 21 runtime compatibility (see the `[21,]` profile in `pom.xml`)
+- Maven build
+- Hadoop RPC and gRPC over Protobuf
+- RocksDB for persistent metadata
+- Apache Ratis for replicated state
+- JUnit 5 for tests
+
+## Aggregators
+
+- `hadoop-hdds/`: storage layer and shared infrastructure. Key submodules: `server-scm`,
+  `container-service`, `framework`, `managed-rocksdb`, `interface-{admin,client,server}`.
+- `hadoop-ozone/`: Ozone services and clients. Key submodules: `ozone-manager`, `s3gateway`,
+  `recon`, `datanode`, `dist`, `integration-test*`, `ozonefs*`.
+
+## Service boundaries
+
+1. SCM manages containers, pipelines, and replication metadata.
+2. OM manages namespace, keys, buckets, volumes, snapshots, and most user-visible metadata.
+3. Datanodes serve container data and participate in Ratis pipelines.
+4. Recon provides observability and derived metadata views.
+5. S3 Gateway and OzoneFS expose external APIs on top of OM and HDDS services.
+
+Cross-cutting changes often span multiple layers: a feature or bug fix may need updates in
+`hadoop-hdds/interface-*`, server-side handling, client translation code, and integration
+tests.
+
+## Key paths
+
+- `hadoop-hdds/interface-*`: Protobuf definitions and protocol-facing interfaces
+- `hadoop-hdds/server-scm`: SCM server behavior
+- `hadoop-hdds/container-service`: datanode-side container handling
+- `hadoop-hdds/framework`: shared service infrastructure
+- `hadoop-hdds/managed-rocksdb`: RocksDB wrappers and helpers
+- `hadoop-ozone/ozone-manager`: OM request handling and namespace logic
+- `hadoop-ozone/s3gateway`: S3-compatible gateway
+- `hadoop-ozone/recon`: Recon backend and UI
+- `hadoop-ozone/datanode`: Ozone datanode service pieces outside HDDS container-service
+- `hadoop-ozone/integration-test*`: Mini-cluster and integration coverage
+- `hadoop-ozone/dist`: distribution assembly and compose definitions
+- `hadoop-ozone/dev-support/checks`: scripts that mirror CI checks
+- `.run/`: IDE launch configurations for local services and HA topologies
+
+## Local environment
+
+- Use a JDK 21 runtime locally; source and target compatibility remain Java 8.
+- Build requirements: Unix system, JDK 8+ (build with JDK 21), Maven 3.6+, internet on first
+  build, and standard tools (`make`, `gcc`).
+- Formatting conventions are shared through `.editorconfig`.
+- If Maven behaves unexpectedly, check `java -version` and `mvn -version` first.
+
+## Test taxonomy
+
+Pick the narrowest useful type:
+
+- unit — JUnit / Java, local logic
+- integration — single-JVM "mini cluster" (`MiniOzoneCluster`)
+- acceptance — docker + Robot Framework
+- blockade — python-based fault/partition tests
+- performance / load — `ozone freon` generators
+
+## Reference resource
+
+- [DeepWiki](https://deepwiki.com/apache/ozone) — AI-queryable index of the codebase, useful
+  for semantic Q&A during exploration.

--- a/dev-support/rat/rat-exclusions.txt
+++ b/dev-support/rat/rat-exclusions.txt
@@ -26,10 +26,10 @@ CONTRIBUTING.md
 README.md
 SECURITY.md
 
-# agentic tooling config (see AGENTIC_TOOLING.md)
-dev-support/agent/*.md
-**/SKILL.md
-.claude/agents/*.md
+# dev-support/
+agent/*.md
+.agents/**/*.md
+.claude/**/*.md
 
 # hadoop-hdds/interface-client
 src/main/resources/proto.lock

--- a/dev-support/rat/rat-exclusions.txt
+++ b/dev-support/rat/rat-exclusions.txt
@@ -20,9 +20,16 @@
 .github/*
 AGENTS.md
 CLAUDE.md
+GEMINI.md
+AGENTIC_TOOLING.md
 CONTRIBUTING.md
 README.md
 SECURITY.md
+
+# agentic tooling config (see AGENTIC_TOOLING.md)
+dev-support/agent/*.md
+**/SKILL.md
+.claude/agents/*.md
 
 # hadoop-hdds/interface-client
 src/main/resources/proto.lock


### PR DESCRIPTION
## What changes were proposed in this pull request?
Restructures the repo's AI coding agent configuration for cross-tool use.
AGENTS.md remains the source of truth but is slimmed to a behavioral core;
CLAUDE.md/GEMINI.md import it. Reference material (commands + tiered CI checks,
module map) moves to dev-support/agent/*.md, read on demand. Adds an ozone-map
skill (Claude + Codex copy), a Codex-only ozone-build skill, and a Claude-only
ozone-builder subagent, plus AGENTIC_TOOLING.md documenting the layout.
RAT exclusions are updated for the new markdown.

Rationale and full design: see agents_setup_plan.md (attached to the Jira) and
AGENTIC_TOOLING.md in this PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15756

## How was this patch tested?

Markdown/config-only change. rat.sh passes; checkstyle/bats N/A (no Java/shell).
Manually verified agent loading: AGENTS.md loads via the CLAUDE.md import while
the dev-support/agent/* docs stay lazy; the ozone-map skill surfaces on demand;
the ozone-builder subagent delegates on a build/test request;

Generated-by: Claude Code (claude-opus-4-8)
