### PR TITLE
HDDS-15708. List ignored dependencies for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,23 +15,69 @@
 version: 2
 updates:
   - package-ecosystem: maven
+    open-pull-requests-limit: 5
     directory: "/"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "com.fasterxml.jackson:*"
+        versions:
+          - "2.22" # not LTS
+      - dependency-name: "com.github.ekryd.sortpom:sortpom-maven-plugin"
+        versions:
+          - ">=3.1.0" # requires Java 11
+      - dependency-name: "com.github.spotbugs:spotbugs-maven-plugin"
+        versions:
+          - ">=4.0.0.0" # too many new warnings
+          - ">=4.9.0.0" # requires Java 11
+      - dependency-name: "com.googlecode.maven-download-plugin:download-maven-plugin"
+        versions:
+          - ">=1.10.0" # requires Java 11
+      - dependency-name: "dev.langchain4j:*"
+        versions:
+          - ">=0.36.0" # requires Java 17
+      - dependency-name: "info.picocli:*"
+        versions:
+          - "4.7.6" # bug https://github.com/remkop/picocli/issues/2309
+          - "4.7.7" # bug https://github.com/remkop/picocli/issues/2407
+      - dependency-name: "io.netty:*"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "org.apache.derby:derby"
+        versions:
+          - "<10.17.1.0" # CVE-2022-46337 https://issues.apache.org/jira/browse/DERBY-7147
+          - ">=10.17.1.0" # requires Java 21
+      - dependency-name: "org.apache.hadoop:*" # using multiple versions
+      - dependency-name: "org.apache.iceberg:*"
+        versions:
+          - ">=1.11.0" # requires Java 17
+      - dependency-name: "org.apache.parquet:*" # update in sync with iceberg
+      - dependency-name: "org.apache.rat:apache-rat-plugin"
+        versions:
+          - "0.17" # bug https://issues.apache.org/jira/browse/RAT-476
+          - ">=0.18" # requires Java 17
+      - dependency-name: "org.aspectj:*" # using multiple versions
+      - dependency-name: "org.jgrapht"
+        versions:
+          - ">=1.5.0" # requires Java 11
+      - dependency-name: "org.jooq:*"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "org.mockito:mockito-core"
+        versions:
+          - ">=5.0.0" # requires Java 11
+      - dependency-name: "org.rocksdb:*"
+        update-types: ["version-update:semver-minor"]
     schedule:
-      interval: "weekly"
-      day: "saturday"
-      time: "07:00" # UTC
+      interval: "cron"
+      cronjob: "0 5 * * 0,6"
     cooldown:
       default-days: 7
     pull-request-branch-name:
       separator: "-"
   - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 5
     directory: "/"
     schedule:
-      # 'daily' only runs on weekdays
       interval: "cron"
-      cronjob: "15 6 * * *"
+      cronjob: "0 6 * * 0,6"
     cooldown:
       default-days: 7


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Some dependencies cannot be updated for various reasons, e.g. they require newer Java, are not backwards compatible, new version has bug, etc.  List these explicitly in dependabot's config instead of ignoring them via PR commands.  This improves transparency and is easier to update later (e.g. when we upgrade to newer Java).
- Change dependabot schedule: check for updates twice over the weekend, not just once.  Open PRs are still limited to 5 (no change, this is the default).  If we can merge (some) PRs before the next run, and there are further dependencies to be updated, dependabot will open more PRs.  This helps getting dependencies updated sooner if committers are available during the weekend to take care of the process.  Otherwise there is no change, the first (max. 5) PRs will be left open and we can merge them during the week.

This should be merged only after #10674 and #10666.

https://issues.apache.org/jira/browse/HDDS-15708

## How was this patch tested?

```
+------------------------------------------------------------------------------------------------------------------------------------+
|                                                Changes to Dependabot Pull Requests                                                 |
+---------+--------------------------------------------------------------------------------------------------------------------------+
| created | com.github.jnr:jnr-constants ( from 0.10.4 to 0.11.0 )                                                                   |
| created | org.rocksdb:rocksdbjni ( from 7.7.3 to 7.7.8 )                                                                           |
| created | com.gradle:develocity-maven-extension ( from 1.22.2 to 1.23.3 )                                                          |
| created | org.apache.zookeeper:zookeeper ( from 3.8.6 to 3.9.5 )                                                                   |
| created | org.apache.iceberg:iceberg-bom ( from 1.10.1 to 1.10.2 ), org.apache.iceberg:iceberg-orc ( from 1.10.1 to 1.10.2 ), o... |
| created | org.jooq:jooq ( from 3.11.10 to 3.11.12 ), org.jooq:jooq-codegen ( from 3.11.10 to 3.11.12 ), org.jooq:jooq-meta ( fr... |
| created | org.jline:jline ( from 3.30.13 to 3.30.14 )                                                                              |
| created | org.cyclonedx:cyclonedx-maven-plugin ( from 2.9.1 to 2.9.2 )                                                             |
| created | com.amazonaws:aws-java-sdk-core ( from 1.12.788 to 1.12.797 ), com.amazonaws:aws-java-sdk-s3 ( from 1.12.788 to 1.12.... |
| created | io.grpc:grpc-bom ( from 1.77.1 to 1.82.1 )                                                                               |
| created | com.github.jnr:jnr-posix ( from 3.1.22 to 3.2.1 )                                                                        |
| created | javax.servlet.jsp:jsp-api ( from 2.1 to 2.2 )                                                                            |
+---------+--------------------------------------------------------------------------------------------------------------------------+
```

https://github.com/adoroszlai/ozone/actions/runs/28736055921/job/85210344917
