### PR TITLE
HDDS-14544. OM DB Insights: Duplicate API calls triggered when changing limit selector

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/containerMismatchTable.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/containerMismatchTable.tsx
@@ -80,7 +80,6 @@ const ContainerMismatchTable: React.FC<ContainerMismatchTableProps> = ({
     DEFAULT_MISMATCH_RESPONSE,
     {
       retryAttempts: 2,
-      initialFetch: false,
       onError: (error) => showDataFetchError(error)
     }
   );
@@ -91,11 +90,6 @@ const ContainerMismatchTable: React.FC<ContainerMismatchTableProps> = ({
       setData(mismatchData.data.containerDiscrepancyInfo);
     }
   }, [mismatchData.data]);
-
-  // Refetch when limit or missingIn changes
-  useEffect(() => {
-    mismatchData.refetch();
-  }, [limit.value, missingIn]);
 
   const handleExistAtChange: FilterMenuProps['onClick'] = ({ key }) => {
     if (key === 'OM') {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/deletePendingDirsTable.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/deletePendingDirsTable.tsx
@@ -87,7 +87,6 @@ const DeletePendingDirTable: React.FC<DeletePendingDirTableProps> = ({
     DEFAULT_DELETE_PENDING_DIRS_RESPONSE,
     {
       retryAttempts: 2,
-      initialFetch: false,
       onError: (error) => showDataFetchError(error)
     }
   );
@@ -98,11 +97,6 @@ const DeletePendingDirTable: React.FC<DeletePendingDirTableProps> = ({
       setData(deletePendingDirsData.data.deletedDirInfo);
     }
   }, [deletePendingDirsData.data]);
-
-  // Refetch when limit changes
-  useEffect(() => {
-    deletePendingDirsData.refetch();
-  }, [limit.value]);
 
   function filterData(data: DeletedDirInfo[] | undefined) {
     return data?.filter(

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/deletePendingKeysTable.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/deletePendingKeysTable.tsx
@@ -101,7 +101,6 @@ const DeletePendingKeysTable: React.FC<DeletePendingKeysTableProps> = ({
     DEFAULT_DELETE_PENDING_KEYS_RESPONSE,
     {
       retryAttempts: 2,
-      initialFetch: false,
       onError: (error) => showDataFetchError(error)
     }
   );
@@ -135,11 +134,6 @@ const DeletePendingKeysTable: React.FC<DeletePendingKeysTableProps> = ({
       setExpandedDeletePendingKeys(expandedData);
     }
   }, [deletePendingKeysData.data]);
-
-  // Refetch when limit changes
-  useEffect(() => {
-    deletePendingKeysData.refetch();
-  }, [limit.value]);
 
   function filterData(data: DeletePendingKeysColumns[] | undefined) {
     return data?.filter(

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/deletedContainerKeysTable.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/components/tables/insights/deletedContainerKeysTable.tsx
@@ -98,7 +98,6 @@ const DeletedContainerKeysTable: React.FC<DeletedContainerKeysTableProps> = ({
     DEFAULT_DELETED_CONTAINER_KEYS_RESPONSE,
     {
       retryAttempts: 2,
-      initialFetch: false,
       onError: (error) => showDataFetchError(error)
     }
   );
@@ -109,11 +108,6 @@ const DeletedContainerKeysTable: React.FC<DeletedContainerKeysTableProps> = ({
       setData(deletedContainerKeysData.data.containers);
     }
   }, [deletedContainerKeysData.data]);
-
-  // Refetch when limit changes
-  useEffect(() => {
-    deletedContainerKeysData.refetch();
-  }, [limit.value]);
 
   function filterData(data: Container[] | undefined) {
     return data?.filter(

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/insights/omInsights.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/insights/omInsights.tsx
@@ -118,7 +118,7 @@ const OMDBInsights: React.FC<{}> = () => {
     </div>
     <div style={{ padding: '24px' }}>
       <div className='content-div'>
-        <Tabs defaultActiveKey={activeTab ?? '1'}>
+        <Tabs defaultActiveKey={activeTab ?? '1'} destroyInactiveTabPane>
           <Tabs.TabPane key='1' tab={
             <label>
               Container Mismatch Info


### PR DESCRIPTION


## What changes were proposed in this pull request?
2 Independent issues are present in the `omDBInsights` page when we change the value for limit.

**1. 2 API calls are made per tab endpoint when we change the limit:**
_Root Cause:_
- Each OM DB Insights tab uses the useApiData hook to fetch data. This hook also refetches the data when there is change in the URL string.
- Each tab also defines a separate useEffect hook that refetches the data through useApiData when limit.value changes.
- By behaviour, changing the limit results in changing the URL string. As a result, we have 2 listeners - one is useApiData listening to changes in URL string and the other in the same Table listening to limit.value changes. This results in 2 calls to useApiData.

_Fix_:
The redundant useEffect in the OMDBInsights tab pages, which listens to limit.value changes was removed.

**2. Changing the limit results in fetching data for all 5 tab endpoints even though only one tab is active:**
_Root Cause:_
- Limit's state lives in the parent and is shared across all tabs.
- Ant Design Tabs mounts the tab content on the first visit to a tab. These tabs remain mounted even when inactive (default behaviour of Ant design tabs). 
- Changing the limit, results in changing the state for all tabs which are mounted, resulting in refetching data for all tabs.

_Fix:_
Unmount inactive tabs from the ant design tabs using the destroyInactiveTabPane prop.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-14544

## How was this patch tested?
Network Tab in browser.

**Before the changes:**
<img width="231" height="307" alt="image" src="https://github.com/user-attachments/assets/41ca548d-76a0-4fa3-baf9-35ad24ed104d" />
- All tabs on the OMDBInsights page are opened once.
- Limit is changed resulting in 2 API calls per tab, for all tabs.

**After the changes:**
<img width="382" height="143" alt="image" src="https://github.com/user-attachments/assets/be3aa653-513d-4f4d-91be-e2237d695d41" />
- All tabs on the OMDBInsights page are opened once.
- Limit is changed resulting in a single API call for the active tab.