### PR TITLE
HDDS-15733. Fix CompactOMDB showing 'om node: null' without --node-id

### DIFF
--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
@@ -73,6 +73,14 @@ public class CompactOMDB extends RepairTool {
     OzoneConfiguration conf = getOzoneConf();
     OMNodeDetails omNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
         conf, omServiceId, nodeId);
+
+    if (omNodeDetails == null) {
+      error("Couldn't determine OM node from the given service-id: %s and node-id: %s.",
+          omServiceId, nodeId);
+      return;
+    }
+
+    String omDisplay = nodeId != null ? nodeId : omNodeDetails.getRpcAddressString();
     ManagedCompactRangeOptions.BottommostLevelCompaction blcOption =
         CompactDBUtil.getBottommostLevelCompaction(bottommostLevelCompaction);
     if (!isDryRun()) {
@@ -81,8 +89,8 @@ public class CompactOMDB extends RepairTool {
                    UserGroupInformation.getCurrentUser(), omNodeDetails)) {
         omAdminProtocolClient.compactOMDB(columnFamilyName, blcOption.getValue());
         info("Compaction request issued for om.db of om node: %s, column-family: %s" +
-            " with bottommost level compaction: %s.", nodeId, columnFamilyName, blcOption.name());
-        info("Please check role logs of %s for completion status.", nodeId);
+            " with bottommost level compaction: %s.", omDisplay, columnFamilyName, blcOption.name());
+        info("Please check role logs of %s for completion status.", omDisplay);
       } catch (IOException ex) {
         error("Couldn't compact column %s. \nException: %s", columnFamilyName, ex);
       }

--- a/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/om/TestCompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/om/TestCompactOMDB.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.repair.om;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
+import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
+import org.apache.hadoop.ozone.repair.OzoneRepair;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import picocli.CommandLine;
+
+/**
+ * Tests CompactOMDB.
+ */
+public class TestCompactOMDB {
+
+  private static final String COLUMN_FAMILY = "fileTable";
+  private static final String RPC_ADDRESS = "om-host:9862";
+
+  private MockedStatic<OMNodeDetails> mockedNodeDetails;
+  private MockedStatic<OMAdminProtocolClientSideImpl> mockedClient;
+  private OMAdminProtocolClientSideImpl omAdminClient;
+
+  private GenericTestUtils.PrintStreamCapturer out;
+  private GenericTestUtils.PrintStreamCapturer err;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    out = GenericTestUtils.captureOut();
+    err = GenericTestUtils.captureErr();
+
+    omAdminClient = mock(OMAdminProtocolClientSideImpl.class);
+
+    mockedNodeDetails = mockStatic(OMNodeDetails.class);
+    mockedClient = mockStatic(OMAdminProtocolClientSideImpl.class);
+    mockedClient.when(() -> OMAdminProtocolClientSideImpl.createProxyForSingleOM(any(), any(), any()))
+        .thenReturn(omAdminClient);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    IOUtils.closeQuietly(out, err, mockedNodeDetails, mockedClient);
+  }
+
+  private void mockOMNodeDetails(OMNodeDetails omNodeDetails) {
+    mockedNodeDetails.when(() -> OMNodeDetails.getOMNodeDetailsFromConf(any(), any(), any()))
+        .thenReturn(omNodeDetails);
+  }
+
+  private int compact(String... extraArgs) {
+    String[] args = new String[] {"om", "compact", "--column-family", COLUMN_FAMILY};
+    String[] allArgs = new String[args.length + extraArgs.length];
+    System.arraycopy(args, 0, allArgs, 0, args.length);
+    System.arraycopy(extraArgs, 0, allArgs, args.length, extraArgs.length);
+    CommandLine cli = new OzoneRepair().getCmd();
+    return cli.execute(allArgs);
+  }
+
+  @Test
+  public void testCompactWithoutNodeIdShowsResolvedAddress() throws Exception {
+    OMNodeDetails omNodeDetails = mock(OMNodeDetails.class);
+    when(omNodeDetails.getRpcAddressString()).thenReturn(RPC_ADDRESS);
+    mockOMNodeDetails(omNodeDetails);
+
+    compact();
+
+    verify(omAdminClient).compactOMDB(eq(COLUMN_FAMILY), anyInt());
+    assertThat(out.getOutput())
+        .contains("om node: " + RPC_ADDRESS)
+        .doesNotContain("om node: null");
+  }
+
+  @Test
+  public void testCompactWithNodeIdShowsNodeId() throws Exception {
+    OMNodeDetails omNodeDetails = mock(OMNodeDetails.class);
+    mockOMNodeDetails(omNodeDetails);
+
+    compact("--node-id", "om1");
+
+    verify(omAdminClient).compactOMDB(eq(COLUMN_FAMILY), anyInt());
+    assertThat(out.getOutput()).contains("om node: om1");
+  }
+
+  @Test
+  public void testCompactWhenOMNodeDetailsNotFound() {
+    mockOMNodeDetails(null);
+
+    compact();
+
+    assertThat(err.getOutput()).contains("Couldn't determine OM node");
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes `ozone repair om compact` behavior when `--node-id` is omitted.

Previously, the command printed `om node: null` because it used the raw CLI argument. It now prints the provided node ID when specified, or the resolved OM RPC address (`host:port`) otherwise.

Also adds a `null` guard for unresolved OM details, returning a clear error instead of an NPE, consistent with `DefragSubCommand`.

While testing on an HA cluster, I found a separate pre-existing HA issue, where `ozone.om.address` may resolve to `0.0.0.0` and cause RPC retries, which is tracked separately in HDDS-15765 and is out of scope for this PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15733

## How was this patch tested?

* Added `TestCompactOMDB` to verify:

  * resolved OM address is shown when `--node-id` is omitted
  * supplied node ID is shown when provided
  * unresolved OM reports a clean error instead of an NPE

* Manually verified on a local single-OM compose cluster:

  ```bash
  docker compose exec om ozone repair om compact --column-family fileTable
  ```

  Output now shows `om node: om:9862` instead of `null`.

<img width="1472" height="106" alt="Screenshot 2026-07-07 at 8 10 52 PM" src="https://github.com/user-attachments/assets/a8ed5c43-315c-4dd3-add6-67dac58c30d4" />


* Local checks passed:

  ```bash
  hadoop-ozone/dev-support/checks/{checkstyle,rat,author}.sh
  ```
