### PR TITLE
HDDS-14956. Add S3 HAProxy to ozonesecure-ha test-haproxy-s3g.sh

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-haproxy-s3g.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-haproxy-s3g.sh
@@ -25,6 +25,7 @@ export COMPOSE_DIR
 export SECURITY_ENABLED=true
 export OM_SERVICE_ID="omservice"
 export SCM=scm1.org
+export COMPOSE_FILE=docker-compose.yaml:s3-haproxy.yaml
 
 : ${OZONE_BUCKET_KEY_NAME:=key1}
 

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -278,8 +278,8 @@ reorder_om_nodes() {
 
   if [[ -n "${new_order}" ]] && [[ "${new_order}" != "om1,om2,om3" ]]; then
     for c in $(docker-compose ps | cut -f1 -d' ' | grep -v -e '^NAME$' -e '^om'); do
-      docker exec "${c}" bash -c \
-        "if [[ -f /etc/hadoop/ozone-site.xml ]]; then \
+      docker exec "${c}" sh -c \
+        "if [ -f /etc/hadoop/ozone-site.xml ]; then \
           sed -i -e 's/om1,om2,om3/${new_order}/' /etc/hadoop/ozone-site.xml; \
           echo 'Replaced OM order with ${new_order} in ${c}'; \
         fi"


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-12113 moved the S3 HAProxy tests into the HA environments, but `ozonesecure-ha/test-haproxy-s3g.sh` never set `COMPOSE_FILE`, so it ran against a single `s3g` and never started `s3-haproxy.yaml`. The `HA-secure` suite exercised the test without actually routing S3 traffic through HAProxy.

1. `ozonesecure-ha/test-haproxy-s3g.sh`: set `COMPOSE_FILE=docker-compose.yaml:s3-haproxy.yaml` to start the HAProxy proxy and three backend `s3g` workers.
2. `testlib.sh` (`reorder_om_nodes`): use POSIX `sh` instead of `bash`. The `haproxy:lts-alpine` proxy has no `bash`, so the per-container `docker exec` failed with exit 127 and aborted the run under `set -e`. `sh` lets the existing `ozone-site.xml` guard skip non-Ozone containers; behavior is unchanged elsewhere.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14956

## How was this patch tested?

- Ran `ozonesecure-ha/test-haproxy-s3g.sh`: 131/131 S3 robot tests passed, now with the HAProxy proxy and three backends.
- Verified routing: 12 requests to `s3g:9878` round-robined 4/4/4 across the backends, logged with the HAProxy container IP as source.
- `bats.sh` passed.

Generated-by: Claude Code (Opus 4.8)
