### PR TITLE
HDDS-15783. Handle empty lists in ScmListCodec deserialization

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ScmListCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ScmListCodec.java
@@ -69,6 +69,12 @@ class ScmListCodec implements ScmCodec<Object> {
           "Missing ListArgument.type: " + argument);
     }
 
+    // Empty list was serialized with type=Object.class.getName() as a sentinel.
+    // Skip element-type resolution — there are no elements to decode.
+    if (argument.getValueCount() == 0) {
+      return new ArrayList<>();
+    }
+
     final Class<?> elementClass = resolver.get(argument.getType());
 
     final ScmCodec<?> elementCodec = ScmCodecFactory.getInstance().getCodec(elementClass);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ScmListCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ScmListCodec.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.ha.io;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.ListArgument;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -73,7 +72,7 @@ class ScmListCodec implements ScmCodec<Object> {
     // Empty list was serialized with type=Object.class.getName() as a sentinel.
     // Skip element-type resolution — there are no elements to decode.
     if (argument.getValueCount() == 0) {
-      return Collections.emptyList();
+      return new ArrayList<>();
     }
 
     final Class<?> elementClass = resolver.get(argument.getType());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ScmListCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ScmListCodec.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.ha.io;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.ListArgument;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -72,7 +73,7 @@ class ScmListCodec implements ScmCodec<Object> {
     // Empty list was serialized with type=Object.class.getName() as a sentinel.
     // Skip element-type resolution — there are no elements to decode.
     if (argument.getValueCount() == 0) {
-      return new ArrayList<>();
+      return Collections.emptyList();
     }
 
     final Class<?> elementClass = resolver.get(argument.getType());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestScmListCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestScmListCodec.java
@@ -17,10 +17,13 @@
 
 package org.apache.hadoop.hdds.scm.ha.io;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
@@ -48,5 +51,39 @@ public class TestScmListCodec {
         () -> codec.deserialize(listArg.toByteString()));
 
     assertTrue(ex.getMessage().contains("Missing ListArgument.type"));
+  }
+
+  /**
+   * An empty list serialized with the Object.class sentinel must round-trip
+   * cleanly without triggering "Failed to resolve java.lang.Object".
+   */
+  @Test
+  public void testEmptyListRoundTrip() throws Exception {
+    ScmListCodec codec = new ScmListCodec(
+        new ScmCodecFactory.ClassResolver(Collections.emptyList()));
+
+    List<?> result = (List<?>) codec.deserialize(codec.serialize(new ArrayList<>()));
+
+    assertEquals(0, result.size());
+  }
+
+  /**
+   * The EMPTY_LIST sentinel (type=java.lang.Object, no values) stored in an
+   * existing Ratis log must deserialize successfully.
+   */
+  @Test
+  public void testEmptyListSentinelDeserialization() throws Exception {
+    SCMRatisProtocol.ListArgument sentinel =
+        SCMRatisProtocol.ListArgument.newBuilder()
+            .setType(Object.class.getName())
+            // no values
+            .build();
+
+    ScmListCodec codec = new ScmListCodec(
+        new ScmCodecFactory.ClassResolver(Collections.emptyList()));
+
+    List<?> result = (List<?>) codec.deserialize(sentinel.toByteString());
+
+    assertEquals(0, result.size());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestScmListCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestScmListCodec.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
@@ -62,7 +61,7 @@ public class TestScmListCodec {
     ScmListCodec codec = new ScmListCodec(
         new ScmCodecFactory.ClassResolver(Collections.emptyList()));
 
-    List<?> result = (List<?>) codec.deserialize(codec.serialize(new ArrayList<>()));
+    List<?> result = (List<?>) codec.deserialize(codec.serialize(Collections.emptyList()));
 
     assertEquals(0, result.size());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestScmListCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestScmListCodec.java
@@ -18,9 +18,11 @@
 package org.apache.hadoop.hdds.scm.ha.io;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
@@ -61,7 +63,7 @@ public class TestScmListCodec {
     ScmListCodec codec = new ScmListCodec(
         new ScmCodecFactory.ClassResolver(Collections.emptyList()));
 
-    List<?> result = (List<?>) codec.deserialize(codec.serialize(Collections.emptyList()));
+    List<?> result = (List<?>) codec.deserialize(codec.serialize(new ArrayList<>()));
 
     assertEquals(0, result.size());
   }
@@ -84,5 +86,36 @@ public class TestScmListCodec {
     List<?> result = (List<?>) codec.deserialize(sentinel.toByteString());
 
     assertEquals(0, result.size());
+  }
+
+  /**
+   * Deserialized empty lists must be concrete {@link ArrayList} instances.
+   * Generated invokers (e.g. DeletedBlockLogStateManagerInvoker) cast the
+   * decoded argument directly to {@code ArrayList}; returning an unmodifiable
+   * or fixed-size list would cause a ClassCastException during Ratis log
+   * replay even though the list is logically empty.
+   */
+  @Test
+  public void testEmptyListDeserializedAsArrayList() throws Exception {
+    ScmListCodec codec = new ScmListCodec(
+        new ScmCodecFactory.ClassResolver(Collections.emptyList()));
+
+    // Round-trip path: serialize an empty list then deserialize it.
+    Object roundTrip = codec.deserialize(codec.serialize(new ArrayList<>()));
+    assertInstanceOf(ArrayList.class, roundTrip,
+        "round-trip empty list must be an ArrayList, not " + roundTrip.getClass());
+
+    // Sentinel path: the exact bytes that older logs contain.
+    SCMRatisProtocol.ListArgument sentinel =
+        SCMRatisProtocol.ListArgument.newBuilder()
+            .setType(Object.class.getName())
+            .build();
+    Object fromSentinel = codec.deserialize(sentinel.toByteString());
+    assertInstanceOf(ArrayList.class, fromSentinel,
+        "sentinel empty list must be an ArrayList, not " + fromSentinel.getClass());
+
+    // Verify the cast that invokers actually perform does not throw.
+    ArrayList<?> cast = (ArrayList<?>) roundTrip;
+    assertEquals(0, cast.size());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When SCM serializes an empty List into a Ratis log entry, ScmListCodec.serialize writes a ListArgument proto with type = `java.lang.Object` and zero value entries (the EMPTY_LIST sentinel). On replay (follower sync or SCM restart), the old deserialize path unconditionally called resolver.get("java.lang.Object"), which threw InvalidProtocolBufferException: Failed to resolve java.lang.Object because Object is not a registered SCM codec type. The guard short-circuits as soon as it sees zero value entries and returns an empty ArrayList directly, which is the correct result regardless of what the sentinel type string says

## What is the link to the Apache JIRA

HDDS-15783

## How was this patch tested?

Tested using unit test and tested the environment applying the patch