### PR TITLE
HDDS-15754. Rename TestableCluster to MockCluster.

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockCluster.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockCluster.java
@@ -46,9 +46,9 @@ import org.slf4j.LoggerFactory;
  * 1. Fill the cluster by generating some data.
  * 2. Nodes in the cluster have utilization values determined by generateUtilization method.
  */
-public final class TestableCluster {
+public final class MockCluster {
   static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
-  private static final Logger LOG = LoggerFactory.getLogger(TestableCluster.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MockCluster.class);
   private final int nodeCount;
   private final double[] nodeUtilizationList;
   private final DatanodeUsageInfo[] nodesInCluster;
@@ -57,7 +57,7 @@ public final class TestableCluster {
   private final Map<DatanodeUsageInfo, Set<ContainerID>> dnUsageToContainersMap = new HashMap<>();
   private final double averageUtilization;
 
-  TestableCluster(int numberOfNodes, long storageUnit) {
+  MockCluster(int numberOfNodes, long storageUnit) {
     nodeCount = numberOfNodes;
     nodeUtilizationList = createUtilizationList(nodeCount);
     nodesInCluster = new DatanodeUsageInfo[nodeCount];

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockedSCM.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockedSCM.java
@@ -60,20 +60,20 @@ import org.mockito.Mockito;
 
 /**
  * Class for test used for setting up testable StorageContainerManager.
- * Provides an access to {@link TestableCluster} and to necessary mocked instances
+ * Provides an access to {@link MockCluster} and to necessary mocked instances
  */
 public final class MockedSCM {
   private final StorageContainerManager scm;
-  private final TestableCluster cluster;
+  private final MockCluster cluster;
   private final MockNodeManager mockNodeManager;
   private final MockedReplicationManager mockedReplicaManager;
   private final MoveManager moveManager;
   private final ContainerManager containerManager;
   private MockedPlacementPolicies mockedPlacementPolicies;
 
-  public MockedSCM(@Nonnull TestableCluster testableCluster) {
+  public MockedSCM(@Nonnull MockCluster mockCluster) {
     scm = mock(StorageContainerManager.class);
-    cluster = testableCluster;
+    cluster = mockCluster;
     mockNodeManager = new MockNodeManager(cluster.getDatanodeToContainersMap());
     try {
       moveManager = mockMoveManager();
@@ -185,7 +185,7 @@ public final class MockedSCM {
     return scm;
   }
 
-  public @Nonnull TestableCluster getCluster() {
+  public @Nonnull MockCluster getCluster() {
     return cluster;
   }
 
@@ -201,7 +201,7 @@ public final class MockedSCM {
     return mockedPlacementPolicies.ecPlacementPolicy;
   }
 
-  private static @Nonnull ContainerManager mockContainerManager(@Nonnull TestableCluster cluster)
+  private static @Nonnull ContainerManager mockContainerManager(@Nonnull MockCluster cluster)
       throws ContainerNotFoundException {
     ContainerManager containerManager = mock(ContainerManager.class);
     Mockito

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.container.balancer;
 
-import static org.apache.hadoop.hdds.scm.container.balancer.TestableCluster.RANDOM;
+import static org.apache.hadoop.hdds.scm.container.balancer.MockCluster.RANDOM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -207,7 +207,7 @@ public class TestContainerBalancerDatanodeNodeLimit {
   @ParameterizedTest(name = "MockedSCM #{index}: {0}")
   @MethodSource("createMockedSCMs")
   public void testCalculationOfUtilization(@Nonnull MockedSCM mockedSCM) {
-    TestableCluster cluster = mockedSCM.getCluster();
+    MockCluster cluster = mockedSCM.getCluster();
     DatanodeUsageInfo[] nodesInCluster = cluster.getNodesInCluster();
     double[] nodeUtilizations = cluster.getNodeUtilizationList();
     assertEquals(nodesInCluster.length, nodeUtilizations.length);
@@ -590,7 +590,7 @@ public class TestContainerBalancerDatanodeNodeLimit {
   }
 
   public static @Nonnull MockedSCM getMockedSCM(int datanodeCount) {
-    return new MockedSCM(new TestableCluster(datanodeCount, STORAGE_UNIT));
+    return new MockedSCM(new MockCluster(datanodeCount, STORAGE_UNIT));
   }
 
   private static CompletableFuture<MoveManager.MoveResult> genCompletableFuture(int sleepMilSec) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerStatusInfo.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerStatusInfo.java
@@ -42,7 +42,7 @@ class TestContainerBalancerStatusInfo {
 
   @Test
   void testGetIterationStatistics() {
-    MockedSCM mockedScm = new MockedSCM(new TestableCluster(20, OzoneConsts.GB));
+    MockedSCM mockedScm = new MockedSCM(new MockCluster(20, OzoneConsts.GB));
 
     ContainerBalancerConfiguration config = new OzoneConfiguration().getObject(ContainerBalancerConfiguration.class);
 
@@ -63,7 +63,7 @@ class TestContainerBalancerStatusInfo {
 
   @Test
   void testReRequestIterationStatistics() throws Exception {
-    MockedSCM mockedScm = new MockedSCM(new TestableCluster(20, OzoneConsts.GB));
+    MockedSCM mockedScm = new MockedSCM(new MockCluster(20, OzoneConsts.GB));
 
     ContainerBalancerConfiguration config = new OzoneConfiguration().getObject(ContainerBalancerConfiguration.class);
 
@@ -83,7 +83,7 @@ class TestContainerBalancerStatusInfo {
 
   @Test
   void testGetCurrentStatisticsRequestInPeriodBetweenIterations() throws Exception {
-    MockedSCM mockedScm = new MockedSCM(new TestableCluster(20, OzoneConsts.GB));
+    MockedSCM mockedScm = new MockedSCM(new MockCluster(20, OzoneConsts.GB));
 
     ContainerBalancerConfiguration config = new OzoneConfiguration().getObject(ContainerBalancerConfiguration.class);
 
@@ -104,7 +104,7 @@ class TestContainerBalancerStatusInfo {
 
   @Test
   void testCurrentStatisticsDoesntChangeWhenReRequestInPeriodBetweenIterations() throws InterruptedException {
-    MockedSCM mockedScm = new MockedSCM(new TestableCluster(20, OzoneConsts.GB));
+    MockedSCM mockedScm = new MockedSCM(new MockCluster(20, OzoneConsts.GB));
 
     ContainerBalancerConfiguration config = new OzoneConfiguration().getObject(ContainerBalancerConfiguration.class);
 
@@ -128,7 +128,7 @@ class TestContainerBalancerStatusInfo {
 
   @Test
   void testGetCurrentStatisticsWithDelay() throws Exception {
-    MockedSCM mockedScm = new MockedSCM(new TestableCluster(20, OzoneConsts.GB));
+    MockedSCM mockedScm = new MockedSCM(new MockCluster(20, OzoneConsts.GB));
 
     ContainerBalancerConfiguration config = new OzoneConfiguration().getObject(ContainerBalancerConfiguration.class);
 
@@ -148,7 +148,7 @@ class TestContainerBalancerStatusInfo {
 
   @Test
   void testGetCurrentStatisticsWhileBalancingInProgress() throws Exception {
-    MockedSCM mockedScm = new MockedSCM(new TestableCluster(20, OzoneConsts.GB));
+    MockedSCM mockedScm = new MockedSCM(new MockCluster(20, OzoneConsts.GB));
 
     ContainerBalancerConfiguration config = new OzoneConfiguration().getObject(ContainerBalancerConfiguration.class);
 
@@ -238,7 +238,7 @@ class TestContainerBalancerStatusInfo {
    */
   @Test
   void testGetCurrentIterationsStatisticDoesNotThrowNullPointerExceptionWhenBalancingThreadIsSleeping() {
-    MockedSCM mockedScm = new MockedSCM(new TestableCluster(10, OzoneConsts.GB));
+    MockedSCM mockedScm = new MockedSCM(new MockCluster(10, OzoneConsts.GB));
     OzoneConfiguration ozoneConfig = new OzoneConfiguration();
     ContainerBalancerConfiguration config = ozoneConfig.getObject(ContainerBalancerConfiguration.class);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Renamed "TestableCluster" to align with existing Mock* test naming conventions
- Renamed .../balancer/TestableCluster.java to .../balancer/MockCluster.java
- Updated references for "TestableCluster" in `MockedSCM.java`, `TestContainerBalancerDatanodeNodeLimit.java`,
  and `TestContainerBalancerStatusInfo.java` in the path : hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/*

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15754

## How was this patch tested?

 - `TestContainerBalancerStatusInfo` — 7/7 tests passed
 - `TestContainerBalancerDatanodeNodeLimit` — 336/336 tests passed
 -  Also ran the full `.../balancer/*` test suite as a regression check.
 -  CI success : https://github.com/prathmesh12-coder/ozone/actions/runs/28950234386
