### PR TITLE
HDDS-15766. Make Recon OM DB large tarball transfer reliable

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -97,6 +97,21 @@ public abstract class RDBSnapshotProvider implements Closeable {
   }
 
   /**
+   * Hook invoked after the candidate dir consistency check and before the
+   * download loop begins. Subclasses may override this to pre-populate the
+   * candidate dir (for example, hard-linking files a client already has) so
+   * that those files are advertised in the exclude list and are not
+   * re-downloaded. The default implementation is a no-op.
+   *
+   * @param leaderNodeID the ID of the leader node the snapshot is downloaded
+   *                     from
+   * @throws IOException if seeding the candidate dir fails
+   */
+  protected void seedCandidateDir(String leaderNodeID) throws IOException {
+    // no-op by default
+  }
+
+  /**
    * Download the latest DB snapshot(checkpoint) from the Leader.
    *
    * @param leaderNodeID the ID of leader node
@@ -108,6 +123,7 @@ public abstract class RDBSnapshotProvider implements Closeable {
     LOG.info("Prepare to download the snapshot from leader OM {} and " +
         "reloading state from the snapshot.", leaderNodeID);
     checkLeaderConsistency(leaderNodeID);
+    seedCandidateDir(leaderNodeID);
     int numParts = 0;
 
     while (true) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -97,21 +97,6 @@ public abstract class RDBSnapshotProvider implements Closeable {
   }
 
   /**
-   * Hook invoked after the candidate dir consistency check and before the
-   * download loop begins. Subclasses may override this to pre-populate the
-   * candidate dir (for example, hard-linking files a client already has) so
-   * that those files are advertised in the exclude list and are not
-   * re-downloaded. The default implementation is a no-op.
-   *
-   * @param leaderNodeID the ID of the leader node the snapshot is downloaded
-   *                     from
-   * @throws IOException if seeding the candidate dir fails
-   */
-  protected void seedCandidateDir(String leaderNodeID) throws IOException {
-    // no-op by default
-  }
-
-  /**
    * Download the latest DB snapshot(checkpoint) from the Leader.
    *
    * @param leaderNodeID the ID of leader node
@@ -123,7 +108,6 @@ public abstract class RDBSnapshotProvider implements Closeable {
     LOG.info("Prepare to download the snapshot from leader OM {} and " +
         "reloading state from the snapshot.", leaderNodeID);
     checkLeaderConsistency(leaderNodeID);
-    seedCandidateDir(leaderNodeID);
     int numParts = 0;
 
     while (true) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -142,7 +142,7 @@ public abstract class RDBSnapshotProvider implements Closeable {
       LOG.info("Successfully untar the downloaded snapshot {} at {}.",
           targetFile, unTarredDb.toAbsolutePath());
       if (ratisSnapshotComplete(unTarredDb)) {
-        LOG.info("Ratis snapshot transfer is complete.");
+        LOG.info("DB snapshot transfer is complete.");
         return getCheckpointFromUntarredDb(unTarredDb);
       }
     }

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.recon;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 import static org.apache.hadoop.ozone.recon.ReconOmMetaManagerTestUtils.waitForEventBufferEmpty;
 import static org.apache.hadoop.ozone.recon.ReconOmMetaManagerTestUtils.waitUntilReconKeyCounts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -120,14 +119,6 @@ public class TestReconWithOzoneManagerHA {
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
         recon.getReconServer().getOzoneManagerServiceProvider();
 
-    String hostname =
-        ozoneManager.get().getHttpServer().getHttpAddress().getHostName();
-    String expectedUrl = "http://" +
-        (hostname.equals("0.0.0.0") ? "localhost" : hostname) + ":" +
-        ozoneManager.get().getHttpServer().getHttpAddress().getPort() +
-        OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
-    String snapshotUrl = impl.getOzoneManagerSnapshotUrl();
-    assertEquals(expectedUrl, snapshotUrl);
     // Write some data
     String keyPrefix = "ratis";
     OzoneOutputStream key = objectStore.getVolume(VOL_NAME)

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -139,10 +139,6 @@
       <artifactId>hadoop-hdfs-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-cli-common</artifactId>
     </dependency>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -139,6 +139,10 @@
       <artifactId>hadoop-hdfs-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-cli-common</artifactId>
     </dependency>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -18,7 +18,11 @@
 package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DB_DIRS_PERMISSIONS_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_CHECKPOINT_USE_INODE_BASED_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_CHECKPOINT_USE_INODE_BASED_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
+import static org.apache.hadoop.ozone.recon.ReconConstants.STAGING;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_TIMEOUT;
@@ -45,6 +49,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -108,6 +113,7 @@ public class OzoneManagerServiceProviderImpl
   private URLConnectionFactory connectionFactory;
 
   private File reconDbDir = null;
+  private File omSnapshotDBParentDir = null;
 
   private OzoneManagerProtocol ozoneManagerClient;
   private final OzoneConfiguration configuration;
@@ -169,7 +175,7 @@ public class OzoneManagerServiceProviderImpl
     long deltaUpdateLimits = configuration.getLong(RECON_OM_DELTA_UPDATE_LIMIT,
         RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT);
 
-    File omSnapshotDBParentDir = reconUtils.getReconDbDir(configuration,
+    omSnapshotDBParentDir = reconUtils.getReconDbDir(configuration,
         OZONE_RECON_OM_SNAPSHOT_DB_DIR);
     reconDbDir = reconUtils.getReconDbDir(configuration,
         ReconConfigKeys.OZONE_RECON_DB_DIR);
@@ -182,6 +188,12 @@ public class OzoneManagerServiceProviderImpl
             ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
             false)
     );
+    // Same switch OM followers honor: use the inode-based v2 checkpoint endpoint
+    // by default, or fall back to the v1 endpoint when disabled (e.g. mixed
+    // versions during an upgrade).
+    boolean useV2CheckpointApi = configuration.getBoolean(
+        OZONE_OM_DB_CHECKPOINT_USE_INODE_BASED_KEY,
+        OZONE_OM_DB_CHECKPOINT_USE_INODE_BASED_DEFAULT);
 
     this.reconUtils = reconUtils;
     this.omMetadataManager = omMetadataManager;
@@ -201,12 +213,12 @@ public class OzoneManagerServiceProviderImpl
     this.taskStatusUpdaterManager = taskStatusUpdaterManager;
     this.omDBLagThreshold = configuration.getLong(RECON_OM_DELTA_UPDATE_LAG_THRESHOLD,
         RECON_OM_DELTA_UPDATE_LAG_THRESHOLD_DEFAULT);
-    // Download the OM DB snapshot using the OM-follower incremental bootstrap
-    // mechanism (chunked POST /v2/dbCheckpoint with SST exclusion + hard-link
-    // dedup), seeding the exclude list from Recon's live OM DB.
+    // Download the full OM DB snapshot by reusing OM's checkpoint transfer path
+    // (the same one an OM follower uses): POST /v2/dbCheckpoint, or the v1
+    // /dbCheckpoint endpoint when the inode-based transfer is disabled.
     this.reconSnapshotProvider = new ReconRDBSnapshotProvider(
         omSnapshotDBParentDir, connectionFactory, isOmSpnegoEnabled(), policy,
-        flushParam, this::getLeaderServiceInfo);
+        flushParam, useV2CheckpointApi, this::getLeaderServiceInfo);
   }
 
   @Override
@@ -419,10 +431,58 @@ public class OzoneManagerServiceProviderImpl
    */
   @VisibleForTesting
   public DBCheckpoint getOzoneManagerDBSnapshot() {
+    // Before fetching a new full snapshot, delete the last known OM DB snapshot
+    // dir so we don't hold two full copies at once (keeps peak disk ~1x). This
+    // also clears any snapshot dir left over after switching v1/v2 endpoints.
+    File lastKnownDB = reconUtils.getLastKnownDB(omSnapshotDBParentDir,
+        RECON_OM_SNAPSHOT_DB);
+    if (lastKnownDB != null) {
+      boolean existingOmSnapshotDBDeleted = FileUtils.deleteQuietly(lastKnownDB);
+      if (existingOmSnapshotDBDeleted) {
+        LOG.info("Successfully deleted existing OM DB snapshot directory: {}",
+            lastKnownDB.getAbsolutePath());
+      } else {
+        LOG.warn("Failed to delete existing OM DB snapshot directory: {}",
+            lastKnownDB.getAbsolutePath());
+      }
+    }
+
+    // Remove any leftover staging dirs from a previous partial extraction
+    // (for example artifacts left by the v1 tar-extraction path).
+    File[] leftOverStagingDirs =
+        omSnapshotDBParentDir.listFiles(f -> f.getName().startsWith(STAGING));
+    if (leftOverStagingDirs != null) {
+      for (File stagingDir : leftOverStagingDirs) {
+        LOG.warn("Cleaning up leftover staging folder from failed extraction: {}",
+            stagingDir.getAbsolutePath());
+        if (FileUtils.deleteQuietly(stagingDir)) {
+          LOG.info("Successfully deleted leftover staging folder: {}",
+              stagingDir.getAbsolutePath());
+        } else {
+          LOG.warn("Failed to delete leftover staging folder: {}",
+              stagingDir.getAbsolutePath());
+        }
+      }
+    }
+
     try {
       String leaderNodeId = getLeaderNodeId();
       DBCheckpoint checkpoint =
           reconSnapshotProvider.downloadDBSnapshotFromLeader(leaderNodeId);
+
+      // Validate the assembled snapshot: log how many SST files it contains.
+      File untarredDbDir = checkpoint.getCheckpointLocation().toFile();
+      File[] sstFiles =
+          untarredDbDir.listFiles((dir, name) -> name.endsWith(".sst"));
+      if (sstFiles != null && sstFiles.length > 0) {
+        LOG.info("Number of SST files found in the OM snapshot directory: {} - {}",
+            untarredDbDir, sstFiles.length);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Valid SST files found: {}", Arrays.stream(sstFiles)
+              .map(File::getName).collect(Collectors.toList()));
+        }
+      }
+
       reconContext.updateHealthStatus(new AtomicBoolean(true));
       reconContext.getErrors()
           .remove(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
@@ -432,13 +492,11 @@ public class OzoneManagerServiceProviderImpl
       reconContext.updateHealthStatus(new AtomicBoolean(false));
       reconContext.updateErrors(
           ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
-      // Reset the candidate dir so the next attempt starts from a clean state.
-      try {
-        reconSnapshotProvider.init();
-      } catch (RuntimeException resetEx) {
-        LOG.warn("Failed to reset snapshot provider candidate dir after error.",
-            resetEx);
-      }
+      // Do not wipe the candidate dir here. The shared RDBSnapshotProvider's
+      // checkLeaderConsistency() manages it on the next attempt: kept for the
+      // same leader (so a future batched/chunked transfer can resume the parts
+      // already received), reset on a leader change. This matches how the OM
+      // follower handles a failed download.
       return null;
     }
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -64,7 +64,6 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.recon.ReconConfigKeys;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
-import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
@@ -207,7 +206,7 @@ public class OzoneManagerServiceProviderImpl
     // dedup), seeding the exclude list from Recon's live OM DB.
     this.reconSnapshotProvider = new ReconRDBSnapshotProvider(
         omSnapshotDBParentDir, connectionFactory, isOmSpnegoEnabled(), policy,
-        flushParam, this::getLeaderServiceInfo, this::getLiveOmDbDir);
+        flushParam, this::getLeaderServiceInfo);
   }
 
   @Override
@@ -409,19 +408,9 @@ public class OzoneManagerServiceProviderImpl
   }
 
   /**
-   * Return the directory of Recon's currently-open (live) OM DB, or
-   * {@code null} if no DB is open yet (first boot). Used to seed the exclude
-   * list so only changed SSTs are transferred.
-   */
-  private File getLiveOmDbDir() {
-    DBStore store = omMetadataManager.getStore();
-    return store == null ? null : store.getDbLocation();
-  }
-
-  /**
-   * Obtain the current OM DB snapshot using the OM-follower incremental
-   * bootstrap mechanism (chunked {@code POST /v2/dbCheckpoint} with SST
-   * exclusion and hard-link dedup). The returned {@link DBCheckpoint} points at
+   * Obtain the current OM DB snapshot using the same OM-follower bootstrap
+   * mechanism (chunked, resumable {@code POST /v2/dbCheckpoint} with hard-link
+   * dedup on the leader). The returned {@link DBCheckpoint} points at
    * a stable {@code om.snapshot.db_<ts>} directory ready to be promoted by
    * {@link #updateReconOmDBWithNewSnapshot()}; returns {@code null} on failure,
    * leaving the current active DB untouched.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -191,6 +191,11 @@ public class OzoneManagerServiceProviderImpl
     // Same switch OM followers honor: use the inode-based v2 checkpoint endpoint
     // by default, or fall back to the v1 endpoint when disabled (e.g. mixed
     // versions during an upgrade).
+    // NOTE: this flag is read from Recon's OzoneConfiguration, not OM's. During
+    // a mixed-version rollout, operators must set
+    // ozone.om.db.checkpoint.use.inode.based.transfer on Recon to match the
+    // OM cluster's setting; otherwise Recon may hit an endpoint the OM side
+    // does not serve.
     boolean useV2CheckpointApi = configuration.getBoolean(
         OZONE_OM_DB_CHECKPOINT_USE_INODE_BASED_KEY,
         OZONE_OM_DB_CHECKPOINT_USE_INODE_BASED_DEFAULT);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -108,7 +108,6 @@ public class OzoneManagerServiceProviderImpl
       LoggerFactory.getLogger(OzoneManagerServiceProviderImpl.class);
   private URLConnectionFactory connectionFactory;
 
-  private File omSnapshotDBParentDir = null;
   private File reconDbDir = null;
 
   private OzoneManagerProtocol ozoneManagerClient;
@@ -171,7 +170,7 @@ public class OzoneManagerServiceProviderImpl
     long deltaUpdateLimits = configuration.getLong(RECON_OM_DELTA_UPDATE_LIMIT,
         RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT);
 
-    omSnapshotDBParentDir = reconUtils.getReconDbDir(configuration,
+    File omSnapshotDBParentDir = reconUtils.getReconDbDir(configuration,
         OZONE_RECON_OM_SNAPSHOT_DB_DIR);
     reconDbDir = reconUtils.getReconDbDir(configuration,
         ReconConfigKeys.OZONE_RECON_DB_DIR);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -18,11 +18,7 @@
 package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DB_DIRS_PERMISSIONS_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
-import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
-import static org.apache.hadoop.ozone.recon.ReconConstants.STAGING;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_TIMEOUT;
@@ -45,13 +41,10 @@ import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,25 +64,23 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.recon.ReconConfigKeys;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
-import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteBatch;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort.Type;
 import org.apache.hadoop.ozone.recon.ReconContext;
 import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconUtils;
-import org.apache.hadoop.ozone.recon.TarExtractor;
 import org.apache.hadoop.ozone.recon.metrics.OzoneManagerSyncMetrics;
 import org.apache.hadoop.ozone.recon.metrics.ReconSyncMetrics;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
@@ -101,7 +92,6 @@ import org.apache.hadoop.ozone.recon.tasks.ReconTaskController;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskReInitializationEvent;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdater;
 import org.apache.hadoop.ozone.recon.tasks.updater.ReconTaskStatusUpdaterManager;
-import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.util.Time;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
@@ -120,7 +110,6 @@ public class OzoneManagerServiceProviderImpl
 
   private File omSnapshotDBParentDir = null;
   private File reconDbDir = null;
-  private String omDBSnapshotUrl;
 
   private OzoneManagerProtocol ozoneManagerClient;
   private final OzoneConfiguration configuration;
@@ -140,7 +129,7 @@ public class OzoneManagerServiceProviderImpl
   private ThreadFactory threadFactory;
   private ReconContext reconContext;
   private ReconTaskStatusUpdaterManager taskStatusUpdaterManager;
-  private TarExtractor tarExtractor;
+  private ReconRDBSnapshotProvider reconSnapshotProvider;
 
   /**
    * OM Snapshot related task names.
@@ -179,12 +168,6 @@ public class OzoneManagerServiceProviderImpl
         URLConnectionFactory.newDefaultURLConnectionFactory(connectionTimeout,
             connectionRequestTimeout, configuration);
 
-    String ozoneManagerHttpAddress = configuration.get(OMConfigKeys
-        .OZONE_OM_HTTP_ADDRESS_KEY);
-
-    String ozoneManagerHttpsAddress = configuration.get(OMConfigKeys
-        .OZONE_OM_HTTPS_ADDRESS_KEY);
-
     long deltaUpdateLimits = configuration.getLong(RECON_OM_DELTA_UPDATE_LIMIT,
         RECON_OM_DELTA_UPDATE_LIMIT_DEFAULT);
 
@@ -195,24 +178,12 @@ public class OzoneManagerServiceProviderImpl
 
     HttpConfig.Policy policy = HttpConfig.getHttpPolicy(configuration);
 
-    omDBSnapshotUrl = "http://" + ozoneManagerHttpAddress +
-        OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
-
-    if (policy.isHttpsEnabled()) {
-      omDBSnapshotUrl = "https://" + ozoneManagerHttpsAddress +
-          OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
-    }
-
     boolean flushParam = configuration.getBoolean(
         OZONE_RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
         configuration.getBoolean(
             ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
             false)
     );
-
-    if (flushParam) {
-      omDBSnapshotUrl += "?" + OZONE_DB_CHECKPOINT_REQUEST_FLUSH + "=true";
-    }
 
     this.reconUtils = reconUtils;
     this.omMetadataManager = omMetadataManager;
@@ -228,13 +199,16 @@ public class OzoneManagerServiceProviderImpl
     this.threadFactory =
         new ThreadFactoryBuilder().setNameFormat(threadNamePrefix + "SyncOM-%d")
             .build();
-    // Number of parallel workers
-    int omDBTarProcessorThreadCount = Math.min(64, Runtime.getRuntime().availableProcessors());
     this.reconContext = reconContext;
     this.taskStatusUpdaterManager = taskStatusUpdaterManager;
     this.omDBLagThreshold = configuration.getLong(RECON_OM_DELTA_UPDATE_LAG_THRESHOLD,
         RECON_OM_DELTA_UPDATE_LAG_THRESHOLD_DEFAULT);
-    this.tarExtractor = new TarExtractor(omDBTarProcessorThreadCount, threadNamePrefix);
+    // Download the OM DB snapshot using the OM-follower incremental bootstrap
+    // mechanism (chunked POST /v2/dbCheckpoint with SST exclusion + hard-link
+    // dedup), seeding the exclude list from Recon's live OM DB.
+    this.reconSnapshotProvider = new ReconRDBSnapshotProvider(
+        omSnapshotDBParentDir, connectionFactory, isOmSpnegoEnabled(), policy,
+        flushParam, this::getLeaderServiceInfo, this::getLiveOmDbDir);
   }
 
   @Override
@@ -247,7 +221,6 @@ public class OzoneManagerServiceProviderImpl
     LOG.info("Starting Ozone Manager Service Provider.");
     scheduler = Executors.newScheduledThreadPool(1, threadFactory);
     try {
-      tarExtractor.start();
       omMetadataManager.start(configuration);
     } catch (IOException ioEx) {
       LOG.error("Error starting Recon OM Metadata Manager.", ioEx);
@@ -375,7 +348,6 @@ public class OzoneManagerServiceProviderImpl
       scheduler.shutdownNow();
       Thread.currentThread().interrupt();
     }
-    tarExtractor.stop();
     LOG.debug("Shutdown the OM DB sync scheduler.");
   }
 
@@ -387,7 +359,6 @@ public class OzoneManagerServiceProviderImpl
       // immediately.
       stopSyncDataFromOMThread();
       scheduler = Executors.newScheduledThreadPool(1, threadFactory);
-      tarExtractor.start();
       startSyncDataFromOM(0L);
       return true;
     } else {
@@ -402,34 +373,10 @@ public class OzoneManagerServiceProviderImpl
     reconTaskController.stop();
     omMetadataManager.stop();
     scheduler.shutdownNow();
-    tarExtractor.stop();
+    reconSnapshotProvider.close();
     metrics.unRegister();
     reconSyncMetrics.unRegister();
     connectionFactory.destroy();
-  }
-
-  /**
-   * Find the OM leader's address to get the snapshot from.
-   */
-  @VisibleForTesting
-  public String getOzoneManagerSnapshotUrl() throws IOException {
-    String omLeaderUrl = omDBSnapshotUrl;
-    List<org.apache.hadoop.ozone.om.helpers.ServiceInfo> serviceList =
-        ozoneManagerClient.getServiceList();
-    HttpConfig.Policy policy = HttpConfig.getHttpPolicy(configuration);
-    if (!serviceList.isEmpty()) {
-      for (org.apache.hadoop.ozone.om.helpers.ServiceInfo info : serviceList) {
-        if (info.getNodeType().equals(HddsProtos.NodeType.OM) &&
-            info.getOmRoleInfo().hasServerRole() &&
-            info.getOmRoleInfo().getServerRole().equals(LEADER.name())) {
-          omLeaderUrl = (policy.isHttpsEnabled() ?
-              "https://" + info.getServiceAddress(Type.HTTPS) :
-              "http://" + info.getServiceAddress(Type.HTTP)) +
-              OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
-        }
-      }
-    }
-    return omLeaderUrl;
   }
 
   private boolean isOmSpnegoEnabled() {
@@ -438,79 +385,74 @@ public class OzoneManagerServiceProviderImpl
   }
 
   /**
-   * Method to obtain current OM DB Snapshot.
-   * @return DBCheckpoint instance.
+   * Return the current OM leader's {@link ServiceInfo} from the OM service
+   * list. The retained transfer checkpoint is local to the leader, so Recon
+   * always downloads from (and resumes against) the leader.
+   */
+  private ServiceInfo getLeaderServiceInfo() {
+    try {
+      List<ServiceInfo> serviceList = ozoneManagerClient.getServiceList();
+      for (ServiceInfo info : serviceList) {
+        if (info.getNodeType().equals(HddsProtos.NodeType.OM)
+            && info.getOmRoleInfo().hasServerRole()
+            && info.getOmRoleInfo().getServerRole().equals(LEADER.name())) {
+          return info;
+        }
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to fetch OM service list", e);
+    }
+    throw new IllegalStateException("No OM leader found in the OM service list.");
+  }
+
+  private String getLeaderNodeId() {
+    return getLeaderServiceInfo().getOmRoleInfo().getNodeId();
+  }
+
+  /**
+   * Return the directory of Recon's currently-open (live) OM DB, or
+   * {@code null} if no DB is open yet (first boot). Used to seed the exclude
+   * list so only changed SSTs are transferred.
+   */
+  private File getLiveOmDbDir() {
+    DBStore store = omMetadataManager.getStore();
+    return store == null ? null : store.getDbLocation();
+  }
+
+  /**
+   * Obtain the current OM DB snapshot using the OM-follower incremental
+   * bootstrap mechanism (chunked {@code POST /v2/dbCheckpoint} with SST
+   * exclusion and hard-link dedup). The returned {@link DBCheckpoint} points at
+   * a stable {@code om.snapshot.db_<ts>} directory ready to be promoted by
+   * {@link #updateReconOmDBWithNewSnapshot()}; returns {@code null} on failure,
+   * leaving the current active DB untouched.
+   *
+   * @return DBCheckpoint instance, or {@code null} on failure.
    */
   @VisibleForTesting
   public DBCheckpoint getOzoneManagerDBSnapshot() {
-    String snapshotFileName = RECON_OM_SNAPSHOT_DB + "_" + System.currentTimeMillis();
-    Path untarredDbDir = Paths.get(omSnapshotDBParentDir.getAbsolutePath(), snapshotFileName);
-
-    // Before fetching full snapshot again and create a new OM DB snapshot directory, check and delete
-    // any existing OM DB snapshot directories under recon om db dir location and delete all such
-    // om db snapshot dirs including the last known om db snapshot dir returned by reconUtils.getLastKnownDB
-    File lastKnownDB = reconUtils.getLastKnownDB(omSnapshotDBParentDir, RECON_OM_SNAPSHOT_DB);
-    if (lastKnownDB != null) {
-      boolean existingOmSnapshotDBDeleted = FileUtils.deleteQuietly(lastKnownDB);
-      if (existingOmSnapshotDBDeleted) {
-        LOG.info("Successfully deleted existing OM DB snapshot directory: {}",
-            lastKnownDB.getAbsolutePath());
-      } else {
-        LOG.warn("Failed to delete existing OM DB snapshot directory: {}",
-            lastKnownDB.getAbsolutePath());
-      }
-    }
-
-    // Now below cleanup operation will even remove any left over staging dirs in recon om db dir location which
-    // may be left due to any previous partial extraction of tar entries and during copy sst files process by
-    // tarExtractor.extractTar
-    File[] leftOverStagingDirs = omSnapshotDBParentDir.listFiles(f -> f.getName().startsWith(STAGING));
-    if (leftOverStagingDirs != null) {
-      for (File stagingDir : leftOverStagingDirs) {
-        LOG.warn("Cleaning up leftover staging folder from failed extraction: {}", stagingDir.getAbsolutePath());
-        boolean stagingDirDeleted = FileUtils.deleteQuietly(stagingDir);
-        if (stagingDirDeleted) {
-          LOG.info("Successfully deleted leftover staging folder: {}", stagingDir.getAbsolutePath());
-        } else {
-          LOG.warn("Failed to delete leftover staging folder: {}", stagingDir.getAbsolutePath());
-        }
-      }
-    }
-
     try {
-      SecurityUtil.doAsLoginUser(() -> {
-        try (InputStream inputStream = reconUtils.makeHttpCall(
-            connectionFactory, getOzoneManagerSnapshotUrl(), isOmSpnegoEnabled()).getInputStream()) {
-          tarExtractor.extractTar(inputStream, untarredDbDir);
-        } catch (IOException | InterruptedException e) {
-          reconContext.updateHealthStatus(new AtomicBoolean(false));
-          reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
-          throw new RuntimeException("Error while extracting OM DB Snapshot TAR.", e);
-        }
-        return null;
-      });
-      // Validate extracted files
-      File[] sstFiles = untarredDbDir.toFile().listFiles((dir, name) -> name.endsWith(".sst"));
-      if (sstFiles != null && sstFiles.length > 0) {
-        LOG.info("Number of SST files found in the OM snapshot directory: {} - {}", untarredDbDir, sstFiles.length);
-      }
-
-      List<String> sstFileNames = Arrays.stream(sstFiles)
-          .map(File::getName)
-          .collect(Collectors.toList());
-      LOG.debug("Valid SST files found: {}", sstFileNames);
-
-      // Currently, OM DB type is not configurable. Hence, defaulting to
-      // RocksDB.
+      String leaderNodeId = getLeaderNodeId();
+      DBCheckpoint checkpoint =
+          reconSnapshotProvider.downloadDBSnapshotFromLeader(leaderNodeId);
       reconContext.updateHealthStatus(new AtomicBoolean(true));
-      reconContext.getErrors().remove(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
-      return new RocksDBCheckpoint(untarredDbDir);
-    } catch (IOException e) {
+      reconContext.getErrors()
+          .remove(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
+      return checkpoint;
+    } catch (IOException | RuntimeException e) {
       LOG.error("Unable to obtain Ozone Manager DB Snapshot.", e);
       reconContext.updateHealthStatus(new AtomicBoolean(false));
-      reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
+      reconContext.updateErrors(
+          ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
+      // Reset the candidate dir so the next attempt starts from a clean state.
+      try {
+        reconSnapshotProvider.init();
+      } catch (RuntimeException resetEx) {
+        LOG.warn("Failed to reset snapshot provider candidate dir after error.",
+            resetEx);
+      }
+      return null;
     }
-    return null;
   }
 
   /**
@@ -993,8 +935,9 @@ public class OzoneManagerServiceProviderImpl
   }
 
   @VisibleForTesting
-  public TarExtractor getTarExtractor() {
-    return tarExtractor;
+  public void setReconSnapshotProvider(
+      ReconRDBSnapshotProvider reconSnapshotProvider) {
+    this.reconSnapshotProvider = reconSnapshotProvider;
   }
 
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
@@ -21,16 +21,19 @@ import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.OzoneConsts.MULTIPART_FORM_DATA_BOUNDARY;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_INCLUDE_SNAPSHOT_DATA;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -49,7 +52,6 @@ import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.ratis_snapshot.OmRatisSnapshotProvider;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort.Type;
 import org.apache.hadoop.security.SecurityUtil;
-import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +65,9 @@ import org.slf4j.LoggerFactory;
  * <p>This mirrors {@link OmRatisSnapshotProvider}: it overrides
  * {@link #downloadSnapshot} to POST to the leader's {@code /v2/dbCheckpoint}
  * endpoint and {@link #getCheckpointFromUntarredDb} to assemble and promote the
- * downloaded DB into a stable snapshot dir Recon can open.
+ * downloaded DB into a stable snapshot dir Recon can open. Like the OM follower,
+ * it honors {@code ozone.om.db.checkpoint.use.inode.based.transfer}: when that is
+ * {@code false} it falls back to the v1 {@code /dbCheckpoint} endpoint.
  */
 public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
 
@@ -74,17 +78,20 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
   private final boolean spnegoEnabled;
   private final boolean httpsEnabled;
   private final boolean flushBeforeCheckpoint;
+  private final boolean useV2CheckpointApi;
   private final Supplier<ServiceInfo> leaderInfoSupplier;
 
   public ReconRDBSnapshotProvider(File snapshotDir,
       URLConnectionFactory connectionFactory, boolean spnegoEnabled,
       HttpConfig.Policy httpPolicy, boolean flushBeforeCheckpoint,
+      boolean useV2CheckpointApi,
       Supplier<ServiceInfo> leaderInfoSupplier) {
     super(snapshotDir, RECON_OM_SNAPSHOT_DB);
     this.connectionFactory = connectionFactory;
     this.spnegoEnabled = spnegoEnabled;
     this.httpsEnabled = httpPolicy.isHttpsEnabled();
     this.flushBeforeCheckpoint = flushBeforeCheckpoint;
+    this.useV2CheckpointApi = useV2CheckpointApi;
     this.leaderInfoSupplier = leaderInfoSupplier;
   }
 
@@ -103,7 +110,9 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
           "multipart/form-data; boundary=" + MULTIPART_FORM_DATA_BOUNDARY);
       connection.setDoOutput(true);
 
-      List<String> existingFiles = HAUtils.getExistingFiles(getCandidateDir());
+      List<String> existingFiles = useV2CheckpointApi
+          ? HAUtils.getExistingFiles(getCandidateDir())
+          : HAUtils.getExistingSstFilesRelativeToDbDir(getCandidateDir());
       OmRatisSnapshotProvider.writeFormData(connection, existingFiles);
 
       connection.connect();
@@ -145,8 +154,9 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
     // means "the leader finished sending the checkpoint".
 
     // Installs hard links from hardLinkFile (tolerates a missing/empty file)
-    // and moves root-level DB files into <untarredDbDir>/om.db.
-    new InodeMetadataRocksDBCheckpoint(untarredDbDir, true);
+    // and moves root-level DB files into <untarredDbDir>/om.db. deleteSourceFiles
+    // follows the endpoint: true for v2 (inode-based), false for the v1 layout.
+    new InodeMetadataRocksDBCheckpoint(untarredDbDir, useV2CheckpointApi);
 
     Path omDbDir = untarredDbDir.resolve(OM_DB_NAME);
     if (!Files.isDirectory(omDbDir)) {
@@ -166,19 +176,19 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
     return new RocksDBCheckpoint(stablePath);
   }
 
-  private URL buildCheckpointUrl(ServiceInfo leader) throws IOException {
+  @VisibleForTesting
+  URL buildCheckpointUrl(ServiceInfo leader) throws IOException {
     Type portType = httpsEnabled ? Type.HTTPS : Type.HTTP;
+    String scheme = httpsEnabled ? "https" : "http";
+    String path = useV2CheckpointApi ? OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2
+        : OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
+    // Recon does not need OM's nested snapshot data.
+    String query = OZONE_DB_CHECKPOINT_INCLUDE_SNAPSHOT_DATA + "=false&"
+        + OZONE_DB_CHECKPOINT_REQUEST_FLUSH + "="
+        + (flushBeforeCheckpoint ? "true" : "false");
     try {
-      return new URIBuilder()
-          .setScheme(httpsEnabled ? "https" : "http")
-          .setHost(leader.getHostname())
-          .setPort(leader.getPort(portType))
-          .setPath(OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2)
-          // Recon does not need OM's nested snapshot data.
-          .addParameter(OZONE_DB_CHECKPOINT_INCLUDE_SNAPSHOT_DATA, "false")
-          .addParameter(OZONE_DB_CHECKPOINT_REQUEST_FLUSH,
-              flushBeforeCheckpoint ? "true" : "false")
-          .build().toURL();
+      return new URI(scheme, null, leader.getHostname(),
+          leader.getPort(portType), path, query, null).toURL();
     } catch (URISyntaxException | MalformedURLException e) {
       throw new IOException("Could not build OM DB checkpoint URL", e);
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
@@ -204,7 +204,6 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
     return new RocksDBCheckpoint(stablePath);
   }
 
-  @VisibleForTesting
   URL buildCheckpointUrl(ServiceInfo leader) throws IOException {
     Type portType = httpsEnabled ? Type.HTTPS : Type.HTTP;
     String scheme = httpsEnabled ? "https" : "http";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
@@ -27,7 +27,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_INCLUDE_SN
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -223,7 +222,6 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
     }
   }
 
-  @VisibleForTesting
   ServiceInfo getPinnedLeader() {
     return pinnedLeader.get();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
@@ -185,6 +185,13 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
   @Override
   public DBCheckpoint getCheckpointFromUntarredDb(Path untarredDbDir)
       throws IOException {
+    // The base class only calls this once it has seen the leader's
+    // end-of-tarball marker. That marker is named "ratis snapshot complete"
+    // for historical reasons, but it is not Ratis-specific: OM's shared
+    // DBCheckpointServlet appends it to the end of every /v2/dbCheckpoint
+    // response (the same one an OM follower bootstraps from), so here it just
+    // means "the leader finished sending the checkpoint".
+
     // Installs hard links from hardLinkFile (tolerates a missing/empty file)
     // and moves root-level DB files into <untarredDbDir>/om.db.
     new InodeMetadataRocksDBCheckpoint(untarredDbDir, true);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
@@ -24,7 +24,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_INCLUDE_SNAPSHOT_DATA;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
-import static org.apache.hadoop.ozone.OzoneConsts.ROCKSDB_SST_SUFFIX;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 
 import java.io.File;
@@ -56,22 +55,15 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Recon's {@link RDBSnapshotProvider} implementation that downloads the OM DB
- * checkpoint using the same incremental bootstrap mechanism an OM follower
- * uses: a chunked {@code POST /v2/dbCheckpoint} request carrying a
- * {@code toExcludeList[]} of SST files Recon already has, with hard-link dedup
- * on the leader and a completion sentinel to end the transfer.
+ * checkpoint using the same bootstrap mechanism an OM follower uses: a chunked
+ * {@code POST /v2/dbCheckpoint} request that carries a {@code toExcludeList[]}
+ * of the parts already received so an interrupted transfer can resume, with
+ * hard-link dedup on the leader and a completion sentinel to end the transfer.
  *
- * <p>On top of the follower behavior, this provider <b>seeds</b> the candidate
- * dir with hard links to the SST files in Recon's currently-installed OM DB
- * (the "live" DB). Those SSTs then appear in the exclude list, so a
- * full-snapshot fallback only transfers SST files that actually changed. The
- * resulting DB is always complete: RocksDB SST file numbers are content-stable
- * within a DB lineage, so a seeded {@code 000123.sst} is byte-identical to the
- * leader's, and non-SST files (CURRENT/MANIFEST/OPTIONS) are always re-sent.
- *
- * <p>Only {@code .sst} files are seeded. Non-SST files are small, are always
- * re-sent by the leader, and hard-linking the live DB's {@code LOCK} file would
- * risk a lock conflict when the assembled DB is opened.
+ * <p>This mirrors {@link OmRatisSnapshotProvider}: it overrides
+ * {@link #downloadSnapshot} to POST to the leader's {@code /v2/dbCheckpoint}
+ * endpoint and {@link #getCheckpointFromUntarredDb} to assemble and promote the
+ * downloaded DB into a stable snapshot dir Recon can open.
  */
 public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
 
@@ -83,57 +75,17 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
   private final boolean httpsEnabled;
   private final boolean flushBeforeCheckpoint;
   private final Supplier<ServiceInfo> leaderInfoSupplier;
-  private final Supplier<File> liveDbDirSupplier;
 
   public ReconRDBSnapshotProvider(File snapshotDir,
       URLConnectionFactory connectionFactory, boolean spnegoEnabled,
       HttpConfig.Policy httpPolicy, boolean flushBeforeCheckpoint,
-      Supplier<ServiceInfo> leaderInfoSupplier,
-      Supplier<File> liveDbDirSupplier) {
+      Supplier<ServiceInfo> leaderInfoSupplier) {
     super(snapshotDir, RECON_OM_SNAPSHOT_DB);
     this.connectionFactory = connectionFactory;
     this.spnegoEnabled = spnegoEnabled;
     this.httpsEnabled = httpPolicy.isHttpsEnabled();
     this.flushBeforeCheckpoint = flushBeforeCheckpoint;
     this.leaderInfoSupplier = leaderInfoSupplier;
-    this.liveDbDirSupplier = liveDbDirSupplier;
-  }
-
-  /**
-   * Seed the candidate dir with hard links to the live DB's SST files so they
-   * are advertised in the exclude list and not re-downloaded. Only runs when
-   * the candidate dir is empty (first sync, after a wipe on leader change, or
-   * after a previous clean download); if a partial download is present it is
-   * left untouched so it can resume.
-   */
-  @Override
-  protected void seedCandidateDir(String leaderNodeID) throws IOException {
-    File candidate = getCandidateDir();
-    if (!HAUtils.getExistingFiles(candidate).isEmpty()) {
-      // Partial download in progress - resume, do not re-seed.
-      return;
-    }
-    File liveDbDir = liveDbDirSupplier.get();
-    if (liveDbDir == null || !liveDbDir.exists()) {
-      LOG.info("No live Recon OM DB found to seed from; a full snapshot will "
-          + "be downloaded.");
-      return;
-    }
-    File[] sstFiles = liveDbDir.listFiles(
-        (dir, name) -> name.endsWith(ROCKSDB_SST_SUFFIX));
-    if (sstFiles == null || sstFiles.length == 0) {
-      return;
-    }
-    int linked = 0;
-    for (File sst : sstFiles) {
-      Path target = candidate.toPath().resolve(sst.getName());
-      if (!Files.exists(target)) {
-        Files.createLink(target, sst.toPath());
-        linked++;
-      }
-    }
-    LOG.info("Seeded {} SST files into candidate dir {} from live OM DB {} for "
-        + "incremental exclusion.", linked, candidate, liveDbDir);
   }
 
   @Override
@@ -180,7 +132,7 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
    * normalize the layout to {@code <candidate>/om.db}, then move that DB out of
    * the reused candidate dir into a stable timestamped snapshot dir that Recon
    * opens as its new live DB. The candidate dir is emptied so the next sync
-   * re-seeds from the freshly promoted DB.
+   * starts from a clean candidate dir.
    */
   @Override
   public DBCheckpoint getCheckpointFromUntarredDb(Path untarredDbDir)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.spi.impl;
+
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.apache.hadoop.ozone.OzoneConsts.MULTIPART_FORM_DATA_BOUNDARY;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_INCLUDE_SNAPSHOT_DATA;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
+import static org.apache.hadoop.ozone.OzoneConsts.ROCKSDB_SST_SUFFIX;
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.server.http.HttpConfig;
+import org.apache.hadoop.hdds.utils.HAUtils;
+import org.apache.hadoop.hdds.utils.RDBSnapshotProvider;
+import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.InodeMetadataRocksDBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
+import org.apache.hadoop.hdfs.web.URLConnectionFactory;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
+import org.apache.hadoop.ozone.om.ratis_snapshot.OmRatisSnapshotProvider;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort.Type;
+import org.apache.hadoop.security.SecurityUtil;
+import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Recon's {@link RDBSnapshotProvider} implementation that downloads the OM DB
+ * checkpoint using the same incremental bootstrap mechanism an OM follower
+ * uses: a chunked {@code POST /v2/dbCheckpoint} request carrying a
+ * {@code toExcludeList[]} of SST files Recon already has, with hard-link dedup
+ * on the leader and a completion sentinel to end the transfer.
+ *
+ * <p>On top of the follower behavior, this provider <b>seeds</b> the candidate
+ * dir with hard links to the SST files in Recon's currently-installed OM DB
+ * (the "live" DB). Those SSTs then appear in the exclude list, so a
+ * full-snapshot fallback only transfers SST files that actually changed. The
+ * resulting DB is always complete: RocksDB SST file numbers are content-stable
+ * within a DB lineage, so a seeded {@code 000123.sst} is byte-identical to the
+ * leader's, and non-SST files (CURRENT/MANIFEST/OPTIONS) are always re-sent.
+ *
+ * <p>Only {@code .sst} files are seeded. Non-SST files are small, are always
+ * re-sent by the leader, and hard-linking the live DB's {@code LOCK} file would
+ * risk a lock conflict when the assembled DB is opened.
+ */
+public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ReconRDBSnapshotProvider.class);
+
+  private final URLConnectionFactory connectionFactory;
+  private final boolean spnegoEnabled;
+  private final boolean httpsEnabled;
+  private final boolean flushBeforeCheckpoint;
+  private final Supplier<ServiceInfo> leaderInfoSupplier;
+  private final Supplier<File> liveDbDirSupplier;
+
+  public ReconRDBSnapshotProvider(File snapshotDir,
+      URLConnectionFactory connectionFactory, boolean spnegoEnabled,
+      HttpConfig.Policy httpPolicy, boolean flushBeforeCheckpoint,
+      Supplier<ServiceInfo> leaderInfoSupplier,
+      Supplier<File> liveDbDirSupplier) {
+    super(snapshotDir, RECON_OM_SNAPSHOT_DB);
+    this.connectionFactory = connectionFactory;
+    this.spnegoEnabled = spnegoEnabled;
+    this.httpsEnabled = httpPolicy.isHttpsEnabled();
+    this.flushBeforeCheckpoint = flushBeforeCheckpoint;
+    this.leaderInfoSupplier = leaderInfoSupplier;
+    this.liveDbDirSupplier = liveDbDirSupplier;
+  }
+
+  /**
+   * Seed the candidate dir with hard links to the live DB's SST files so they
+   * are advertised in the exclude list and not re-downloaded. Only runs when
+   * the candidate dir is empty (first sync, after a wipe on leader change, or
+   * after a previous clean download); if a partial download is present it is
+   * left untouched so it can resume.
+   */
+  @Override
+  protected void seedCandidateDir(String leaderNodeID) throws IOException {
+    File candidate = getCandidateDir();
+    if (!HAUtils.getExistingFiles(candidate).isEmpty()) {
+      // Partial download in progress - resume, do not re-seed.
+      return;
+    }
+    File liveDbDir = liveDbDirSupplier.get();
+    if (liveDbDir == null || !liveDbDir.exists()) {
+      LOG.info("No live Recon OM DB found to seed from; a full snapshot will "
+          + "be downloaded.");
+      return;
+    }
+    File[] sstFiles = liveDbDir.listFiles(
+        (dir, name) -> name.endsWith(ROCKSDB_SST_SUFFIX));
+    if (sstFiles == null || sstFiles.length == 0) {
+      return;
+    }
+    int linked = 0;
+    for (File sst : sstFiles) {
+      Path target = candidate.toPath().resolve(sst.getName());
+      if (!Files.exists(target)) {
+        Files.createLink(target, sst.toPath());
+        linked++;
+      }
+    }
+    LOG.info("Seeded {} SST files into candidate dir {} from live OM DB {} for "
+        + "incremental exclusion.", linked, candidate, liveDbDir);
+  }
+
+  @Override
+  public void downloadSnapshot(String leaderNodeID, File targetFile)
+      throws IOException {
+    ServiceInfo leader = leaderInfoSupplier.get();
+    URL checkpointUrl = buildCheckpointUrl(leader);
+    LOG.info("Downloading OM DB checkpoint from leader {}. Checkpoint: {}, "
+        + "URL: {}", leaderNodeID, targetFile.getName(), checkpointUrl);
+    SecurityUtil.doAsLoginUser(() -> {
+      HttpURLConnection connection = (HttpURLConnection)
+          connectionFactory.openConnection(checkpointUrl, spnegoEnabled);
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Content-Type",
+          "multipart/form-data; boundary=" + MULTIPART_FORM_DATA_BOUNDARY);
+      connection.setDoOutput(true);
+
+      List<String> existingFiles = HAUtils.getExistingFiles(getCandidateDir());
+      OmRatisSnapshotProvider.writeFormData(connection, existingFiles);
+
+      connection.connect();
+      int errorCode = connection.getResponseCode();
+      if (errorCode != HTTP_OK && errorCode != HTTP_CREATED) {
+        throw new IOException("Unexpected response code " + errorCode
+            + " when downloading OM DB checkpoint from " + checkpointUrl);
+      }
+      try (InputStream inputStream = connection.getInputStream()) {
+        OmRatisSnapshotProvider.downloadFileWithProgress(inputStream,
+            targetFile);
+      } catch (IOException ex) {
+        if (!FileUtils.deleteQuietly(targetFile)) {
+          LOG.error("Failed to delete partial checkpoint file {}", targetFile);
+        }
+        throw ex;
+      } finally {
+        connection.disconnect();
+      }
+      return null;
+    });
+  }
+
+  /**
+   * After the transfer completes, install the leader's hard-link inventory,
+   * normalize the layout to {@code <candidate>/om.db}, then move that DB out of
+   * the reused candidate dir into a stable timestamped snapshot dir that Recon
+   * opens as its new live DB. The candidate dir is emptied so the next sync
+   * re-seeds from the freshly promoted DB.
+   */
+  @Override
+  public DBCheckpoint getCheckpointFromUntarredDb(Path untarredDbDir)
+      throws IOException {
+    // Installs hard links from hardLinkFile (tolerates a missing/empty file)
+    // and moves root-level DB files into <untarredDbDir>/om.db.
+    new InodeMetadataRocksDBCheckpoint(untarredDbDir, true);
+
+    Path omDbDir = untarredDbDir.resolve(OM_DB_NAME);
+    if (!Files.isDirectory(omDbDir)) {
+      throw new IOException("Expected RocksDB directory not found after "
+          + "assembling checkpoint: " + omDbDir);
+    }
+
+    String stableName = RECON_OM_SNAPSHOT_DB + "_" + System.currentTimeMillis();
+    Path stablePath = getSnapshotDir().toPath().resolve(stableName);
+    Files.move(omDbDir, stablePath);
+    LOG.info("Assembled OM DB moved from {} to {}", omDbDir, stablePath);
+
+    // Clear residual entries (completion flag, orphan seeded files, empty dirs)
+    // so the candidate dir is empty for the next sync cycle.
+    cleanupCandidateDir(untarredDbDir.toFile());
+
+    return new RocksDBCheckpoint(stablePath);
+  }
+
+  private URL buildCheckpointUrl(ServiceInfo leader) throws IOException {
+    Type portType = httpsEnabled ? Type.HTTPS : Type.HTTP;
+    try {
+      return new URIBuilder()
+          .setScheme(httpsEnabled ? "https" : "http")
+          .setHost(leader.getHostname())
+          .setPort(leader.getPort(portType))
+          .setPath(OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2)
+          // Recon does not need OM's nested snapshot data.
+          .addParameter(OZONE_DB_CHECKPOINT_INCLUDE_SNAPSHOT_DATA, "false")
+          .addParameter(OZONE_DB_CHECKPOINT_REQUEST_FLUSH,
+              flushBeforeCheckpoint ? "true" : "false")
+          .build().toURL();
+    } catch (URISyntaxException | MalformedURLException e) {
+      throw new IOException("Could not build OM DB checkpoint URL", e);
+    }
+  }
+
+  private void cleanupCandidateDir(File candidate) {
+    File[] entries = candidate.listFiles();
+    if (entries == null) {
+      return;
+    }
+    for (File entry : entries) {
+      if (!FileUtils.deleteQuietly(entry)) {
+        LOG.warn("Failed to clean up candidate dir entry {}", entry);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    // The URLConnectionFactory is owned and destroyed by
+    // OzoneManagerServiceProviderImpl; nothing to release here.
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconRDBSnapshotProvider.java
@@ -39,6 +39,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
@@ -80,6 +81,9 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
   private final boolean flushBeforeCheckpoint;
   private final boolean useV2CheckpointApi;
   private final Supplier<ServiceInfo> leaderInfoSupplier;
+  // Leader pinned for the duration of a single (possibly multi-part) transfer.
+  private final AtomicReference<ServiceInfo> pinnedLeader =
+      new AtomicReference<>();
 
   public ReconRDBSnapshotProvider(File snapshotDir,
       URLConnectionFactory connectionFactory, boolean spnegoEnabled,
@@ -95,10 +99,35 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
     this.leaderInfoSupplier = leaderInfoSupplier;
   }
 
+  /**
+   * Pin the OM leader for the whole transfer before delegating to the shared
+   * driver loop. The base loop resolves the leader only once (via
+   * {#checkLeaderConsistency}); re-resolving per part would let a
+   * mid-transfer OM failover merge parts from two leaders into the same
+   * candidate dir. Recon's transfer is single-part today (it excludes snapshot
+   * data), but pinning keeps this correct if that ever changes, matching how
+   * {@link OmRatisSnapshotProvider} pins the leader for every part.
+   */
+  @Override
+  public DBCheckpoint downloadDBSnapshotFromLeader(String leaderNodeID)
+      throws IOException {
+    pinnedLeader.set(leaderInfoSupplier.get());
+    try {
+      return super.downloadDBSnapshotFromLeader(leaderNodeID);
+    } finally {
+      pinnedLeader.set(null);
+    }
+  }
+
   @Override
   public void downloadSnapshot(String leaderNodeID, File targetFile)
       throws IOException {
-    ServiceInfo leader = leaderInfoSupplier.get();
+    // Use the leader pinned for this transfer. The fallback only applies to a
+    // direct downloadSnapshot call outside downloadDBSnapshotFromLeader.
+    ServiceInfo leader = pinnedLeader.get();
+    if (leader == null) {
+      leader = leaderInfoSupplier.get();
+    }
     URL checkpointUrl = buildCheckpointUrl(leader);
     LOG.info("Downloading OM DB checkpoint from leader {}. Checkpoint: {}, "
         + "URL: {}", leaderNodeID, targetFile.getName(), checkpointUrl);
@@ -192,6 +221,11 @@ public class ReconRDBSnapshotProvider extends RDBSnapshotProvider {
     } catch (URISyntaxException | MalformedURLException e) {
       throw new IOException("Could not build OM DB checkpoint URL", e);
     }
+  }
+
+  @VisibleForTesting
+  ServiceInfo getPinnedLeader() {
+    return pinnedLeader.get();
   }
 
   private void cleanupCandidateDir(File candidate) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
@@ -120,6 +120,7 @@ public class TestTriggerDBSyncEndpoint {
     }
     when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
         .thenReturn(httpURLConnectionMock);
+    when(reconUtilsMock.getReconDbDir(any(), anyString())).thenCallRealMethod();
     when(reconUtilsMock.getReconNodeDetails(
         any(OzoneConfiguration.class))).thenReturn(
         ReconTestUtils.getReconNodeDetails());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -22,21 +22,19 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestRe
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeEmptyOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LAG_THRESHOLD;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LIMIT;
-import static org.apache.hadoop.ozone.recon.ReconUtils.createTarFile;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmDeltaRequest;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmSnapshotRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
@@ -47,13 +45,12 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
@@ -62,6 +59,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedTransactionLogIterator;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.recon.ReconContext;
@@ -92,6 +90,7 @@ public class TestOzoneManagerServiceProviderImpl {
   private OzoneConfiguration configuration;
   private OzoneManagerProtocol ozoneManagerProtocol;
   private ReconContext reconContext;
+  private File omSnapshotDbParentDir;
 
   @BeforeEach
   public void setUp(@TempDir File dirReconSnapDB, @TempDir File dirReconDB)
@@ -104,6 +103,8 @@ public class TestOzoneManagerServiceProviderImpl {
     configuration.set("ozone.om.address", "localhost:9862");
     ozoneManagerProtocol = getMockOzoneManagerClient(new DBUpdates());
     reconContext = new ReconContext(configuration, new ReconUtils());
+    omSnapshotDbParentDir = new ReconUtils()
+        .getReconDbDir(configuration, OZONE_RECON_OM_SNAPSHOT_DB_DIR);
   }
 
   @AfterEach
@@ -130,42 +131,37 @@ public class TestOzoneManagerServiceProviderImpl {
 
     DBCheckpoint checkpoint = omMetadataManager.getStore()
         .getCheckpoint(true);
-    File tarFile = createTarFile(checkpoint.getCheckpointLocation());
-    try (InputStream inputStream = Files.newInputStream(tarFile.toPath())) {
-      ReconUtils reconUtilsMock = getMockReconUtils();
-      HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
-      when(httpURLConnectionMock.getInputStream()).thenReturn(inputStream);
-      when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
-          .thenReturn(httpURLConnectionMock);
-      when(reconUtilsMock.getReconNodeDetails(
-          any(OzoneConfiguration.class))).thenReturn(
-          ReconTestUtils.getReconNodeDetails());
-      ReconTaskController reconTaskController = getMockTaskController();
+    ReconUtils reconUtilsMock = getMockReconUtils();
+    when(reconUtilsMock.getReconNodeDetails(
+        any(OzoneConfiguration.class))).thenReturn(
+        ReconTestUtils.getReconNodeDetails());
+    ReconTaskController reconTaskController = getMockTaskController();
 
-      OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
-          new OzoneManagerServiceProviderImpl(configuration,
-              reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
-              reconContext, getMockTaskStatusUpdaterManager());
+    OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
+        new OzoneManagerServiceProviderImpl(configuration,
+            reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
+            reconContext, getMockTaskStatusUpdaterManager());
+    ozoneManagerServiceProvider.setReconSnapshotProvider(
+        newStubSnapshotProvider(omSnapshotDbParentDir,
+            checkpoint.getCheckpointLocation(), false));
 
-      assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
-          .get("/sampleVol/bucketOne/key_one"));
-      assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
-          .get("/sampleVol/bucketOne/key_two"));
+    assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+        .get("/sampleVol/bucketOne/key_one"));
+    assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+        .get("/sampleVol/bucketOne/key_two"));
 
-      ozoneManagerServiceProvider.getTarExtractor().start();
-      assertTrue(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
+    assertTrue(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
 
-      assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
-          .get("/sampleVol/bucketOne/key_one"));
-      assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
-          .get("/sampleVol/bucketOne/key_two"));
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+        .get("/sampleVol/bucketOne/key_one"));
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+        .get("/sampleVol/bucketOne/key_two"));
 
-      // Verifying if context error GET_OM_DB_SNAPSHOT_FAILED is removed
-      assertFalse(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
-      omMetadataManager.stop();
-      reconOMMetadataManager.stop();
-      reconTaskController.stop();
-    }
+    // Verifying if context error GET_OM_DB_SNAPSHOT_FAILED is removed
+    assertFalse(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
+    omMetadataManager.stop();
+    reconOMMetadataManager.stop();
+    reconTaskController.stop();
   }
 
   @Test
@@ -180,9 +176,6 @@ public class TestOzoneManagerServiceProviderImpl {
             dirReconMetadata);
 
     ReconUtils reconUtilsMock = getMockReconUtils();
-
-    when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
-        .thenThrow(new IOException("Mocked IOException"));
     when(reconUtilsMock.getReconNodeDetails(
         any(OzoneConfiguration.class))).thenReturn(
         ReconTestUtils.getReconNodeDetails());
@@ -192,12 +185,11 @@ public class TestOzoneManagerServiceProviderImpl {
         new OzoneManagerServiceProviderImpl(configuration,
             reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
             reconContext, getMockTaskStatusUpdaterManager());
+    // Stub provider that fails the download; the active DB must be kept.
+    ozoneManagerServiceProvider.setReconSnapshotProvider(
+        newStubSnapshotProvider(omSnapshotDbParentDir, null, true));
 
-    Exception exception = assertThrows(RuntimeException.class, () -> {
-      ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot();
-    });
-
-    assertTrue(exception.getCause() instanceof IOException);
+    assertFalse(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
 
     // Verifying if context error GET_OM_DB_SNAPSHOT_FAILED is added
     assertTrue(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
@@ -219,34 +211,29 @@ public class TestOzoneManagerServiceProviderImpl {
     writeDataToOm(omMetadataManager, "key_two");
 
     DBCheckpoint checkpoint = omMetadataManager.getStore().getCheckpoint(true);
-    File tarFile = createTarFile(checkpoint.getCheckpointLocation());
-    try (InputStream inputStream = Files.newInputStream(tarFile.toPath())) {
-      ReconUtils reconUtilsMock = getMockReconUtils();
-      HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
-      when(httpURLConnectionMock.getInputStream()).thenReturn(inputStream);
-      when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
-          .thenReturn(httpURLConnectionMock);
-      when(reconUtilsMock.getReconNodeDetails(any(OzoneConfiguration.class)))
-          .thenReturn(ReconTestUtils.getReconNodeDetails());
-      ReconTaskController reconTaskController = getMockTaskController();
+    ReconUtils reconUtilsMock = getMockReconUtils();
+    when(reconUtilsMock.getReconNodeDetails(any(OzoneConfiguration.class)))
+        .thenReturn(ReconTestUtils.getReconNodeDetails());
+    ReconTaskController reconTaskController = getMockTaskController();
 
-      reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
+    reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
 
-      OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
-          new OzoneManagerServiceProviderImpl(configuration,
-              reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
-              reconContext, getMockTaskStatusUpdaterManager());
+    OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
+        new OzoneManagerServiceProviderImpl(configuration,
+            reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
+            reconContext, getMockTaskStatusUpdaterManager());
+    ozoneManagerServiceProvider.setReconSnapshotProvider(
+        newStubSnapshotProvider(omSnapshotDbParentDir,
+            checkpoint.getCheckpointLocation(), false));
 
-      assertTrue(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
-      ozoneManagerServiceProvider.getTarExtractor().start();
-      assertTrue(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
-      assertFalse(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
+    assertTrue(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
+    assertTrue(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
+    assertFalse(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
 
-      assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
-          .get("/sampleVol/bucketOne/key_one"));
-      assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
-          .get("/sampleVol/bucketOne/key_two"));
-    }
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+        .get("/sampleVol/bucketOne/key_one"));
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+        .get("/sampleVol/bucketOne/key_two"));
     omMetadataManager.stop();
     reconOMMetadataManager.stop();
   }
@@ -265,39 +252,30 @@ public class TestOzoneManagerServiceProviderImpl {
 
     DBCheckpoint checkpoint = omMetadataManager.getStore()
         .getCheckpoint(true);
-    File tarFile1 = createTarFile(checkpoint.getCheckpointLocation());
-    File tarFile2 = createTarFile(checkpoint.getCheckpointLocation());
     ReconUtils reconUtilsMock = getMockReconUtils();
+    when(reconUtilsMock.getReconNodeDetails(
+        any(OzoneConfiguration.class))).thenReturn(
+        ReconTestUtils.getReconNodeDetails());
     ReconTaskController reconTaskController = getMockTaskController();
-    try (InputStream inputStream1 = Files.newInputStream(tarFile1.toPath())) {
-      HttpURLConnection httpURLConnectionMock1 = mock(HttpURLConnection.class);
-      when(httpURLConnectionMock1.getInputStream()).thenReturn(inputStream1);
-      when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
-          .thenReturn(httpURLConnectionMock1);
-      when(reconUtilsMock.getReconNodeDetails(
-          any(OzoneConfiguration.class))).thenReturn(
-          ReconTestUtils.getReconNodeDetails());
 
-      OzoneManagerServiceProviderImpl ozoneManagerServiceProvider1 =
-          new OzoneManagerServiceProviderImpl(configuration,
-              reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
-              reconContext, getMockTaskStatusUpdaterManager());
-      ozoneManagerServiceProvider1.getTarExtractor().start();
-      assertTrue(ozoneManagerServiceProvider1.updateReconOmDBWithNewSnapshot());
-    }
+    OzoneManagerServiceProviderImpl ozoneManagerServiceProvider1 =
+        new OzoneManagerServiceProviderImpl(configuration,
+            reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
+            reconContext, getMockTaskStatusUpdaterManager());
+    ozoneManagerServiceProvider1.setReconSnapshotProvider(
+        newStubSnapshotProvider(omSnapshotDbParentDir,
+            checkpoint.getCheckpointLocation(), false));
+    assertTrue(ozoneManagerServiceProvider1.updateReconOmDBWithNewSnapshot());
 
-    try (InputStream inputStream2 = Files.newInputStream(tarFile2.toPath())) {
-      HttpURLConnection httpURLConnectionMock2 = mock(HttpURLConnection.class);
-      when(httpURLConnectionMock2.getInputStream()).thenReturn(inputStream2);
-      when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
-          .thenReturn(httpURLConnectionMock2);
-      OzoneManagerServiceProviderImpl ozoneManagerServiceProvider2 =
-          new OzoneManagerServiceProviderImpl(configuration,
-              reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
-              reconContext, getMockTaskStatusUpdaterManager());
-      ozoneManagerServiceProvider2.getTarExtractor().start();
-      assertTrue(ozoneManagerServiceProvider2.updateReconOmDBWithNewSnapshot());
-    }
+    OzoneManagerServiceProviderImpl ozoneManagerServiceProvider2 =
+        new OzoneManagerServiceProviderImpl(configuration,
+            reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
+            reconContext, getMockTaskStatusUpdaterManager());
+    ozoneManagerServiceProvider2.setReconSnapshotProvider(
+        newStubSnapshotProvider(omSnapshotDbParentDir,
+            checkpoint.getCheckpointLocation(), false));
+    assertTrue(ozoneManagerServiceProvider2.updateReconOmDBWithNewSnapshot());
+
     omMetadataManager.stop();
     reconOMMetadataManager.stop();
     reconTaskController.stop();
@@ -319,35 +297,29 @@ public class TestOzoneManagerServiceProviderImpl {
         .toFile();
     FileUtils.write(file2, "File2 Contents", UTF_8);
 
-    //Create test tar file.
-    File tarFile = createTarFile(checkpointDir.toPath());
-    try (InputStream fileInputStream = Files.newInputStream(tarFile.toPath())) {
-      ReconUtils reconUtilsMock = getMockReconUtils();
-      HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
-      when(httpURLConnectionMock.getInputStream()).thenReturn(fileInputStream);
-      when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
-          .thenReturn(httpURLConnectionMock);
-      when(reconUtilsMock.getReconNodeDetails(
-          any(OzoneConfiguration.class))).thenReturn(
-          ReconTestUtils.getReconNodeDetails());
-      ReconOMMetadataManager reconOMMetadataManager =
-          mock(ReconOMMetadataManager.class);
-      ReconTaskController reconTaskController = getMockTaskController();
-      OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
-          new OzoneManagerServiceProviderImpl(configuration,
-              reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
-              reconContext, getMockTaskStatusUpdaterManager());
+    ReconUtils reconUtilsMock = getMockReconUtils();
+    when(reconUtilsMock.getReconNodeDetails(
+        any(OzoneConfiguration.class))).thenReturn(
+        ReconTestUtils.getReconNodeDetails());
+    ReconOMMetadataManager reconOMMetadataManager =
+        mock(ReconOMMetadataManager.class);
+    ReconTaskController reconTaskController = getMockTaskController();
+    OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
+        new OzoneManagerServiceProviderImpl(configuration,
+            reconOMMetadataManager, reconTaskController, reconUtilsMock, ozoneManagerProtocol,
+            reconContext, getMockTaskStatusUpdaterManager());
+    ozoneManagerServiceProvider.setReconSnapshotProvider(
+        newStubSnapshotProvider(omSnapshotDbParentDir, checkpointDir.toPath(),
+            false));
 
-      ozoneManagerServiceProvider.getTarExtractor().start();
-      DBCheckpoint checkpoint = ozoneManagerServiceProvider
-          .getOzoneManagerDBSnapshot();
-      assertNotNull(checkpoint);
-      assertTrue(checkpoint.getCheckpointLocation().toFile().isDirectory());
+    DBCheckpoint checkpoint = ozoneManagerServiceProvider
+        .getOzoneManagerDBSnapshot();
+    assertNotNull(checkpoint);
+    assertTrue(checkpoint.getCheckpointLocation().toFile().isDirectory());
 
-      File[] files = checkpoint.getCheckpointLocation().toFile().listFiles();
-      assertNotNull(files);
-      assertEquals(2, files.length);
-    }
+    File[] files = checkpoint.getCheckpointLocation().toFile().listFiles();
+    assertNotNull(files);
+    assertEquals(2, files.length);
   }
 
   static RocksDatabase getRocksDatabase(OMMetadataManager om) {
@@ -636,7 +608,42 @@ public class TestOzoneManagerServiceProviderImpl {
         mock(OzoneManagerProtocol.class);
     when(ozoneManagerProtocolMock.getDBUpdates(any(OzoneManagerProtocolProtos
         .DBUpdatesRequest.class))).thenReturn(dbUpdatesWrapper);
+    // Provide an OM leader so getLeaderNodeId() can resolve the download source.
+    ServiceInfo leaderInfo = mock(ServiceInfo.class);
+    when(leaderInfo.getNodeType()).thenReturn(HddsProtos.NodeType.OM);
+    OzoneManagerProtocolProtos.OMRoleInfo roleInfo =
+        OzoneManagerProtocolProtos.OMRoleInfo.newBuilder()
+            .setNodeId("om1").setServerRole("LEADER").build();
+    when(leaderInfo.getOmRoleInfo()).thenReturn(roleInfo);
+    when(ozoneManagerProtocolMock.getServiceList())
+        .thenReturn(Collections.singletonList(leaderInfo));
     return ozoneManagerProtocolMock;
+  }
+
+  /**
+   * A stub {@link ReconRDBSnapshotProvider} that bypasses HTTP/tar and simply
+   * promotes a copy of {@code sourceCheckpoint} into a fresh timestamped
+   * snapshot dir (or fails). Used to drive the provider's install path
+   * deterministically.
+   */
+  private ReconRDBSnapshotProvider newStubSnapshotProvider(
+      File snapshotParent, java.nio.file.Path sourceCheckpoint,
+      boolean fail) {
+    return new ReconRDBSnapshotProvider(snapshotParent, null, false,
+        org.apache.hadoop.hdds.server.http.HttpConfig.Policy.HTTP_ONLY, false,
+        () -> null, () -> null) {
+      @Override
+      public DBCheckpoint downloadDBSnapshotFromLeader(String leaderNodeID)
+          throws IOException {
+        if (fail) {
+          throw new IOException("Mocked download failure");
+        }
+        java.nio.file.Path dest = snapshotParent.toPath().resolve(
+            RECON_OM_SNAPSHOT_DB + "_" + System.nanoTime());
+        FileUtils.copyDirectory(sourceCheckpoint.toFile(), dest.toFile());
+        return new org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint(dest);
+      }
+    };
   }
 
   // Mock the case of SNNFE

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -631,7 +631,7 @@ public class TestOzoneManagerServiceProviderImpl {
       boolean fail) {
     return new ReconRDBSnapshotProvider(snapshotParent, null, false,
         org.apache.hadoop.hdds.server.http.HttpConfig.Policy.HTTP_ONLY, false,
-        () -> null, () -> null) {
+        () -> null) {
       @Override
       public DBCheckpoint downloadDBSnapshotFromLeader(String leaderNodeID)
           throws IOException {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -631,7 +631,7 @@ public class TestOzoneManagerServiceProviderImpl {
       boolean fail) {
     return new ReconRDBSnapshotProvider(snapshotParent, null, false,
         org.apache.hadoop.hdds.server.http.HttpConfig.Policy.HTTP_ONLY, false,
-        () -> null) {
+        true, () -> null) {
       @Override
       public DBCheckpoint downloadDBSnapshotFromLeader(String leaderNodeID)
           throws IOException {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPO
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -32,12 +33,21 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
+import org.apache.hadoop.hdds.utils.Archiver;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.InodeMetadataRocksDBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -124,6 +134,72 @@ public class TestReconRDBSnapshotProvider {
     assertEquals(RECON_OM_SNAPSHOT_DB + ".candidate",
         provider.getCandidateDir().getName());
     assertEquals(snapshotDir, provider.getCandidateDir().getParentFile());
+  }
+
+  @Test
+  public void testLeaderPinnedForEntireTransfer(@TempDir File snapshotDir)
+      throws IOException {
+    ServiceInfo leaderA = mock(ServiceInfo.class);
+    when(leaderA.getHostname()).thenReturn("om-leader-a");
+    ServiceInfo leaderB = mock(ServiceInfo.class);
+    when(leaderB.getHostname()).thenReturn("om-leader-b");
+
+    // Supplier resolves leaderA first, then leaderB, mimicking an OM failover
+    // during the transfer.
+    AtomicInteger supplierCalls = new AtomicInteger();
+    Supplier<ServiceInfo> supplier = () ->
+        supplierCalls.getAndIncrement() == 0 ? leaderA : leaderB;
+
+    List<String> leadersUsedPerPart = new ArrayList<>();
+
+    ReconRDBSnapshotProvider provider =
+        new ReconRDBSnapshotProvider(snapshotDir, null, false,
+            HttpConfig.Policy.HTTP_ONLY, false, true, supplier) {
+          @Override
+          public void downloadSnapshot(String leaderNodeID, File targetFile)
+              throws IOException {
+            // Mirror the production leader resolution: use the pinned leader,
+            // falling back to the supplier only when nothing is pinned.
+            ServiceInfo leader = getPinnedLeader();
+            if (leader == null) {
+              leader = supplier.get();
+            }
+            leadersUsedPerPart.add(leader.getHostname());
+            // First part is partial; the second carries the completion flag.
+            writeTar(targetFile, leadersUsedPerPart.size() > 1);
+          }
+
+          @Override
+          public DBCheckpoint getCheckpointFromUntarredDb(Path untarredDbDir) {
+            return new RocksDBCheckpoint(untarredDbDir);
+          }
+        };
+
+    provider.downloadDBSnapshotFromLeader("om-leader-a-node-id");
+
+    assertEquals(2, leadersUsedPerPart.size(),
+        "Test should exercise a two-part transfer");
+    assertTrue(leadersUsedPerPart.stream().allMatch("om-leader-a"::equals),
+        "All parts must come from the leader pinned at the start of the "
+            + "transfer, even if the resolved leader changes mid-transfer; "
+            + "leadersUsedPerPart=" + leadersUsedPerPart);
+    assertEquals(1, supplierCalls.get(),
+        "Leader should be resolved exactly once per transfer");
+    assertNull(provider.getPinnedLeader(),
+        "Pinned leader must be cleared after the transfer completes");
+  }
+
+  private void writeTar(File targetFile, boolean complete) throws IOException {
+    try (ArchiveOutputStream<TarArchiveEntry> out =
+             Archiver.tar(Files.newOutputStream(targetFile.toPath()))) {
+      if (complete) {
+        HddsServerUtil.includeRatisSnapshotCompleteFlag(out);
+      } else {
+        File tmp = File.createTempFile("recon-part", ".sst");
+        FileUtils.write(tmp, "partial", UTF_8);
+        Archiver.includeFile(tmp, "000100.sst", out);
+      }
+    }
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
@@ -19,10 +19,15 @@ package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.HARDLINK_SEPARATOR;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,8 +50,13 @@ public class TestReconRDBSnapshotProvider {
   private static final Supplier<ServiceInfo> NO_LEADER = () -> null;
 
   private ReconRDBSnapshotProvider newProvider(File snapshotDir) {
+    return newProvider(snapshotDir, true);
+  }
+
+  private ReconRDBSnapshotProvider newProvider(File snapshotDir,
+      boolean useV2CheckpointApi) {
     return new ReconRDBSnapshotProvider(snapshotDir, null, false,
-        HttpConfig.Policy.HTTP_ONLY, false, NO_LEADER);
+        HttpConfig.Policy.HTTP_ONLY, false, useV2CheckpointApi, NO_LEADER);
   }
 
   private void writeFile(File dir, String name, String content)
@@ -113,5 +123,20 @@ public class TestReconRDBSnapshotProvider {
     assertEquals(RECON_OM_SNAPSHOT_DB + ".candidate",
         provider.getCandidateDir().getName());
     assertEquals(snapshotDir, provider.getCandidateDir().getParentFile());
+  }
+
+  @Test
+  public void testBuildCheckpointUrlHonorsInodeBasedConfig(
+      @TempDir File snapshotDir) throws IOException {
+    ServiceInfo leader = mock(ServiceInfo.class);
+    when(leader.getHostname()).thenReturn("om-host");
+    when(leader.getPort(any())).thenReturn(9874);
+
+    // Inode-based transfer on (default) -> v2 endpoint.
+    assertEquals(OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2,
+        newProvider(snapshotDir, true).buildCheckpointUrl(leader).getPath());
+    // Disabled -> fall back to the v1 endpoint.
+    assertEquals(OZONE_DB_CHECKPOINT_HTTP_ENDPOINT,
+        newProvider(snapshotDir, false).buildCheckpointUrl(leader).getPath());
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.spi.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.OzoneConsts.HARDLINK_SEPARATOR;
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.server.http.HttpConfig;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
+import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.InodeMetadataRocksDBCheckpoint;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link ReconRDBSnapshotProvider}: candidate-dir seeding from the
+ * live OM DB and normalization/promotion of the assembled checkpoint.
+ */
+public class TestReconRDBSnapshotProvider {
+
+  private static final Supplier<ServiceInfo> NO_LEADER = () -> null;
+
+  private ReconRDBSnapshotProvider newProvider(File snapshotDir,
+      Supplier<File> liveDbDirSupplier) {
+    return new ReconRDBSnapshotProvider(snapshotDir, null, false,
+        HttpConfig.Policy.HTTP_ONLY, false, NO_LEADER, liveDbDirSupplier);
+  }
+
+  private void writeFile(File dir, String name, String content)
+      throws IOException {
+    FileUtils.write(new File(dir, name), content, UTF_8);
+  }
+
+  @Test
+  public void testSeedLinksOnlySstFiles(@TempDir File snapshotDir,
+      @TempDir File liveDbDir) throws IOException {
+    writeFile(liveDbDir, "000001.sst", "sst-one");
+    writeFile(liveDbDir, "000002.sst", "sst-two");
+    writeFile(liveDbDir, "CURRENT", "current");
+    writeFile(liveDbDir, "MANIFEST-000005", "manifest");
+
+    ReconRDBSnapshotProvider provider =
+        newProvider(snapshotDir, () -> liveDbDir);
+    provider.seedCandidateDir("leader-1");
+
+    Set<String> seeded = new HashSet<>(
+        Arrays.asList(provider.getCandidateDir().list()));
+    assertEquals(new HashSet<>(Arrays.asList("000001.sst", "000002.sst")),
+        seeded, "Only .sst files should be seeded");
+
+    // Seeded files must be hard links (identical content) to the live DB.
+    assertEquals("sst-one", FileUtils.readFileToString(
+        new File(provider.getCandidateDir(), "000001.sst"), UTF_8));
+  }
+
+  @Test
+  public void testSeedSkippedWhenCandidateNotEmpty(@TempDir File snapshotDir,
+      @TempDir File liveDbDir) throws IOException {
+    writeFile(liveDbDir, "000001.sst", "sst-one");
+
+    ReconRDBSnapshotProvider provider =
+        newProvider(snapshotDir, () -> liveDbDir);
+    // Simulate a partial download already present in the candidate dir.
+    writeFile(provider.getCandidateDir(), "partial.sst", "partial");
+
+    provider.seedCandidateDir("leader-1");
+
+    Set<String> candidate = new HashSet<>(
+        Arrays.asList(provider.getCandidateDir().list()));
+    assertEquals(new HashSet<>(Arrays.asList("partial.sst")), candidate,
+        "Existing partial download must not be re-seeded");
+  }
+
+  @Test
+  public void testSeedNoOpWhenNoLiveDb(@TempDir File snapshotDir)
+      throws IOException {
+    ReconRDBSnapshotProvider provider = newProvider(snapshotDir, () -> null);
+    provider.seedCandidateDir("leader-1");
+    assertEquals(0, provider.getCandidateDir().list().length);
+  }
+
+  @Test
+  public void testGetCheckpointPromotesDbAndClearsCandidate(
+      @TempDir File snapshotDir) throws IOException {
+    ReconRDBSnapshotProvider provider = newProvider(snapshotDir, () -> null);
+    File candidate = provider.getCandidateDir();
+
+    // Simulate a fully untarred v2 checkpoint: flat DB files at the root plus
+    // the completion sentinel (no hardLinkFile - it should be tolerated).
+    writeFile(candidate, "000010.sst", "data-a");
+    writeFile(candidate, "CURRENT", "current");
+    writeFile(candidate, HddsServerUtil.OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME,
+        "");
+
+    DBCheckpoint checkpoint =
+        provider.getCheckpointFromUntarredDb(candidate.toPath());
+
+    File promoted = checkpoint.getCheckpointLocation().toFile();
+    assertTrue(promoted.getName().startsWith(RECON_OM_SNAPSHOT_DB + "_"),
+        "Promoted DB should be a timestamped snapshot dir");
+    assertEquals(snapshotDir, promoted.getParentFile());
+    assertTrue(new File(promoted, "000010.sst").exists());
+    assertTrue(new File(promoted, "CURRENT").exists());
+    // The completion sentinel must not leak into the DB.
+    assertFalse(new File(promoted,
+        HddsServerUtil.OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME).exists());
+    // Candidate dir must be emptied so the next sync re-seeds cleanly.
+    assertEquals(0, candidate.list().length);
+  }
+
+  @Test
+  public void testGetCheckpointInstallsHardLinks(@TempDir File snapshotDir)
+      throws IOException {
+    ReconRDBSnapshotProvider provider = newProvider(snapshotDir, () -> null);
+    File candidate = provider.getCandidateDir();
+
+    writeFile(candidate, "000001.sst", "shared-content");
+    // hardLinkFile: create 000002.sst as a hard link to 000001.sst.
+    writeFile(candidate, InodeMetadataRocksDBCheckpoint.OM_HARDLINK_FILE,
+        "000002.sst" + HARDLINK_SEPARATOR + "000001.sst" + "\n");
+
+    DBCheckpoint checkpoint =
+        provider.getCheckpointFromUntarredDb(candidate.toPath());
+
+    File promoted = checkpoint.getCheckpointLocation().toFile();
+    File linked = new File(promoted, "000002.sst");
+    assertTrue(linked.exists(), "Hard-linked SST should be materialized");
+    assertEquals("shared-content",
+        FileUtils.readFileToString(linked, UTF_8));
+    assertFalse(new File(promoted,
+        InodeMetadataRocksDBCheckpoint.OM_HARDLINK_FILE).exists(),
+        "hardLinkFile must be consumed, not left in the DB");
+  }
+
+  @Test
+  public void testCandidateDirLocation(@TempDir File snapshotDir) {
+    ReconRDBSnapshotProvider provider = newProvider(snapshotDir, () -> null);
+    assertEquals(RECON_OM_SNAPSHOT_DB + ".candidate",
+        provider.getCandidateDir().getName());
+    assertEquals(snapshotDir, provider.getCandidateDir().getParentFile());
+  }
+}

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.function.Supplier;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
@@ -133,10 +134,14 @@ public class TestReconRDBSnapshotProvider {
     when(leader.getPort(any())).thenReturn(9874);
 
     // Inode-based transfer on (default) -> v2 endpoint.
-    assertEquals(OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2,
-        newProvider(snapshotDir, true).buildCheckpointUrl(leader).getPath());
+    URL v2Url = newProvider(snapshotDir, true).buildCheckpointUrl(leader);
+    assertEquals(OZONE_DB_CHECKPOINT_HTTP_ENDPOINT_V2, v2Url.getPath());
+    assertTrue(v2Url.getQuery().contains("includeSnapshotData=false"));
+    assertTrue(v2Url.getQuery().contains("flushBeforeCheckpoint=false"));
     // Disabled -> fall back to the v1 endpoint.
-    assertEquals(OZONE_DB_CHECKPOINT_HTTP_ENDPOINT,
-        newProvider(snapshotDir, false).buildCheckpointUrl(leader).getPath());
+    URL v1Url = newProvider(snapshotDir, false).buildCheckpointUrl(leader);
+    assertEquals(OZONE_DB_CHECKPOINT_HTTP_ENDPOINT, v1Url.getPath());
+    assertTrue(v1Url.getQuery().contains("includeSnapshotData=false"));
+    assertTrue(v1Url.getQuery().contains("flushBeforeCheckpoint=false"));
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.HARDLINK_SEPARATOR;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -72,7 +71,9 @@ public class TestReconRDBSnapshotProvider {
     provider.seedCandidateDir("leader-1");
 
     String[] seededFiles = provider.getCandidateDir().list();
-    assertNotNull(seededFiles);
+    if (seededFiles == null) {
+      throw new AssertionError("candidate dir listing returned null");
+    }
     Set<String> seeded = new HashSet<>(Arrays.asList(seededFiles));
     assertEquals(new HashSet<>(Arrays.asList("000001.sst", "000002.sst")),
         seeded, "Only .sst files should be seeded");
@@ -95,7 +96,9 @@ public class TestReconRDBSnapshotProvider {
     provider.seedCandidateDir("leader-1");
 
     String[] candidateFiles = provider.getCandidateDir().list();
-    assertNotNull(candidateFiles);
+    if (candidateFiles == null) {
+      throw new AssertionError("candidate dir listing returned null");
+    }
     Set<String> candidate = new HashSet<>(Arrays.asList(candidateFiles));
     assertEquals(new HashSet<>(Arrays.asList("partial.sst")), candidate,
         "Existing partial download must not be re-seeded");

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
@@ -18,11 +18,11 @@
 package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.ozone.OzoneConsts.HARDLINK_SEPARATOR;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -71,8 +71,9 @@ public class TestReconRDBSnapshotProvider {
         newProvider(snapshotDir, () -> liveDbDir);
     provider.seedCandidateDir("leader-1");
 
-    Set<String> seeded = new HashSet<>(
-        Arrays.asList(requireNonNull(provider.getCandidateDir().list())));
+    String[] seededFiles = provider.getCandidateDir().list();
+    assertNotNull(seededFiles);
+    Set<String> seeded = new HashSet<>(Arrays.asList(seededFiles));
     assertEquals(new HashSet<>(Arrays.asList("000001.sst", "000002.sst")),
         seeded, "Only .sst files should be seeded");
 
@@ -93,8 +94,9 @@ public class TestReconRDBSnapshotProvider {
 
     provider.seedCandidateDir("leader-1");
 
-    Set<String> candidate = new HashSet<>(
-        Arrays.asList(requireNonNull(provider.getCandidateDir().list())));
+    String[] candidateFiles = provider.getCandidateDir().list();
+    assertNotNull(candidateFiles);
+    Set<String> candidate = new HashSet<>(Arrays.asList(candidateFiles));
     assertEquals(new HashSet<>(Arrays.asList("partial.sst")), candidate,
         "Existing partial download must not be re-seeded");
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.ozone.OzoneConsts.HARDLINK_SEPARATOR;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -71,7 +72,7 @@ public class TestReconRDBSnapshotProvider {
     provider.seedCandidateDir("leader-1");
 
     Set<String> seeded = new HashSet<>(
-        Arrays.asList(provider.getCandidateDir().list()));
+        Arrays.asList(requireNonNull(provider.getCandidateDir().list())));
     assertEquals(new HashSet<>(Arrays.asList("000001.sst", "000002.sst")),
         seeded, "Only .sst files should be seeded");
 
@@ -93,7 +94,7 @@ public class TestReconRDBSnapshotProvider {
     provider.seedCandidateDir("leader-1");
 
     Set<String> candidate = new HashSet<>(
-        Arrays.asList(provider.getCandidateDir().list()));
+        Arrays.asList(requireNonNull(provider.getCandidateDir().list())));
     assertEquals(new HashSet<>(Arrays.asList("partial.sst")), candidate,
         "Existing partial download must not be re-seeded");
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconRDBSnapshotProvider.java
@@ -26,9 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
@@ -40,17 +37,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Tests for {@link ReconRDBSnapshotProvider}: candidate-dir seeding from the
- * live OM DB and normalization/promotion of the assembled checkpoint.
+ * Tests for {@link ReconRDBSnapshotProvider}: normalization and promotion of
+ * the assembled checkpoint after the transfer completes.
  */
 public class TestReconRDBSnapshotProvider {
 
   private static final Supplier<ServiceInfo> NO_LEADER = () -> null;
 
-  private ReconRDBSnapshotProvider newProvider(File snapshotDir,
-      Supplier<File> liveDbDirSupplier) {
+  private ReconRDBSnapshotProvider newProvider(File snapshotDir) {
     return new ReconRDBSnapshotProvider(snapshotDir, null, false,
-        HttpConfig.Policy.HTTP_ONLY, false, NO_LEADER, liveDbDirSupplier);
+        HttpConfig.Policy.HTTP_ONLY, false, NO_LEADER);
   }
 
   private void writeFile(File dir, String name, String content)
@@ -59,63 +55,9 @@ public class TestReconRDBSnapshotProvider {
   }
 
   @Test
-  public void testSeedLinksOnlySstFiles(@TempDir File snapshotDir,
-      @TempDir File liveDbDir) throws IOException {
-    writeFile(liveDbDir, "000001.sst", "sst-one");
-    writeFile(liveDbDir, "000002.sst", "sst-two");
-    writeFile(liveDbDir, "CURRENT", "current");
-    writeFile(liveDbDir, "MANIFEST-000005", "manifest");
-
-    ReconRDBSnapshotProvider provider =
-        newProvider(snapshotDir, () -> liveDbDir);
-    provider.seedCandidateDir("leader-1");
-
-    String[] seededFiles = provider.getCandidateDir().list();
-    if (seededFiles == null) {
-      throw new AssertionError("candidate dir listing returned null");
-    }
-    Set<String> seeded = new HashSet<>(Arrays.asList(seededFiles));
-    assertEquals(new HashSet<>(Arrays.asList("000001.sst", "000002.sst")),
-        seeded, "Only .sst files should be seeded");
-
-    // Seeded files must be hard links (identical content) to the live DB.
-    assertEquals("sst-one", FileUtils.readFileToString(
-        new File(provider.getCandidateDir(), "000001.sst"), UTF_8));
-  }
-
-  @Test
-  public void testSeedSkippedWhenCandidateNotEmpty(@TempDir File snapshotDir,
-      @TempDir File liveDbDir) throws IOException {
-    writeFile(liveDbDir, "000001.sst", "sst-one");
-
-    ReconRDBSnapshotProvider provider =
-        newProvider(snapshotDir, () -> liveDbDir);
-    // Simulate a partial download already present in the candidate dir.
-    writeFile(provider.getCandidateDir(), "partial.sst", "partial");
-
-    provider.seedCandidateDir("leader-1");
-
-    String[] candidateFiles = provider.getCandidateDir().list();
-    if (candidateFiles == null) {
-      throw new AssertionError("candidate dir listing returned null");
-    }
-    Set<String> candidate = new HashSet<>(Arrays.asList(candidateFiles));
-    assertEquals(new HashSet<>(Arrays.asList("partial.sst")), candidate,
-        "Existing partial download must not be re-seeded");
-  }
-
-  @Test
-  public void testSeedNoOpWhenNoLiveDb(@TempDir File snapshotDir)
-      throws IOException {
-    ReconRDBSnapshotProvider provider = newProvider(snapshotDir, () -> null);
-    provider.seedCandidateDir("leader-1");
-    assertEquals(0, provider.getCandidateDir().list().length);
-  }
-
-  @Test
   public void testGetCheckpointPromotesDbAndClearsCandidate(
       @TempDir File snapshotDir) throws IOException {
-    ReconRDBSnapshotProvider provider = newProvider(snapshotDir, () -> null);
+    ReconRDBSnapshotProvider provider = newProvider(snapshotDir);
     File candidate = provider.getCandidateDir();
 
     // Simulate a fully untarred v2 checkpoint: flat DB files at the root plus
@@ -137,14 +79,14 @@ public class TestReconRDBSnapshotProvider {
     // The completion sentinel must not leak into the DB.
     assertFalse(new File(promoted,
         HddsServerUtil.OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME).exists());
-    // Candidate dir must be emptied so the next sync re-seeds cleanly.
+    // Candidate dir must be emptied so the next sync starts clean.
     assertEquals(0, candidate.list().length);
   }
 
   @Test
   public void testGetCheckpointInstallsHardLinks(@TempDir File snapshotDir)
       throws IOException {
-    ReconRDBSnapshotProvider provider = newProvider(snapshotDir, () -> null);
+    ReconRDBSnapshotProvider provider = newProvider(snapshotDir);
     File candidate = provider.getCandidateDir();
 
     writeFile(candidate, "000001.sst", "shared-content");
@@ -167,7 +109,7 @@ public class TestReconRDBSnapshotProvider {
 
   @Test
   public void testCandidateDirLocation(@TempDir File snapshotDir) {
-    ReconRDBSnapshotProvider provider = newProvider(snapshotDir, () -> null);
+    ReconRDBSnapshotProvider provider = newProvider(snapshotDir);
     assertEquals(RECON_OM_SNAPSHOT_DB + ".candidate",
         provider.getCandidateDir().getName());
     assertEquals(snapshotDir, provider.getCandidateDir().getParentFile());


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Problem:**                                                                                                                                                                                                 
                                                                                                                                                                                                           
  Recon keeps its own copy of the OM DB and syncs it two ways: incremental delta updates (`getDBUpdates`) for the normal case, and a full OM DB snapshot download as the fallback when delta sync cannot be  
  used (Recon fell too far behind, OM no longer has the requested updates, etc.).                                                                                                                          
                                                                                                                                                                                                           
  The full-snapshot fallback was Recon's own implementation:                                                                                                                                       
                                                                                                                                                                                                           
  - It used a one-shot GET `/dbCheckpoint` call with Recon-specific download-and-extract code (`TarExtractor`), separate from the checkpoint-transfer path OM itself uses internally.                          
  - On failure it did not degrade gracefully (it surfaced the error rather than falling back to the existing DB).                                                                                          
                                                                                                                                                                                                           
  Maintaining a separate downloader in Recon meant it could deviate from OM's own, well tested checkpoint-transfer code and had to be kept in sync manually over time.                                                
                                                                                                                                                                                                           
  **Approach:**                                                                                                                                                                                                
                                                                                                                                                                                                           
  Instead of maintaining Recon's own download logic, Recon now reuses the same OM checkpoint-download path an OM follower uses to bootstrap from the leader — POST `/v2/dbCheckpoint` — through the shared   
  `RDBSnapshotProvider` base class that `OmRatisSnapshotProvider` also extends:                                                                                                                                
                                                                                                                                                                                                           
  - `ReconRDBSnapshotProvider` overrides only the download step (POST `/v2/dbCheckpoint)` and the step that assembles and promotes the finished DB; the surrounding logic (driver loop, untar) is the shared OM code.                                
  - Recon requests only the active OM DB (`includeSnapshotData`=false, since it does not need OM's snapshots), which OM sends as a single tarball.                                                           
  - On failure, Recon keeps its current DB and retries on the next sync cycle instead of crashing.                                                                                                         
                                                                                                                                                                                                           
  The assembled DB is always the complete OM DB, so a full snapshot still triggers a full task reprocess in Recon, exactly as before. This change is about reusing OM's proven transfer code and handling  
  failure cleanly — not about changing how the bytes move (the active DB is still transferred as one tarball).                                                                   
                                                                                                                                                                                                           
                                                                              
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15766


## How was this patch tested?
  **Testing:**                                                                                                                                                                                                 
                                                                                                                                                                                                           
  - New unit test `TestReconRDBSnapshotProvider` — covers the post-download assembly path: promoting the untarred checkpoint into a stable om.snapshot.db_<ts> directory while clearing the candidate dir    
  (`testGetCheckpointPromotesDbAndClearsCandidate`), installing the leader's hardLinkFile inventory (`testGetCheckpointInstallsHardLinks`), and the candidate-dir layout (`testCandidateDirLocation`).           
  - Updated `TestOzoneManagerServiceProviderImpl` — drives the new provider path for both the success and the download-failure cases (via a stub `ReconRDBSnapshotProvider`).                                  
  - Updated `TestTriggerDBSyncEndpoint` — stubs `reconUtils.getReconDbDir(...)` so the now-eagerly-constructed provider receives a real snapshot dir (the provider is created in the                           
  `OzoneManagerServiceProviderImpl` constructor).                                                                                                                                                            
  - Existing `TestReconWithOzoneManager.testOmDBSyncWithSeqNumberMismatch `— end-to-end coverage of the full-snapshot fallback against a mini-cluster: it forces `getDBUpdates` to fail and asserts Recon      
  recovers via a full snapshot and normalizes the OM/Recon sequence numbers.                                                                                                                               
  - `TestReconWithOzoneManagerHA` — dropped the stale v1-URL assertion, keeping its end-to-end leader-sync verification. 