### PR TITLE
HDDS-15794. StreamBlockInputStream.onNext may throw IndexOutOfBoundsException on short payloads

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
@@ -539,12 +539,11 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
         // Record the failure first: the log and observer calls below must not mask it.
         setFailed(e);
         final ByteString data = readBlock.getData();
-        final ByteString preview = data.substring(0, Math.min(10, data.size()));
         final long offset = readBlock.getOffset();
         final StreamingReadResponse r = getResponse();
         LOG.warn("Failed to process block {} response at offset={}, size={}: {}, {}",
             getBlockID().getContainerBlockID(),
-            offset, data.size(), StringUtils.bytes2Hex(preview.asReadOnlyByteBuffer()),
+            offset, data.size(), StringUtils.bytes2Hex(data.asReadOnlyByteBuffer(), 10),
             readBlock.getChecksumData(), e);
         if (r != null) {
           r.getRequestObserver().onError(e);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
@@ -482,7 +482,11 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
 
       while (true) {
         final ByteBuffer buf = readFromQueue();
-        if (buf != null && buf.hasRemaining()) {
+        if (buf == null) {
+          // The stream ended before the requested data arrived.
+          return null;
+        }
+        if (buf.hasRemaining()) {
           return buf;
         }
       }
@@ -490,6 +494,10 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
 
     ByteBuffer readFromQueue() throws IOException {
       final ReadBlockResponseProto readBlock = poll();
+      if (readBlock == null) {
+        // poll() returns null only when the stream has ended and the queue is drained.
+        return null;
+      }
       // The server always returns data starting from the last checksum boundary. Therefore if the reader position is
       // ahead of the position we received from the server, we need to adjust the buffer position accordingly.
       // If the reader position is behind
@@ -528,15 +536,19 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
         }
         offerToQueue(readBlock);
       } catch (Exception e) {
+        // Record the failure first: the log and observer calls below must not mask it.
+        setFailed(e);
         final ByteString data = readBlock.getData();
+        final ByteString preview = data.substring(0, Math.min(10, data.size()));
         final long offset = readBlock.getOffset();
         final StreamingReadResponse r = getResponse();
         LOG.warn("Failed to process block {} response at offset={}, size={}: {}, {}",
             getBlockID().getContainerBlockID(),
-            offset, data.size(), StringUtils.bytes2Hex(data.substring(0, 10).asReadOnlyByteBuffer()),
+            offset, data.size(), StringUtils.bytes2Hex(preview.asReadOnlyByteBuffer()),
             readBlock.getChecksumData(), e);
-        setFailed(e);
-        r.getRequestObserver().onError(e);
+        if (r != null) {
+          r.getRequestObserver().onError(e);
+        }
         releaseResources();
       }
     }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.scm.storage;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -30,6 +32,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collections;
@@ -54,6 +57,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
+import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.io.grpc.stub.ClientCallStreamObserver;
@@ -472,6 +476,142 @@ public class TestStreamBlockInputStream {
     }
   }
 
+  /**
+   * The server may end the stream (onCompleted) after a request has been sent but before any
+   * data is delivered, e.g. when the datanode shuts down gracefully. poll() then returns null
+   * (stream done, queue drained) while readFromQueue() is waiting for data. The premature end
+   * of the stream must surface as EOF, not as a NullPointerException that bypasses
+   * handleExceptions() retry handling.
+   */
+  @Test
+  public void testStreamCompletedMidReadWithEmptyQueueSurfacesEof() throws Exception {
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    BlockID blockID = new BlockID(1L, 14L);
+    Pipeline pipeline = mockStandalonePipeline();
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver =
+        mock(ClientCallStreamObserver.class);
+    StreamingReadResponse streamingReadResponse = mock(StreamingReadResponse.class);
+    when(streamingReadResponse.getRequestObserver()).thenReturn(requestObserver);
+
+    AtomicReference<StreamingReaderSpi> readerRef = new AtomicReference<>();
+    XceiverClientGrpc xceiverClient = mock(XceiverClientGrpc.class);
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = inv.getArgument(1);
+      reader.setStreamingReadResponse(streamingReadResponse);
+      readerRef.set(reader);
+      return null;
+    }).when(xceiverClient).initStreamRead(any(BlockID.class), any(), any());
+
+    // The server closes the stream without delivering any of the requested data, so the
+    // reader ends up polling a drained queue with the future already completed.
+    doAnswer(inv -> {
+      readerRef.get().onCompleted();
+      return null;
+    }).when(xceiverClient).streamRead(any(), any());
+
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
+        .thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, 4L, pipeline, null, xceiverClientFactory,
+        NO_REFRESH, clientConfig)) {
+      ByteBuffer buf = ByteBuffer.allocate(4);
+      int bytesRead = assertDoesNotThrow(() -> sbis.read(buf),
+          "premature stream completion must not throw NullPointerException");
+      assertEquals(-1, bytesRead, "premature stream completion should surface as EOF");
+      assertEquals(0, buf.position());
+    }
+  }
+
+  /**
+   * A truncated payload fails checksum verification in onNext(). The failure handling must
+   * record the real failure via setFailed() and propagate it, even though the payload is
+   * shorter than the 10-byte hex preview included in the warning log.
+   */
+  @Test
+  public void testChecksumFailureOnShortPayloadSurfacesRealError() throws Exception {
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    clientConfig.setChecksumVerify(true);
+    BlockID blockID = new BlockID(1L, 15L);
+    byte[] data = {1, 2, 3, 4};
+    Pipeline pipeline = mockStandalonePipeline();
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver =
+        mock(ClientCallStreamObserver.class);
+    StreamingReadResponse streamingReadResponse = mock(StreamingReadResponse.class);
+    when(streamingReadResponse.getRequestObserver()).thenReturn(requestObserver);
+
+    AtomicReference<StreamingReaderSpi> readerRef = new AtomicReference<>();
+    XceiverClientGrpc xceiverClient = mock(XceiverClientGrpc.class);
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = inv.getArgument(1);
+      reader.setStreamingReadResponse(streamingReadResponse);
+      readerRef.set(reader);
+      return null;
+    }).when(xceiverClient).initStreamRead(any(BlockID.class), any(), any());
+
+    // Deliver a payload shorter than 10 bytes whose checksum does not match the data.
+    doAnswer(inv -> {
+      readerRef.get().onNext(buildCorruptResponseProto(data, 0));
+      return null;
+    }).when(xceiverClient).streamRead(any(), any());
+
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
+        .thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, data.length, pipeline, null, xceiverClientFactory,
+        NO_REFRESH, clientConfig)) {
+      ByteBuffer buf = ByteBuffer.allocate(data.length);
+      IOException thrown = assertThrows(IOException.class, () -> sbis.read(buf),
+          "checksum failure should surface as an IOException");
+      assertCauseChainContains(thrown, OzoneChecksumException.class);
+    }
+    verify(requestObserver, times(1)).onError(any(OzoneChecksumException.class));
+  }
+
+  /**
+   * onNext() may fail before XceiverClientGrpc has registered the StreamingReadResponse, so
+   * getResponse() is still null while the failure is reported. The real failure must still be
+   * recorded and surfaced to the reader.
+   */
+  @Test
+  public void testChecksumFailureBeforeResponseRegistered() throws Exception {
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    clientConfig.setChecksumVerify(true);
+    BlockID blockID = new BlockID(1L, 16L);
+    byte[] data = {1, 2, 3};
+    Pipeline pipeline = mockStandalonePipeline();
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver =
+        mock(ClientCallStreamObserver.class);
+    StreamingReadResponse streamingReadResponse = mock(StreamingReadResponse.class);
+    when(streamingReadResponse.getRequestObserver()).thenReturn(requestObserver);
+
+    XceiverClientGrpc xceiverClient = mock(XceiverClientGrpc.class);
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = inv.getArgument(1);
+      // The corrupt response arrives before setStreamingReadResponse() has been called.
+      reader.onNext(buildCorruptResponseProto(data, 0));
+      reader.setStreamingReadResponse(streamingReadResponse);
+      return null;
+    }).when(xceiverClient).initStreamRead(any(BlockID.class), any(), any());
+
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
+        .thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, data.length, pipeline, null, xceiverClientFactory,
+        NO_REFRESH, clientConfig)) {
+      ByteBuffer buf = ByteBuffer.allocate(data.length);
+      IOException thrown = assertThrows(IOException.class, () -> sbis.read(buf),
+          "checksum failure should surface as an IOException");
+      assertCauseChainContains(thrown, OzoneChecksumException.class);
+    }
+    verify(requestObserver, never()).onError(any());
+  }
+
   private ReadBlockResponseProto buildReadBlockResponse(byte[] data) {
     return ReadBlockResponseProto.newBuilder()
         .setOffset(0)
@@ -496,5 +636,32 @@ public class TestStreamBlockInputStream {
                 .build())
             .build())
         .build();
+  }
+
+  private ContainerCommandResponseProto buildCorruptResponseProto(byte[] data, long offset) {
+    return ContainerCommandResponseProto.newBuilder()
+        .setCmdType(Type.ReadBlock)
+        .setResult(ContainerProtos.Result.SUCCESS)
+        .setReadBlock(ReadBlockResponseProto.newBuilder()
+            .setOffset(offset)
+            .setData(ByteString.copyFrom(data))
+            .setChecksumData(ChecksumData.newBuilder()
+                .setType(ContainerProtos.ChecksumType.CRC32)
+                .setBytesPerChecksum(data.length)
+                .addChecksums(ByteString.copyFrom(new byte[4]))
+                .build())
+            .build())
+        .build();
+  }
+
+  private static void assertCauseChainContains(Throwable thrown, Class<? extends Throwable> expected) {
+    Throwable cause = thrown;
+    while (cause != null) {
+      if (expected.isInstance(cause)) {
+        return;
+      }
+      cause = cause.getCause();
+    }
+    fail("Expected " + expected.getSimpleName() + " in the cause chain of: " + thrown);
   }
 }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
@@ -17,11 +17,11 @@
 
 package org.apache.hadoop.hdds.scm.storage;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -698,7 +698,7 @@ public class TestStreamBlockInputStream {
       ByteBuffer buf = ByteBuffer.allocate(data.length);
       IOException thrown = assertThrows(IOException.class, () -> sbis.read(buf),
           "checksum failure should surface as an IOException");
-      assertCauseChainContains(thrown, OzoneChecksumException.class);
+      assertThat(thrown).hasRootCauseInstanceOf(OzoneChecksumException.class);
     }
     verify(requestObserver, times(1)).onError(any(OzoneChecksumException.class));
   }
@@ -739,7 +739,7 @@ public class TestStreamBlockInputStream {
       ByteBuffer buf = ByteBuffer.allocate(data.length);
       IOException thrown = assertThrows(IOException.class, () -> sbis.read(buf),
           "checksum failure should surface as an IOException");
-      assertCauseChainContains(thrown, OzoneChecksumException.class);
+      assertThat(thrown).hasRootCauseInstanceOf(OzoneChecksumException.class);
     }
     verify(requestObserver, never()).onError(any());
   }
@@ -784,16 +784,5 @@ public class TestStreamBlockInputStream {
                 .build())
             .build())
         .build();
-  }
-
-  private static void assertCauseChainContains(Throwable thrown, Class<? extends Throwable> expected) {
-    Throwable cause = thrown;
-    while (cause != null) {
-      if (expected.isInstance(cause)) {
-        return;
-      }
-      cause = cause.getCause();
-    }
-    fail("Expected " + expected.getSimpleName() + " in the cause chain of: " + thrown);
   }
 }


### PR DESCRIPTION
Generated-by: Claude Code (Fable 5)

## What changes were proposed in this pull request?

After HDDS-15480 (#10431) landed, the premature-stream-completion / null-poll() NPE is fixed. One independent bug remains in `StreamBlockInputStream.StreamingReader.onNext()`, in the catch block that handles a failure while processing a response (for example a checksum mismatch):

1. It builds a hex preview with `data.substring(0, 10)`, which throws `IndexOutOfBoundsException` when the payload is shorter than 10 bytes. That secondary exception replaces the real failure.
2. It dereferences `getResponse()` (`r.getRequestObserver().onError(e)`) before the real failure is recorded, and `getResponse()` can be null if the failure happens before the streaming read response is registered, producing an NPE that again masks the original cause.
3. `setFailed(e)` is called after the logging/observer work, so any exception thrown above prevents the real error from ever being recorded.

### Changes

- Call `setFailed(e)` first so the real failure is always recorded before any log or observer call can throw.
- Build the log preview with the existing `StringUtils.bytes2Hex(ByteBuffer, int)` overload, which clamps to 10 bytes and appends `...` on overflow, instead of the unguarded `data.substring(0, 10)`.
- Null-guard `getResponse()` before invoking `onError`.

This PR originally also fixed the premature-completion / null-poll() NPE, which overlapped with #10431. That overlap is now merged on master via HDDS-15480, so this PR is rebased down to just the `onNext()` error-handling fix.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15794

## How was this patch tested?

- Added new unit tests in `TestStreamBlockInputStream`
  - `testChecksumFailureOnShortPayloadSurfacesRealError`: a checksum failure on a sub-10-byte payload surfaces the real `OzoneChecksumException` rather than `IndexOutOfBoundsException`.
  - `testChecksumFailureBeforeResponseRegistered`: a failure before the response is registered no longer NPEs on a null response.
  - `testStreamCompletedMidReadWithEmptyQueueSurfacesEof`: read surfaces EOF (not NPE) when the stream completes mid-read with a drained queue.