### PR TITLE
HDDS-15765. Fail fast when --node-id is omitted for OM compact/defrag on an HA cluster

### DIFF
--- a/hadoop-hdds/docs/content/tools/Admin.md
+++ b/hadoop-hdds/docs/content/tools/Admin.md
@@ -195,7 +195,7 @@ works only on OzoneManager HA cluster.
                              complete. The command will return immediately
                              after triggering the task.
       --node-id=<nodeId>   NodeID of the OM to trigger snapshot defragmentation
-                             on.
+                             on. Required when OM HA is configured.
       --service-id, --om-service-id=<serviceID>
                            Ozone Manager Service ID.
   -V, --version            Print version information and exit.

--- a/hadoop-hdds/docs/content/tools/Admin.md
+++ b/hadoop-hdds/docs/content/tools/Admin.md
@@ -179,7 +179,7 @@ Note in JSON output mode, field `contToken` won't show up at all in the result i
 The snapshot defrag command triggers the Snapshot Defragmentation Service to run immediately on a specific Ozone Manager node.
 This command manually initiates the snapshot defragmentation process which compacts snapshot data and removes fragmentation to improve storage efficiency.
 
-This command only works on Ozone Manager HA clusters.
+This command only works on Ozone Manager HA clusters. Specify `--node-id` to select which OM to defragment.
 
 ```bash
 $ ozone admin om snapshot defrag --help

--- a/hadoop-hdds/docs/content/tools/Repair.md
+++ b/hadoop-hdds/docs/content/tools/Repair.md
@@ -182,7 +182,8 @@ CLI to get the status of last trigger quota repair if available.
 
 ### compact
 Compact a column family in the OM DB to clean up tombstones. The compaction happens asynchronously. Requires admin privileges.
-OM should be running for this tool.
+OM should be running for this tool. On an HA OM cluster, specify `--node-id` to select which OM's db to compact.
+
 ```bash
 Usage: ozone repair om compact [-hV] [--dry-run] [--force] [--verbose]
                                --cf=<columnFamilyName> [--node-id=<nodeId>]

--- a/hadoop-hdds/docs/content/tools/Repair.md
+++ b/hadoop-hdds/docs/content/tools/Repair.md
@@ -193,6 +193,7 @@ asynchronously. Requires admin privileges. OM should be running for this tool.
       --cf, --column-family=<columnFamilyName>
                            Column family name
       --node-id=<nodeId>   NodeID of the OM for which db needs to be compacted.
+                           Required when OM HA is configured.
       --service-id, --om-service-id=<omServiceId>
                            Ozone Manager Service ID
 ```

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/snapshot/DefragSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/snapshot/DefragSubCommand.java
@@ -49,7 +49,8 @@ public class DefragSubCommand extends AbstractSubcommand implements Callable<Voi
 
   @CommandLine.Option(
       names = {"--node-id"},
-      description = "NodeID of the OM to trigger snapshot defragmentation on.",
+      description = "NodeID of the OM to trigger snapshot defragmentation on. "
+          + "Required when OM HA is configured.",
       required = false
   )
   private String nodeId;

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/snapshot/DefragSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/om/snapshot/DefragSubCommand.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.admin.om.OmAddressOptions;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
@@ -64,6 +65,13 @@ public class DefragSubCommand extends AbstractSubcommand implements Callable<Voi
   @Override
   public Void call() throws Exception {
     OzoneConfiguration conf = getOzoneConf();
+
+    if (nodeId == null && OmUtils.isServiceIdsDefined(conf)) {
+      System.err.println("Error: This is an HA OM cluster; specify --node-id "
+          + "to select which OM to defragment.");
+      return null;
+    }
+
     OMNodeDetails omNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
         conf, omServiceOption.getServiceID(), nodeId);
 

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/om/snapshot/TestDefragSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/om/snapshot/TestDefragSubCommand.java
@@ -18,9 +18,11 @@
 package org.apache.hadoop.ozone.admin.om.snapshot;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -54,9 +56,15 @@ public class TestDefragSubCommand {
    */
   private static class TestableDefragSubCommand extends DefragSubCommand {
     private final OMAdminProtocolClientSideImpl mockClient;
+    private final OzoneConfiguration testConf = new OzoneConfiguration();
 
     TestableDefragSubCommand(OMAdminProtocolClientSideImpl mockClient) {
       this.mockClient = mockClient;
+    }
+
+    @Override
+    protected OzoneConfiguration getOzoneConf() {
+      return testConf;
     }
 
     @Override
@@ -139,6 +147,19 @@ public class TestDefragSubCommand {
     // Verify success message
     String output = outContent.toString(DEFAULT_ENCODING);
     assertTrue(output.contains("Snapshot defragmentation completed successfully"));
+  }
+
+  @Test
+  public void testDefragHAWithoutNodeIdFailsFast() throws Exception {
+    cmd.testConf.set("ozone.om.service.ids", "omservice");
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs();
+    cmd.call();
+
+    verify(omAdminClient, never()).triggerSnapshotDefrag(anyBoolean());
+    String error = errContent.toString(DEFAULT_ENCODING);
+    assertTrue(error.contains("specify --node-id"));
   }
 
   @Test

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/om/snapshot/TestDefragSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/om/snapshot/TestDefragSubCommand.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.admin.om.snapshot;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -151,7 +152,7 @@ public class TestDefragSubCommand {
 
   @Test
   public void testDefragHAWithoutNodeIdFailsFast() throws Exception {
-    cmd.testConf.set("ozone.om.service.ids", "omservice");
+    cmd.testConf.set(OZONE_OM_SERVICE_IDS_KEY, "omservice");
 
     CommandLine c = new CommandLine(cmd);
     c.parseArgs();

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedCompactRangeOptions;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
 import org.apache.hadoop.ozone.om.service.CompactDBUtil;
@@ -71,6 +72,13 @@ public class CompactOMDB extends RepairTool {
   public void execute() throws Exception {
 
     OzoneConfiguration conf = getOzoneConf();
+
+    if (nodeId == null && OmUtils.isServiceIdsDefined(conf)) {
+      error("This is an HA OM cluster; specify --node-id to select which OM's"
+          + " db to compact.");
+      return;
+    }
+
     OMNodeDetails omNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
         conf, omServiceId, nodeId);
 

--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/om/CompactOMDB.java
@@ -56,7 +56,8 @@ public class CompactOMDB extends RepairTool {
 
   @CommandLine.Option(
       names = {"--node-id"},
-      description = "NodeID of the OM for which db needs to be compacted.",
+      description = "NodeID of the OM for which db needs to be compacted. "
+          + "Required when OM HA is configured.",
       required = false
   )
   private String nodeId;

--- a/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/om/TestCompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/om/TestCompactOMDB.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.repair.om;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -122,7 +123,7 @@ public class TestCompactOMDB {
   @Test
   public void testCompactHAWithoutNodeIdFailsFast() throws Exception {
     CommandLine cli = new OzoneRepair().getCmd();
-    cli.execute("-D", "ozone.om.service.ids=omservice",
+    cli.execute("-D", OZONE_OM_SERVICE_IDS_KEY + "=omservice",
         "om", "compact", "--column-family", COLUMN_FAMILY);
 
     verify(omAdminClient, never()).compactOMDB(any(), anyInt());

--- a/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/om/TestCompactOMDB.java
+++ b/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/om/TestCompactOMDB.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -116,5 +117,15 @@ public class TestCompactOMDB {
     compact();
 
     assertThat(err.getOutput()).contains("Couldn't determine OM node");
+  }
+
+  @Test
+  public void testCompactHAWithoutNodeIdFailsFast() throws Exception {
+    CommandLine cli = new OzoneRepair().getCmd();
+    cli.execute("-D", "ozone.om.service.ids=omservice",
+        "om", "compact", "--column-family", COLUMN_FAMILY);
+
+    verify(omAdminClient, never()).compactOMDB(any(), anyInt());
+    assertThat(err.getOutput()).contains("specify --node-id");
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

On an HA OM cluster, `ozone repair om compact` and `ozone admin om snapshot defrag` without `--node-id` do not fail cleanly; they hang for a long time before eventually timing out.

**Root cause**: with no `--node-id`/`--service-id`, `OMNodeDetails.getOMNodeDetailsFromConf(conf, null, null)` falls back to the base config key `ozone.om.address`, which in an HA deployment defaults to `0.0.0.0:9862`. That default is the OM *server bind* address (bind to all interfaces) and is meaningless as a *client* target. Because it resolves to a non-null (but useless) address, the tool builds a valid-looking `OMNodeDetails` for `0.0.0.0` and proceeds to the RPC, which then retries in the Hadoop IPC retry loop and blocks.

This PR adds a fail-fast check in both CLI commands: when `--node-id` is omitted but the config defines an HA service (`OmUtils.isServiceIdsDefined(conf)`), the command exits immediately and asks the operator to specify `--node-id`, instead of resolving to `0.0.0.0`. Each command reports the error with its own existing convention.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15765

## How was this patch tested?

- New unit tests `TestCompactOMDB#testCompactHAWithoutNodeIdFailsFast` and `TestDefragSubCommand#testDefragHAWithoutNodeIdFailsFast` 
- Existing `TestCompactOMDB`, `TestDefragSubCommand`, and `TestOMNodeDetails` still pass, and `checkstyle` is clean.
- Manual end-to-end run on the `compose/ozone-ha` cluster (om1/om2/om3, `service.ids=omservice`):

| Command | Before | After |
|---|---|---|
| `ozone repair om compact --cf keyTable` (**no** `--node-id`) | hangs until timeout | returns immediately: `This is an HA OM cluster; specify --node-id ...` |
| `ozone admin om snapshot defrag` (**no** `--node-id`) | hangs until timeout | returns immediately: `Error: This is an HA OM cluster; specify --node-id ...` |
| `ozone repair om compact --cf keyTable --service-id omservice --node-id om3` | issues request | unchanged: `Compaction request issued for om.db of om node: om3` |
| `ozone admin om snapshot defrag --service-id omservice --node-id om3` | reaches `om3:9862` | unchanged: reaches real `om3:9862` (not `0.0.0.0`) |

Generated-by: Claude Code (Opus 4.8)
