### PR TITLE
HDDS-15791. EC reconstructed RECOVERING container while still idle can be deleted by SCM and recreated as new partial OPEN container

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -907,11 +907,11 @@ public class BlockOutputStream extends OutputStream {
     ChecksumData checksumData = checksum.computeChecksum(chunk, false);
     // side note: checksum object is shared with PutBlock's (blockData) checksum calc,
     // current impl does not support caching both
-    ChunkInfo chunkInfo = ChunkInfo.newBuilder()
+    ChunkInfo chunkInfo = decorateChunkInfo(ChunkInfo.newBuilder()
         .setChunkName(blockID.get().getLocalID() + "_chunk_" + ++chunkIndex)
         .setOffset(offset)
         .setLen(effectiveChunkSize)
-        .setChecksumData(checksumData.getProtoBufMessage())
+        .setChecksumData(checksumData.getProtoBufMessage()))
         .build();
 
     long flushPos = totalWriteChunkLength;
@@ -1148,16 +1148,23 @@ public class BlockOutputStream extends OutputStream {
     ChecksumData revisedChecksumData = checksum.computeChecksum(lastChunkBuffer, true);
 
     long chunkID = lastPartialChunkOffset / config.getStreamBufferSize();
-    ChunkInfo.Builder revisedChunkInfo = ChunkInfo.newBuilder()
+    ChunkInfo.Builder revisedChunkInfo = decorateChunkInfo(ChunkInfo.newBuilder()
         .setChunkName(blockID.get().getLocalID() + "_chunk_" + chunkID)
         .setOffset(lastPartialChunkOffset)
         .setLen(revisedChunkSize)
-        .setChecksumData(revisedChecksumData.getProtoBufMessage());
+        .setChecksumData(revisedChecksumData.getProtoBufMessage()));
     // if full chunk
     if (revisedChunkSize == config.getStreamBufferSize()) {
       revisedChunkInfo.addMetadata(FULL_CHUNK_KV);
     }
     return revisedChunkInfo.build();
+  }
+
+  /**
+   * Subclasses may add chunk metadata (e.g. EC reconstruction write flags).
+   */
+  protected ChunkInfo.Builder decorateChunkInfo(ChunkInfo.Builder builder) {
+    return builder;
   }
 
   private boolean isFullChunk(ChunkInfo chunkInfo) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -597,7 +597,7 @@ public class BlockOutputStream extends OutputStream {
 
       // if block is full, send the eof
       boolean isBlockFull = (blockSize != -1 && flushPos == blockSize);
-      asyncReply = putBlockAsync(xceiverClient, blockData, close || isBlockFull, tokenString);
+      asyncReply = putBlockAsync(xceiverClient, blockData, close || isBlockFull, tokenString, containerAutoCreate());
       CompletableFuture<ContainerCommandResponseProto> future = asyncReply.getResponse();
       flushFuture = future.thenApplyAsync(e -> {
         try {
@@ -907,11 +907,11 @@ public class BlockOutputStream extends OutputStream {
     ChecksumData checksumData = checksum.computeChecksum(chunk, false);
     // side note: checksum object is shared with PutBlock's (blockData) checksum calc,
     // current impl does not support caching both
-    ChunkInfo chunkInfo = decorateChunkInfo(ChunkInfo.newBuilder()
+    ChunkInfo chunkInfo = ChunkInfo.newBuilder()
         .setChunkName(blockID.get().getLocalID() + "_chunk_" + ++chunkIndex)
         .setOffset(offset)
         .setLen(effectiveChunkSize)
-        .setChecksumData(checksumData.getProtoBufMessage()))
+        .setChecksumData(checksumData.getProtoBufMessage())
         .build();
 
     long flushPos = totalWriteChunkLength;
@@ -964,7 +964,7 @@ public class BlockOutputStream extends OutputStream {
       }
 
       asyncReply = writeChunkAsync(xceiverClient, chunkInfo,
-          blockID.get(), data, tokenString, replicationIndex, blockData, close);
+          blockID.get(), data, tokenString, replicationIndex, blockData, close, containerAutoCreate());
       CompletableFuture<ContainerCommandResponseProto>
           respFuture = asyncReply.getResponse();
       validateFuture = respFuture.thenApplyAsync(e -> {
@@ -1148,11 +1148,11 @@ public class BlockOutputStream extends OutputStream {
     ChecksumData revisedChecksumData = checksum.computeChecksum(lastChunkBuffer, true);
 
     long chunkID = lastPartialChunkOffset / config.getStreamBufferSize();
-    ChunkInfo.Builder revisedChunkInfo = decorateChunkInfo(ChunkInfo.newBuilder()
+    ChunkInfo.Builder revisedChunkInfo = ChunkInfo.newBuilder()
         .setChunkName(blockID.get().getLocalID() + "_chunk_" + chunkID)
         .setOffset(lastPartialChunkOffset)
         .setLen(revisedChunkSize)
-        .setChecksumData(revisedChecksumData.getProtoBufMessage()));
+        .setChecksumData(revisedChecksumData.getProtoBufMessage());
     // if full chunk
     if (revisedChunkSize == config.getStreamBufferSize()) {
       revisedChunkInfo.addMetadata(FULL_CHUNK_KV);
@@ -1161,10 +1161,15 @@ public class BlockOutputStream extends OutputStream {
   }
 
   /**
-   * Subclasses may add chunk metadata (e.g. EC reconstruction write flags).
+   * @return true when the DataNode may auto-create a missing container for this write.
    */
-  protected ChunkInfo.Builder decorateChunkInfo(ChunkInfo.Builder builder) {
-    return builder;
+  protected boolean containerAutoCreate() {
+    return true;
+  }
+
+  @VisibleForTesting
+  public boolean isContainerAutoCreate() {
+    return containerAutoCreate();
   }
 
   private boolean isFullChunk(ChunkInfo chunkInfo) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -91,6 +91,14 @@ public class ECBlockOutputStream extends BlockOutputStream {
   }
 
   @Override
+  protected ChunkInfo.Builder decorateChunkInfo(ChunkInfo.Builder builder) {
+    return builder.addMetadata(ContainerProtos.KeyValue.newBuilder()
+        .setKey(OzoneConsts.CONTAINER_CREATABLE)
+        .setValue(OzoneConsts.CONTAINER_CREATABLE_FALSE)
+        .build());
+  }
+
+  @Override
   public synchronized void write(byte[] b, int off, int len) throws IOException {
     this.currentChunkRspFuture =
         writeChunkToContainer(

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.storage;
 
 import static org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls.putBlockAsync;
-import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE_KEY;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
@@ -60,7 +59,7 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 public class ECBlockOutputStream extends BlockOutputStream {
 
   private final DatanodeDetails datanodeDetails;
-  private final boolean denyContainerAutoCreate;
+  private final boolean containerAutoCreate;
   private CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
       currentChunkRspFuture = null;
 
@@ -87,7 +86,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
       Supplier<ExecutorService> executorServiceSupplier
   ) throws IOException {
     this(blockID, xceiverClientManager, pipeline, bufferPool, config, token, clientMetrics,
-        streamBufferArgs, executorServiceSupplier, false);
+        streamBufferArgs, executorServiceSupplier, true);
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
@@ -100,31 +99,18 @@ public class ECBlockOutputStream extends BlockOutputStream {
       Token<? extends TokenIdentifier> token,
       ContainerClientMetrics clientMetrics, StreamBufferArgs streamBufferArgs,
       Supplier<ExecutorService> executorServiceSupplier,
-      boolean denyContainerAutoCreate
+      boolean containerAutoCreate
   ) throws IOException {
     super(blockID, -1, xceiverClientManager,
         pipeline, bufferPool, config, token, clientMetrics, streamBufferArgs, executorServiceSupplier);
     // In EC stream, there will be only one node in pipeline.
     this.datanodeDetails = pipeline.getClosestNode();
-    this.denyContainerAutoCreate = denyContainerAutoCreate;
-    if (denyContainerAutoCreate) {
-      getContainerBlockData().addMetadata(containerCreatableFalseKv());
-    }
+    this.containerAutoCreate = containerAutoCreate;
   }
 
   @Override
-  protected ChunkInfo.Builder decorateChunkInfo(ChunkInfo.Builder builder) {
-    if (!denyContainerAutoCreate) {
-      return builder;
-    }
-    return builder.addMetadata(containerCreatableFalseKv());
-  }
-
-  private static ContainerProtos.KeyValue containerCreatableFalseKv() {
-    return ContainerProtos.KeyValue.newBuilder()
-        .setKey(CONTAINER_CREATABLE_KEY)
-        .setValue(OzoneConsts.CONTAINER_CREATABLE)
-        .build();
+  protected boolean containerAutoCreate() {
+    return containerAutoCreate;
   }
 
   @Override
@@ -309,7 +295,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
     try {
       ContainerProtos.BlockData blockData = getContainerBlockData().build();
       XceiverClientReply asyncReply =
-          putBlockAsync(getXceiverClient(), blockData, close, getTokenString());
+          putBlockAsync(getXceiverClient(), blockData, close, getTokenString(), containerAutoCreate());
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future =
           asyncReply.getResponse();
       flushFuture = future.thenApplyAsync(e -> {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.storage;
 
 import static org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls.putBlockAsync;
+import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE_KEY;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
@@ -59,6 +60,7 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 public class ECBlockOutputStream extends BlockOutputStream {
 
   private final DatanodeDetails datanodeDetails;
+  private final boolean denyContainerAutoCreate;
   private CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
       currentChunkRspFuture = null;
 
@@ -84,18 +86,45 @@ public class ECBlockOutputStream extends BlockOutputStream {
       ContainerClientMetrics clientMetrics, StreamBufferArgs streamBufferArgs,
       Supplier<ExecutorService> executorServiceSupplier
   ) throws IOException {
+    this(blockID, xceiverClientManager, pipeline, bufferPool, config, token, clientMetrics,
+        streamBufferArgs, executorServiceSupplier, false);
+  }
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public ECBlockOutputStream(
+      BlockID blockID,
+      XceiverClientFactory xceiverClientManager,
+      Pipeline pipeline,
+      BufferPool bufferPool,
+      OzoneClientConfig config,
+      Token<? extends TokenIdentifier> token,
+      ContainerClientMetrics clientMetrics, StreamBufferArgs streamBufferArgs,
+      Supplier<ExecutorService> executorServiceSupplier,
+      boolean denyContainerAutoCreate
+  ) throws IOException {
     super(blockID, -1, xceiverClientManager,
         pipeline, bufferPool, config, token, clientMetrics, streamBufferArgs, executorServiceSupplier);
     // In EC stream, there will be only one node in pipeline.
     this.datanodeDetails = pipeline.getClosestNode();
+    this.denyContainerAutoCreate = denyContainerAutoCreate;
+    if (denyContainerAutoCreate) {
+      getContainerBlockData().addMetadata(containerCreatableFalseKv());
+    }
   }
 
   @Override
   protected ChunkInfo.Builder decorateChunkInfo(ChunkInfo.Builder builder) {
-    return builder.addMetadata(ContainerProtos.KeyValue.newBuilder()
-        .setKey(OzoneConsts.CONTAINER_CREATABLE)
-        .setValue(OzoneConsts.CONTAINER_CREATABLE_FALSE)
-        .build());
+    if (!denyContainerAutoCreate) {
+      return builder;
+    }
+    return builder.addMetadata(containerCreatableFalseKv());
+  }
+
+  private static ContainerProtos.KeyValue containerCreatableFalseKv() {
+    return ContainerProtos.KeyValue.newBuilder()
+        .setKey(CONTAINER_CREATABLE_KEY)
+        .setValue(OzoneConsts.CONTAINER_CREATABLE)
+        .build();
   }
 
   @Override

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -18,8 +18,6 @@
 package org.apache.hadoop.hdds.scm.storage;
 
 import static java.util.concurrent.Executors.newFixedThreadPool;
-import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE;
-import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,7 +36,6 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
@@ -57,7 +54,6 @@ import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -139,39 +135,7 @@ class TestBlockOutputStreamCorrectness {
   }
 
   @Test
-  public void testEcReconstructionWriteChunkSetsContainerCreatableFalse() throws IOException {
-    OzoneClientConfig config = new OzoneClientConfig();
-    ECReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
-    BlockID blockID = new BlockID(1, 1);
-    DatanodeDetails datanodeDetails = MockDatanodeDetails.randomDatanodeDetails();
-    Pipeline pipeline = Pipeline.newBuilder()
-        .setId(datanodeDetails.getID())
-        .setReplicationConfig(replicationConfig)
-        .setNodes(ImmutableList.of(datanodeDetails))
-        .setState(Pipeline.PipelineState.CLOSED)
-        .setReplicaIndexes(ImmutableMap.of(datanodeDetails, 2))
-        .build();
-
-    try (ECBlockOutputStream ecBlockOutputStream = createECBlockOutputStream(config, replicationConfig,
-        blockID, pipeline, true)) {
-      ContainerProtos.ChunkInfo chunk = ecBlockOutputStream.decorateChunkInfo(
-          ContainerProtos.ChunkInfo.newBuilder()
-              .setChunkName("chunk")
-              .setOffset(0)
-              .setLen(1)
-              .setChecksumData(Checksum.getNoChecksumDataProto()))
-          .build();
-      assertTrue(chunk.getMetadataList().stream()
-          .anyMatch(kv -> CONTAINER_CREATABLE_KEY.equals(kv.getKey())
-              && CONTAINER_CREATABLE.equals(kv.getValue())));
-      assertTrue(ecBlockOutputStream.getContainerBlockData().getMetadataList().stream()
-          .anyMatch(kv -> CONTAINER_CREATABLE_KEY.equals(kv.getKey())
-              && CONTAINER_CREATABLE.equals(kv.getValue())));
-    }
-  }
-
-  @Test
-  public void testEcClientWriteChunkDoesNotSetContainerCreatableFalse() throws IOException {
+  public void testEcReconstructionStreamDisablesContainerAutoCreate() throws IOException {
     OzoneClientConfig config = new OzoneClientConfig();
     ECReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
     BlockID blockID = new BlockID(1, 1);
@@ -186,17 +150,27 @@ class TestBlockOutputStreamCorrectness {
 
     try (ECBlockOutputStream ecBlockOutputStream = createECBlockOutputStream(config, replicationConfig,
         blockID, pipeline, false)) {
-      ContainerProtos.ChunkInfo chunk = ecBlockOutputStream.decorateChunkInfo(
-          ContainerProtos.ChunkInfo.newBuilder()
-              .setChunkName("chunk")
-              .setOffset(0)
-              .setLen(1)
-              .setChecksumData(Checksum.getNoChecksumDataProto()))
-          .build();
-      assertFalse(chunk.getMetadataList().stream()
-          .anyMatch(kv -> CONTAINER_CREATABLE_KEY.equals(kv.getKey())));
-      assertFalse(ecBlockOutputStream.getContainerBlockData().getMetadataList().stream()
-          .anyMatch(kv -> CONTAINER_CREATABLE_KEY.equals(kv.getKey())));
+      assertFalse(ecBlockOutputStream.isContainerAutoCreate());
+    }
+  }
+
+  @Test
+  public void testEcClientStreamAllowsContainerAutoCreate() throws IOException {
+    OzoneClientConfig config = new OzoneClientConfig();
+    ECReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
+    BlockID blockID = new BlockID(1, 1);
+    DatanodeDetails datanodeDetails = MockDatanodeDetails.randomDatanodeDetails();
+    Pipeline pipeline = Pipeline.newBuilder()
+        .setId(datanodeDetails.getID())
+        .setReplicationConfig(replicationConfig)
+        .setNodes(ImmutableList.of(datanodeDetails))
+        .setState(Pipeline.PipelineState.CLOSED)
+        .setReplicaIndexes(ImmutableMap.of(datanodeDetails, 2))
+        .build();
+
+    try (ECBlockOutputStream ecBlockOutputStream = createECBlockOutputStream(config, replicationConfig,
+        blockID, pipeline)) {
+      assertTrue(ecBlockOutputStream.isContainerAutoCreate());
     }
   }
 
@@ -252,7 +226,7 @@ class TestBlockOutputStreamCorrectness {
 
   private ECBlockOutputStream createECBlockOutputStream(OzoneClientConfig clientConfig,
       ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline,
-      boolean denyContainerAutoCreate) throws IOException {
+      boolean containerAutoCreate) throws IOException {
     final XceiverClientManager xcm = mock(XceiverClientManager.class);
     when(xcm.acquireClient(any()))
         .thenReturn(new MockXceiverClientSpi(pipeline));
@@ -262,12 +236,12 @@ class TestBlockOutputStreamCorrectness {
         StreamBufferArgs.getDefaultStreamBufferArgs(repConfig, clientConfig);
 
     return new ECBlockOutputStream(blockID, xcm, pipeline, BufferPool.empty(), clientConfig, null,
-        clientMetrics, streamBufferArgs, () -> newFixedThreadPool(2), denyContainerAutoCreate);
+        clientMetrics, streamBufferArgs, () -> newFixedThreadPool(2), containerAutoCreate);
   }
 
   private ECBlockOutputStream createECBlockOutputStream(OzoneClientConfig clientConfig,
       ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline) throws IOException {
-    return createECBlockOutputStream(clientConfig, repConfig, blockID, pipeline, false);
+    return createECBlockOutputStream(clientConfig, repConfig, blockID, pipeline, true);
   }
 
   /**

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -18,7 +18,10 @@
 package org.apache.hadoop.hdds.scm.storage;
 
 import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE;
+import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE_FALSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -34,6 +37,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
@@ -52,6 +56,7 @@ import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -129,6 +134,35 @@ class TestBlockOutputStreamCorrectness {
         pipeline)) {
       Assertions.assertDoesNotThrow(() -> ecBlockOutputStream.executePutBlock(true, true, locationInfo.getLength(),
           blockData));
+    }
+  }
+
+  @Test
+  public void testEcReconstructionWriteChunkSetsContainerCreatableFalse() throws IOException {
+    OzoneClientConfig config = new OzoneClientConfig();
+    ECReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
+    BlockID blockID = new BlockID(1, 1);
+    DatanodeDetails datanodeDetails = MockDatanodeDetails.randomDatanodeDetails();
+    Pipeline pipeline = Pipeline.newBuilder()
+        .setId(datanodeDetails.getID())
+        .setReplicationConfig(replicationConfig)
+        .setNodes(ImmutableList.of(datanodeDetails))
+        .setState(Pipeline.PipelineState.CLOSED)
+        .setReplicaIndexes(ImmutableMap.of(datanodeDetails, 2))
+        .build();
+
+    try (ECBlockOutputStream ecBlockOutputStream = createECBlockOutputStream(config, replicationConfig,
+        blockID, pipeline)) {
+      ContainerProtos.ChunkInfo chunk = ecBlockOutputStream.decorateChunkInfo(
+          ContainerProtos.ChunkInfo.newBuilder()
+              .setChunkName("chunk")
+              .setOffset(0)
+              .setLen(1)
+              .setChecksumData(Checksum.getNoChecksumDataProto()))
+          .build();
+      assertTrue(chunk.getMetadataList().stream()
+          .anyMatch(kv -> CONTAINER_CREATABLE.equals(kv.getKey())
+              && CONTAINER_CREATABLE_FALSE.equals(kv.getValue())));
     }
   }
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -19,8 +19,9 @@ package org.apache.hadoop.hdds.scm.storage;
 
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE;
-import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE_FALSE;
+import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -152,7 +153,7 @@ class TestBlockOutputStreamCorrectness {
         .build();
 
     try (ECBlockOutputStream ecBlockOutputStream = createECBlockOutputStream(config, replicationConfig,
-        blockID, pipeline)) {
+        blockID, pipeline, true)) {
       ContainerProtos.ChunkInfo chunk = ecBlockOutputStream.decorateChunkInfo(
           ContainerProtos.ChunkInfo.newBuilder()
               .setChunkName("chunk")
@@ -161,8 +162,41 @@ class TestBlockOutputStreamCorrectness {
               .setChecksumData(Checksum.getNoChecksumDataProto()))
           .build();
       assertTrue(chunk.getMetadataList().stream()
-          .anyMatch(kv -> CONTAINER_CREATABLE.equals(kv.getKey())
-              && CONTAINER_CREATABLE_FALSE.equals(kv.getValue())));
+          .anyMatch(kv -> CONTAINER_CREATABLE_KEY.equals(kv.getKey())
+              && CONTAINER_CREATABLE.equals(kv.getValue())));
+      assertTrue(ecBlockOutputStream.getContainerBlockData().getMetadataList().stream()
+          .anyMatch(kv -> CONTAINER_CREATABLE_KEY.equals(kv.getKey())
+              && CONTAINER_CREATABLE.equals(kv.getValue())));
+    }
+  }
+
+  @Test
+  public void testEcClientWriteChunkDoesNotSetContainerCreatableFalse() throws IOException {
+    OzoneClientConfig config = new OzoneClientConfig();
+    ECReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
+    BlockID blockID = new BlockID(1, 1);
+    DatanodeDetails datanodeDetails = MockDatanodeDetails.randomDatanodeDetails();
+    Pipeline pipeline = Pipeline.newBuilder()
+        .setId(datanodeDetails.getID())
+        .setReplicationConfig(replicationConfig)
+        .setNodes(ImmutableList.of(datanodeDetails))
+        .setState(Pipeline.PipelineState.CLOSED)
+        .setReplicaIndexes(ImmutableMap.of(datanodeDetails, 2))
+        .build();
+
+    try (ECBlockOutputStream ecBlockOutputStream = createECBlockOutputStream(config, replicationConfig,
+        blockID, pipeline, false)) {
+      ContainerProtos.ChunkInfo chunk = ecBlockOutputStream.decorateChunkInfo(
+          ContainerProtos.ChunkInfo.newBuilder()
+              .setChunkName("chunk")
+              .setOffset(0)
+              .setLen(1)
+              .setChecksumData(Checksum.getNoChecksumDataProto()))
+          .build();
+      assertFalse(chunk.getMetadataList().stream()
+          .anyMatch(kv -> CONTAINER_CREATABLE_KEY.equals(kv.getKey())));
+      assertFalse(ecBlockOutputStream.getContainerBlockData().getMetadataList().stream()
+          .anyMatch(kv -> CONTAINER_CREATABLE_KEY.equals(kv.getKey())));
     }
   }
 
@@ -217,7 +251,8 @@ class TestBlockOutputStreamCorrectness {
   }
 
   private ECBlockOutputStream createECBlockOutputStream(OzoneClientConfig clientConfig,
-      ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline) throws IOException {
+      ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline,
+      boolean denyContainerAutoCreate) throws IOException {
     final XceiverClientManager xcm = mock(XceiverClientManager.class);
     when(xcm.acquireClient(any()))
         .thenReturn(new MockXceiverClientSpi(pipeline));
@@ -227,7 +262,12 @@ class TestBlockOutputStreamCorrectness {
         StreamBufferArgs.getDefaultStreamBufferArgs(repConfig, clientConfig);
 
     return new ECBlockOutputStream(blockID, xcm, pipeline, BufferPool.empty(), clientConfig, null,
-        clientMetrics, streamBufferArgs, () -> newFixedThreadPool(2));
+        clientMetrics, streamBufferArgs, () -> newFixedThreadPool(2), denyContainerAutoCreate);
+  }
+
+  private ECBlockOutputStream createECBlockOutputStream(OzoneClientConfig clientConfig,
+      ECReplicationConfig repConfig, BlockID blockID, Pipeline pipeline) throws IOException {
+    return createECBlockOutputStream(clientConfig, repConfig, blockID, pipeline, false);
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -318,8 +318,18 @@ public final class ContainerProtocolCalls  {
                                                  boolean eof,
                                                  String tokenString)
       throws IOException, InterruptedException, ExecutionException {
+    return putBlockAsync(xceiverClient, containerBlockData, eof, tokenString, true);
+  }
+
+  public static XceiverClientReply putBlockAsync(XceiverClientSpi xceiverClient,
+                                                 BlockData containerBlockData,
+                                                 boolean eof,
+                                                 String tokenString,
+                                                 boolean containerAutoCreate)
+      throws IOException, InterruptedException, ExecutionException {
     final ContainerCommandRequestProto request = getPutBlockRequest(
-        xceiverClient.getPipeline(), containerBlockData, eof, tokenString);
+        xceiverClient.getPipeline(), containerBlockData, eof, tokenString,
+        containerAutoCreate);
     return xceiverClient.sendCommandAsync(request);
   }
 
@@ -356,10 +366,19 @@ public final class ContainerProtocolCalls  {
   public static ContainerCommandRequestProto getPutBlockRequest(
       Pipeline pipeline, BlockData containerBlockData, boolean eof,
       String tokenString) throws IOException {
+    return getPutBlockRequest(pipeline, containerBlockData, eof, tokenString, true);
+  }
+
+  public static ContainerCommandRequestProto getPutBlockRequest(
+      Pipeline pipeline, BlockData containerBlockData, boolean eof,
+      String tokenString, boolean containerAutoCreate) throws IOException {
     PutBlockRequestProto.Builder createBlockRequest =
         PutBlockRequestProto.newBuilder()
             .setBlockData(containerBlockData)
             .setEof(eof);
+    if (!containerAutoCreate) {
+      createBlockRequest.setContainerAutoCreate(false);
+    }
     final String id = pipeline.getFirstNode().getUuidString();
     ContainerCommandRequestProto.Builder builder =
         ContainerCommandRequestProto.newBuilder().setCmdType(Type.PutBlock)
@@ -467,6 +486,17 @@ public final class ContainerProtocolCalls  {
       ByteString data, String tokenString,
       int replicationIndex, BlockData blockData, boolean close)
       throws IOException, ExecutionException, InterruptedException {
+    return writeChunkAsync(xceiverClient, chunk, blockID, data, tokenString,
+        replicationIndex, blockData, close, true);
+  }
+
+  @SuppressWarnings("parameternumber")
+  public static XceiverClientReply writeChunkAsync(
+      XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
+      ByteString data, String tokenString,
+      int replicationIndex, BlockData blockData, boolean close,
+      boolean containerAutoCreate)
+      throws IOException, ExecutionException, InterruptedException {
 
     WriteChunkRequestProto.Builder writeChunkRequest =
         WriteChunkRequestProto.newBuilder()
@@ -484,6 +514,9 @@ public final class ContainerProtocolCalls  {
               .setBlockData(blockData)
               .setEof(close);
       writeChunkRequest.setBlock(createBlockRequest);
+    }
+    if (!containerAutoCreate) {
+      writeChunkRequest.setContainerAutoCreate(false);
     }
     String id = xceiverClient.getPipeline().getFirstNode().getUuidString();
     ContainerCommandRequestProto.Builder builder =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -103,12 +103,6 @@ public final class OzoneConsts {
   public static final int CHUNK_SIZE = 1 * 1024 * 1024; // 1 MB
   // for client and DataNode to label a block contains a incremental chunk list.
   public static final String INCREMENTAL_CHUNK_LIST = "incremental";
-  /**
-   * Write metadata value for key {@code containerCreatable}: the DataNode must not
-   * auto-create a missing container (EC reconstruction writes).
-   */
-  public static final String CONTAINER_CREATABLE_KEY = "containerCreatable";
-  public static final String CONTAINER_CREATABLE = "false";
   public static final long KB = 1024L;
   public static final long MB = KB * 1024L;
   public static final long GB = MB * 1024L;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -103,6 +103,12 @@ public final class OzoneConsts {
   public static final int CHUNK_SIZE = 1 * 1024 * 1024; // 1 MB
   // for client and DataNode to label a block contains a incremental chunk list.
   public static final String INCREMENTAL_CHUNK_LIST = "incremental";
+  /**
+   * Write metadata: when value is {@link #CONTAINER_CREATABLE_FALSE}, the DataNode must not
+   * auto-create a missing container on WriteChunk (EC reconstruction writes).
+   */
+  public static final String CONTAINER_CREATABLE = "containerCreatable";
+  public static final String CONTAINER_CREATABLE_FALSE = "false";
   public static final long KB = 1024L;
   public static final long MB = KB * 1024L;
   public static final long GB = MB * 1024L;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -104,11 +104,11 @@ public final class OzoneConsts {
   // for client and DataNode to label a block contains a incremental chunk list.
   public static final String INCREMENTAL_CHUNK_LIST = "incremental";
   /**
-   * Write metadata: when value is {@link #CONTAINER_CREATABLE_FALSE}, the DataNode must not
-   * auto-create a missing container on WriteChunk (EC reconstruction writes).
+   * Write metadata value for key {@code containerCreatable}: the DataNode must not
+   * auto-create a missing container (EC reconstruction writes).
    */
-  public static final String CONTAINER_CREATABLE = "containerCreatable";
-  public static final String CONTAINER_CREATABLE_FALSE = "false";
+  public static final String CONTAINER_CREATABLE_KEY = "containerCreatable";
+  public static final String CONTAINER_CREATABLE = "false";
   public static final long KB = 1024L;
   public static final long MB = KB * 1024L;
   public static final long GB = MB * 1024L;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_ALGORITHM;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_DATA_DIR;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getContainerCommandResponse;
+import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE_KEY;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerData.CHARSET_ENCODING;
 
 import java.io.File;
@@ -35,6 +36,7 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
@@ -404,23 +406,53 @@ public final class ContainerUtils {
     }
   }
 
+  public static ContainerProtos.KeyValue containerCreatableFalseKv() {
+    return ContainerProtos.KeyValue.newBuilder()
+        .setKey(CONTAINER_CREATABLE_KEY)
+        .setValue(OzoneConsts.CONTAINER_CREATABLE)
+        .build();
+  }
+
   /**
-   * @return true if the DataNode may auto-create a missing container for this WriteChunk request
+   * @return true if the DataNode may auto-create a missing container for this request
    */
   public static boolean isContainerCreatable(ContainerCommandRequestProto request) {
-    if (!request.hasWriteChunk()) {
-      return true;
+    if (request.hasWriteChunk()) {
+      ContainerProtos.WriteChunkRequestProto writeChunk = request.getWriteChunk();
+      if (writeChunk.hasChunkData()
+          && deniesContainerAutoCreate(writeChunk.getChunkData().getMetadataList())) {
+        return false;
+      }
     }
-    ContainerProtos.WriteChunkRequestProto writeChunk = request.getWriteChunk();
-    if (!writeChunk.hasChunkData()) {
-      return true;
+    if (request.hasPutBlock()) {
+      ContainerProtos.PutBlockRequestProto putBlock = request.getPutBlock();
+      if (putBlock.hasBlockData()
+          && deniesContainerAutoCreate(putBlock.getBlockData().getMetadataList())) {
+        return false;
+      }
     }
-    for (ContainerProtos.KeyValue kv : writeChunk.getChunkData().getMetadataList()) {
-      if (OzoneConsts.CONTAINER_CREATABLE.equals(kv.getKey())
-          && OzoneConsts.CONTAINER_CREATABLE_FALSE.equals(kv.getValue())) {
+    if (request.hasPutSmallFile()) {
+      ContainerProtos.PutSmallFileRequestProto putSmallFile = request.getPutSmallFile();
+      if (putSmallFile.hasChunkInfo()
+          && deniesContainerAutoCreate(putSmallFile.getChunkInfo().getMetadataList())) {
+        return false;
+      }
+      if (putSmallFile.hasBlock() && putSmallFile.getBlock().hasBlockData()
+          && deniesContainerAutoCreate(putSmallFile.getBlock().getBlockData().getMetadataList())) {
         return false;
       }
     }
     return true;
+  }
+
+  private static boolean deniesContainerAutoCreate(
+      List<ContainerProtos.KeyValue> metadataList) {
+    for (ContainerProtos.KeyValue kv : metadataList) {
+      if (CONTAINER_CREATABLE_KEY.equals(kv.getKey())
+          && OzoneConsts.CONTAINER_CREATABLE.equals(kv.getValue())) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -403,4 +403,24 @@ public final class ContainerUtils {
               " not support.");
     }
   }
+
+  /**
+   * @return true if the DataNode may auto-create a missing container for this WriteChunk request
+   */
+  public static boolean isContainerCreatable(ContainerCommandRequestProto request) {
+    if (!request.hasWriteChunk()) {
+      return true;
+    }
+    ContainerProtos.WriteChunkRequestProto writeChunk = request.getWriteChunk();
+    if (!writeChunk.hasChunkData()) {
+      return true;
+    }
+    for (ContainerProtos.KeyValue kv : writeChunk.getChunkData().getMetadataList()) {
+      if (OzoneConsts.CONTAINER_CREATABLE.equals(kv.getKey())
+          && OzoneConsts.CONTAINER_CREATABLE_FALSE.equals(kv.getValue())) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -25,7 +25,6 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_ALGORITHM;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_DATA_DIR;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getContainerCommandResponse;
-import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_CREATABLE_KEY;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerData.CHARSET_ENCODING;
 
 import java.io.File;
@@ -36,7 +35,6 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
@@ -406,53 +404,29 @@ public final class ContainerUtils {
     }
   }
 
-  public static ContainerProtos.KeyValue containerCreatableFalseKv() {
-    return ContainerProtos.KeyValue.newBuilder()
-        .setKey(CONTAINER_CREATABLE_KEY)
-        .setValue(OzoneConsts.CONTAINER_CREATABLE)
-        .build();
-  }
-
   /**
    * @return true if the DataNode may auto-create a missing container for this request
    */
   public static boolean isContainerCreatable(ContainerCommandRequestProto request) {
-    if (request.hasWriteChunk()) {
-      ContainerProtos.WriteChunkRequestProto writeChunk = request.getWriteChunk();
-      if (writeChunk.hasChunkData()
-          && deniesContainerAutoCreate(writeChunk.getChunkData().getMetadataList())) {
-        return false;
-      }
+    switch (request.getCmdType()) {
+    case PutBlock:
+      return isContainerAutoCreateAllowed(request.getPutBlock());
+    case WriteChunk:
+      return isContainerAutoCreateAllowed(request.getWriteChunk());
+    case PutSmallFile:
+      return isContainerAutoCreateAllowed(request.getPutSmallFile().getBlock());
+    default:
+      return true;
     }
-    if (request.hasPutBlock()) {
-      ContainerProtos.PutBlockRequestProto putBlock = request.getPutBlock();
-      if (putBlock.hasBlockData()
-          && deniesContainerAutoCreate(putBlock.getBlockData().getMetadataList())) {
-        return false;
-      }
-    }
-    if (request.hasPutSmallFile()) {
-      ContainerProtos.PutSmallFileRequestProto putSmallFile = request.getPutSmallFile();
-      if (putSmallFile.hasChunkInfo()
-          && deniesContainerAutoCreate(putSmallFile.getChunkInfo().getMetadataList())) {
-        return false;
-      }
-      if (putSmallFile.hasBlock() && putSmallFile.getBlock().hasBlockData()
-          && deniesContainerAutoCreate(putSmallFile.getBlock().getBlockData().getMetadataList())) {
-        return false;
-      }
-    }
-    return true;
   }
 
-  private static boolean deniesContainerAutoCreate(
-      List<ContainerProtos.KeyValue> metadataList) {
-    for (ContainerProtos.KeyValue kv : metadataList) {
-      if (CONTAINER_CREATABLE_KEY.equals(kv.getKey())
-          && OzoneConsts.CONTAINER_CREATABLE.equals(kv.getValue())) {
-        return true;
-      }
-    }
-    return false;
+  private static boolean isContainerAutoCreateAllowed(
+      ContainerProtos.PutBlockRequestProto putBlock) {
+    return !putBlock.hasContainerAutoCreate() || putBlock.getContainerAutoCreate();
+  }
+
+  private static boolean isContainerAutoCreateAllowed(
+      ContainerProtos.WriteChunkRequestProto writeChunk) {
+    return !writeChunk.hasContainerAutoCreate() || writeChunk.getContainerAutoCreate();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -441,6 +441,16 @@ public class ContainerSet implements Iterable<Container<?>> {
   }
 
   /**
+   * Reset the stale recovering scrub deadline for an active RECOVERING container.
+   */
+  public void updateRecoveringContainerTimeout(long containerId) {
+    Preconditions.checkState(containerId >= 0, "Container Id cannot be negative.");
+    removeRecoveringContainer(containerId);
+    recoveringContainerSet.add(
+        new RecoveringContainer(clock.millis() + recoveringTimeout, containerId));
+  }
+
+  /**
    * Return number of containers in container map.
    * @return container count
    */

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -74,8 +75,7 @@ public class ContainerSet implements Iterable<Container<?>> {
   private final ConcurrentSkipListSet<Long> missingContainerSet =
       new ConcurrentSkipListSet<>();
 
-  private final ConcurrentSkipListSet<RecoveringContainer> recoveringContainerSet =
-      new ConcurrentSkipListSet<>();
+  private final ConcurrentHashMap<Long, Long> recoveringContainerMap = new ConcurrentHashMap<>();
   private final Clock clock;
   private long recoveringTimeout;
   @Nullable
@@ -209,9 +209,7 @@ public class ContainerSet implements Iterable<Container<?>> {
       updateContainerIdTable(containerId, container.getContainerData());
       missingContainerSet.remove(containerId);
       if (container.getContainerData().getState() == RECOVERING) {
-        recoveringContainerSet.add(
-            new RecoveringContainer(clock.millis() + recoveringTimeout,
-                containerId));
+        recoveringContainerMap.put(containerId, getCurrentTime() + recoveringTimeout);
       }
       HddsVolume volume = container.getContainerData().getVolume();
       if (volume != null) {
@@ -422,22 +420,7 @@ public class ContainerSet implements Iterable<Container<?>> {
   public boolean removeRecoveringContainer(long containerId) {
     Preconditions.checkState(containerId >= 0,
         "Container Id cannot be negative.");
-    //it might take a little long time to iterate all the entries
-    // in recoveringContainerSet, but it seems ok here since:
-    // 1 In the vast majority of cases，there will not be too
-    // many recovering containers.
-    // 2 closing container is not a sort of urgent action
-    //
-    // we can revisit here if any performance problem happens
-    Iterator<RecoveringContainer> it = getRecoveringContainerIterator();
-    while (it.hasNext()) {
-      RecoveringContainer entry = it.next();
-      if (entry.getContainerId() == containerId) {
-        it.remove();
-        return true;
-      }
-    }
-    return false;
+    return recoveringContainerMap.remove(containerId) != null;
   }
 
   /**
@@ -445,9 +428,12 @@ public class ContainerSet implements Iterable<Container<?>> {
    */
   public void updateRecoveringContainerTimeout(long containerId) {
     Preconditions.checkState(containerId >= 0, "Container Id cannot be negative.");
-    removeRecoveringContainer(containerId);
-    recoveringContainerSet.add(
-        new RecoveringContainer(clock.millis() + recoveringTimeout, containerId));
+    recoveringContainerMap.put(containerId, getCurrentTime() + recoveringTimeout);
+  }
+
+  @VisibleForTesting
+  public Map<Long, Long> getRecoveringContainerMap() {
+    return recoveringContainerMap;
   }
 
   /**
@@ -497,15 +483,6 @@ public class ContainerSet implements Iterable<Container<?>> {
   @Override
   public Iterator<Container<?>> iterator() {
     return containerMap.values().iterator();
-  }
-
-  /**
-   * Return an container Iterator over
-   * {@link ContainerSet#recoveringContainerSet}.
-   * @return {@literal Iterator<RecoveringContainer>}
-   */
-  public Iterator<RecoveringContainer> getRecoveringContainerIterator() {
-    return recoveringContainerSet.iterator();
   }
 
   /**
@@ -678,53 +655,5 @@ public class ContainerSet implements Iterable<Container<?>> {
         }
       }
     });
-  }
-
-  /**
-   * A class that holds information about a recovering container.
-   */
-  public static class RecoveringContainer
-      implements Comparable<RecoveringContainer> {
-    private final long timeout;
-    private final long containerId;
-
-    public RecoveringContainer(long timeout, long containerId) {
-      this.timeout = timeout;
-      this.containerId = containerId;
-    }
-
-    public long getTimeout() {
-      return timeout;
-    }
-
-    public long getContainerId() {
-      return containerId;
-    }
-
-    @Override
-    public int compareTo(RecoveringContainer other) {
-      int timeoutCompare = Long.compare(this.timeout, other.timeout);
-      if (timeoutCompare != 0) {
-        return timeoutCompare;
-      }
-      return Long.compare(this.containerId, other.containerId);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      RecoveringContainer that = (RecoveringContainer) o;
-      return timeout == that.timeout && containerId == that.containerId;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(timeout, containerId);
-    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -298,6 +298,14 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
       if (container == null && ((isWriteStage || isCombinedStage)
           || cmdType == Type.PutSmallFile
           || cmdType == Type.PutBlock)) {
+
+        if (!ContainerUtils.isContainerCreatable(msg)) {
+          StorageContainerException sce = new StorageContainerException(
+              "ContainerID " + containerID + " does not exist",
+              ContainerProtos.Result.CONTAINER_NOT_FOUND);
+          audit(action, eventType, msg, dispatcherContext, AuditEventStatus.FAILURE, sce);
+          return ContainerUtils.logAndReturnError(LOG, sce, msg);
+        }
         // If container does not exist, create one for WriteChunk and
         // PutSmallFile request
         responseProto = createContainer(msg);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -231,7 +231,8 @@ public class ECReconstructionCoordinator implements Closeable {
         containerOperationClient.singleNodePipeline(datanodeDetails,
             repConfig, replicaIndex),
         BufferPool.empty(), ozoneClientConfig,
-        blockLocationInfo.getToken(), clientMetrics, streamBufferArgs, ecReconstructWriteExecutor);
+        blockLocationInfo.getToken(), clientMetrics, streamBufferArgs, ecReconstructWriteExecutor,
+        true);
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -232,7 +232,7 @@ public class ECReconstructionCoordinator implements Closeable {
             repConfig, replicaIndex),
         BufferPool.empty(), ozoneClientConfig,
         blockLocationInfo.getToken(), clientMetrics, streamBufferArgs, ecReconstructWriteExecutor,
-        true);
+        false);
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -697,6 +697,7 @@ public class KeyValueHandler extends Handler {
           request);
     }
 
+    updateRecoveringContainerTimeout(kvContainer);
     return putBlockResponseSuccess(request, blockDataProto);
   }
 
@@ -1105,16 +1106,15 @@ public class KeyValueHandler extends Handler {
           request);
     }
 
-    maybeUpdateRecoveringContainerTimeout(kvContainer);
+    updateRecoveringContainerTimeout(kvContainer);
     return getWriteChunkResponseSuccess(request, blockDataProto);
   }
 
-  private void maybeUpdateRecoveringContainerTimeout(KeyValueContainer kvContainer) {
+  private void updateRecoveringContainerTimeout(KeyValueContainer kvContainer) {
     if (kvContainer.getContainerState() != RECOVERING) {
       return;
     }
-    containerSet.updateRecoveringContainerTimeout(
-        kvContainer.getContainerData().getContainerID());
+    containerSet.updateRecoveringContainerTimeout(kvContainer.getContainerData().getContainerID());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1105,7 +1105,16 @@ public class KeyValueHandler extends Handler {
           request);
     }
 
+    maybeUpdateRecoveringContainerTimeout(kvContainer);
     return getWriteChunkResponseSuccess(request, blockDataProto);
+  }
+
+  private void maybeUpdateRecoveringContainerTimeout(KeyValueContainer kvContainer) {
+    if (kvContainer.getContainerState() != RECOVERING) {
+      return;
+    }
+    containerSet.updateRecoveringContainerTimeout(
+        kvContainer.getContainerData().getContainerID());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/StaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/StaleRecoveringContainerScrubbingService.java
@@ -18,13 +18,13 @@
 package org.apache.hadoop.ozone.container.keyvalue.statemachine.background;
 
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
-import org.apache.hadoop.ozone.container.common.impl.ContainerSet.RecoveringContainer;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,16 +55,15 @@ public class StaleRecoveringContainerScrubbingService
     BackgroundTaskQueue backgroundTaskQueue =
         new BackgroundTaskQueue();
     long currentTime = containerSet.getCurrentTime();
-    Iterator<RecoveringContainer> it =
-        containerSet.getRecoveringContainerIterator();
+    Iterator<Map.Entry<Long, Long>> it = containerSet.getRecoveringContainerMap().entrySet().iterator();
     while (it.hasNext()) {
-      RecoveringContainer entry = it.next();
-      if (currentTime >= entry.getTimeout()) {
+      Map.Entry<Long, Long> entry = it.next();
+      long containerId = entry.getKey();
+      long deadline = entry.getValue();
+      if (currentTime >= deadline) {
         backgroundTaskQueue.add(new RecoveringContainerScrubbingTask(
-            containerSet, entry.getContainerId()));
+            containerSet, containerId));
         it.remove();
-      } else {
-        break;
       }
     }
     return backgroundTaskQueue;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/StaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/StaleRecoveringContainerScrubbingService.java
@@ -81,6 +81,12 @@ public class StaleRecoveringContainerScrubbingService
 
     @Override
     public BackgroundTaskResult call() throws Exception {
+      Long deadline = containerSet.getRecoveringContainerMap().get(containerID);
+      if (deadline != null && containerSet.getCurrentTime() < deadline) {
+        LOG.debug("Skipping stale recovering scrub for container {} - deadline extended",
+            containerID);
+        return new BackgroundTaskResult.EmptyTaskResult();
+      }
       Container con = containerSet.getContainer(containerID);
       if (null != con) {
         con.markContainerUnhealthy();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -187,4 +187,26 @@ public class TestStaleRecoveringContainerScrubbingService {
               containerStateMap.get(entry.getContainerData().getContainerID()));
     }
   }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testUpdateRecoveringContainerTimeoutExtendsScrubDeadline(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    initVersionInfo(versionInfo);
+    ContainerSet containerSet = newContainerSet(1000, testClock);
+    StaleRecoveringContainerScrubbingService srcss =
+        new StaleRecoveringContainerScrubbingService(
+            50, TimeUnit.MILLISECONDS, 10,
+            Duration.ofSeconds(300).toMillis(),
+            containerSet);
+    List<Long> ids = createTestContainers(containerSet, 1, RECOVERING);
+    long containerId = ids.get(0);
+    testClock.fastForward(800L);
+    containerSet.updateRecoveringContainerTimeout(containerId);
+    testClock.fastForward(800L);
+    srcss.runPeriodicalTaskNow();
+    assertEquals(RECOVERING, containerSet.getContainer(containerId).getContainerState());
+    testClock.fastForward(500L);
+    srcss.runPeriodicalTaskNow();
+    assertEquals(UNHEALTHY, containerSet.getContainer(containerId).getContainerState());
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -22,6 +22,8 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Con
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerImplTestUtils.newContainerSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
@@ -47,6 +49,8 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.hdds.utils.BackgroundTask;
+import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
@@ -208,5 +212,29 @@ public class TestStaleRecoveringContainerScrubbingService {
     testClock.fastForward(500L);
     srcss.runPeriodicalTaskNow();
     assertEquals(UNHEALTHY, containerSet.getContainer(containerId).getContainerState());
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testScrubSkippedWhenDeadlineExtendedBeforeTaskRuns(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    initVersionInfo(versionInfo);
+    ContainerSet containerSet = newContainerSet(1000, testClock);
+    StaleRecoveringContainerScrubbingService srcss =
+        new StaleRecoveringContainerScrubbingService(
+            50, TimeUnit.MILLISECONDS, 10,
+            Duration.ofSeconds(300).toMillis(),
+            containerSet);
+    List<Long> ids = createTestContainers(containerSet, 1, RECOVERING);
+    long containerId = ids.get(0);
+    testClock.fastForward(1000L);
+    BackgroundTaskQueue tasks = srcss.getTasks();
+    assertFalse(containerSet.getRecoveringContainerMap().containsKey(containerId));
+    containerSet.updateRecoveringContainerTimeout(containerId);
+    while (!tasks.isEmpty()) {
+      BackgroundTask task = tasks.poll();
+      task.call();
+    }
+    assertEquals(RECOVERING, containerSet.getContainer(containerId).getContainerState());
+    assertTrue(containerSet.getRecoveringContainerMap().containsKey(containerId));
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
@@ -68,6 +69,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.security.token.TokenVerifier;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
@@ -729,6 +731,22 @@ public class TestHddsDispatcher {
         .build();
   }
 
+  private static ContainerCommandRequestProto withCreatableFalse(
+      ContainerCommandRequestProto writeChunk) {
+    WriteChunkRequestProto wc = writeChunk.getWriteChunk();
+    ContainerProtos.ChunkInfo chunk = ContainerProtos.ChunkInfo.newBuilder(wc.getChunkData())
+        .addMetadata(ContainerProtos.KeyValue.newBuilder()
+            .setKey(OzoneConsts.CONTAINER_CREATABLE)
+            .setValue(OzoneConsts.CONTAINER_CREATABLE_FALSE)
+            .build())
+        .build();
+    return ContainerCommandRequestProto.newBuilder(writeChunk)
+        .setWriteChunk(WriteChunkRequestProto.newBuilder(wc)
+            .setChunkData(chunk)
+            .build())
+        .build();
+  }
+
   static ChecksumData checksum(ByteString data) {
     try {
       return new Checksum(ContainerProtos.ChecksumType.CRC32, 256)
@@ -1005,6 +1023,24 @@ public class TestHddsDispatcher {
       volumeSet.shutdown();
       ContainerMetrics.remove();
     }
+  }
+
+  @Test
+  public void testEcReconstructionWriteChunkDeniedWhenContainerCreatableFalse()
+      throws IOException {
+    String testDirPath = testDir.getPath();
+    UUID scmId = UUID.randomUUID();
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_DATANODE_DIR_KEY, testDirPath);
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testDirPath);
+    DatanodeDetails dd = randomDatanodeDetails();
+    HddsDispatcher dispatcher = createDispatcher(dd, scmId, conf);
+    long containerId = 99L;
+
+    ContainerCommandResponseProto response = dispatcher.dispatch(
+        withCreatableFalse(getWriteChunkRequest(dd.getUuidString(), containerId, 1L)), null);
+    assertEquals(ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
+    assertNull(dispatcher.getContainer(containerId));
   }
 
   static DispatcherContext newContext(Op op) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -77,7 +77,6 @@ import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.checksum.ContainerChecksumTreeManager;
 import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
-import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
@@ -733,13 +732,9 @@ public class TestHddsDispatcher {
 
   private static ContainerCommandRequestProto withCreatableFalse(
       ContainerCommandRequestProto writeChunk) {
-    WriteChunkRequestProto wc = writeChunk.getWriteChunk();
-    ContainerProtos.ChunkInfo chunk = ContainerProtos.ChunkInfo.newBuilder(wc.getChunkData())
-        .addMetadata(ContainerUtils.containerCreatableFalseKv())
-        .build();
     return ContainerCommandRequestProto.newBuilder(writeChunk)
-        .setWriteChunk(WriteChunkRequestProto.newBuilder(wc)
-            .setChunkData(chunk)
+        .setWriteChunk(writeChunk.getWriteChunk().toBuilder()
+            .setContainerAutoCreate(false)
             .build())
         .build();
   }
@@ -765,13 +760,9 @@ public class TestHddsDispatcher {
 
   private static ContainerCommandRequestProto withCreatableFalsePutBlock(
       ContainerCommandRequestProto putBlock) {
-    ContainerProtos.PutBlockRequestProto pb = putBlock.getPutBlock();
-    ContainerProtos.BlockData blockData = ContainerProtos.BlockData.newBuilder(pb.getBlockData())
-        .addMetadata(ContainerUtils.containerCreatableFalseKv())
-        .build();
     return ContainerCommandRequestProto.newBuilder(putBlock)
-        .setPutBlock(ContainerProtos.PutBlockRequestProto.newBuilder(pb)
-            .setBlockData(blockData)
+        .setPutBlock(putBlock.getPutBlock().toBuilder()
+            .setContainerAutoCreate(false)
             .build())
         .build();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -69,7 +69,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.security.token.TokenVerifier;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
@@ -78,6 +77,7 @@ import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.checksum.ContainerChecksumTreeManager;
 import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
+import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
@@ -735,14 +735,43 @@ public class TestHddsDispatcher {
       ContainerCommandRequestProto writeChunk) {
     WriteChunkRequestProto wc = writeChunk.getWriteChunk();
     ContainerProtos.ChunkInfo chunk = ContainerProtos.ChunkInfo.newBuilder(wc.getChunkData())
-        .addMetadata(ContainerProtos.KeyValue.newBuilder()
-            .setKey(OzoneConsts.CONTAINER_CREATABLE)
-            .setValue(OzoneConsts.CONTAINER_CREATABLE_FALSE)
-            .build())
+        .addMetadata(ContainerUtils.containerCreatableFalseKv())
         .build();
     return ContainerCommandRequestProto.newBuilder(writeChunk)
         .setWriteChunk(WriteChunkRequestProto.newBuilder(wc)
             .setChunkData(chunk)
+            .build())
+        .build();
+  }
+
+  private static ContainerCommandRequestProto getEmptyPutBlockRequest(
+      String datanodeId, Long containerId, Long localId) {
+    BlockID blockID = new BlockID(containerId, localId);
+    ContainerProtos.BlockData blockData = ContainerProtos.BlockData.newBuilder()
+        .setBlockID(blockID.getDatanodeBlockIDProtobuf())
+        .build();
+    ContainerProtos.PutBlockRequestProto putBlockRequest =
+        ContainerProtos.PutBlockRequestProto.newBuilder()
+            .setBlockData(blockData)
+            .setEof(true)
+            .build();
+    return ContainerCommandRequestProto.newBuilder()
+        .setContainerID(containerId)
+        .setCmdType(ContainerProtos.Type.PutBlock)
+        .setDatanodeUuid(datanodeId)
+        .setPutBlock(putBlockRequest)
+        .build();
+  }
+
+  private static ContainerCommandRequestProto withCreatableFalsePutBlock(
+      ContainerCommandRequestProto putBlock) {
+    ContainerProtos.PutBlockRequestProto pb = putBlock.getPutBlock();
+    ContainerProtos.BlockData blockData = ContainerProtos.BlockData.newBuilder(pb.getBlockData())
+        .addMetadata(ContainerUtils.containerCreatableFalseKv())
+        .build();
+    return ContainerCommandRequestProto.newBuilder(putBlock)
+        .setPutBlock(ContainerProtos.PutBlockRequestProto.newBuilder(pb)
+            .setBlockData(blockData)
             .build())
         .build();
   }
@@ -1039,6 +1068,25 @@ public class TestHddsDispatcher {
 
     ContainerCommandResponseProto response = dispatcher.dispatch(
         withCreatableFalse(getWriteChunkRequest(dd.getUuidString(), containerId, 1L)), null);
+    assertEquals(ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
+    assertNull(dispatcher.getContainer(containerId));
+  }
+
+  @Test
+  public void testEcReconstructionPutBlockDeniedWhenContainerCreatableFalse()
+      throws IOException {
+    String testDirPath = testDir.getPath();
+    UUID scmId = UUID.randomUUID();
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_DATANODE_DIR_KEY, testDirPath);
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testDirPath);
+    DatanodeDetails dd = randomDatanodeDetails();
+    HddsDispatcher dispatcher = createDispatcher(dd, scmId, conf);
+    long containerId = 100L;
+
+    ContainerCommandResponseProto response = dispatcher.dispatch(
+        withCreatableFalsePutBlock(getEmptyPutBlockRequest(dd.getUuidString(), containerId, 1L)),
+        null);
     assertEquals(ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
     assertNull(dispatcher.getContainer(containerId));
   }

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -326,6 +326,7 @@ message BlockData {
 message PutBlockRequestProto {
   required BlockData blockData = 1;
   optional bool eof = 2;
+  optional bool containerAutoCreate = 3;
 }
 
 message PutBlockResponseProto {
@@ -441,6 +442,7 @@ message WriteChunkRequestProto  {
   optional ChunkInfo chunkData = 2;
   optional bytes data = 3;
   optional PutBlockRequestProto block = 4;
+  optional bool containerAutoCreate = 5;
 }
 
 message WriteChunkResponseProto {


### PR DESCRIPTION
## What changes were proposed in this pull request?
During EC offline reconstruction, the coordinator creates a RECOVERING replica on a spare DataNode and writes blocks over time. If reconstruction stalls (e.g. slow block-group processing) longer than `ozone.recovering.container.timeout` (~20m, measured from creation, not last write), the DN scrubber marks the replica UNHEALTHY and SCM force-deletes it.

The coordinator may still be running. The next `WriteChunk` finds no container; `HddsDispatcher` auto-creates a new OPEN container instead of failing. The coordinator continues and closes that replica shortly after, leaving a partial container (fewer blocks/chunks than the reference) that SCM can accept as CLOSED — silent data loss.

This PR fixes the issue my not allowing create container during `WriteChunk` for RECOVERING containers. Also update the recovering container timeout based on the last write to the container.

## What is the link to the Apache JIRA
[HDDS-15791](https://issues.apache.org/jira/browse/HDDS-15791)

## How was this patch tested?

Added Unit Tests
