### PR TITLE
HDDS-15692. Enable GitHub Copilot code review when a pull request is opened

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,6 +37,10 @@ github:
     squash_commit_message: PR_TITLE
     merge: false
     rebase: false
+  copilot_code_review:
+    enabled: true
+    review_drafts: true
+    review_on_push: true
   rulesets:
     - name: "Default Branch Protection"
       type: branch


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have a consensus to enable github copilot reviews for pull requests in Ozone.

https://lists.apache.org/thread/p9vcmdcdwmglf1k2165m5b4p3cf00wp0

Instructions: https://github.com/apache/infrastructure-asfyaml#copilot_code_review

Note: `review_drafts` is also set to `true` because we encourage contributors to submit as draft first to conserve upstream repo CI quota.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15692

## How was this patch tested?

- n/a