### PR TITLE
HDDS-15680. Cache per-block EC checksum pipeline within a file

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -18,10 +18,13 @@
 package org.apache.hadoop.ozone.client.checksum;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -48,7 +51,7 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
 
   // Blocks in the same EC placement group share identical node sets, so the
   // STANDALONE checksum pipeline is the same for every block. Cache it to
-  // avoid rebuilding it (node filtering, toBuilder, object allocation) per block.
+  // avoid rebuilding it (node filtering, UUID computation, object allocation) per block.
   private final Map<PipelineID, Pipeline> checksumPipelineCache = new HashMap<>();
 
   public ECFileChecksumHelper(OzoneVolume volume, OzoneBucket bucket,
@@ -98,19 +101,37 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
   // index 1 (which holds stripe checksums) and the parity nodes. Blocks in the
   // same placement group share the same node set, so this result is cached by
   // the caller and built at most once per placement group per file.
+  //
+  // The pipeline ID is derived deterministically from the sorted node UUIDs so
+  // that XceiverClientManager can reuse the same gRPC connection across files
+  // that land on the same EC placement group (cross-file reuse).
+  // Pipeline.newBuilder() is used instead of toBuilder() because toBuilder()
+  // copies the EC nodeStatus; the size mismatch when setNodes() is called
+  // triggers PipelineID.randomId() and defeats the deterministic ID.
   private Pipeline buildChecksumPipeline(Pipeline ecPipeline) {
     ECReplicationConfig repConfig = (ECReplicationConfig) ecPipeline.getReplicationConfig();
     List<DatanodeDetails> nodes = new ArrayList<>();
+    Map<DatanodeDetails, Integer> replicaIndexes = new HashMap<>();
     for (DatanodeDetails dn : ecPipeline.getNodes()) {
       int replicaIndex = ecPipeline.getReplicaIndex(dn);
       if (replicaIndex == 1 || replicaIndex > repConfig.getData()) {
         nodes.add(dn);
+        replicaIndexes.put(dn, replicaIndex);
       }
     }
-    return ecPipeline.toBuilder()
+    String nodeKey = nodes.stream()
+        .map(DatanodeDetails::getUuidString)
+        .sorted()
+        .collect(Collectors.joining(","));
+    PipelineID deterministicId = PipelineID.valueOf(
+        UUID.nameUUIDFromBytes(nodeKey.getBytes(StandardCharsets.UTF_8)));
+    return Pipeline.newBuilder()
+        .setId(deterministicId)
         .setReplicationConfig(StandaloneReplicationConfig
             .getInstance(HddsProtos.ReplicationFactor.THREE))
+        .setState(ecPipeline.getPipelineState())
         .setNodes(nodes)
+        .setReplicaIndexes(replicaIndexes)
         .build();
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -18,13 +18,10 @@
 package org.apache.hadoop.ozone.client.checksum;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -49,6 +46,11 @@ import org.apache.hadoop.security.token.Token;
  */
 public class ECFileChecksumHelper extends BaseFileChecksumHelper {
 
+  // Blocks in the same EC placement group share identical node sets, so the
+  // STANDALONE checksum pipeline is the same for every block. Cache it to
+  // avoid rebuilding it (node filtering, toBuilder, object allocation) per block.
+  private final Map<PipelineID, Pipeline> checksumPipelineCache = new HashMap<>();
+
   public ECFileChecksumHelper(OzoneVolume volume, OzoneBucket bucket,
       String keyName, long length, OzoneClientConfig.ChecksumCombineMode
       checksumCombineMode, ClientProtocol rpcClient, OmKeyInfo keyInfo)
@@ -64,54 +66,12 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
   }
 
   @Override
-  protected List<ContainerProtos.ChunkInfo> getChunkInfos(OmKeyLocationInfo
-                                                              keyLocationInfo) throws IOException {
-    // To read an EC block, we create a STANDALONE pipeline that contains the
-    // single location for the block index we want to read. The EC blocks are
-    // indexed from 1 to N, however the data locations are stored in the
-    // dataLocations array indexed from zero.
+  protected List<ContainerProtos.ChunkInfo> getChunkInfos(OmKeyLocationInfo keyLocationInfo) throws IOException {
     Token<OzoneBlockTokenIdentifier> token = keyLocationInfo.getToken();
     BlockID blockID = keyLocationInfo.getBlockID();
-
-    Pipeline pipeline = keyLocationInfo.getPipeline();
-
-    List<DatanodeDetails> nodes = new ArrayList<>();
-    Map<DatanodeDetails, Integer> selectedReplicaIndexes = new HashMap<>();
-    ECReplicationConfig repConfig = (ECReplicationConfig)
-        pipeline.getReplicationConfig();
-
-    for (DatanodeDetails dn : pipeline.getNodes()) {
-      int replicaIndex = pipeline.getReplicaIndex(dn);
-      if (replicaIndex == 1 || replicaIndex > repConfig.getData()) {
-        // The stripe checksum we need to calculate checksums is only stored on
-        // replica_index = 1 and all the parity nodes.
-        nodes.add(dn);
-        selectedReplicaIndexes.put(dn, replicaIndex);
-      }
-    }
-
-    // Build a deterministic pipeline ID from the sorted node UUIDs so that
-    // XceiverClientManager can cache and reuse the gRPC connection across files
-    // that share the same EC placement group (avoids a new connection per file).
-    String nodeKey = nodes.stream()
-        .map(DatanodeDetails::getUuidString)
-        .sorted()
-        .collect(Collectors.joining(","));
-    PipelineID deterministicId = PipelineID.valueOf(
-        UUID.nameUUIDFromBytes(nodeKey.getBytes(StandardCharsets.UTF_8)));
-
-    // Use Pipeline.newBuilder() (not toBuilder()) so that nodeStatus starts null.
-    // toBuilder() would copy the 5-node EC nodeStatus, causing setNodes(3 nodes)
-    // to detect the size mismatch and call PipelineID.randomId() -> SecureRandom
-    // even though setId(deterministicId) immediately overrides it.
-    pipeline = Pipeline.newBuilder()
-        .setId(deterministicId)
-        .setReplicationConfig(StandaloneReplicationConfig
-            .getInstance(HddsProtos.ReplicationFactor.THREE))
-        .setState(pipeline.getPipelineState())
-        .setNodes(nodes)
-        .setReplicaIndexes(selectedReplicaIndexes)
-        .build();
+    Pipeline ecPipeline = keyLocationInfo.getPipeline();
+    Pipeline checksumPipeline = checksumPipelineCache.computeIfAbsent(
+        ecPipeline.getId(), id -> buildChecksumPipeline(ecPipeline));
 
     List<ContainerProtos.ChunkInfo> chunks;
     XceiverClientSpi xceiverClientSpi = null;
@@ -120,18 +80,37 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
         LOG.debug("Initializing BlockInputStream for get key to access {}",
             blockID.getContainerID());
       }
-      xceiverClientSpi = getXceiverClientFactory().acquireClientForReadData(pipeline);
+      xceiverClientSpi = getXceiverClientFactory().acquireClientForReadData(checksumPipeline);
 
       ContainerProtos.GetBlockResponseProto response = ContainerProtocolCalls
-          .getBlock(xceiverClientSpi, blockID, token, pipeline.getReplicaIndexes());
+          .getBlock(xceiverClientSpi, blockID, token, checksumPipeline.getReplicaIndexes());
 
       chunks = response.getBlockData().getChunksList();
     } finally {
       if (xceiverClientSpi != null) {
-        getXceiverClientFactory().releaseClientForReadData(
-            xceiverClientSpi, false);
+        getXceiverClientFactory().releaseClientForReadData(xceiverClientSpi, false);
       }
     }
     return chunks;
+  }
+
+  // To read an EC block we need a STANDALONE pipeline containing only replica
+  // index 1 (which holds stripe checksums) and the parity nodes. Blocks in the
+  // same placement group share the same node set, so this result is cached by
+  // the caller and built at most once per placement group per file.
+  private Pipeline buildChecksumPipeline(Pipeline ecPipeline) {
+    ECReplicationConfig repConfig = (ECReplicationConfig) ecPipeline.getReplicationConfig();
+    List<DatanodeDetails> nodes = new ArrayList<>();
+    for (DatanodeDetails dn : ecPipeline.getNodes()) {
+      int replicaIndex = ecPipeline.getReplicaIndex(dn);
+      if (replicaIndex == 1 || replicaIndex > repConfig.getData()) {
+        nodes.add(dn);
+      }
+    }
+    return ecPipeline.toBuilder()
+        .setReplicationConfig(StandaloneReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE))
+        .setNodes(nodes)
+        .build();
   }
 }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
@@ -113,7 +113,7 @@ public class FileChecksumBenchmark {
   private static final int WARMUP_SECS = 10;
   private static final int MEASURE_SECS = 20;
   private static final int[] LATENCIES_MS = {0, 5, 10};
-  private static final int[] BLOCKS_PER_FILE_VARIANTS = {1, 2, 3, 5};
+  private static final int[] BLOCKS_PER_FILE_VARIANTS = {1, 3, 5, 10};
   private static final long CONTAINER_ID = 1001L;
   private static final long FILE_SIZE = 5000L;
   // 136 = 4 x 34: every 4th file (idx % 4 == 0) gets a freshly built OmKeyInfo

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -88,11 +89,13 @@ import org.junit.jupiter.api.Timeout;
  * Run with:
  *   mvn test -pl hadoop-ozone/client \
  *     -Dtest=FileChecksumBenchmark#runBenchmark \
- *     -Dsurefire.failIfNoSpecifiedTests=false
+ *     -Dsurefire.failIfNoSpecifiedTests=false \
+ *     -Dsurefire.fork.timeout=3600
  *
  *   mvn test -pl hadoop-ozone/client \
  *     -Dtest=FileChecksumBenchmark#runBlockCacheBenchmark \
- *     -Dsurefire.failIfNoSpecifiedTests=false
+ *     -Dsurefire.failIfNoSpecifiedTests=false \
+ *     -Dsurefire.fork.timeout=3600
  *
  * To profile with async-profiler, pass the agent via surefire argLine, e.g.:
  *   mvn test -pl hadoop-ozone/client \
@@ -108,11 +111,6 @@ public class FileChecksumBenchmark {
   private static final int WARMUP_SECS = 10;
   private static final int MEASURE_SECS = 20;
   private static final int[] LATENCIES_MS = {0, 5, 10};
-  // Block-cache benchmark: shorter warmup, same measurement window.
-  // Grid: 2 EC configs × 3 latencies × 4 block variants × (5+20)s ≈ 10 minutes.
-  private static final int BLOCK_WARMUP_SECS = 5;
-  private static final int BLOCK_MEASURE_SECS = 20;
-  private static final int[] DN_LATENCIES_MS = {0, 5, 10};
   private static final int[] BLOCKS_PER_FILE_VARIANTS = {1, 2, 3, 5};
   private static final long CONTAINER_ID = 1001L;
   private static final long FILE_SIZE = 5000L;
@@ -145,14 +143,9 @@ public class FileChecksumBenchmark {
   // ---------------------------------------------------------------------------
 
   static class CountingXceiverClientFactory implements XceiverClientFactory {
-    // For runBenchmark: cap just above the stable-pipeline count (102) so stable
-    // files hit the cache and unstable (random-UUID) files are GC'd immediately.
-    private static final int DEFAULT_MAX_POOL_SIZE = KEY_POOL - KEY_POOL / UNSTABLE_STEP + 10;
-    // For runBlockCacheBenchmark Scenario A: each file generates a fresh unique standalone
-    // pipeline. Pool must hold all unique entries from warmup + measurement so blocks 2..N
-    // can reuse the entry block 1 just added. At 0ms, peak throughput is ~35K files/s;
-    // 2M entries comfortably covers 5s warmup + 20s measurement across all block counts.
-    static final int BLOCK_CACHE_MAX_POOL_SIZE = 2_000_000;
+    // Large enough so the pool never fills during measurement: at 0ms, peak throughput
+    // is ~35K files/s; 2M entries comfortably covers warmup + measurement across all configs.
+    private static final int MAX_POOL_SIZE = 2_000_000;
     private final ContainerProtos.ContainerCommandResponseProto blockResponse;
     private final int dnConnectionLatencyMs;
     private final int maxPoolSize;
@@ -166,7 +159,7 @@ public class FileChecksumBenchmark {
 
     CountingXceiverClientFactory(
         ContainerProtos.ContainerCommandResponseProto blockResponse) {
-      this(blockResponse, 0, DEFAULT_MAX_POOL_SIZE);
+      this(blockResponse, 0, MAX_POOL_SIZE);
     }
 
     CountingXceiverClientFactory(ContainerProtos.ContainerCommandResponseProto blockResponse,
@@ -317,7 +310,7 @@ public class FileChecksumBenchmark {
         new CountingXceiverClientFactory(blockResponse);
     AtomicLong fileIdx = new AtomicLong();
 
-    OzoneManagerProtocol mockOm = mock(OzoneManagerProtocol.class);
+    OzoneManagerProtocol mockOm = mock(OzoneManagerProtocol.class, withSettings().stubOnly());
     when(mockOm.lookupKey(any(OmKeyArgs.class))).thenAnswer(invocation -> {
       omCallCount.incrementAndGet();
       if (latencyMs > 0) {
@@ -339,13 +332,13 @@ public class FileChecksumBenchmark {
       return keyPool[idx];
     });
 
-    RpcClient mockRpcClient = mock(RpcClient.class);
+    RpcClient mockRpcClient = mock(RpcClient.class, withSettings().stubOnly());
     when(mockRpcClient.getOzoneManagerClient()).thenReturn(mockOm);
     when(mockRpcClient.getXceiverClientManager()).thenReturn(xceiverFactory);
 
-    OzoneVolume mockVolume = mock(OzoneVolume.class);
+    OzoneVolume mockVolume = mock(OzoneVolume.class, withSettings().stubOnly());
     when(mockVolume.getName()).thenReturn("vol");
-    OzoneBucket mockBucket = mock(OzoneBucket.class);
+    OzoneBucket mockBucket = mock(OzoneBucket.class, withSettings().stubOnly());
     when(mockBucket.getName()).thenReturn("bucket");
 
     OzoneClientConfig.ChecksumCombineMode combineMode =
@@ -389,14 +382,10 @@ public class FileChecksumBenchmark {
   }
 
   /**
-   * Measures ECFileChecksumHelper throughput for multi-block files.
-   *
-   * @param freshEcConfig when non-null, each lookupKey call returns a freshly built OmKeyInfo
-   *     with a unique EC pipeline (unique node-0 UUID per call). Simulates Fix-3-only behavior
-   *     where the standalone pipeline ID is random per file → block 1 always misses the
-   *     XceiverClient pool. Pass null to use the pre-built {@code keyInfos} array instead.
-   * @param keyInfos pre-built OmKeyInfo pool for Scenario B (shared pipeline). Ignored when
-   *     {@code freshEcConfig} is non-null.
+   * @param freshEcConfig  when non-null, each lookupKey call generates a fresh OmKeyInfo with
+   *                       random node UUIDs (simulates Fix-3-only: unique pipeline per file,
+   *                       no cross-file reuse). When null, {@code keyInfos} is used instead.
+   * @param keyInfos       pre-built pool; used when {@code freshEcConfig} is null.
    */
   private static BenchmarkResult measureBlockCache(int blocksPerFile, int dnLatencyMs,
       ECReplicationConfig freshEcConfig, OmKeyInfo[] keyInfos,
@@ -404,33 +393,29 @@ public class FileChecksumBenchmark {
       throws Exception {
     AtomicLong omCallCount = new AtomicLong();
     CountingXceiverClientFactory xceiverFactory = new CountingXceiverClientFactory(
-        blockResponse, dnLatencyMs, CountingXceiverClientFactory.BLOCK_CACHE_MAX_POOL_SIZE);
+        blockResponse, dnLatencyMs, CountingXceiverClientFactory.MAX_POOL_SIZE);
     AtomicLong fileIdx = new AtomicLong();
-    AtomicLong fileSeq = new AtomicLong();
 
     long fileLength = (long) blocksPerFile * FILE_SIZE;
-    int nodeCount = freshEcConfig != null ? freshEcConfig.getData() + freshEcConfig.getParity() : 0;
 
-    OzoneManagerProtocol mockOm = mock(OzoneManagerProtocol.class);
+    OzoneManagerProtocol mockOm = mock(OzoneManagerProtocol.class, withSettings().stubOnly());
     when(mockOm.lookupKey(any(OmKeyArgs.class))).thenAnswer(invocation -> {
       omCallCount.incrementAndGet();
       OmKeyArgs args = invocation.getArgument(0);
-      if (keyInfos != null) {
-        int idx = Integer.parseInt(args.getKeyName().split("-")[1]);
-        return keyInfos[idx % KEY_POOL];
+      if (freshEcConfig != null) {
+        return buildRandomKeyInfoMultiBlock(args.getKeyName(), freshEcConfig, blocksPerFile);
       }
-      // Fresh mode: unique EC pipeline per call so block 1 always misses the XceiverClient pool.
-      return buildFreshOmKeyInfo(args.getKeyName(), fileSeq.getAndIncrement(),
-          blocksPerFile, fileLength, freshEcConfig, nodeCount);
+      int idx = Integer.parseInt(args.getKeyName().split("-")[1]);
+      return keyInfos[idx % KEY_POOL];
     });
 
-    RpcClient mockRpcClient = mock(RpcClient.class);
+    RpcClient mockRpcClient = mock(RpcClient.class, withSettings().stubOnly());
     when(mockRpcClient.getOzoneManagerClient()).thenReturn(mockOm);
     when(mockRpcClient.getXceiverClientManager()).thenReturn(xceiverFactory);
 
-    OzoneVolume mockVolume = mock(OzoneVolume.class);
+    OzoneVolume mockVolume = mock(OzoneVolume.class, withSettings().stubOnly());
     when(mockVolume.getName()).thenReturn("vol");
-    OzoneBucket mockBucket = mock(OzoneBucket.class);
+    OzoneBucket mockBucket = mock(OzoneBucket.class, withSettings().stubOnly());
     when(mockBucket.getName()).thenReturn("bucket");
 
     OzoneClientConfig.ChecksumCombineMode combineMode =
@@ -456,13 +441,13 @@ public class FileChecksumBenchmark {
       }
     };
 
-    runFor(BLOCK_WARMUP_SECS * 1000L, task);
+    runFor(WARMUP_SECS * 1000L, task);
     omCallCount.set(0);
     xceiverFactory.resetCounters();
     fileIdx.set(0);
 
     long start = System.currentTimeMillis();
-    long measuredFiles = runFor(BLOCK_MEASURE_SECS * 1000L, task);
+    long measuredFiles = runFor(MEASURE_SECS * 1000L, task);
     long wallMs = System.currentTimeMillis() - start;
 
     return new BenchmarkResult(measuredFiles, wallMs, omCallCount.get(),
@@ -529,22 +514,23 @@ public class FileChecksumBenchmark {
   /**
    * Compares two scenarios for multi-block EC file checksum collection:
    *
-   * Scenario A — Fix 3 only (per-file unique pipeline, no cross-file pool reuse):
-   *   Each file lands on a distinct EC placement group (unique node 0 UUID),
-   *   so buildChecksumPipeline produces a unique deterministic pipeline ID
-   *   per file. Block 1 of every file always opens a new DN connection
-   *   (pool miss), while blocks 2..N reuse the same connection within the file.
-   *   Expected: NewConn/file = 1.00 at any latency.
+   * Scenario A — Fix 3 only (intra-file reuse, no cross-file reuse):
+   *   Each file gets a unique EC pipeline with fresh random node UUIDs on every
+   *   lookupKey call. Fix 2 is active but the node UUIDs differ per file, so
+   *   the deterministic standalone pipeline ID is also unique per file → pool
+   *   miss on the first block of each file (DN latency paid once per file).
+   *   Fix 3 cache ensures blocks 2..N reuse block 1's standalone pipeline.
+   *   Expected: NewConn/file ≈ 1.00 at all latencies.
+   *   CacheHit% = (N-1)/N for N-block files (block 1 always misses, 2..N hit).
    *
-   * Scenario B — Fix 2+3 combined (shared pipeline, cross-file + intra-file reuse):
-   *   All files share the same EC placement group (same node UUIDs).
-   *   buildChecksumPipeline produces the same deterministic pipeline ID for
-   *   every file, so after the pool warms up during the warmup phase, every
-   *   subsequent connection (including block 1 of each file) is a pool hit.
-   *   Expected: NewConn/file ≈ 0.00 at any latency after warmup.
+   * Scenario B — Fix 2+3 combined (cross-file + intra-file reuse):
+   *   All files in the pool share the same EC pipeline. Fix 2 produces the
+   *   same deterministic standalone pipeline ID for every file → pool hit after
+   *   warmup (DN latency never paid after warmup). Fix 3 ensures blocks 2..N
+   *   skip buildChecksumPipeline entirely. Expected: NewConn/file ≈ 0.00.
    *
-   * The speedup of B over A equals the cost of one DN connection per file,
-   * which is especially significant at high latency (5ms, 10ms).
+   * Speedup at 5ms/10ms is driven by connection count: A pays 1 × latency per
+   * file; B pays 0 × latency.
    */
   @Test
   @Timeout(value = 2400, unit = TimeUnit.SECONDS)
@@ -552,7 +538,7 @@ public class FileChecksumBenchmark {
     System.out.println();
     System.out.println("=== ECFileChecksum Per-Block Pipeline Cache Benchmark ===");
     System.out.printf("Workload: %d threads, %ds warmup + %ds measurement%n%n",
-        NUM_THREADS, BLOCK_WARMUP_SECS, BLOCK_MEASURE_SECS);
+        NUM_THREADS, WARMUP_SECS, MEASURE_SECS);
 
     String[] ecLabels = {"RS-3-2", "RS-6-3"};
     ECReplicationConfig[] ecConfigs = {EC32, EC63};
@@ -567,8 +553,10 @@ public class FileChecksumBenchmark {
     for (int ecIdx = 0; ecIdx < ecLabels.length; ecIdx++) {
       System.out.printf("=== %s ===%n", ecLabels[ecIdx]);
 
-      for (int dnLatencyMs : DN_LATENCIES_MS) {
+      for (int dnLatencyMs : LATENCIES_MS) {
         System.out.printf("DN latency = %dms%n", dnLatencyMs);
+
+        Pipeline refPipeline = ecIdx == 0 ? EC_PIPELINE : EC63_PIPELINE;
 
         System.out.println("  [A] Fix 3 only: per-file unique pipeline (intra-file reuse, no cross-file reuse)");
         System.out.println("  " + hdr);
@@ -585,7 +573,7 @@ public class FileChecksumBenchmark {
         System.out.println("  " + rule);
         for (int blocksPerFile : BLOCKS_PER_FILE_VARIANTS) {
           OmKeyInfo[] sharedInfos = buildKeyInfosMultiBlock(
-              ecIdx == 0 ? EC_PIPELINE : EC63_PIPELINE, blocksPerFile, ecConfigs[ecIdx]);
+              refPipeline, blocksPerFile, ecConfigs[ecIdx]);
           BenchmarkResult r = measureBlockCache(blocksPerFile, dnLatencyMs,
               null, sharedInfos, blockResponses[ecIdx]);
           printBlockCacheRow(rowFmt, blocksPerFile, r);
@@ -705,53 +693,6 @@ public class FileChecksumBenchmark {
     return infos;
   }
 
-  /**
-   * Builds an OmKeyInfo with a fresh unique EC pipeline: node 0 gets UUID derived from
-   * {@code seq} (unique per call), all other nodes get stable UUIDs. This ensures
-   * buildChecksumPipeline produces a unique deterministic standalone pipeline ID per call,
-   * so block 1 of each file always misses the XceiverClient pool regardless of warmup.
-   * Used to simulate Fix-3-only behavior in the block-cache benchmark.
-   */
-  private static OmKeyInfo buildFreshOmKeyInfo(String keyName, long seq, int nBlocks,
-      long fileLength, ECReplicationConfig ecConfig, int nodeCount) {
-    List<DatanodeDetails> nodes = new ArrayList<>();
-    Map<DatanodeDetails, Integer> replicaIndexes = new HashMap<>();
-    for (int n = 0; n < nodeCount; n++) {
-      // Node 0 (replica index 1) gets a unique UUID per seq value.
-      // Use mostSigBits=1 so it never collides with stable parity-node UUIDs (mostSigBits=0).
-      UUID uuid = n == 0
-          ? new UUID(1L, seq)
-          : UUID.fromString("00000000-0000-0000-0000-00000000000" + n);
-      nodes.add(DatanodeDetails.newBuilder()
-          .setUuid(uuid).setHostName("dn" + n).setIpAddress("10.0.0." + n).build());
-      replicaIndexes.put(nodes.get(n), n + 1);
-    }
-    Pipeline ecPipeline = Pipeline.newBuilder()
-        .setId(PipelineID.randomId())
-        .setReplicationConfig(ecConfig)
-        .setState(Pipeline.PipelineState.CLOSED)
-        .setNodes(nodes)
-        .setReplicaIndexes(replicaIndexes)
-        .build();
-    List<OmKeyLocationInfo> locs = new ArrayList<>();
-    for (int b = 0; b < nBlocks; b++) {
-      locs.add(new OmKeyLocationInfo.Builder()
-          .setBlockID(new BlockID(CONTAINER_ID + b, (int) seq))
-          .setPipeline(ecPipeline)
-          .setLength(FILE_SIZE)
-          .build());
-    }
-    return new OmKeyInfo.Builder()
-        .setVolumeName("vol").setBucketName("bucket").setKeyName(keyName)
-        .setOmKeyLocationInfos(Collections.singletonList(
-            new OmKeyLocationInfoGroup(0, locs)))
-        .setCreationTime(0L).setModificationTime(0L)
-        .setDataSize(fileLength)
-        .setReplicationConfig(ecConfig)
-        .setFileChecksum(null).setAcls(Collections.emptyList())
-        .build();
-  }
-
   private static ContainerProtos.ContainerCommandResponseProto buildGetBlockResponse(
       int stripeChecksumBytes) {
     ByteString fourBytes = ByteString.copyFrom(new byte[4]);
@@ -798,13 +739,24 @@ public class FileChecksumBenchmark {
   }
 
   /**
-   * Builds an OmKeyInfo whose EC pipeline has freshly generated random node
-   * UUIDs. Called on every lookupKey invocation for unstable files so the
-   * deterministic pipeline ID computed by Fix 2 is also effectively random per
-   * call, guaranteeing a cache miss.
+   * Builds an OmKeyInfo whose EC pipeline has freshly generated random node UUIDs.
+   * Used by unstable files in {@link #measure} and by Scenario A in
+   * {@link #runBlockCacheBenchmark} so the deterministic pipeline ID computed
+   * by Fix 2 is also effectively random per call, guaranteeing a cache miss.
    */
   private static OmKeyInfo buildRandomKeyInfo(String keyName,
       ECReplicationConfig repConfig) {
+    return buildRandomKeyInfoMultiBlock(keyName, repConfig, 1);
+  }
+
+  /**
+   * Like {@link #buildRandomKeyInfo} but produces a file with {@code nBlocks} blocks,
+   * all backed by the same freshly-randomized EC pipeline. All N blocks share the same
+   * (unique-per-call) EC pipeline ID, so Fix 3's cache fires for blocks 2..N while
+   * Fix 2 still produces a unique standalone pipeline ID per file (random nodes).
+   */
+  private static OmKeyInfo buildRandomKeyInfoMultiBlock(String keyName,
+      ECReplicationConfig repConfig, int nBlocks) {
     int nodeCount = repConfig.getData() + repConfig.getParity();
     List<DatanodeDetails> nodes = new ArrayList<>();
     Map<DatanodeDetails, Integer> replicaIndexes = new HashMap<>();
@@ -824,21 +776,23 @@ public class FileChecksumBenchmark {
         .setNodes(nodes)
         .setReplicaIndexes(replicaIndexes)
         .build();
-    OmKeyLocationInfo loc = new OmKeyLocationInfo.Builder()
-        .setBlockID(new BlockID(CONTAINER_ID, 0))
-        .setPipeline(pipeline)
-        .setLength(FILE_SIZE)
-        .build();
+    List<OmKeyLocationInfo> locs = new ArrayList<>();
+    for (int b = 0; b < nBlocks; b++) {
+      locs.add(new OmKeyLocationInfo.Builder()
+          .setBlockID(new BlockID(CONTAINER_ID + b, 0))
+          .setPipeline(pipeline)
+          .setLength(FILE_SIZE)
+          .build());
+    }
     return new OmKeyInfo.Builder()
         .setVolumeName("vol")
         .setBucketName("bucket")
         .setKeyName(keyName)
         .setOmKeyLocationInfos(Collections.singletonList(
-            new OmKeyLocationInfoGroup(0,
-                Collections.singletonList(loc))))
+            new OmKeyLocationInfoGroup(0, locs)))
         .setCreationTime(0L)
         .setModificationTime(0L)
-        .setDataSize(FILE_SIZE)
+        .setDataSize((long) nBlocks * FILE_SIZE)
         .setReplicationConfig(repConfig)
         .setFileChecksum(null)
         .setAcls(Collections.emptyList())
@@ -847,7 +801,8 @@ public class FileChecksumBenchmark {
 
   private static XceiverClientSpi createMockDnClient(Pipeline standalonePipeline,
       ContainerProtos.ContainerCommandResponseProto response) throws IOException {
-    XceiverClientSpi mockDn = mock(XceiverClientSpi.class, CALLS_REAL_METHODS);
+    XceiverClientSpi mockDn = mock(XceiverClientSpi.class,
+        withSettings().stubOnly().defaultAnswer(CALLS_REAL_METHODS));
     XceiverClientReply reply = new XceiverClientReply(
         CompletableFuture.completedFuture(response));
     try {

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
@@ -511,36 +511,24 @@ public class FileChecksumBenchmark {
   }
 
   /**
-   * Compares Fix 1+2 (no intra-file cache) against Fix 1+2+3 (with intra-file cache)
-   * for multi-block EC file checksum collection. Both scenarios use the same 15-node
-   * cluster pool and the same random-placement file generation, so the only variable
-   * is whether Fix 3 (checksumPipelineCache per ECFileChecksumHelper instance) is active.
+   * Measures multi-block EC file checksum collection through the real
+   * ECFileChecksumHelper.compute() path. All N blocks of each file share one EC
+   * placement group (the case the checksumPipelineCache is designed for) and the
+   * files are drawn from a 15-node cluster with random placement, so the
+   * deterministic standalone pipeline ID keeps the XceiverClient pool warm
+   * (NewConn/file ≈ 0.00) regardless of the fix under test.
    *
-   * Scenario A — Fix 1+2 only (no intra-file pipeline cache):
-   *   Each file uses the same randomly-selected node subset, but every block in the
-   *   file carries a distinct EC pipeline ID (PipelineID.randomId() per block). The
-   *   checksumPipelineCache in ECFileChecksumHelper sees N distinct IDs → N
-   *   buildChecksumPipeline calls per file. Fix 2 is still active: each call derives
-   *   the same deterministic standalone pipeline ID from the sorted node UUIDs, so
-   *   the XceiverClient pool is reused across files after warmup.
-   *   Expected: NewConn/file ≈ 0.00, CacheHit% = 0% for all block counts.
-   *
-   * Scenario B — Fix 1+2+3 combined (intra-file + cross-file reuse):
-   *   All N blocks in each file share one EC pipeline ID. The checksumPipelineCache
-   *   fires for blocks 2..N → 1 buildChecksumPipeline call per file instead of N.
-   *   Fix 2 continues to give cross-file pool reuse.
-   *   Expected: NewConn/file ≈ 0.00, CacheHit% = (N-1)/N for N-block files.
-   *
-   * Throughput difference reflects the overhead of N vs 1 buildChecksumPipeline
-   * calls per file. At 0ms DN latency this overhead dominates; at higher latencies
-   * the DN sleep cost is amortized across connections and the Fix 3 gain is
-   * proportionally smaller.
+   * This is a single-arm benchmark: run it as-is for the "after" numbers, then
+   * run it again with the pre-Fix-3 ECFileChecksumHelper (which rebuilds the
+   * standalone pipeline for every block instead of caching it per placement
+   * group) for the "before" numbers. The throughput delta between the two runs
+   * is the real effect of Fix 3.
    */
   @Test
   @Timeout(value = 2400, unit = TimeUnit.SECONDS)
   public void runBlockCacheBenchmark() throws Exception {
     System.out.println();
-    System.out.println("=== ECFileChecksum Per-Block Pipeline Cache Benchmark ===");
+    System.out.println("=== ECFileChecksum Multi-Block Checksum Benchmark ===");
     System.out.printf("Workload: %d threads, %ds warmup + %ds measurement%n%n",
         NUM_THREADS, WARMUP_SECS, MEASURE_SECS);
 
@@ -561,26 +549,12 @@ public class FileChecksumBenchmark {
 
       for (int dnLatencyMs : LATENCIES_MS) {
         System.out.printf("DN latency = %dms%n", dnLatencyMs);
-
-        System.out.println("  [A] Fix 1+2 only (no intra-file cache): N buildChecksumPipeline calls/file");
         System.out.println("  " + hdr);
         System.out.println("  " + rule);
         for (int blocksPerFile : BLOCKS_PER_FILE_VARIANTS) {
           int bpf = blocksPerFile;
           BenchmarkResult r = measureBlockCache(blocksPerFile, dnLatencyMs,
-              () -> buildSharedClusterKeyInfoMultiBlock("file", EC15_NODES, ecConfig, bpf, false),
-              blockResponse);
-          printBlockCacheRow(rowFmt, blocksPerFile, r);
-        }
-
-        System.out.println();
-        System.out.println("  [B] Fix 1+2+3 (intra-file cache): 1 buildChecksumPipeline call/file");
-        System.out.println("  " + hdr);
-        System.out.println("  " + rule);
-        for (int blocksPerFile : BLOCKS_PER_FILE_VARIANTS) {
-          int bpf = blocksPerFile;
-          BenchmarkResult r = measureBlockCache(blocksPerFile, dnLatencyMs,
-              () -> buildSharedClusterKeyInfoMultiBlock("file", EC15_NODES, ecConfig, bpf, true),
+              () -> buildSharedClusterKeyInfoMultiBlock("file", EC15_NODES, ecConfig, bpf),
               blockResponse);
           printBlockCacheRow(rowFmt, blocksPerFile, r);
         }
@@ -778,19 +752,11 @@ public class FileChecksumBenchmark {
 
   /**
    * Builds an OmKeyInfo whose EC pipeline has nodes randomly selected from {@code clusterNodes}.
-   *
-   * @param sharedPipelineId  when {@code true} (Scenario B / Fix 1+2+3): all N blocks share one
-   *                          EC pipeline ID, so ECFileChecksumHelper's checksumPipelineCache fires
-   *                          for blocks 2..N → 1 buildChecksumPipeline call per file.
-   *                          When {@code false} (Scenario A / Fix 1+2 only): each block carries a
-   *                          distinct PipelineID.randomId() with the same node set → N cache misses
-   *                          → N buildChecksumPipeline calls per file. Fix 2 still produces the
-   *                          same deterministic standalone pipeline ID from sorted node UUIDs in
-   *                          both cases, so XceiverClient pool reuse is unaffected.
+   * All N blocks of the file share one EC pipeline (same placement group) — the realistic case
+   * that ECFileChecksumHelper's checksumPipelineCache is designed to exploit.
    */
   private static OmKeyInfo buildSharedClusterKeyInfoMultiBlock(String keyName,
-      List<DatanodeDetails> clusterNodes, ECReplicationConfig ecConfig, int nBlocks,
-      boolean sharedPipelineId) {
+      List<DatanodeDetails> clusterNodes, ECReplicationConfig ecConfig, int nBlocks) {
     int nodeCount = ecConfig.getData() + ecConfig.getParity();
     int clusterSize = clusterNodes.size();
     // O(nodeCount) selection without replacement using a small stack-allocated array
@@ -815,8 +781,7 @@ public class FileChecksumBenchmark {
     for (int i = 0; i < selected.size(); i++) {
       replicaIndexes.put(selected.get(i), i + 1);
     }
-    // Build the first (or shared) pipeline once.
-    Pipeline firstPipeline = Pipeline.newBuilder()
+    Pipeline sharedPipeline = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setReplicationConfig(ecConfig)
         .setState(Pipeline.PipelineState.CLOSED)
@@ -825,19 +790,9 @@ public class FileChecksumBenchmark {
         .build();
     List<OmKeyLocationInfo> locs = new ArrayList<>();
     for (int b = 0; b < nBlocks; b++) {
-      // sharedPipelineId=true: reuse firstPipeline for all blocks (Fix 3 fires for blocks 2..N).
-      // sharedPipelineId=false: unique pipeline ID per block, same nodes (Fix 3 always misses).
-      Pipeline blockPipeline = (b == 0 || sharedPipelineId) ? firstPipeline
-          : Pipeline.newBuilder()
-              .setId(PipelineID.randomId())
-              .setReplicationConfig(ecConfig)
-              .setState(Pipeline.PipelineState.CLOSED)
-              .setNodes(selected)
-              .setReplicaIndexes(replicaIndexes)
-              .build();
       locs.add(new OmKeyLocationInfo.Builder()
           .setBlockID(new BlockID(CONTAINER_ID + b, 0))
-          .setPipeline(blockPipeline)
+          .setPipeline(sharedPipeline)
           .setLength(FILE_SIZE)
           .build());
     }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
@@ -38,9 +38,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -138,13 +140,20 @@ public class FileChecksumBenchmark {
   private static final ContainerProtos.ContainerCommandResponseProto EC63_GET_BLOCK_RESPONSE =
       buildGetBlockResponse(16);
 
+  // 15-node cluster pool for runBlockCacheBenchmark. Both scenarios draw from this pool.
+  // RS-3-2 draws 5 from 15 → C(15,5)=3,003 distinct placement groups.
+  // RS-6-3 draws 9 from 15 → C(15,9)=5,005 distinct placement groups.
+  // Fix 2 ensures the same node subset maps to the same standalone pipeline ID,
+  // so the XceiverClient pool is fully warmed after warmup (≈ 0 new connections/file).
+  private static final List<DatanodeDetails> EC15_NODES = buildEcNodes(15);
+
   // ---------------------------------------------------------------------------
   // Instrumented XceiverClientFactory
   // ---------------------------------------------------------------------------
 
   static class CountingXceiverClientFactory implements XceiverClientFactory {
-    // Large enough so the pool never fills during measurement: at 0ms, peak throughput
-    // is ~35K files/s; 2M entries comfortably covers warmup + measurement across all configs.
+    // Both scenarios use the 15-node pool, so the pool converges to at most C(15,9)=5,005
+    // entries (all placement groups covered during warmup). 2M is a safe upper bound.
     private static final int MAX_POOL_SIZE = 2_000_000;
     private final ContainerProtos.ContainerCommandResponseProto blockResponse;
     private final int dnConnectionLatencyMs;
@@ -382,31 +391,23 @@ public class FileChecksumBenchmark {
   }
 
   /**
-   * @param freshEcConfig  when non-null, each lookupKey call generates a fresh OmKeyInfo with
-   *                       random node UUIDs (simulates Fix-3-only: unique pipeline per file,
-   *                       no cross-file reuse). When null, {@code keyInfos} is used instead.
-   * @param keyInfos       pre-built pool; used when {@code freshEcConfig} is null.
+   * @param keyInfoSupplier  called once per lookupKey invocation to produce a fresh OmKeyInfo;
+   *                         must be thread-safe (called concurrently by {@link #NUM_THREADS}).
    */
   private static BenchmarkResult measureBlockCache(int blocksPerFile, int dnLatencyMs,
-      ECReplicationConfig freshEcConfig, OmKeyInfo[] keyInfos,
+      Supplier<OmKeyInfo> keyInfoSupplier,
       ContainerProtos.ContainerCommandResponseProto blockResponse)
       throws Exception {
     AtomicLong omCallCount = new AtomicLong();
     CountingXceiverClientFactory xceiverFactory = new CountingXceiverClientFactory(
         blockResponse, dnLatencyMs, CountingXceiverClientFactory.MAX_POOL_SIZE);
-    AtomicLong fileIdx = new AtomicLong();
 
     long fileLength = (long) blocksPerFile * FILE_SIZE;
 
     OzoneManagerProtocol mockOm = mock(OzoneManagerProtocol.class, withSettings().stubOnly());
     when(mockOm.lookupKey(any(OmKeyArgs.class))).thenAnswer(invocation -> {
       omCallCount.incrementAndGet();
-      OmKeyArgs args = invocation.getArgument(0);
-      if (freshEcConfig != null) {
-        return buildRandomKeyInfoMultiBlock(args.getKeyName(), freshEcConfig, blocksPerFile);
-      }
-      int idx = Integer.parseInt(args.getKeyName().split("-")[1]);
-      return keyInfos[idx % KEY_POOL];
+      return keyInfoSupplier.get();
     });
 
     RpcClient mockRpcClient = mock(RpcClient.class, withSettings().stubOnly());
@@ -423,18 +424,17 @@ public class FileChecksumBenchmark {
 
     Runnable task = () -> {
       try {
-        int idx = (int) (fileIdx.getAndIncrement() % KEY_POOL);
-        String keyName = "file-" + idx;
         OmKeyInfo keyInfo = mockRpcClient.getOzoneManagerClient().lookupKey(
             new OmKeyArgs.Builder()
                 .setVolumeName("vol")
                 .setBucketName("bucket")
-                .setKeyName(keyName)
+                .setKeyName("file")
                 .setSortDatanodesInPipeline(true)
                 .setLatestVersionLocation(true)
                 .build());
         new ECFileChecksumHelper(
-            mockVolume, mockBucket, keyName, fileLength, combineMode, mockRpcClient, keyInfo)
+            mockVolume, mockBucket, keyInfo.getKeyName(), fileLength, combineMode,
+            mockRpcClient, keyInfo)
             .compute();
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -444,7 +444,6 @@ public class FileChecksumBenchmark {
     runFor(WARMUP_SECS * 1000L, task);
     omCallCount.set(0);
     xceiverFactory.resetCounters();
-    fileIdx.set(0);
 
     long start = System.currentTimeMillis();
     long measuredFiles = runFor(MEASURE_SECS * 1000L, task);
@@ -512,25 +511,30 @@ public class FileChecksumBenchmark {
   }
 
   /**
-   * Compares two scenarios for multi-block EC file checksum collection:
+   * Compares Fix 1+2 (no intra-file cache) against Fix 1+2+3 (with intra-file cache)
+   * for multi-block EC file checksum collection. Both scenarios use the same 15-node
+   * cluster pool and the same random-placement file generation, so the only variable
+   * is whether Fix 3 (checksumPipelineCache per ECFileChecksumHelper instance) is active.
    *
-   * Scenario A — Fix 3 only (intra-file reuse, no cross-file reuse):
-   *   Each file gets a unique EC pipeline with fresh random node UUIDs on every
-   *   lookupKey call. Fix 2 is active but the node UUIDs differ per file, so
-   *   the deterministic standalone pipeline ID is also unique per file → pool
-   *   miss on the first block of each file (DN latency paid once per file).
-   *   Fix 3 cache ensures blocks 2..N reuse block 1's standalone pipeline.
-   *   Expected: NewConn/file ≈ 1.00 at all latencies.
-   *   CacheHit% = (N-1)/N for N-block files (block 1 always misses, 2..N hit).
+   * Scenario A — Fix 1+2 only (no intra-file pipeline cache):
+   *   Each file uses the same randomly-selected node subset, but every block in the
+   *   file carries a distinct EC pipeline ID (PipelineID.randomId() per block). The
+   *   checksumPipelineCache in ECFileChecksumHelper sees N distinct IDs → N
+   *   buildChecksumPipeline calls per file. Fix 2 is still active: each call derives
+   *   the same deterministic standalone pipeline ID from the sorted node UUIDs, so
+   *   the XceiverClient pool is reused across files after warmup.
+   *   Expected: NewConn/file ≈ 0.00, CacheHit% = 0% for all block counts.
    *
-   * Scenario B — Fix 2+3 combined (cross-file + intra-file reuse):
-   *   All files in the pool share the same EC pipeline. Fix 2 produces the
-   *   same deterministic standalone pipeline ID for every file → pool hit after
-   *   warmup (DN latency never paid after warmup). Fix 3 ensures blocks 2..N
-   *   skip buildChecksumPipeline entirely. Expected: NewConn/file ≈ 0.00.
+   * Scenario B — Fix 1+2+3 combined (intra-file + cross-file reuse):
+   *   All N blocks in each file share one EC pipeline ID. The checksumPipelineCache
+   *   fires for blocks 2..N → 1 buildChecksumPipeline call per file instead of N.
+   *   Fix 2 continues to give cross-file pool reuse.
+   *   Expected: NewConn/file ≈ 0.00, CacheHit% = (N-1)/N for N-block files.
    *
-   * Speedup at 5ms/10ms is driven by connection count: A pays 1 × latency per
-   * file; B pays 0 × latency.
+   * Throughput difference reflects the overhead of N vs 1 buildChecksumPipeline
+   * calls per file. At 0ms DN latency this overhead dominates; at higher latencies
+   * the DN sleep cost is amortized across connections and the Fix 3 gain is
+   * proportionally smaller.
    */
   @Test
   @Timeout(value = 2400, unit = TimeUnit.SECONDS)
@@ -552,30 +556,32 @@ public class FileChecksumBenchmark {
 
     for (int ecIdx = 0; ecIdx < ecLabels.length; ecIdx++) {
       System.out.printf("=== %s ===%n", ecLabels[ecIdx]);
+      ECReplicationConfig ecConfig = ecConfigs[ecIdx];
+      ContainerProtos.ContainerCommandResponseProto blockResponse = blockResponses[ecIdx];
 
       for (int dnLatencyMs : LATENCIES_MS) {
         System.out.printf("DN latency = %dms%n", dnLatencyMs);
 
-        Pipeline refPipeline = ecIdx == 0 ? EC_PIPELINE : EC63_PIPELINE;
-
-        System.out.println("  [A] Fix 3 only: per-file unique pipeline (intra-file reuse, no cross-file reuse)");
+        System.out.println("  [A] Fix 1+2 only (no intra-file cache): N buildChecksumPipeline calls/file");
         System.out.println("  " + hdr);
         System.out.println("  " + rule);
         for (int blocksPerFile : BLOCKS_PER_FILE_VARIANTS) {
+          int bpf = blocksPerFile;
           BenchmarkResult r = measureBlockCache(blocksPerFile, dnLatencyMs,
-              ecConfigs[ecIdx], null, blockResponses[ecIdx]);
+              () -> buildSharedClusterKeyInfoMultiBlock("file", EC15_NODES, ecConfig, bpf, false),
+              blockResponse);
           printBlockCacheRow(rowFmt, blocksPerFile, r);
         }
 
         System.out.println();
-        System.out.println("  [B] Fix 2+3: shared pipeline (intra-file + cross-file reuse)");
+        System.out.println("  [B] Fix 1+2+3 (intra-file cache): 1 buildChecksumPipeline call/file");
         System.out.println("  " + hdr);
         System.out.println("  " + rule);
         for (int blocksPerFile : BLOCKS_PER_FILE_VARIANTS) {
-          OmKeyInfo[] sharedInfos = buildKeyInfosMultiBlock(
-              refPipeline, blocksPerFile, ecConfigs[ecIdx]);
+          int bpf = blocksPerFile;
           BenchmarkResult r = measureBlockCache(blocksPerFile, dnLatencyMs,
-              null, sharedInfos, blockResponses[ecIdx]);
+              () -> buildSharedClusterKeyInfoMultiBlock("file", EC15_NODES, ecConfig, bpf, true),
+              blockResponse);
           printBlockCacheRow(rowFmt, blocksPerFile, r);
         }
         System.out.println();
@@ -614,7 +620,7 @@ public class FileChecksumBenchmark {
     List<DatanodeDetails> nodes = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       nodes.add(DatanodeDetails.newBuilder()
-          .setUuid(UUID.fromString("00000000-0000-0000-0000-00000000000" + i))
+          .setUuid(UUID.fromString(String.format("00000000-0000-0000-0000-%012d", i)))
           .setHostName("dn" + i)
           .setIpAddress("10.0.0." + i)
           .build());
@@ -657,35 +663,6 @@ public class FileChecksumBenchmark {
           .setModificationTime(0L)
           .setDataSize(FILE_SIZE)
           .setReplicationConfig(repConfig)
-          .setFileChecksum(null)
-          .setAcls(Collections.emptyList())
-          .build();
-    }
-    return infos;
-  }
-
-  private static OmKeyInfo[] buildKeyInfosMultiBlock(Pipeline ecPipeline, int nBlocks,
-      ECReplicationConfig ecConfig) {
-    OmKeyInfo[] infos = new OmKeyInfo[KEY_POOL];
-    for (int i = 0; i < KEY_POOL; i++) {
-      List<OmKeyLocationInfo> locs = new ArrayList<>();
-      for (int b = 0; b < nBlocks; b++) {
-        locs.add(new OmKeyLocationInfo.Builder()
-            .setBlockID(new BlockID(CONTAINER_ID + b, i))
-            .setPipeline(ecPipeline)
-            .setLength(FILE_SIZE)
-            .build());
-      }
-      infos[i] = new OmKeyInfo.Builder()
-          .setVolumeName("vol")
-          .setBucketName("bucket")
-          .setKeyName("file-" + i)
-          .setOmKeyLocationInfos(Collections.singletonList(
-              new OmKeyLocationInfoGroup(0, locs)))
-          .setCreationTime(0L)
-          .setModificationTime(0L)
-          .setDataSize((long) nBlocks * FILE_SIZE)
-          .setReplicationConfig(ecConfig)
           .setFileChecksum(null)
           .setAcls(Collections.emptyList())
           .build();
@@ -794,6 +771,86 @@ public class FileChecksumBenchmark {
         .setModificationTime(0L)
         .setDataSize((long) nBlocks * FILE_SIZE)
         .setReplicationConfig(repConfig)
+        .setFileChecksum(null)
+        .setAcls(Collections.emptyList())
+        .build();
+  }
+
+  /**
+   * Builds an OmKeyInfo whose EC pipeline has nodes randomly selected from {@code clusterNodes}.
+   *
+   * @param sharedPipelineId  when {@code true} (Scenario B / Fix 1+2+3): all N blocks share one
+   *                          EC pipeline ID, so ECFileChecksumHelper's checksumPipelineCache fires
+   *                          for blocks 2..N → 1 buildChecksumPipeline call per file.
+   *                          When {@code false} (Scenario A / Fix 1+2 only): each block carries a
+   *                          distinct PipelineID.randomId() with the same node set → N cache misses
+   *                          → N buildChecksumPipeline calls per file. Fix 2 still produces the
+   *                          same deterministic standalone pipeline ID from sorted node UUIDs in
+   *                          both cases, so XceiverClient pool reuse is unaffected.
+   */
+  private static OmKeyInfo buildSharedClusterKeyInfoMultiBlock(String keyName,
+      List<DatanodeDetails> clusterNodes, ECReplicationConfig ecConfig, int nBlocks,
+      boolean sharedPipelineId) {
+    int nodeCount = ecConfig.getData() + ecConfig.getParity();
+    int clusterSize = clusterNodes.size();
+    // O(nodeCount) selection without replacement using a small stack-allocated array
+    // to track already-picked indices. For nodeCount <= 9 the inner scan is O(1).
+    int[] picked = new int[nodeCount];
+    List<DatanodeDetails> selected = new ArrayList<>(nodeCount);
+    while (selected.size() < nodeCount) {
+      int idx = ThreadLocalRandom.current().nextInt(clusterSize);
+      boolean duplicate = false;
+      for (int p = 0; p < selected.size(); p++) {
+        if (picked[p] == idx) {
+          duplicate = true;
+          break;
+        }
+      }
+      if (!duplicate) {
+        picked[selected.size()] = idx;
+        selected.add(clusterNodes.get(idx));
+      }
+    }
+    Map<DatanodeDetails, Integer> replicaIndexes = new HashMap<>();
+    for (int i = 0; i < selected.size(); i++) {
+      replicaIndexes.put(selected.get(i), i + 1);
+    }
+    // Build the first (or shared) pipeline once.
+    Pipeline firstPipeline = Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setReplicationConfig(ecConfig)
+        .setState(Pipeline.PipelineState.CLOSED)
+        .setNodes(selected)
+        .setReplicaIndexes(replicaIndexes)
+        .build();
+    List<OmKeyLocationInfo> locs = new ArrayList<>();
+    for (int b = 0; b < nBlocks; b++) {
+      // sharedPipelineId=true: reuse firstPipeline for all blocks (Fix 3 fires for blocks 2..N).
+      // sharedPipelineId=false: unique pipeline ID per block, same nodes (Fix 3 always misses).
+      Pipeline blockPipeline = (b == 0 || sharedPipelineId) ? firstPipeline
+          : Pipeline.newBuilder()
+              .setId(PipelineID.randomId())
+              .setReplicationConfig(ecConfig)
+              .setState(Pipeline.PipelineState.CLOSED)
+              .setNodes(selected)
+              .setReplicaIndexes(replicaIndexes)
+              .build();
+      locs.add(new OmKeyLocationInfo.Builder()
+          .setBlockID(new BlockID(CONTAINER_ID + b, 0))
+          .setPipeline(blockPipeline)
+          .setLength(FILE_SIZE)
+          .build());
+    }
+    return new OmKeyInfo.Builder()
+        .setVolumeName("vol")
+        .setBucketName("bucket")
+        .setKeyName(keyName)
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, locs)))
+        .setCreationTime(0L)
+        .setModificationTime(0L)
+        .setDataSize((long) nBlocks * FILE_SIZE)
+        .setReplicationConfig(ecConfig)
         .setFileChecksum(null)
         .setAcls(Collections.emptyList())
         .build();

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -60,6 +61,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Benchmark for ECFileChecksumHelper that measures the actual checksum
@@ -69,24 +71,27 @@ import org.junit.jupiter.api.Test;
  * Validates fixes to BaseFileChecksumHelper and ECFileChecksumHelper:
  *   Fix 1: BaseFileChecksumHelper 7-arg constructor no longer chains to 6-arg
  *           (redundant OM lookupKey RPC eliminated: 2 calls/file -> 1).
- *   Fix 2: ECFileChecksumHelper uses a deterministic pipeline ID so
- *           XceiverClientManager can cache and reuse gRPC connections
- *           (new connection per file -> one connection per placement group).
- *   Fix 3: Pipeline.newBuilder() instead of toBuilder() avoids an unnecessary
- *           SecureRandom.nextBytes call on every file.
+ *           Measured by runBenchmark.
+ *   Fix 3: ECFileChecksumHelper caches the STANDALONE checksum pipeline per
+ *           EC placement group; blocks 2..N within a file reuse the same
+ *           XceiverClient connection (new connections/file drops from N to 1).
+ *           Measured by runBlockCacheBenchmark.
  *
  * Covers RS-3-2 (5 nodes, 3 data + 2 parity) and RS-6-3 (9 nodes, 6 data + 3 parity).
  * For RS-3-2 the standalone pipeline has 3 selected nodes (index=1 + parity {4,5}),
  * stripe checksum = 12 bytes. For RS-6-3: 4 selected nodes (index=1 + parity {7,8,9}),
  * stripe checksum = 16 bytes.
  *
- * Each latency bucket runs a 10-second warmup followed by a 20-second
- * measurement window. Throughput and per-file RPC counts are reported from
- * the measurement window only.
+ * Each latency bucket runs a warmup followed by a 20-second measurement window.
+ * Throughput and per-file RPC counts are reported from the measurement window only.
  *
  * Run with:
  *   mvn test -pl hadoop-ozone/client \
  *     -Dtest=FileChecksumBenchmark#runBenchmark \
+ *     -Dsurefire.failIfNoSpecifiedTests=false
+ *
+ *   mvn test -pl hadoop-ozone/client \
+ *     -Dtest=FileChecksumBenchmark#runBlockCacheBenchmark \
  *     -Dsurefire.failIfNoSpecifiedTests=false
  *
  * To profile with async-profiler, pass the agent via surefire argLine, e.g.:
@@ -103,6 +108,12 @@ public class FileChecksumBenchmark {
   private static final int WARMUP_SECS = 10;
   private static final int MEASURE_SECS = 20;
   private static final int[] LATENCIES_MS = {0, 5, 10};
+  // Block-cache benchmark: shorter warmup, same measurement window.
+  // Grid: 2 EC configs × 3 latencies × 4 block variants × (5+20)s ≈ 10 minutes.
+  private static final int BLOCK_WARMUP_SECS = 5;
+  private static final int BLOCK_MEASURE_SECS = 20;
+  private static final int[] DN_LATENCIES_MS = {0, 5, 10};
+  private static final int[] BLOCKS_PER_FILE_VARIANTS = {1, 2, 3, 5};
   private static final long CONTAINER_ID = 1001L;
   private static final long FILE_SIZE = 5000L;
   // 136 = 4 x 34: every 4th file (idx % 4 == 0) gets a freshly built OmKeyInfo
@@ -134,11 +145,15 @@ public class FileChecksumBenchmark {
   // ---------------------------------------------------------------------------
 
   static class CountingXceiverClientFactory implements XceiverClientFactory {
-    // Stable pipeline IDs = KEY_POOL - KEY_POOL/UNSTABLE_STEP = 102.
-    // Cap the pool just above that so stable files always hit the cache while
-    // unstable files (random pipeline IDs) are never stored and are GC'd immediately.
-    private static final int MAX_POOL_SIZE = KEY_POOL - KEY_POOL / UNSTABLE_STEP + 10;
+    // For runBenchmark: cap just above the stable-pipeline count (102) so stable
+    // files hit the cache and unstable (random-UUID) files are GC'd immediately.
+    private static final int DEFAULT_MAX_POOL_SIZE = KEY_POOL - KEY_POOL / UNSTABLE_STEP + 10;
+    // For runBlockCacheBenchmark: Fix 3 assigns one random standalone pipeline per
+    // file; pool must accommodate all files in the measurement window (~14K at 5ms).
+    static final int BLOCK_CACHE_MAX_POOL_SIZE = 100_000;
     private final ContainerProtos.ContainerCommandResponseProto blockResponse;
+    private final int dnConnectionLatencyMs;
+    private final int maxPoolSize;
     private final AtomicLong newConnectionCount = new AtomicLong();
     private final AtomicLong reuseCount = new AtomicLong();
     // clientPool is intentionally NOT cleared between warmup and measurement:
@@ -149,7 +164,14 @@ public class FileChecksumBenchmark {
 
     CountingXceiverClientFactory(
         ContainerProtos.ContainerCommandResponseProto blockResponse) {
+      this(blockResponse, 0, DEFAULT_MAX_POOL_SIZE);
+    }
+
+    CountingXceiverClientFactory(ContainerProtos.ContainerCommandResponseProto blockResponse,
+        int dnConnectionLatencyMs, int maxPoolSize) {
       this.blockResponse = blockResponse;
+      this.dnConnectionLatencyMs = dnConnectionLatencyMs;
+      this.maxPoolSize = maxPoolSize;
     }
 
     void resetCounters() {
@@ -174,8 +196,16 @@ public class FileChecksumBenchmark {
         reuseCount.incrementAndGet();
         return existing;
       }
+      if (dnConnectionLatencyMs > 0) {
+        try {
+          Thread.sleep(dnConnectionLatencyMs);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw new IOException(ie);
+        }
+      }
       XceiverClientSpi newClient = createMockDnClient(pipeline, blockResponse);
-      if (clientPool.size() < MAX_POOL_SIZE) {
+      if (clientPool.size() < maxPoolSize) {
         XceiverClientSpi winner = clientPool.putIfAbsent(key, newClient);
         if (winner != null) {
           reuseCount.incrementAndGet();
@@ -356,6 +386,70 @@ public class FileChecksumBenchmark {
         latencyMs);
   }
 
+  private static BenchmarkResult measureBlockCache(int blocksPerFile, int dnLatencyMs,
+      Pipeline ecPipeline, ECReplicationConfig ecConfig,
+      ContainerProtos.ContainerCommandResponseProto blockResponse) throws Exception {
+    AtomicLong omCallCount = new AtomicLong();
+    CountingXceiverClientFactory xceiverFactory = new CountingXceiverClientFactory(
+        blockResponse, dnLatencyMs, CountingXceiverClientFactory.BLOCK_CACHE_MAX_POOL_SIZE);
+    AtomicLong fileIdx = new AtomicLong();
+
+    OmKeyInfo[] keyInfos = buildKeyInfosMultiBlock(ecPipeline, blocksPerFile, ecConfig);
+    long fileLength = (long) blocksPerFile * FILE_SIZE;
+
+    OzoneManagerProtocol mockOm = mock(OzoneManagerProtocol.class);
+    when(mockOm.lookupKey(any(OmKeyArgs.class))).thenAnswer(invocation -> {
+      omCallCount.incrementAndGet();
+      OmKeyArgs args = invocation.getArgument(0);
+      int idx = Integer.parseInt(args.getKeyName().split("-")[1]);
+      return keyInfos[idx % KEY_POOL];
+    });
+
+    RpcClient mockRpcClient = mock(RpcClient.class);
+    when(mockRpcClient.getOzoneManagerClient()).thenReturn(mockOm);
+    when(mockRpcClient.getXceiverClientManager()).thenReturn(xceiverFactory);
+
+    OzoneVolume mockVolume = mock(OzoneVolume.class);
+    when(mockVolume.getName()).thenReturn("vol");
+    OzoneBucket mockBucket = mock(OzoneBucket.class);
+    when(mockBucket.getName()).thenReturn("bucket");
+
+    OzoneClientConfig.ChecksumCombineMode combineMode =
+        OzoneClientConfig.ChecksumCombineMode.COMPOSITE_CRC;
+
+    Runnable task = () -> {
+      try {
+        int idx = (int) (fileIdx.getAndIncrement() % KEY_POOL);
+        String keyName = "file-" + idx;
+        OmKeyInfo keyInfo = mockRpcClient.getOzoneManagerClient().lookupKey(
+            new OmKeyArgs.Builder()
+                .setVolumeName("vol")
+                .setBucketName("bucket")
+                .setKeyName(keyName)
+                .setSortDatanodesInPipeline(true)
+                .setLatestVersionLocation(true)
+                .build());
+        new ECFileChecksumHelper(
+            mockVolume, mockBucket, keyName, fileLength, combineMode, mockRpcClient, keyInfo)
+            .compute();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    runFor(BLOCK_WARMUP_SECS * 1000L, task);
+    omCallCount.set(0);
+    xceiverFactory.resetCounters();
+    fileIdx.set(0);
+
+    long start = System.currentTimeMillis();
+    long measuredFiles = runFor(BLOCK_MEASURE_SECS * 1000L, task);
+    long wallMs = System.currentTimeMillis() - start;
+
+    return new BenchmarkResult(measuredFiles, wallMs, omCallCount.get(),
+        xceiverFactory.getNewConnectionCount(), xceiverFactory.getReuseCount(), dnLatencyMs);
+  }
+
   private static long runFor(long durationMs, Runnable task) throws Exception {
     AtomicBoolean running = new AtomicBoolean(true);
     AtomicLong count = new AtomicLong();
@@ -411,6 +505,61 @@ public class FileChecksumBenchmark {
       printRow(measure(latencyMs, EC63, EC63_KEY_INFOS, EC63_GET_BLOCK_RESPONSE));
     }
 
+  }
+
+  /**
+   * Measures Fix 3 (HDDS-15647): per-block pipeline caching in ECFileChecksumHelper.
+   *
+   * With fix: checksumPipelineCache returns the same Pipeline for all blocks in
+   * a file; acquireClientForReadData hits the pool for blocks 2..N
+   * (newConnections/file = 1 regardless of how many blocks).
+   *
+   * Without fix: buildChecksumPipeline called per block; toBuilder() with a
+   * different node count triggers PipelineID.randomId() → unique pipeline ID
+   * per block → pool miss per block (newConnections/file = blocksPerFile).
+   *
+   * dnConnectionLatencyMs simulates gRPC handshake cost. Reused connections
+   * skip the delay, so the speedup grows with latency and blocks/file.
+   */
+  @Test
+  @Timeout(value = 1200, unit = TimeUnit.SECONDS)
+  public void runBlockCacheBenchmark() throws Exception {
+    System.out.println();
+    System.out.println("=== ECFileChecksum Per-Block Pipeline Cache Benchmark ===");
+    System.out.printf("Workload: %d threads, %ds warmup + %ds measurement%n%n",
+        NUM_THREADS, BLOCK_WARMUP_SECS, BLOCK_MEASURE_SECS);
+
+    String[] ecLabels = {"RS-3-2", "RS-6-3"};
+    Pipeline[] ecPipelines = {EC_PIPELINE, EC63_PIPELINE};
+    ECReplicationConfig[] ecConfigs = {EC32, EC63};
+    ContainerProtos.ContainerCommandResponseProto[] blockResponses =
+        {GET_BLOCK_RESPONSE, EC63_GET_BLOCK_RESPONSE};
+
+    for (int ecIdx = 0; ecIdx < ecLabels.length; ecIdx++) {
+      System.out.printf("=== %s ===%n", ecLabels[ecIdx]);
+      for (int dnLatencyMs : DN_LATENCIES_MS) {
+        System.out.printf("DN connection latency = %dms%n", dnLatencyMs);
+        System.out.printf("%-14s  %-10s  %-12s  %-14s  %-14s  %-14s  %-14s  %-9s%n",
+            "Blocks/file", "Wall(ms)", "Files/s", "Blocks/s", "NewConn/file",
+            "XcNew(conn)", "XcReuse", "CacheHit%");
+        System.out.println(new String(new char[115]).replace('\0', '-'));
+
+        for (int blocksPerFile : BLOCKS_PER_FILE_VARIANTS) {
+          BenchmarkResult r = measureBlockCache(blocksPerFile, dnLatencyMs,
+              ecPipelines[ecIdx], ecConfigs[ecIdx], blockResponses[ecIdx]);
+          long totalBlocks = r.getMeasuredFiles() * blocksPerFile;
+          double blocksPerSec = r.getWallMs() == 0
+              ? Double.POSITIVE_INFINITY : totalBlocks * 1000.0 / r.getWallMs();
+          double newConnPerFile = r.getMeasuredFiles() == 0
+              ? 0 : (double) r.getXceiverNewCount() / r.getMeasuredFiles();
+          System.out.printf("%-14d  %-10d  %-12.1f  %-14.1f  %-14.2f  %-14d  %-14d  %d%%%n",
+              blocksPerFile, r.getWallMs(), r.filesPerSec(), blocksPerSec,
+              newConnPerFile, r.getXceiverNewCount(), r.getXceiverReuseCount(),
+              r.cacheHitPercent());
+        }
+        System.out.println();
+      }
+    }
   }
 
   private static void printRow(BenchmarkResult r) {
@@ -478,6 +627,35 @@ public class FileChecksumBenchmark {
           .setModificationTime(0L)
           .setDataSize(FILE_SIZE)
           .setReplicationConfig(repConfig)
+          .setFileChecksum(null)
+          .setAcls(Collections.emptyList())
+          .build();
+    }
+    return infos;
+  }
+
+  private static OmKeyInfo[] buildKeyInfosMultiBlock(Pipeline ecPipeline, int nBlocks,
+      ECReplicationConfig ecConfig) {
+    OmKeyInfo[] infos = new OmKeyInfo[KEY_POOL];
+    for (int i = 0; i < KEY_POOL; i++) {
+      List<OmKeyLocationInfo> locs = new ArrayList<>();
+      for (int b = 0; b < nBlocks; b++) {
+        locs.add(new OmKeyLocationInfo.Builder()
+            .setBlockID(new BlockID(CONTAINER_ID + b, i))
+            .setPipeline(ecPipeline)
+            .setLength(FILE_SIZE)
+            .build());
+      }
+      infos[i] = new OmKeyInfo.Builder()
+          .setVolumeName("vol")
+          .setBucketName("bucket")
+          .setKeyName("file-" + i)
+          .setOmKeyLocationInfos(Collections.singletonList(
+              new OmKeyLocationInfoGroup(0, locs)))
+          .setCreationTime(0L)
+          .setModificationTime(0L)
+          .setDataSize((long) nBlocks * FILE_SIZE)
+          .setReplicationConfig(ecConfig)
           .setFileChecksum(null)
           .setAcls(Collections.emptyList())
           .build();

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/FileChecksumBenchmark.java
@@ -72,10 +72,10 @@ import org.junit.jupiter.api.Timeout;
  *   Fix 1: BaseFileChecksumHelper 7-arg constructor no longer chains to 6-arg
  *           (redundant OM lookupKey RPC eliminated: 2 calls/file -> 1).
  *           Measured by runBenchmark.
- *   Fix 3: ECFileChecksumHelper caches the STANDALONE checksum pipeline per
- *           EC placement group; blocks 2..N within a file reuse the same
- *           XceiverClient connection (new connections/file drops from N to 1).
- *           Measured by runBlockCacheBenchmark.
+ *   Fix 2+3 combined: ECFileChecksumHelper caches the STANDALONE checksum
+ *           pipeline per EC placement group (Fix 3 intra-file reuse) and
+ *           derives its ID deterministically from the sorted node UUIDs
+ *           (Fix 2 cross-file reuse). Measured by runBlockCacheBenchmark.
  *
  * Covers RS-3-2 (5 nodes, 3 data + 2 parity) and RS-6-3 (9 nodes, 6 data + 3 parity).
  * For RS-3-2 the standalone pipeline has 3 selected nodes (index=1 + parity {4,5}),
@@ -148,9 +148,11 @@ public class FileChecksumBenchmark {
     // For runBenchmark: cap just above the stable-pipeline count (102) so stable
     // files hit the cache and unstable (random-UUID) files are GC'd immediately.
     private static final int DEFAULT_MAX_POOL_SIZE = KEY_POOL - KEY_POOL / UNSTABLE_STEP + 10;
-    // For runBlockCacheBenchmark: Fix 3 assigns one random standalone pipeline per
-    // file; pool must accommodate all files in the measurement window (~14K at 5ms).
-    static final int BLOCK_CACHE_MAX_POOL_SIZE = 100_000;
+    // For runBlockCacheBenchmark Scenario A: each file generates a fresh unique standalone
+    // pipeline. Pool must hold all unique entries from warmup + measurement so blocks 2..N
+    // can reuse the entry block 1 just added. At 0ms, peak throughput is ~35K files/s;
+    // 2M entries comfortably covers 5s warmup + 20s measurement across all block counts.
+    static final int BLOCK_CACHE_MAX_POOL_SIZE = 2_000_000;
     private final ContainerProtos.ContainerCommandResponseProto blockResponse;
     private final int dnConnectionLatencyMs;
     private final int maxPoolSize;
@@ -386,23 +388,40 @@ public class FileChecksumBenchmark {
         latencyMs);
   }
 
+  /**
+   * Measures ECFileChecksumHelper throughput for multi-block files.
+   *
+   * @param freshEcConfig when non-null, each lookupKey call returns a freshly built OmKeyInfo
+   *     with a unique EC pipeline (unique node-0 UUID per call). Simulates Fix-3-only behavior
+   *     where the standalone pipeline ID is random per file → block 1 always misses the
+   *     XceiverClient pool. Pass null to use the pre-built {@code keyInfos} array instead.
+   * @param keyInfos pre-built OmKeyInfo pool for Scenario B (shared pipeline). Ignored when
+   *     {@code freshEcConfig} is non-null.
+   */
   private static BenchmarkResult measureBlockCache(int blocksPerFile, int dnLatencyMs,
-      Pipeline ecPipeline, ECReplicationConfig ecConfig,
-      ContainerProtos.ContainerCommandResponseProto blockResponse) throws Exception {
+      ECReplicationConfig freshEcConfig, OmKeyInfo[] keyInfos,
+      ContainerProtos.ContainerCommandResponseProto blockResponse)
+      throws Exception {
     AtomicLong omCallCount = new AtomicLong();
     CountingXceiverClientFactory xceiverFactory = new CountingXceiverClientFactory(
         blockResponse, dnLatencyMs, CountingXceiverClientFactory.BLOCK_CACHE_MAX_POOL_SIZE);
     AtomicLong fileIdx = new AtomicLong();
+    AtomicLong fileSeq = new AtomicLong();
 
-    OmKeyInfo[] keyInfos = buildKeyInfosMultiBlock(ecPipeline, blocksPerFile, ecConfig);
     long fileLength = (long) blocksPerFile * FILE_SIZE;
+    int nodeCount = freshEcConfig != null ? freshEcConfig.getData() + freshEcConfig.getParity() : 0;
 
     OzoneManagerProtocol mockOm = mock(OzoneManagerProtocol.class);
     when(mockOm.lookupKey(any(OmKeyArgs.class))).thenAnswer(invocation -> {
       omCallCount.incrementAndGet();
       OmKeyArgs args = invocation.getArgument(0);
-      int idx = Integer.parseInt(args.getKeyName().split("-")[1]);
-      return keyInfos[idx % KEY_POOL];
+      if (keyInfos != null) {
+        int idx = Integer.parseInt(args.getKeyName().split("-")[1]);
+        return keyInfos[idx % KEY_POOL];
+      }
+      // Fresh mode: unique EC pipeline per call so block 1 always misses the XceiverClient pool.
+      return buildFreshOmKeyInfo(args.getKeyName(), fileSeq.getAndIncrement(),
+          blocksPerFile, fileLength, freshEcConfig, nodeCount);
     });
 
     RpcClient mockRpcClient = mock(RpcClient.class);
@@ -508,21 +527,27 @@ public class FileChecksumBenchmark {
   }
 
   /**
-   * Measures Fix 3 (HDDS-15647): per-block pipeline caching in ECFileChecksumHelper.
+   * Compares two scenarios for multi-block EC file checksum collection:
    *
-   * With fix: checksumPipelineCache returns the same Pipeline for all blocks in
-   * a file; acquireClientForReadData hits the pool for blocks 2..N
-   * (newConnections/file = 1 regardless of how many blocks).
+   * Scenario A — Fix 3 only (per-file unique pipeline, no cross-file pool reuse):
+   *   Each file lands on a distinct EC placement group (unique node 0 UUID),
+   *   so buildChecksumPipeline produces a unique deterministic pipeline ID
+   *   per file. Block 1 of every file always opens a new DN connection
+   *   (pool miss), while blocks 2..N reuse the same connection within the file.
+   *   Expected: NewConn/file = 1.00 at any latency.
    *
-   * Without fix: buildChecksumPipeline called per block; toBuilder() with a
-   * different node count triggers PipelineID.randomId() → unique pipeline ID
-   * per block → pool miss per block (newConnections/file = blocksPerFile).
+   * Scenario B — Fix 2+3 combined (shared pipeline, cross-file + intra-file reuse):
+   *   All files share the same EC placement group (same node UUIDs).
+   *   buildChecksumPipeline produces the same deterministic pipeline ID for
+   *   every file, so after the pool warms up during the warmup phase, every
+   *   subsequent connection (including block 1 of each file) is a pool hit.
+   *   Expected: NewConn/file ≈ 0.00 at any latency after warmup.
    *
-   * dnConnectionLatencyMs simulates gRPC handshake cost. Reused connections
-   * skip the delay, so the speedup grows with latency and blocks/file.
+   * The speedup of B over A equals the cost of one DN connection per file,
+   * which is especially significant at high latency (5ms, 10ms).
    */
   @Test
-  @Timeout(value = 1200, unit = TimeUnit.SECONDS)
+  @Timeout(value = 2400, unit = TimeUnit.SECONDS)
   public void runBlockCacheBenchmark() throws Exception {
     System.out.println();
     System.out.println("=== ECFileChecksum Per-Block Pipeline Cache Benchmark ===");
@@ -530,36 +555,53 @@ public class FileChecksumBenchmark {
         NUM_THREADS, BLOCK_WARMUP_SECS, BLOCK_MEASURE_SECS);
 
     String[] ecLabels = {"RS-3-2", "RS-6-3"};
-    Pipeline[] ecPipelines = {EC_PIPELINE, EC63_PIPELINE};
     ECReplicationConfig[] ecConfigs = {EC32, EC63};
     ContainerProtos.ContainerCommandResponseProto[] blockResponses =
         {GET_BLOCK_RESPONSE, EC63_GET_BLOCK_RESPONSE};
 
+    String rowFmt = "%-6d  %-10d  %-10.1f  %-13.2f  %-11d  %-9d  %-9s";
+    String hdr = String.format("%-6s  %-10s  %-10s  %-13s  %-11s  %-9s  %-9s",
+        "Blk/f", "Wall(ms)", "Files/s", "NewConn/file", "XcNew", "XcReuse", "CacheHit%");
+    String rule = new String(new char[hdr.length()]).replace('\0', '-');
+
     for (int ecIdx = 0; ecIdx < ecLabels.length; ecIdx++) {
       System.out.printf("=== %s ===%n", ecLabels[ecIdx]);
-      for (int dnLatencyMs : DN_LATENCIES_MS) {
-        System.out.printf("DN connection latency = %dms%n", dnLatencyMs);
-        System.out.printf("%-14s  %-10s  %-12s  %-14s  %-14s  %-14s  %-14s  %-9s%n",
-            "Blocks/file", "Wall(ms)", "Files/s", "Blocks/s", "NewConn/file",
-            "XcNew(conn)", "XcReuse", "CacheHit%");
-        System.out.println(new String(new char[115]).replace('\0', '-'));
 
+      for (int dnLatencyMs : DN_LATENCIES_MS) {
+        System.out.printf("DN latency = %dms%n", dnLatencyMs);
+
+        System.out.println("  [A] Fix 3 only: per-file unique pipeline (intra-file reuse, no cross-file reuse)");
+        System.out.println("  " + hdr);
+        System.out.println("  " + rule);
         for (int blocksPerFile : BLOCKS_PER_FILE_VARIANTS) {
           BenchmarkResult r = measureBlockCache(blocksPerFile, dnLatencyMs,
-              ecPipelines[ecIdx], ecConfigs[ecIdx], blockResponses[ecIdx]);
-          long totalBlocks = r.getMeasuredFiles() * blocksPerFile;
-          double blocksPerSec = r.getWallMs() == 0
-              ? Double.POSITIVE_INFINITY : totalBlocks * 1000.0 / r.getWallMs();
-          double newConnPerFile = r.getMeasuredFiles() == 0
-              ? 0 : (double) r.getXceiverNewCount() / r.getMeasuredFiles();
-          System.out.printf("%-14d  %-10d  %-12.1f  %-14.1f  %-14.2f  %-14d  %-14d  %d%%%n",
-              blocksPerFile, r.getWallMs(), r.filesPerSec(), blocksPerSec,
-              newConnPerFile, r.getXceiverNewCount(), r.getXceiverReuseCount(),
-              r.cacheHitPercent());
+              ecConfigs[ecIdx], null, blockResponses[ecIdx]);
+          printBlockCacheRow(rowFmt, blocksPerFile, r);
+        }
+
+        System.out.println();
+        System.out.println("  [B] Fix 2+3: shared pipeline (intra-file + cross-file reuse)");
+        System.out.println("  " + hdr);
+        System.out.println("  " + rule);
+        for (int blocksPerFile : BLOCKS_PER_FILE_VARIANTS) {
+          OmKeyInfo[] sharedInfos = buildKeyInfosMultiBlock(
+              ecIdx == 0 ? EC_PIPELINE : EC63_PIPELINE, blocksPerFile, ecConfigs[ecIdx]);
+          BenchmarkResult r = measureBlockCache(blocksPerFile, dnLatencyMs,
+              null, sharedInfos, blockResponses[ecIdx]);
+          printBlockCacheRow(rowFmt, blocksPerFile, r);
         }
         System.out.println();
       }
     }
+  }
+
+  private static void printBlockCacheRow(String fmt, int blocksPerFile, BenchmarkResult r) {
+    double newConnPerFile = r.getMeasuredFiles() == 0
+        ? 0 : (double) r.getXceiverNewCount() / r.getMeasuredFiles();
+    System.out.printf("  " + fmt + "%n",
+        blocksPerFile, r.getWallMs(), r.filesPerSec(), newConnPerFile,
+        r.getXceiverNewCount(), r.getXceiverReuseCount(),
+        r.cacheHitPercent() + "%");
   }
 
   private static void printRow(BenchmarkResult r) {
@@ -661,6 +703,53 @@ public class FileChecksumBenchmark {
           .build();
     }
     return infos;
+  }
+
+  /**
+   * Builds an OmKeyInfo with a fresh unique EC pipeline: node 0 gets UUID derived from
+   * {@code seq} (unique per call), all other nodes get stable UUIDs. This ensures
+   * buildChecksumPipeline produces a unique deterministic standalone pipeline ID per call,
+   * so block 1 of each file always misses the XceiverClient pool regardless of warmup.
+   * Used to simulate Fix-3-only behavior in the block-cache benchmark.
+   */
+  private static OmKeyInfo buildFreshOmKeyInfo(String keyName, long seq, int nBlocks,
+      long fileLength, ECReplicationConfig ecConfig, int nodeCount) {
+    List<DatanodeDetails> nodes = new ArrayList<>();
+    Map<DatanodeDetails, Integer> replicaIndexes = new HashMap<>();
+    for (int n = 0; n < nodeCount; n++) {
+      // Node 0 (replica index 1) gets a unique UUID per seq value.
+      // Use mostSigBits=1 so it never collides with stable parity-node UUIDs (mostSigBits=0).
+      UUID uuid = n == 0
+          ? new UUID(1L, seq)
+          : UUID.fromString("00000000-0000-0000-0000-00000000000" + n);
+      nodes.add(DatanodeDetails.newBuilder()
+          .setUuid(uuid).setHostName("dn" + n).setIpAddress("10.0.0." + n).build());
+      replicaIndexes.put(nodes.get(n), n + 1);
+    }
+    Pipeline ecPipeline = Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setReplicationConfig(ecConfig)
+        .setState(Pipeline.PipelineState.CLOSED)
+        .setNodes(nodes)
+        .setReplicaIndexes(replicaIndexes)
+        .build();
+    List<OmKeyLocationInfo> locs = new ArrayList<>();
+    for (int b = 0; b < nBlocks; b++) {
+      locs.add(new OmKeyLocationInfo.Builder()
+          .setBlockID(new BlockID(CONTAINER_ID + b, (int) seq))
+          .setPipeline(ecPipeline)
+          .setLength(FILE_SIZE)
+          .build());
+    }
+    return new OmKeyInfo.Builder()
+        .setVolumeName("vol").setBucketName("bucket").setKeyName(keyName)
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, locs)))
+        .setCreationTime(0L).setModificationTime(0L)
+        .setDataSize(fileLength)
+        .setReplicationConfig(ecConfig)
+        .setFileChecksum(null).setAcls(Collections.emptyList())
+        .build();
   }
 
   private static ContainerProtos.ContainerCommandResponseProto buildGetBlockResponse(

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestFileChecksumHelper.java
@@ -22,19 +22,29 @@ import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType.CRC32;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
@@ -43,6 +53,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.InMemoryConfigurationForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -76,11 +87,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Unit tests for Replicated and EC FileChecksumHelper class.
  */
 public class TestFileChecksumHelper {
+  // RS-6-3: replica indexes 1..9. The checksum pipeline keeps index 1 plus the
+  // three parity nodes (indexes 7, 8, 9) and drops data indexes 2..6.
+  private static final int EC_DATA = 6;
+  private static final int EC_PARITY = 3;
+
   private final FileChecksum noCachedChecksum = null;
   private OzoneClient client;
   private ObjectStore store;
@@ -161,6 +178,152 @@ public class TestFileChecksumHelper {
         .setState(Pipeline.PipelineState.CLOSED)
         .setNodes(datanodeDetails)
         .build();
+  }
+
+  private List<DatanodeDetails> ecNodes() {
+    List<DatanodeDetails> nodes = new ArrayList<>();
+    for (int i = 0; i < EC_DATA + EC_PARITY; i++) {
+      nodes.add(DatanodeDetails.newBuilder().setUuid(UUID.randomUUID()).build());
+    }
+    return nodes;
+  }
+
+  private Pipeline ecPipeline(List<DatanodeDetails> nodes, PipelineID id) {
+    Map<DatanodeDetails, Integer> replicaIndexes = new HashMap<>();
+    for (int i = 0; i < nodes.size(); i++) {
+      replicaIndexes.put(nodes.get(i), i + 1);
+    }
+    return Pipeline.newBuilder()
+        .setId(id)
+        .setReplicationConfig(new ECReplicationConfig(EC_DATA, EC_PARITY))
+        .setState(Pipeline.PipelineState.CLOSED)
+        .setNodes(nodes)
+        .setReplicaIndexes(replicaIndexes)
+        .build();
+  }
+
+  private OmKeyLocationInfo ecBlock(long localId, Pipeline pipeline) {
+    return new OmKeyLocationInfo.Builder()
+        .setPipeline(pipeline)
+        .setBlockID(new BlockID(1, localId))
+        .setLength(100)
+        .build();
+  }
+
+  private ECFileChecksumHelper ecHelper(List<OmKeyLocationInfo> blocks,
+      XceiverClientFactory factory) throws IOException {
+    RpcClient mockRpcClient = mock(RpcClient.class);
+    when(mockRpcClient.getXceiverClientManager()).thenReturn(factory);
+    OzoneVolume mockVolume = mock(OzoneVolume.class);
+    when(mockVolume.getName()).thenReturn("vol1");
+    OzoneBucket mockBucket = mock(OzoneBucket.class);
+    when(mockBucket.getName()).thenReturn("bucket1");
+    OmKeyInfo keyInfo = omKeyInfo(ReplicationType.EC, noCachedChecksum, blocks);
+    return new ECFileChecksumHelper(mockVolume, mockBucket, "dummy",
+        100L * blocks.size(), OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC,
+        mockRpcClient, keyInfo);
+  }
+
+  private XceiverClientFactory ecReadFactory(ArgumentCaptor<Pipeline> captor) throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    XceiverClientGrpc grpc = new XceiverClientGrpc(pipeline(ReplicationType.EC, ecNodes()), conf) {
+      @Override
+      public XceiverClientReply sendCommandAsync(
+          ContainerProtos.ContainerCommandRequestProto request, DatanodeDetails dn) {
+        return buildValidResponse(ReplicationType.EC);
+      }
+    };
+    XceiverClientFactory factory = mock(XceiverClientFactory.class);
+    when(factory.acquireClientForReadData(captor.capture())).thenReturn(grpc);
+    return factory;
+  }
+
+  /**
+   * Blocks that share the same EC pipeline ID must reuse a single cached
+   * STANDALONE checksum pipeline, which is filtered down to replica index 1
+   * plus the parity nodes and given a deterministic ID from the sorted node
+   * UUIDs. Exercises the cache-hit path and the node-filter branches.
+   */
+  @Test
+  public void testEcChecksumPipelineCachedAndFilteredAcrossBlocks() throws IOException {
+    List<DatanodeDetails> nodes = ecNodes();
+    Pipeline sharedPipeline = ecPipeline(nodes, PipelineID.randomId());
+    List<OmKeyLocationInfo> blocks = Arrays.asList(
+        ecBlock(1, sharedPipeline), ecBlock(2, sharedPipeline));
+
+    ArgumentCaptor<Pipeline> captor = ArgumentCaptor.forClass(Pipeline.class);
+    XceiverClientFactory factory = ecReadFactory(captor);
+    ECFileChecksumHelper helper = ecHelper(blocks, factory);
+
+    helper.compute();
+
+    assertInstanceOf(MD5MD5CRC32GzipFileChecksum.class, helper.getFileChecksum());
+
+    List<Pipeline> acquired = captor.getAllValues();
+    assertEquals(2, acquired.size());
+    // Both blocks acquired the identical cached instance (cache hit on block 2).
+    assertSame(acquired.get(0), acquired.get(1));
+
+    Pipeline checksumPipeline = acquired.get(0);
+    assertInstanceOf(StandaloneReplicationConfig.class, checksumPipeline.getReplicationConfig());
+    // index 1 + parity {7, 8, 9}; data indexes 2..6 are filtered out.
+    assertEquals(1 + EC_PARITY, checksumPipeline.getNodes().size());
+    for (DatanodeDetails dn : checksumPipeline.getNodes()) {
+      int ri = checksumPipeline.getReplicaIndex(dn);
+      assertTrue(ri == 1 || ri > EC_DATA, "unexpected replica index " + ri);
+    }
+    String nodeKey = checksumPipeline.getNodes().stream()
+        .map(DatanodeDetails::getUuidString)
+        .sorted()
+        .collect(Collectors.joining(","));
+    assertEquals(PipelineID.valueOf(UUID.nameUUIDFromBytes(nodeKey.getBytes(UTF_8))),
+        checksumPipeline.getId());
+  }
+
+  /**
+   * Blocks carrying distinct EC pipeline IDs miss the cache and rebuild the
+   * checksum pipeline, but the deterministic ID keeps them equal so the
+   * XceiverClient pool can still be reused. Exercises the cache-miss path.
+   */
+  @Test
+  public void testEcChecksumPipelineRebuiltForDistinctPipelineIds() throws IOException {
+    List<DatanodeDetails> nodes = ecNodes();
+    List<OmKeyLocationInfo> blocks = Arrays.asList(
+        ecBlock(1, ecPipeline(nodes, PipelineID.randomId())),
+        ecBlock(2, ecPipeline(nodes, PipelineID.randomId())));
+
+    ArgumentCaptor<Pipeline> captor = ArgumentCaptor.forClass(Pipeline.class);
+    ECFileChecksumHelper helper = ecHelper(blocks, ecReadFactory(captor));
+
+    helper.compute();
+
+    assertInstanceOf(MD5MD5CRC32GzipFileChecksum.class, helper.getFileChecksum());
+    List<Pipeline> acquired = captor.getAllValues();
+    assertEquals(2, acquired.size());
+    // Distinct EC IDs miss the cache, so each block builds its own instance ...
+    assertNotSame(acquired.get(0), acquired.get(1));
+    // ... yet the deterministic ID (same nodes) is identical for pool reuse.
+    assertEquals(acquired.get(0).getId(), acquired.get(1).getId());
+  }
+
+  /**
+   * When acquiring the read client fails, getChunkInfos must not attempt to
+   * release a client. Exercises the {@code xceiverClientSpi == null} branch of
+   * the finally block.
+   */
+  @Test
+  public void testEcChecksumAcquireFailureSkipsRelease() throws IOException {
+    List<DatanodeDetails> nodes = ecNodes();
+    List<OmKeyLocationInfo> blocks = Collections.singletonList(
+        ecBlock(1, ecPipeline(nodes, PipelineID.randomId())));
+
+    XceiverClientFactory factory = mock(XceiverClientFactory.class);
+    when(factory.acquireClientForReadData(any()))
+        .thenThrow(new IOException("acquire failed"));
+    ECFileChecksumHelper helper = ecHelper(blocks, factory);
+
+    assertThrows(IOException.class, helper::compute);
+    verify(factory, never()).releaseClientForReadData(any(), anyBoolean());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## What changes were proposed in this pull request?

When computing a file checksum for an erasure-coded key, ECFileChecksumHelper builds a temporary STANDALONE pipeline (replica index 1 + parity nodes) for every block. All blocks of a file share the same EC placement group, so that pipeline is identical for every block — rebuilding it per block (node filtering, deterministic-ID hashing, allocation) is wasted work that grows with the number of blocks.

This PR caches the standalone pipeline per placement group inside the helper, so it is built once per file (on the first block) and reused for the rest. It builds on HDDS-15643 (#10594) — already on master — which removed the redundant OM lookupKey RPC and made the pipeline ID deterministic for cross-file connection reuse. This adds the intra-file reuse on top. It is purely client-side CPU savings: no wire, OM/SCM, or checksum-result changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15680

## How was this patch tested?

New unit tests in TestFileChecksumHelper cover the cache hit/miss paths, the node filtering, and the acquire-failure path.

Benchmarked with FileChecksumBenchmark#runBlockCacheBenchmark (5 threads, each checksumming random-placement EC files), comparing the cache off vs on while holding everything else equal.

Results — throughput gain (cache on ÷ off), by file size in blocks

EC | Blocks/file | Before | After | Speedup
-- | -- | -- | -- | --
RS-3-2 | 1 | 244,351 | 239,566 | ~1.00×
RS-3-2 | 3 | 126,262 | 130,494 | 1.03×
RS-3-2 | 5 | 86,606 | 91,613 | 1.06×
RS-3-2 | 10 | 48,442 | 51,364 | 1.06×
RS-6-3 | 1 | 236,776 | 229,178 | ~1.00×
RS-6-3 | 3 | 123,013 | 128,283 | 1.04×
RS-6-3 | 5 | 84,271 | 88,997 | 1.06×
RS-6-3 | 10 | 47,155 | 50,820 | 1.08×


Single-block files show no change (nothing to cache — the 1-block row is a control and sits within ~2-3% noise). The gain grows with file size as the cache eliminates the redundant per-block pipeline rebuilds — up to ~6–8% for large multi-block EC files, slightly higher for wider EC schemes (RS-6-3). The improvement is client-side CPU only and does not change the checksum result.

As a summary the fix would have slight performance penalty for small files, and single digit improvement for files spans to multiple blocks.