### PR TITLE
HDDS-15753. Rename TestClock to MockClock.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/SlidingWindow.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/SlidingWindow.java
@@ -156,7 +156,7 @@ public class SlidingWindow {
   /**
    * A custom monotonic clock implementation to allow overriding the current time for testing purposes.
    * Implementation of Clock that uses System.nanoTime() for real usage.
-   * The class {@code org.apache.ozone.test.TestClock} provides a mock clock which can be used
+   * The class {@code org.apache.ozone.test.MockClock} provides a mock clock which can be used
    * to manipulate the current time in tests.
    */
   public static final class MonotonicClock extends Clock {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerInfo.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerInfo.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -110,7 +110,7 @@ public class TestContainerInfo {
 
   @Test
   void restoreState() {
-    TestClock clock = TestClock.newInstance();
+    MockClock clock = MockClock.newInstance();
     ContainerInfo subject = newBuilderForTest()
         .setClock(clock)
         .build();

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/common/helpers/TestExcludeList.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/common/helpers/TestExcludeList.java
@@ -23,14 +23,14 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests the exclude nodes list behavior at client.
  */
 public class TestExcludeList {
-  private TestClock clock = new TestClock(Instant.now(), ZoneOffset.UTC);
+  private MockClock clock = new MockClock(Instant.now(), ZoneOffset.UTC);
 
   @Test
   public void excludeNodesShouldBeCleanedBasedOnGivenTime() {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestSlidingWindow.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestSlidingWindow.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,11 +32,11 @@ import org.junit.jupiter.api.Test;
  */
 class TestSlidingWindow {
 
-  private TestClock testClock;
+  private MockClock mockClock;
 
   @BeforeEach
   void setup() {
-    testClock = TestClock.newInstance();
+    mockClock = MockClock.newInstance();
   }
   
   @Test
@@ -51,7 +51,7 @@ class TestSlidingWindow {
 
   @Test
   void testAdd() {
-    SlidingWindow slidingWindow = new SlidingWindow(3, Duration.ofSeconds(5), testClock);
+    SlidingWindow slidingWindow = new SlidingWindow(3, Duration.ofSeconds(5), mockClock);
     for (int i = 0; i < slidingWindow.getWindowSize(); i++) {
       slidingWindow.add();
       assertEquals(i + 1, slidingWindow.getNumEvents());
@@ -65,7 +65,7 @@ class TestSlidingWindow {
 
   @Test
   void testEventExpiration() {
-    SlidingWindow slidingWindow = new SlidingWindow(2, Duration.ofMillis(500), testClock);
+    SlidingWindow slidingWindow = new SlidingWindow(2, Duration.ofMillis(500), mockClock);
 
     // Add events to reach threshold
     slidingWindow.add();
@@ -75,7 +75,7 @@ class TestSlidingWindow {
     assertTrue(slidingWindow.isExceeded());
 
     // Fast forward time to expire events
-    testClock.fastForward(600);
+    mockClock.fastForward(600);
 
     assertEquals(0, slidingWindow.getNumEvents());
     assertFalse(slidingWindow.isExceeded());
@@ -88,7 +88,7 @@ class TestSlidingWindow {
 
   @Test
   void testPartialExpiration() {
-    SlidingWindow slidingWindow = new SlidingWindow(3, Duration.ofSeconds(1), testClock);
+    SlidingWindow slidingWindow = new SlidingWindow(3, Duration.ofSeconds(1), mockClock);
 
     slidingWindow.add();
     slidingWindow.add();
@@ -97,19 +97,19 @@ class TestSlidingWindow {
     assertEquals(4, slidingWindow.getNumEvents());
     assertTrue(slidingWindow.isExceeded());
 
-    testClock.fastForward(600);
+    mockClock.fastForward(600);
     slidingWindow.add(); // this will remove the oldest event as the window is full
     assertEquals(4, slidingWindow.getNumEvents());
 
     // Fast forward time to expire the oldest events
-    testClock.fastForward(500);
+    mockClock.fastForward(500);
     assertEquals(1, slidingWindow.getNumEvents());
     assertFalse(slidingWindow.isExceeded());
   }
 
   @Test
   void testZeroWindowSize() {
-    SlidingWindow slidingWindow = new SlidingWindow(0, Duration.ofSeconds(5), testClock);
+    SlidingWindow slidingWindow = new SlidingWindow(0, Duration.ofSeconds(5), mockClock);
     
     // Verify initial state
     assertEquals(0, slidingWindow.getWindowSize());
@@ -127,7 +127,7 @@ class TestSlidingWindow {
     assertTrue(slidingWindow.isExceeded());
     
     // Test expiration
-    testClock.fastForward(6000); // Move past expiry time
+    mockClock.fastForward(6000); // Move past expiry time
     assertEquals(0, slidingWindow.getNumEvents());
     assertFalse(slidingWindow.isExceeded());
     

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestSlidingWindow.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestSlidingWindow.java
@@ -32,11 +32,11 @@ import org.junit.jupiter.api.Test;
  */
 class TestSlidingWindow {
 
-  private MockClock mockClock;
+  private MockClock testClock;
 
   @BeforeEach
   void setup() {
-    mockClock = MockClock.newInstance();
+    testClock = MockClock.newInstance();
   }
   
   @Test
@@ -51,7 +51,7 @@ class TestSlidingWindow {
 
   @Test
   void testAdd() {
-    SlidingWindow slidingWindow = new SlidingWindow(3, Duration.ofSeconds(5), mockClock);
+    SlidingWindow slidingWindow = new SlidingWindow(3, Duration.ofSeconds(5), testClock);
     for (int i = 0; i < slidingWindow.getWindowSize(); i++) {
       slidingWindow.add();
       assertEquals(i + 1, slidingWindow.getNumEvents());
@@ -65,7 +65,7 @@ class TestSlidingWindow {
 
   @Test
   void testEventExpiration() {
-    SlidingWindow slidingWindow = new SlidingWindow(2, Duration.ofMillis(500), mockClock);
+    SlidingWindow slidingWindow = new SlidingWindow(2, Duration.ofMillis(500), testClock);
 
     // Add events to reach threshold
     slidingWindow.add();
@@ -75,7 +75,7 @@ class TestSlidingWindow {
     assertTrue(slidingWindow.isExceeded());
 
     // Fast forward time to expire events
-    mockClock.fastForward(600);
+    testClock.fastForward(600);
 
     assertEquals(0, slidingWindow.getNumEvents());
     assertFalse(slidingWindow.isExceeded());
@@ -88,7 +88,7 @@ class TestSlidingWindow {
 
   @Test
   void testPartialExpiration() {
-    SlidingWindow slidingWindow = new SlidingWindow(3, Duration.ofSeconds(1), mockClock);
+    SlidingWindow slidingWindow = new SlidingWindow(3, Duration.ofSeconds(1), testClock);
 
     slidingWindow.add();
     slidingWindow.add();
@@ -97,19 +97,19 @@ class TestSlidingWindow {
     assertEquals(4, slidingWindow.getNumEvents());
     assertTrue(slidingWindow.isExceeded());
 
-    mockClock.fastForward(600);
+    testClock.fastForward(600);
     slidingWindow.add(); // this will remove the oldest event as the window is full
     assertEquals(4, slidingWindow.getNumEvents());
 
     // Fast forward time to expire the oldest events
-    mockClock.fastForward(500);
+    testClock.fastForward(500);
     assertEquals(1, slidingWindow.getNumEvents());
     assertFalse(slidingWindow.isExceeded());
   }
 
   @Test
   void testZeroWindowSize() {
-    SlidingWindow slidingWindow = new SlidingWindow(0, Duration.ofSeconds(5), mockClock);
+    SlidingWindow slidingWindow = new SlidingWindow(0, Duration.ofSeconds(5), testClock);
     
     // Verify initial state
     assertEquals(0, slidingWindow.getWindowSize());
@@ -127,7 +127,7 @@ class TestSlidingWindow {
     assertTrue(slidingWindow.isExceeded());
     
     // Test expiration
-    mockClock.fastForward(6000); // Move past expiry time
+    testClock.fastForward(6000); // Move past expiry time
     assertEquals(0, slidingWindow.getNumEvents());
     assertFalse(slidingWindow.isExceeded());
     

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.StaleRecoveringContainerScrubbingService;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -77,8 +77,8 @@ public class TestStaleRecoveringContainerScrubbingService {
   private int containerIdNum = 0;
   private MutableVolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
-  private final TestClock testClock =
-      new TestClock(Instant.now(), ZoneOffset.UTC);
+  private final MockClock mockClock =
+      new MockClock(Instant.now(), ZoneOffset.UTC);
 
   private void initVersionInfo(ContainerTestVersionInfo versionInfo)
       throws IOException {
@@ -122,7 +122,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     List<Long> createdIds = new ArrayList<>();
     int end = containerIdNum + num;
     for (; containerIdNum < end; containerIdNum++) {
-      testClock.fastForward(10L);
+      mockClock.fastForward(10L);
       KeyValueContainerData recoveringContainerData = new KeyValueContainerData(
           containerIdNum, layout, (long) StorageUnit.GB.toBytes(5),
           UUID.randomUUID().toString(), datanodeUuid);
@@ -144,19 +144,19 @@ public class TestStaleRecoveringContainerScrubbingService {
   public void testScrubbingStaleRecoveringContainers(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initVersionInfo(versionInfo);
-    ContainerSet containerSet = newContainerSet(10, testClock);
+    ContainerSet containerSet = newContainerSet(10, mockClock);
     StaleRecoveringContainerScrubbingService srcss =
         new StaleRecoveringContainerScrubbingService(
             50, TimeUnit.MILLISECONDS, 10,
             Duration.ofSeconds(300).toMillis(),
             containerSet);
-    testClock.fastForward(1000L);
+    mockClock.fastForward(1000L);
     Map<Long, ContainerProtos.ContainerDataProto.State> containerStateMap =
         new HashMap<>();
     containerStateMap.putAll(createTestContainers(containerSet, 5, CLOSED)
             .stream().collect(Collectors.toMap(i -> i, i -> CLOSED)));
 
-    testClock.fastForward(1000L);
+    mockClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //closed container should not be scrubbed
     assertEquals(5, containerSet.containerCount());
@@ -164,7 +164,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     containerStateMap.putAll(createTestContainers(containerSet, 5,
             RECOVERING).stream()
             .collect(Collectors.toMap(i -> i, i -> UNHEALTHY)));
-    testClock.fastForward(1000L);
+    mockClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //recovering container should be scrubbed since recovering timeout
     assertEquals(10, containerSet.containerCount());
@@ -178,7 +178,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     containerStateMap.putAll(createTestContainers(containerSet, 5,
             RECOVERING).stream()
             .collect(Collectors.toMap(i -> i, i -> RECOVERING)));
-    testClock.fastForward(1000L);
+    mockClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //recovering container should not be scrubbed
     assertEquals(15, containerSet.containerCount());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -77,7 +77,7 @@ public class TestStaleRecoveringContainerScrubbingService {
   private int containerIdNum = 0;
   private MutableVolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
-  private final MockClock mockClock =
+  private final MockClock testClock =
       new MockClock(Instant.now(), ZoneOffset.UTC);
 
   private void initVersionInfo(ContainerTestVersionInfo versionInfo)
@@ -122,7 +122,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     List<Long> createdIds = new ArrayList<>();
     int end = containerIdNum + num;
     for (; containerIdNum < end; containerIdNum++) {
-      mockClock.fastForward(10L);
+      testClock.fastForward(10L);
       KeyValueContainerData recoveringContainerData = new KeyValueContainerData(
           containerIdNum, layout, (long) StorageUnit.GB.toBytes(5),
           UUID.randomUUID().toString(), datanodeUuid);
@@ -144,19 +144,19 @@ public class TestStaleRecoveringContainerScrubbingService {
   public void testScrubbingStaleRecoveringContainers(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initVersionInfo(versionInfo);
-    ContainerSet containerSet = newContainerSet(10, mockClock);
+    ContainerSet containerSet = newContainerSet(10, testClock);
     StaleRecoveringContainerScrubbingService srcss =
         new StaleRecoveringContainerScrubbingService(
             50, TimeUnit.MILLISECONDS, 10,
             Duration.ofSeconds(300).toMillis(),
             containerSet);
-    mockClock.fastForward(1000L);
+    testClock.fastForward(1000L);
     Map<Long, ContainerProtos.ContainerDataProto.State> containerStateMap =
         new HashMap<>();
     containerStateMap.putAll(createTestContainers(containerSet, 5, CLOSED)
             .stream().collect(Collectors.toMap(i -> i, i -> CLOSED)));
 
-    mockClock.fastForward(1000L);
+    testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //closed container should not be scrubbed
     assertEquals(5, containerSet.containerCount());
@@ -164,7 +164,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     containerStateMap.putAll(createTestContainers(containerSet, 5,
             RECOVERING).stream()
             .collect(Collectors.toMap(i -> i, i -> UNHEALTHY)));
-    mockClock.fastForward(1000L);
+    testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //recovering container should be scrubbed since recovering timeout
     assertEquals(10, containerSet.containerCount());
@@ -178,7 +178,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     containerStateMap.putAll(createTestContainers(containerSet, 5,
             RECOVERING).stream()
             .collect(Collectors.toMap(i -> i, i -> RECOVERING)));
-    mockClock.fastForward(1000L);
+    testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //recovering container should not be scrubbed
     assertEquals(15, containerSet.containerCount());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,14 +51,14 @@ import org.junit.jupiter.api.Test;
  */
 public class TestDeleteContainerCommandHandler {
 
-  private TestClock clock;
+  private MockClock clock;
   private OzoneContainer ozoneContainer;
   private ContainerController controller;
   private StateContext context;
 
   @BeforeEach
   public void setup() {
-    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    clock = new MockClock(Instant.now(), ZoneId.systemDefault());
     ozoneContainer = mock(OzoneContainer.class);
     controller = mock(ContainerController.class);
     when(ozoneContainer.getController()).thenReturn(controller);
@@ -114,13 +114,13 @@ public class TestDeleteContainerCommandHandler {
     when(context.getTermOfLeaderSCM())
         .thenReturn(OptionalLong.of(command.getTerm()));
 
-    TestClock testClock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    MockClock mockClock = new MockClock(Instant.now(), ZoneId.systemDefault());
     CountDownLatch latch = new CountDownLatch(1);
     ThreadFactory threadFactory = new ThreadFactoryBuilder().build();
     ThreadPoolWithLockExecutor executor = new ThreadPoolWithLockExecutor(
         threadFactory, latch);
     DeleteContainerCommandHandler subject = new DeleteContainerCommandHandler(
-        testClock, executor, 100);
+        mockClock, executor, 100);
 
     // WHEN
     subject.handle(command, ozoneContainer, context, null);
@@ -181,12 +181,12 @@ public class TestDeleteContainerCommandHandler {
   }
 
   private static DeleteContainerCommandHandler createSubject() {
-    TestClock clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    MockClock clock = new MockClock(Instant.now(), ZoneId.systemDefault());
     return createSubject(clock, 1000);
   }
 
   private static DeleteContainerCommandHandler createSubject(
-      TestClock clock, int queueSize) {
+      MockClock clock, int queueSize) {
     ThreadFactory threadFactory = new ThreadFactoryBuilder().build();
     ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.
         newFixedThreadPool(1, threadFactory);
@@ -194,7 +194,7 @@ public class TestDeleteContainerCommandHandler {
   }
 
   private static DeleteContainerCommandHandler createSubjectWithPoolSize(
-      TestClock clock, int queueSize) {
+      MockClock clock, int queueSize) {
     return new DeleteContainerCommandHandler(1, clock, queueSize, "");
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
@@ -114,13 +114,13 @@ public class TestDeleteContainerCommandHandler {
     when(context.getTermOfLeaderSCM())
         .thenReturn(OptionalLong.of(command.getTerm()));
 
-    MockClock mockClock = new MockClock(Instant.now(), ZoneId.systemDefault());
+    MockClock testClock = new MockClock(Instant.now(), ZoneId.systemDefault());
     CountDownLatch latch = new CountDownLatch(1);
     ThreadFactory threadFactory = new ThreadFactoryBuilder().build();
     ThreadPoolWithLockExecutor executor = new ThreadPoolWithLockExecutor(
         threadFactory, latch);
     DeleteContainerCommandHandler subject = new DeleteContainerCommandHandler(
-        mockClock, executor, 100);
+        testClock, executor, 100);
 
     // WHEN
     subject.handle(command, ozoneContainer, context, null);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeHealthChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeHealthChecks.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
 import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.utils.DiskCheckUtil;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -52,7 +52,7 @@ public class TestStorageVolumeHealthChecks {
   private static final String DATANODE_UUID = UUID.randomUUID().toString();
   private static final String CLUSTER_ID = UUID.randomUUID().toString();
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
-  private static final TestClock TEST_CLOCK = TestClock.newInstance();
+  private static final MockClock MOCK_CLOCK = MockClock.newInstance();
 
   @TempDir
   private static Path volumePath;
@@ -63,21 +63,21 @@ public class TestStorageVolumeHealthChecks {
             .datanodeUuid(DATANODE_UUID)
             .conf(CONF)
             .usageCheckFactory(MockSpaceUsageCheckFactory.NONE)
-            .clock(TEST_CLOCK);
+            .clock(MOCK_CLOCK);
 
     MetadataVolume.Builder metadataVolumeBuilder =
         new MetadataVolume.Builder(volumePath.toString())
             .datanodeUuid(DATANODE_UUID)
             .conf(CONF)
             .usageCheckFactory(MockSpaceUsageCheckFactory.NONE)
-            .clock(TEST_CLOCK);
+            .clock(MOCK_CLOCK);
 
     DbVolume.Builder dbVolumeBuilder =
         new DbVolume.Builder(volumePath.toString())
             .datanodeUuid(DATANODE_UUID)
             .conf(CONF)
             .usageCheckFactory(MockSpaceUsageCheckFactory.NONE)
-            .clock(TEST_CLOCK);
+            .clock(MOCK_CLOCK);
 
     return Stream.of(
         Arguments.of(Named.of("HDDS Volume", hddsVolumeBuilder)),
@@ -92,7 +92,7 @@ public class TestStorageVolumeHealthChecks {
     // needs to be cleared before each test.
     FileUtils.deleteDirectory(volumePath.toFile());
     DiskCheckUtil.clearTestImpl();
-    TEST_CLOCK.set(Instant.now());
+    MOCK_CLOCK.set(Instant.now());
     DatanodeConfiguration dnConf = CONF.getObject(DatanodeConfiguration.class);
     dnConf.setDiskCheckEnabled(true);
     dnConf.setDiskCheckTimeoutTestEnabled(true);
@@ -305,7 +305,7 @@ public class TestStorageVolumeHealthChecks {
 
     for (int i = 0; i < checkResults.length; i++) {
       // Sleep to allow entries in the sliding window to eventually timeout
-      TEST_CLOCK.fastForward(eventRateMillis);
+      MOCK_CLOCK.fastForward(eventRateMillis);
       final boolean result = checkResults[i];
       final DiskCheckUtil.DiskChecks ioResult = new DiskCheckUtil.DiskChecks() {
             @Override
@@ -391,7 +391,7 @@ public class TestStorageVolumeHealthChecks {
 
     assertFalse(volume.recordTimeoutAndCheckFailure(),
         "First timeout should be tolerated");
-    TEST_CLOCK.fastForward(
+    MOCK_CLOCK.fastForward(
         volume.getTimeoutFailureSlidingWindow().getExpiryDurationMillis() + 1);
 
     assertFalse(volume.recordTimeoutAndCheckFailure(),

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeHealthChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeHealthChecks.java
@@ -52,7 +52,7 @@ public class TestStorageVolumeHealthChecks {
   private static final String DATANODE_UUID = UUID.randomUUID().toString();
   private static final String CLUSTER_ID = UUID.randomUUID().toString();
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
-  private static final MockClock MOCK_CLOCK = MockClock.newInstance();
+  private static final MockClock TEST_CLOCK = MockClock.newInstance();
 
   @TempDir
   private static Path volumePath;
@@ -63,21 +63,21 @@ public class TestStorageVolumeHealthChecks {
             .datanodeUuid(DATANODE_UUID)
             .conf(CONF)
             .usageCheckFactory(MockSpaceUsageCheckFactory.NONE)
-            .clock(MOCK_CLOCK);
+            .clock(TEST_CLOCK);
 
     MetadataVolume.Builder metadataVolumeBuilder =
         new MetadataVolume.Builder(volumePath.toString())
             .datanodeUuid(DATANODE_UUID)
             .conf(CONF)
             .usageCheckFactory(MockSpaceUsageCheckFactory.NONE)
-            .clock(MOCK_CLOCK);
+            .clock(TEST_CLOCK);
 
     DbVolume.Builder dbVolumeBuilder =
         new DbVolume.Builder(volumePath.toString())
             .datanodeUuid(DATANODE_UUID)
             .conf(CONF)
             .usageCheckFactory(MockSpaceUsageCheckFactory.NONE)
-            .clock(MOCK_CLOCK);
+            .clock(TEST_CLOCK);
 
     return Stream.of(
         Arguments.of(Named.of("HDDS Volume", hddsVolumeBuilder)),
@@ -92,7 +92,7 @@ public class TestStorageVolumeHealthChecks {
     // needs to be cleared before each test.
     FileUtils.deleteDirectory(volumePath.toFile());
     DiskCheckUtil.clearTestImpl();
-    MOCK_CLOCK.set(Instant.now());
+    TEST_CLOCK.set(Instant.now());
     DatanodeConfiguration dnConf = CONF.getObject(DatanodeConfiguration.class);
     dnConf.setDiskCheckEnabled(true);
     dnConf.setDiskCheckTimeoutTestEnabled(true);
@@ -305,7 +305,7 @@ public class TestStorageVolumeHealthChecks {
 
     for (int i = 0; i < checkResults.length; i++) {
       // Sleep to allow entries in the sliding window to eventually timeout
-      MOCK_CLOCK.fastForward(eventRateMillis);
+      TEST_CLOCK.fastForward(eventRateMillis);
       final boolean result = checkResults[i];
       final DiskCheckUtil.DiskChecks ioResult = new DiskCheckUtil.DiskChecks() {
             @Override
@@ -391,7 +391,7 @@ public class TestStorageVolumeHealthChecks {
 
     assertFalse(volume.recordTimeoutAndCheckFailure(),
         "First timeout should be tolerated");
-    MOCK_CLOCK.fastForward(
+    TEST_CLOCK.fastForward(
         volume.getTimeoutFailureSlidingWindow().getExpiryDurationMillis() + 1);
 
     assertFalse(volume.recordTimeoutAndCheckFailure(),

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerTask.java
@@ -90,7 +90,7 @@ import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -121,7 +121,7 @@ public class TestDiskBalancerTask {
   private HddsVolume sourceVolume;
   private HddsVolume destVolume;
   private DiskBalancerServiceTestImpl diskBalancerService;
-  private TestClock clock;
+  private MockClock clock;
 
   private static final long CONTAINER_ID = 1L;
   private static final long CONTAINER_SIZE = 1024L * 1024L; // 1 MB
@@ -252,7 +252,7 @@ public class TestDiskBalancerTask {
     DiskBalancerConfiguration diskBalancerConfiguration = conf.getObject(DiskBalancerConfiguration.class);
     diskBalancerConfiguration.setDiskBalancerShouldRun(true);
     conf.setFromObject(diskBalancerConfiguration);
-    clock = TestClock.newInstance();
+    clock = MockClock.newInstance();
     diskBalancerService = new DiskBalancerServiceTestImpl(ozoneContainer,
         100, conf, 1, clock);
     diskBalancerService.setReplicaDeletionDelay(0);
@@ -831,7 +831,7 @@ public class TestDiskBalancerTask {
     assertNotNull(task1);
     assertNotNull(task2);
 
-    // Run both moves concurrently; fixed TestClock => same deadline key.
+    // Run both moves concurrently; fixed MockClock => same deadline key.
     ExecutorService pool = Executors.newFixedThreadPool(2);
     try {
       List<Future<BackgroundTaskResult>> futures = pool.invokeAll(Arrays.asList(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -91,7 +91,7 @@ import org.apache.hadoop.ozone.protocol.commands.ReconcileContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -126,14 +126,14 @@ public class TestReplicationSupervisor {
   private ContainerLayoutVersion layoutVersion;
 
   private StateContext context;
-  private TestClock clock;
+  private MockClock clock;
   private DatanodeDetails datanode;
   private DNContainerOperationClient mockClient;
   private ContainerController mockController;
 
   @BeforeEach
   public void setUp() throws Exception {
-    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    clock = new MockClock(Instant.now(), ZoneId.systemDefault());
     set = newContainerSet();
     DatanodeStateMachine stateMachine = mock(DatanodeStateMachine.class);
     context = new StateContext(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -80,7 +80,7 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -90,7 +90,7 @@ import org.mockito.ArgumentCaptor;
  */
 public class TestMoveManager {
 
-  private TestClock clock;
+  private MockClock clock;
   private ReplicationManager replicationManager;
   private ContainerManager containerManager;
   private MoveManager moveManager;
@@ -104,7 +104,7 @@ public class TestMoveManager {
   @BeforeEach
   public void setup() throws ContainerNotFoundException,
       NodeNotFoundException {
-    clock = TestClock.newInstance();
+    clock = MockClock.newInstance();
     containerInfo = ReplicationTestUtil.createContainerInfo(
         RatisReplicationConfig.getInstance(THREE), 1,
         HddsProtos.LifeCycleState.CLOSED);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Test;
 public class TestContainerReplicaPendingOps {
 
   private ContainerReplicaPendingOps pendingOps;
-  private TestClock clock;
+  private MockClock clock;
   private DatanodeDetails dn1;
   private DatanodeDetails dn2;
   private DatanodeDetails dn3;
@@ -70,7 +70,7 @@ public class TestContainerReplicaPendingOps {
 
   @BeforeEach
   public void setup() {
-    clock = new TestClock(Instant.now(), ZoneOffset.UTC);
+    clock = new MockClock(Instant.now(), ZoneOffset.UTC);
     deadline = clock.millis() + 10000; // Current time plus 10 seconds
 
     OzoneConfiguration conf = new OzoneConfiguration();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -101,7 +101,7 @@ import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -125,7 +125,7 @@ public class TestReplicationManager {
   private EventPublisher eventPublisher;
   private SCMContext scmContext;
   private NodeManager nodeManager;
-  private TestClock clock;
+  private MockClock clock;
   private ContainerReplicaPendingOps containerReplicaPendingOps;
 
   private Map<ContainerID, Set<ContainerReplica>> containerReplicaMap;
@@ -160,7 +160,7 @@ public class TestReplicationManager {
       return null;
     }).when(nodeManager).addDatanodeCommand(any(), any());
 
-    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    clock = new MockClock(Instant.now(), ZoneId.systemDefault());
     containerReplicaPendingOps =
         new ContainerReplicaPendingOps(clock, null);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -69,7 +69,7 @@ import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -110,7 +110,7 @@ public class TestReplicationManagerScenarios {
   private EventPublisher eventPublisher;
   private SCMContext scmContext;
   private NodeManager nodeManager;
-  private TestClock clock;
+  private MockClock clock;
 
   private static List<URI> getTestFiles() throws URISyntaxException {
     File[] fileList = (new File(TestReplicationManagerScenarios.class
@@ -183,7 +183,7 @@ public class TestReplicationManagerScenarios {
       return null;
     }).when(nodeManager).addDatanodeCommand(any(), any());
 
-    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    clock = new MockClock(Instant.now(), ZoneId.systemDefault());
     containerReplicaPendingOps = new ContainerReplicaPendingOps(clock, null);
 
     when(containerManager.getContainerReplicas(any(ContainerID.class))).thenAnswer(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -53,7 +53,7 @@ import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -295,7 +295,7 @@ public class TestReplicationManagerUtil {
     // set up mocks such ContainerReplicaPendingOps returns the containerSizeScheduled map
     ReplicationManagerConfiguration rmConf = new ReplicationManagerConfiguration();
     when(replicationManager.getConfig()).thenReturn(rmConf);
-    TestClock clock = new TestClock(Instant.now(), ZoneOffset.UTC);
+    MockClock clock = new MockClock(Instant.now(), ZoneOffset.UTC);
     ConcurrentHashMap<DatanodeID, SizeAndTime> sizeScheduledMap = new ConcurrentHashMap<>();
 
     // fullDn has 10GB size scheduled, 30GB available and 20GB min free space, so it should be excluded

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -53,7 +53,7 @@ import org.apache.hadoop.hdds.scm.container.TestContainerInfo;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -75,7 +75,7 @@ public class TestClosingContainerHandler {
   private static final RatisReplicationConfig RATIS_REPLICATION_CONFIG =
       RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
 
-  private final TestClock clock = TestClock.newInstance();
+  private final MockClock clock = MockClock.newInstance();
 
   @BeforeEach
   public void setup() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestBackgroundSCMService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestBackgroundSCMService.java
@@ -40,18 +40,18 @@ import org.junit.jupiter.api.Test;
  * */
 public class TestBackgroundSCMService {
   private BackgroundSCMService backgroundSCMService;
-  private MockClock mockClock;
+  private MockClock testClock;
   private SCMContext scmContext;
   private PipelineManager pipelineManager;
 
   @BeforeEach
   public void setup() throws IOException, TimeoutException {
-    mockClock = new MockClock(Instant.now(), ZoneOffset.UTC);
+    testClock = new MockClock(Instant.now(), ZoneOffset.UTC);
     scmContext = SCMContext.emptyContext();
     this.pipelineManager = mock(PipelineManager.class);
     doNothing().when(pipelineManager).scrubPipelines();
     this.backgroundSCMService = new BackgroundSCMService.Builder()
-        .setClock(mockClock)
+        .setClock(testClock)
         .setScmContext(scmContext)
         .setServiceName("testBackgroundService")
         .setIntervalInMillis(1L)
@@ -87,7 +87,7 @@ public class TestBackgroundSCMService {
     // Still cannot run, as the safemode delay has not passed.
     assertFalse(backgroundSCMService.shouldRun());
 
-    mockClock.fastForward(60000);
+    testClock.fastForward(60000);
     assertTrue(backgroundSCMService.shouldRun());
 
     // go into safe mode, RUNNING -> PAUSING
@@ -103,7 +103,7 @@ public class TestBackgroundSCMService {
     synchronized (backgroundSCMService) {
       backgroundSCMService.notifyStatusChanged();
       assertFalse(backgroundSCMService.shouldRun());
-      mockClock.fastForward(60000);
+      testClock.fastForward(60000);
       assertTrue(backgroundSCMService.shouldRun());
       backgroundSCMService.runImmediately();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestBackgroundSCMService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestBackgroundSCMService.java
@@ -30,7 +30,7 @@ import java.time.ZoneOffset;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,18 +40,18 @@ import org.junit.jupiter.api.Test;
  * */
 public class TestBackgroundSCMService {
   private BackgroundSCMService backgroundSCMService;
-  private TestClock testClock;
+  private MockClock mockClock;
   private SCMContext scmContext;
   private PipelineManager pipelineManager;
 
   @BeforeEach
   public void setup() throws IOException, TimeoutException {
-    testClock = new TestClock(Instant.now(), ZoneOffset.UTC);
+    mockClock = new MockClock(Instant.now(), ZoneOffset.UTC);
     scmContext = SCMContext.emptyContext();
     this.pipelineManager = mock(PipelineManager.class);
     doNothing().when(pipelineManager).scrubPipelines();
     this.backgroundSCMService = new BackgroundSCMService.Builder()
-        .setClock(testClock)
+        .setClock(mockClock)
         .setScmContext(scmContext)
         .setServiceName("testBackgroundService")
         .setIntervalInMillis(1L)
@@ -87,7 +87,7 @@ public class TestBackgroundSCMService {
     // Still cannot run, as the safemode delay has not passed.
     assertFalse(backgroundSCMService.shouldRun());
 
-    testClock.fastForward(60000);
+    mockClock.fastForward(60000);
     assertTrue(backgroundSCMService.shouldRun());
 
     // go into safe mode, RUNNING -> PAUSING
@@ -103,7 +103,7 @@ public class TestBackgroundSCMService {
     synchronized (backgroundSCMService) {
       backgroundSCMService.notifyStatusChanged();
       assertFalse(backgroundSCMService.shouldRun());
-      testClock.fastForward(60000);
+      mockClock.fastForward(60000);
       assertTrue(backgroundSCMService.shouldRun());
       backgroundSCMService.runImmediately();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -103,7 +103,7 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.util.function.CheckedRunnable;
 import org.assertj.core.util.Lists;
@@ -124,11 +124,11 @@ public class TestPipelineManagerImpl {
   private SCMContext scmContext;
   private SCMServiceManager serviceManager;
   private StorageContainerManager scm;
-  private TestClock testClock;
+  private MockClock mockClock;
 
   @BeforeEach
   void init(@TempDir File testDir, @TempDir File dbDir) throws Exception {
-    testClock = new TestClock(Instant.now(), ZoneOffset.UTC);
+    mockClock = new MockClock(Instant.now(), ZoneOffset.UTC);
     conf = SCMTestUtils.getConf(dbDir);
     scm = HddsTestUtils.getScm(SCMTestUtils.getConf(testDir));
 
@@ -167,7 +167,7 @@ public class TestPipelineManagerImpl {
         new EventQueue(),
         scmContext,
         serviceManager,
-        testClock);
+        mockClock);
   }
 
   private PipelineManagerImpl createPipelineManager(
@@ -179,7 +179,7 @@ public class TestPipelineManagerImpl {
         new EventQueue(),
         SCMContext.emptyContext(),
         serviceManager,
-        new TestClock(Instant.now(), ZoneOffset.UTC));
+        new MockClock(Instant.now(), ZoneOffset.UTC));
   }
 
   @Test
@@ -531,7 +531,7 @@ public class TestPipelineManagerImpl {
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
 
     // Set the clock to "now". All pipelines were created before this.
-    testClock.set(Instant.now());
+    mockClock.set(Instant.now());
 
     pipelineManager.scrubPipelines();
 
@@ -549,7 +549,7 @@ public class TestPipelineManagerImpl {
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
 
-    testClock.fastForward((60000));
+    mockClock.fastForward((60000));
 
     pipelineManager.scrubPipelines();
 
@@ -599,7 +599,7 @@ public class TestPipelineManagerImpl {
     try (PipelineManagerImpl pipelineManager = createPipelineManager(true)) {
       assertAllocate(pipelineManager);
       changeToFollower(pipelineManager);
-      testClock.fastForward(20000);
+      mockClock.fastForward(20000);
       assertThrows(SCMException.class,
           pipelineManager::scrubPipelines);
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -124,11 +124,11 @@ public class TestPipelineManagerImpl {
   private SCMContext scmContext;
   private SCMServiceManager serviceManager;
   private StorageContainerManager scm;
-  private MockClock mockClock;
+  private MockClock testClock;
 
   @BeforeEach
   void init(@TempDir File testDir, @TempDir File dbDir) throws Exception {
-    mockClock = new MockClock(Instant.now(), ZoneOffset.UTC);
+    testClock = new MockClock(Instant.now(), ZoneOffset.UTC);
     conf = SCMTestUtils.getConf(dbDir);
     scm = HddsTestUtils.getScm(SCMTestUtils.getConf(testDir));
 
@@ -167,7 +167,7 @@ public class TestPipelineManagerImpl {
         new EventQueue(),
         scmContext,
         serviceManager,
-        mockClock);
+        testClock);
   }
 
   private PipelineManagerImpl createPipelineManager(
@@ -531,7 +531,7 @@ public class TestPipelineManagerImpl {
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
 
     // Set the clock to "now". All pipelines were created before this.
-    mockClock.set(Instant.now());
+    testClock.set(Instant.now());
 
     pipelineManager.scrubPipelines();
 
@@ -549,7 +549,7 @@ public class TestPipelineManagerImpl {
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
 
-    mockClock.fastForward((60000));
+    testClock.fastForward((60000));
 
     pipelineManager.scrubPipelines();
 
@@ -599,7 +599,7 @@ public class TestPipelineManagerImpl {
     try (PipelineManagerImpl pipelineManager = createPipelineManager(true)) {
       assertAllocate(pipelineManager);
       changeToFollower(pipelineManager);
-      mockClock.fastForward(20000);
+      testClock.fastForward(20000);
       assertThrows(SCMException.class,
           pipelineManager::scrubPipelines);
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
@@ -103,7 +103,7 @@ public class TestOneReplicaPipelineSafeModeRule {
         eventQueue,
         scmContext,
         serviceManager,
-        new TestClock(Instant.now(), ZoneOffset.UTC));
+        new MockClock(Instant.now(), ZoneOffset.UTC));
 
     PipelineProvider<RatisReplicationConfig> mockRatisProvider =
         new MockRatisPipelineProvider(mockNodeManager,

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/MockClock.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/MockClock.java
@@ -28,16 +28,16 @@ import java.time.temporal.TemporalAmount;
  * moved forward and back. Intended for use only in tests.
  */
 
-public class TestClock extends Clock {
+public class MockClock extends Clock {
 
   private Instant instant;
   private final ZoneId zoneId;
 
-  public static TestClock newInstance() {
-    return new TestClock(Instant.now(), ZoneOffset.UTC);
+  public static MockClock newInstance() {
+    return new MockClock(Instant.now(), ZoneOffset.UTC);
   }
 
-  public TestClock(Instant instant, ZoneId zone) {
+  public MockClock(Instant instant, ZoneId zone) {
     this.instant = instant;
     this.zoneId = zone;
   }
@@ -49,7 +49,7 @@ public class TestClock extends Clock {
 
   @Override
   public Clock withZone(ZoneId zone) {
-    return new TestClock(Instant.now(), zone);
+    return new MockClock(Instant.now(), zone);
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -115,7 +115,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -1203,7 +1203,7 @@ abstract class AbstractOzoneFileSystemTest extends OzoneFileSystemTestBase {
       throws IOException {
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(client, bucketLayout);
-    final TestClock testClock = new TestClock(Instant.now(), ZoneOffset.UTC);
+    final MockClock mockClock = new MockClock(Instant.now(), ZoneOffset.UTC);
 
     String rootPath = String
         .format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucket.getName(),
@@ -1217,7 +1217,7 @@ abstract class AbstractOzoneFileSystemTest extends OzoneFileSystemTestBase {
       OzoneFileSystem o3FS = (OzoneFileSystem) fileSystem;
 
       //Let's reset the clock to control the time.
-      ((BasicOzoneClientAdapterImpl) (o3FS.getAdapter())).setClock(testClock);
+      ((BasicOzoneClientAdapterImpl) (o3FS.getAdapter())).setClock(mockClock);
 
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key"),
           ReplicationType.RATIS);
@@ -1229,7 +1229,7 @@ abstract class AbstractOzoneFileSystemTest extends OzoneFileSystemTestBase {
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key1"),
           ReplicationType.RATIS);
 
-      testClock.fastForward(300 * 1000 + 1);
+      mockClock.fastForward(300 * 1000 + 1);
 
       //After client bucket refresh time, it should create new type what is
       // available on bucket at that moment.
@@ -1244,7 +1244,7 @@ abstract class AbstractOzoneFileSystemTest extends OzoneFileSystemTestBase {
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key3"),
           ReplicationType.EC);
 
-      testClock.fastForward(300 * 1000 + 1);
+      mockClock.fastForward(300 * 1000 + 1);
 
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key4"),
           ReplicationType.RATIS);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -1203,7 +1203,7 @@ abstract class AbstractOzoneFileSystemTest extends OzoneFileSystemTestBase {
       throws IOException {
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(client, bucketLayout);
-    final MockClock mockClock = new MockClock(Instant.now(), ZoneOffset.UTC);
+    final MockClock testClock = new MockClock(Instant.now(), ZoneOffset.UTC);
 
     String rootPath = String
         .format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucket.getName(),
@@ -1217,7 +1217,7 @@ abstract class AbstractOzoneFileSystemTest extends OzoneFileSystemTestBase {
       OzoneFileSystem o3FS = (OzoneFileSystem) fileSystem;
 
       //Let's reset the clock to control the time.
-      ((BasicOzoneClientAdapterImpl) (o3FS.getAdapter())).setClock(mockClock);
+      ((BasicOzoneClientAdapterImpl) (o3FS.getAdapter())).setClock(testClock);
 
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key"),
           ReplicationType.RATIS);
@@ -1229,7 +1229,7 @@ abstract class AbstractOzoneFileSystemTest extends OzoneFileSystemTestBase {
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key1"),
           ReplicationType.RATIS);
 
-      mockClock.fastForward(300 * 1000 + 1);
+      testClock.fastForward(300 * 1000 + 1);
 
       //After client bucket refresh time, it should create new type what is
       // available on bucket at that moment.
@@ -1244,7 +1244,7 @@ abstract class AbstractOzoneFileSystemTest extends OzoneFileSystemTestBase {
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key3"),
           ReplicationType.EC);
 
-      mockClock.fastForward(300 * 1000 + 1);
+      testClock.fastForward(300 * 1000 + 1);
 
       createKeyAndAssertKeyType(bucket, o3FS, new Path(rootPath, "key4"),
           ReplicationType.RATIS);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -104,7 +104,7 @@ public class ReconTaskControllerImpl implements ReconTaskController {
   private static final int MAX_EVENT_PROCESS_RETRIES = 6;
   private static final long RETRY_DELAY_MS = 2000; // 2 seconds
   // Clock for the retry-delay gate; overridable in tests via the
-  // @VisibleForTesting constructor to drive the gate with a TestClock.
+  // @VisibleForTesting constructor to drive the gate with a MockClock.
   private Clock clock = Clock.systemUTC();
 
   @Inject

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -70,7 +70,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
 
   private ReconTaskController reconTaskController;
   private ReconTaskStatusDao reconTaskStatusDao;
-  private MockClock mockClock;
+  private MockClock testClock;
 
   public TestReconTaskControllerImpl() {
     super();
@@ -93,10 +93,10 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     ReconNamespaceSummaryManager nsSummaryManager = mock(ReconNamespaceSummaryManager.class);
     ReconGlobalStatsManager reconGlobalStatsManager = mock(ReconGlobalStatsManager.class);
     ReconFileMetadataManager reconFileMetadataManager = mock(ReconFileMetadataManager.class);
-    mockClock = MockClock.newInstance();
+    testClock = MockClock.newInstance();
     reconTaskController = new ReconTaskControllerImpl(ozoneConfiguration, new HashSet<>(),
         reconTaskStatusUpdaterManagerMock, reconDbProvider, reconContainerMgr, nsSummaryManager,
-        reconGlobalStatsManager, reconFileMetadataManager, mockClock);
+        reconGlobalStatsManager, reconFileMetadataManager, testClock);
     reconTaskController.start();
   }
 
@@ -588,7 +588,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     // Iterations 1-6: should return RETRY_LATER and increment retry count
     for (int i = 1; i <= 6; i++) {
       if (i > 1) {
-        mockClock.fastForward(2100); // Advance virtual time past the retry delay
+        testClock.fastForward(2100); // Advance virtual time past the retry delay
       }
       result = controllerSpy.queueReInitializationEvent(
           ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
@@ -599,7 +599,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     
     // Iteration 7: should return MAX_RETRIES_EXCEEDED (eventProcessRetryCount is now 6,
     // which >= MAX_EVENT_PROCESS_RETRIES)
-    mockClock.fastForward(2100); // Advance virtual time past the retry delay
+    testClock.fastForward(2100); // Advance virtual time past the retry delay
     result = controllerSpy.queueReInitializationEvent(
         ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
     assertEquals(ReconTaskController.ReInitializationResult.MAX_RETRIES_EXCEEDED, result,
@@ -680,7 +680,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     assertTrue(controllerSpy.hasTasksFailed(), "tasksFailed should still be true, triggering retry");
     
     // Advance virtual time past the retry delay before attempting to queue again (RETRY_DELAY_MS = 2000)
-    mockClock.fastForward(2100);
+    testClock.fastForward(2100);
     
     // Queue another reinitialization event (simulating what syncDataFromOM does)
     ReconTaskController.ReInitializationResult result = controllerSpy.queueReInitializationEvent(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.util.Time;
 import org.apache.ozone.recon.schema.generated.tables.daos.ReconTaskStatusDao;
 import org.apache.ozone.recon.schema.generated.tables.pojos.ReconTaskStatus;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.TestClock;
+import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,7 +70,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
 
   private ReconTaskController reconTaskController;
   private ReconTaskStatusDao reconTaskStatusDao;
-  private TestClock testClock;
+  private MockClock mockClock;
 
   public TestReconTaskControllerImpl() {
     super();
@@ -93,10 +93,10 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     ReconNamespaceSummaryManager nsSummaryManager = mock(ReconNamespaceSummaryManager.class);
     ReconGlobalStatsManager reconGlobalStatsManager = mock(ReconGlobalStatsManager.class);
     ReconFileMetadataManager reconFileMetadataManager = mock(ReconFileMetadataManager.class);
-    testClock = TestClock.newInstance();
+    mockClock = MockClock.newInstance();
     reconTaskController = new ReconTaskControllerImpl(ozoneConfiguration, new HashSet<>(),
         reconTaskStatusUpdaterManagerMock, reconDbProvider, reconContainerMgr, nsSummaryManager,
-        reconGlobalStatsManager, reconFileMetadataManager, testClock);
+        reconGlobalStatsManager, reconFileMetadataManager, mockClock);
     reconTaskController.start();
   }
 
@@ -588,7 +588,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     // Iterations 1-6: should return RETRY_LATER and increment retry count
     for (int i = 1; i <= 6; i++) {
       if (i > 1) {
-        testClock.fastForward(2100); // Advance virtual time past the retry delay
+        mockClock.fastForward(2100); // Advance virtual time past the retry delay
       }
       result = controllerSpy.queueReInitializationEvent(
           ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
@@ -599,7 +599,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     
     // Iteration 7: should return MAX_RETRIES_EXCEEDED (eventProcessRetryCount is now 6,
     // which >= MAX_EVENT_PROCESS_RETRIES)
-    testClock.fastForward(2100); // Advance virtual time past the retry delay
+    mockClock.fastForward(2100); // Advance virtual time past the retry delay
     result = controllerSpy.queueReInitializationEvent(
         ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
     assertEquals(ReconTaskController.ReInitializationResult.MAX_RETRIES_EXCEEDED, result,
@@ -680,7 +680,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     assertTrue(controllerSpy.hasTasksFailed(), "tasksFailed should still be true, triggering retry");
     
     // Advance virtual time past the retry delay before attempting to queue again (RETRY_DELAY_MS = 2000)
-    testClock.fastForward(2100);
+    mockClock.fastForward(2100);
     
     // Queue another reinitialization event (simulating what syncDataFromOM does)
     ReconTaskController.ReInitializationResult result = controllerSpy.queueReInitializationEvent(


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Ozone tests are named Test*, but TestClock is not a test. It should be renamed to MockClock.
- Renamed `TestClock.java` to `MockClock.java`.
- Updated imports, types, and variable names (`testClock` → `mockClock`) across all usages.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15753

## How was this patch tested?

CI success : https://github.com/prathmesh12-coder/ozone/actions/runs/29089318338
