### PR TITLE
HDDS-15751. Rename test parent classes for naming convention

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachineTests.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachineTests.java
@@ -70,7 +70,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Test class to ContainerStateMachine class.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-abstract class TestContainerStateMachine {
+abstract class ContainerStateMachineTests {
   private ContainerDispatcher dispatcher;
   private final OzoneConfiguration conf = new OzoneConfiguration();
   private ContainerStateMachine stateMachine;
@@ -82,7 +82,7 @@ abstract class TestContainerStateMachine {
   private final boolean isLeader;
   private static final String CONTAINER_DATA = "Test Data";
 
-  TestContainerStateMachine(boolean isLeader) {
+  ContainerStateMachineTests(boolean isLeader) {
     this.isLeader = isLeader;
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachineFollower.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachineFollower.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 /**
  * Test class to ContainerStateMachine class for follower.
  */
-public class TestContainerStateMachineFollower extends TestContainerStateMachine {
+public class TestContainerStateMachineFollower extends ContainerStateMachineTests {
   public TestContainerStateMachineFollower() {
     super(false);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachineLeader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestContainerStateMachineLeader.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 /**
  * Test class to ContainerStateMachine class for leader.
  */
-public class TestContainerStateMachineLeader extends TestContainerStateMachine {
+public class TestContainerStateMachineLeader extends ContainerStateMachineTests {
   public TestContainerStateMachineLeader() {
     super(true);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScannerTests.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScannerTests.java
@@ -58,7 +58,7 @@ import org.mockito.verification.VerificationMode;
  */
 @MockitoSettings(strictness = Strictness.LENIENT)
 @SuppressWarnings("checkstyle:VisibilityModifier")
-public abstract class TestContainerScannersAbstract {
+public abstract class ContainerScannerTests {
 
   private static final AtomicLong CONTAINER_SEQ_ID = new AtomicLong(100);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
@@ -78,7 +78,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class TestBackgroundContainerDataScanner extends
-    TestContainerScannersAbstract {
+    ContainerScannerTests {
 
   private BackgroundContainerDataScanner scanner;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
@@ -64,7 +64,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class TestBackgroundContainerMetadataScanner extends
-    TestContainerScannersAbstract {
+    ContainerScannerTests {
 
   private BackgroundContainerMetadataScanner scanner;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerScanner.java
@@ -65,7 +65,7 @@ import org.mockito.stubbing.Answer;
  */
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class TestOnDemandContainerScanner extends
-    TestContainerScannersAbstract {
+    ContainerScannerTests {
 
   private OnDemandContainerScanner onDemandScanner;
   private static final String TEST_SCAN = "Test Scan";

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/CoderTests.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/CoderTests.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
  * coders.
  */
 @SuppressWarnings({"checkstyle:VisibilityModifier", "checkstyle:HiddenField"})
-public abstract class TestCoderBase {
+public abstract class CoderTests {
   private static int fixedDataGenerator = 0;
   protected boolean allowDump = true;
   protected int numDataUnits;

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/RSRawCoderTests.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/RSRawCoderTests.java
@@ -22,9 +22,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Test base for raw Reed-solomon coders.
  */
-public abstract class TestRSRawCoderBase extends TestRawCoderBase {
+public abstract class RSRawCoderTests extends RawCoderTests {
 
-  public TestRSRawCoderBase(
+  public RSRawCoderTests(
       Class<? extends RawErasureCoderFactory> encoderFactoryClass,
       Class<? extends RawErasureCoderFactory> decoderFactoryClass) {
     super(encoderFactoryClass, decoderFactoryClass);

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/RawCoderTests.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/RawCoderTests.java
@@ -24,21 +24,21 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.ozone.erasurecode.CoderTests;
 import org.apache.ozone.erasurecode.ECChunk;
-import org.apache.ozone.erasurecode.TestCoderBase;
 import org.junit.jupiter.api.Test;
 
 /**
  * Raw coder test base with utilities.
  */
 @SuppressWarnings("checkstyle:VisibilityModifier")
-public abstract class TestRawCoderBase extends TestCoderBase {
+public abstract class RawCoderTests extends CoderTests {
   private final Class<? extends RawErasureCoderFactory> encoderFactoryClass;
   private final Class<? extends RawErasureCoderFactory> decoderFactoryClass;
   private RawErasureEncoder encoder;
   private RawErasureDecoder decoder;
 
-  public TestRawCoderBase(
+  public RawCoderTests(
       Class<? extends RawErasureCoderFactory> encoderFactoryClass,
       Class<? extends RawErasureCoderFactory> decoderFactoryClass) {
     this.encoderFactoryClass = encoderFactoryClass;

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestDummyRawCoder.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestDummyRawCoder.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test dummy raw coder.
  */
-public class TestDummyRawCoder extends TestRawCoderBase {
+public class TestDummyRawCoder extends RawCoderTests {
 
   public TestDummyRawCoder() {
     super(DummyRawErasureCoderFactory.class, DummyRawErasureCoderFactory.class);

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestNativeRSRawCoder.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestNativeRSRawCoder.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test native raw Reed-solomon encoding and decoding.
  */
-public class TestNativeRSRawCoder extends TestRSRawCoderBase {
+public class TestNativeRSRawCoder extends RSRawCoderTests {
 
   public TestNativeRSRawCoder() {
     super(NativeRSRawErasureCoderFactory.class,

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestNativeXORRawCoder.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestNativeXORRawCoder.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test NativeXOR encoding and decoding.
  */
-public class TestNativeXORRawCoder extends TestXORRawCoderBase {
+public class TestNativeXORRawCoder extends XORRawCoderTests {
 
   public TestNativeXORRawCoder() {
     super(NativeXORRawErasureCoderFactory.class,

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestRSRawCoder.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestRSRawCoder.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 /**
  * Test the new raw Reed-solomon coder implemented in Java.
  */
-public class TestRSRawCoder extends TestRSRawCoderBase {
+public class TestRSRawCoder extends RSRawCoderTests {
 
   public TestRSRawCoder() {
     super(RSRawErasureCoderFactory.class, RSRawErasureCoderFactory.class);

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestXORRawCoder.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestXORRawCoder.java
@@ -20,7 +20,7 @@ package org.apache.ozone.erasurecode.rawcoder;
 /**
  * Test pure Java XOR encoding and decoding.
  */
-public class TestXORRawCoder extends TestXORRawCoderBase {
+public class TestXORRawCoder extends XORRawCoderTests {
 
   public TestXORRawCoder() {
     super(XORRawErasureCoderFactory.class, XORRawErasureCoderFactory.class);

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/XORRawCoderTests.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/XORRawCoderTests.java
@@ -22,9 +22,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Test base for raw XOR coders.
  */
-public abstract class TestXORRawCoderBase extends TestRawCoderBase {
+public abstract class XORRawCoderTests extends RawCoderTests {
 
-  public TestXORRawCoderBase(
+  public XORRawCoderTests(
       Class<? extends RawErasureCoderFactory> encoderFactoryClass,
       Class<? extends RawErasureCoderFactory> decoderFactoryClass) {
     super(encoderFactoryClass, decoderFactoryClass);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandlerTests.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandlerTests.java
@@ -67,7 +67,7 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 /**
  * Tests the MisReplicationHandling functionalities to test implementations.
  */
-public abstract class TestMisReplicationHandler {
+public abstract class MisReplicationHandlerTests {
 
   private ContainerInfo container;
   private OzoneConfiguration conf;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests the ECMisReplicationHandling functionality.
  */
-public class TestECMisReplicationHandler extends TestMisReplicationHandler {
+public class TestECMisReplicationHandler extends MisReplicationHandlerTests {
   private static final int DATA = 3;
   private static final int PARITY = 2;
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests the RatisReplicationHandling functionality.
  */
-public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
+public class TestRatisMisReplicationHandler extends MisReplicationHandlerTests {
 
   @BeforeEach
   void setup(@TempDir File testDir) throws NodeNotFoundException,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/conf/ConfigurationFieldsTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/conf/ConfigurationFieldsTests.java
@@ -43,16 +43,16 @@ import org.slf4j.LoggerFactory;
  * Copied from Hadoop until the original one is migrated to JUnit5.
  */
 @SuppressWarnings("VisibilityModifier")
-public abstract class TestConfigurationFieldsBase {
+public abstract class ConfigurationFieldsTests {
 
   private static final Logger LOG = LoggerFactory.getLogger(
-      TestConfigurationFieldsBase.class);
+      ConfigurationFieldsTests.class);
 
   private static final Logger LOG_CONFIG = LoggerFactory.getLogger(
-      "org.apache.hadoop.conf.TestConfigurationFieldsBase.config");
+      "org.apache.hadoop.conf.ConfigurationFieldsTests.config");
 
   private static final Logger LOG_XML = LoggerFactory.getLogger(
-      "org.apache.hadoop.conf.TestConfigurationFieldsBase.xml");
+      "org.apache.hadoop.conf.ConfigurationFieldsTests.xml");
 
   /**
    * Member variable for storing xml filename.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone;
 
 import java.util.Arrays;
-import org.apache.hadoop.conf.TestConfigurationFieldsBase;
+import org.apache.hadoop.conf.ConfigurationFieldsTests;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.recon.ReconConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -32,7 +32,7 @@ import org.apache.hadoop.ozone.s3secret.S3SecretConfigKeys;
 /**
  * Tests if configuration constants documented in ozone-defaults.xml.
  */
-public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
+public class TestOzoneConfigurationFields extends ConfigurationFieldsTests {
 
   @Override
   public void initializeMemberVariables() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/InputStreamTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/InputStreamTests.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-abstract class TestInputStreamBase {
+abstract class InputStreamTests {
 
   static final int CHUNK_SIZE = 1024 * 1024;          // 1MB
   static final int FLUSH_SIZE = 2 * CHUNK_SIZE;       // 2MB

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.TestInstance;
  * Tests {@link ChunkInputStream}.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TestChunkInputStream extends TestInputStreamBase {
+class TestChunkInputStream extends InputStreamTests {
 
   /**
    * Run the tests as a single test method to avoid needing a new mini-cluster

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -64,7 +64,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class TestKeyInputStream extends TestInputStreamBase {
+class TestKeyInputStream extends InputStreamTests {
 
   /**
    * This method does random seeks and reads and validates the reads are

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestStreamBlockInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestStreamBlockInputStream.java
@@ -43,7 +43,7 @@ import org.slf4j.event.Level;
 /**
  * Tests {@link StreamBlockInputStream}.
  */
-public class TestStreamBlockInputStream extends TestInputStreamBase {
+public class TestStreamBlockInputStream extends InputStreamTests {
   private static final Logger LOG = LoggerFactory.getLogger(TestStreamBlockInputStream.class);
 
   {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/ContainerScannerIntegrationTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/ContainerScannerIntegrationTests.java
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.AfterAll;
 /**
  * This class tests the data scanner functionality.
  */
-public abstract class TestContainerScannerIntegrationAbstract {
+public abstract class ContainerScannerIntegrationTests {
 
   private static MiniOzoneCluster cluster;
   private static OzoneClient ozClient = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.params.provider.EnumSource;
  * checks all data and metadata in the container.
  */
 class TestBackgroundContainerDataScannerIntegration
-    extends TestContainerScannerIntegrationAbstract {
+    extends ContainerScannerIntegrationTests {
 
   @BeforeAll
   static void init() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * faster than a full data scan.
  */
 class TestBackgroundContainerMetadataScannerIntegration
-    extends TestContainerScannerIntegrationAbstract {
+    extends ContainerScannerIntegrationTests {
 
   private final GenericTestUtils.LogCapturer logCapturer =
       GenericTestUtils.LogCapturer.log4j2(ContainerLogger.LOG_NAME);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestOnDemandContainerScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestOnDemandContainerScannerIntegration.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * container.
  */
 class TestOnDemandContainerScannerIntegration
-    extends TestContainerScannerIntegrationAbstract {
+    extends ContainerScannerIntegrationTests {
 
   private final GenericTestUtils.LogCapturer logCapturer =
       GenericTestUtils.LogCapturer.log4j2(ContainerLogger.LOG_NAME);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/DataValidateTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/DataValidateTests.java
@@ -34,7 +34,7 @@ import picocli.CommandLine;
 /**
  * Tests Freon, with MiniOzoneCluster and validate data.
  */
-public abstract class TestDataValidate {
+public abstract class DataValidateTests {
 
   private static MiniOzoneCluster cluster = null;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithDummyContainers.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithDummyContainers.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 
 public class TestDataValidateWithDummyContainers
-    extends TestDataValidate {
+    extends DataValidateTests {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestDataValidateWithDummyContainers.class);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithSafeByteOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithSafeByteOperations.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
  * Tests Freon, with MiniOzoneCluster and validate data.
  */
 
-public class TestDataValidateWithSafeByteOperations extends TestDataValidate {
+public class TestDataValidateWithSafeByteOperations extends DataValidateTests {
 
   @BeforeAll
   public static void init() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithUnsafeByteOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithUnsafeByteOperations.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeAll;
 /**
  * Tests Freon, with MiniOzoneCluster and validate data.
  */
-public class TestDataValidateWithUnsafeByteOperations extends TestDataValidate {
+public class TestDataValidateWithUnsafeByteOperations extends DataValidateTests {
 
   @BeforeAll
   public static void init() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OzoneManagerHAFollowerReadTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OzoneManagerHAFollowerReadTests.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeAll;
 /**
  * Base class for Ozone Manager HA follower read tests.
  */
-public abstract class TestOzoneManagerHAFollowerRead extends AbstractOzoneManagerHATest {
+public abstract class OzoneManagerHAFollowerReadTests extends AbstractOzoneManagerHATest {
 
   @BeforeAll
   public static void init() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OzoneManagerHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OzoneManagerHATests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeAll;
 /**
  * Base class for Ozone Manager HA tests.
  */
-public abstract class TestOzoneManagerHA extends AbstractOzoneManagerHATest {
+public abstract class OzoneManagerHATests extends AbstractOzoneManagerHATest {
 
   @BeforeAll
   public static void init() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -21,7 +21,7 @@ import static org.apache.hadoop.hdds.security.SecurityConfig.OZONE_TEST_AUTHORIZ
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_DUMMY_SERVICE_ID;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DECOMMISSIONED_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT;
-import static org.apache.hadoop.ozone.om.TestOzoneManagerHA.createKey;
+import static org.apache.hadoop.ozone.om.OzoneManagerHATests.createKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithAllRunning.java
@@ -86,7 +86,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Ozone Manager HA follower read tests where all OMs are running throughout all tests.
  * @see TestOzoneManagerHAFollowerReadWithAllRunning
  */
-public class TestOzoneManagerHAFollowerReadWithAllRunning extends TestOzoneManagerHAFollowerRead {
+public class TestOzoneManagerHAFollowerReadWithAllRunning extends OzoneManagerHAFollowerReadTests {
 
   @Test
   void testOMFollowerReadProxyProviderInitialization() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAFollowerReadWithStoppedNodes.java
@@ -64,7 +64,7 @@ import org.junit.jupiter.api.TestMethodOrder;
  * @see TestOzoneManagerHAFollowerReadWithAllRunning
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class TestOzoneManagerHAFollowerReadWithStoppedNodes extends TestOzoneManagerHAFollowerRead {
+public class TestOzoneManagerHAFollowerReadWithStoppedNodes extends OzoneManagerHAFollowerReadTests {
 
   /**
    * After restarting OMs we need to wait

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -94,7 +94,7 @@ import org.junit.jupiter.api.Test;
  * Ozone Manager HA tests where all OMs are running throughout all tests.
  * @see TestOzoneManagerHAWithStoppedNodes
  */
-class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
+class TestOzoneManagerHAWithAllRunning extends OzoneManagerHATests {
 
   @Test
   void testFileOperationsWithRecursive() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -92,7 +92,7 @@ import org.slf4j.LoggerFactory;
  * @see TestOzoneManagerHAWithAllRunning
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
+public class TestOzoneManagerHAWithStoppedNodes extends OzoneManagerHATests {
   private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(
       TestOzoneManagerHAWithStoppedNodes.class);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
  * Test OM prepare against actual mini cluster.
  */
 @Flaky("HDDS-5990")
-public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
+public class TestOzoneManagerPrepare extends OzoneManagerHATests {
   private static final String BUCKET = "bucket";
   private static final String VOLUME = "volume";
   private static final String KEY_PREFIX = "key";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotTests.java
@@ -172,7 +172,7 @@ import org.rocksdb.LiveFileMetaData;
  * Abstract class to test OmSnapshot.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class TestOmSnapshot {
+public abstract class OmSnapshotTests {
   static {
     Logger.getLogger(ManagedRocksObjectUtils.class).setLevel(Level.DEBUG);
   }
@@ -206,7 +206,7 @@ public abstract class TestOmSnapshot {
   private final boolean createLinkedBucket;
   private final Map<String, String> linkedBuckets = new HashMap<>();
 
-  public TestOmSnapshot(BucketLayout newBucketLayout,
+  public OmSnapshotTests(BucketLayout newBucketLayout,
                         boolean newEnableFileSystemPaths,
                         boolean forceFullSnapDiff,
                         boolean disableNativeDiff,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithNativeLib.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithNativeLib.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  * Test OmSnapshot for FSO bucket type when native lib is enabled.
  */
 @EnabledIfSystemProperty(named = ROCKS_TOOLS_NATIVE_PROPERTY, matches = "true")
-class TestOmSnapshotFsoWithNativeLib extends TestOmSnapshot {
+class TestOmSnapshotFsoWithNativeLib extends OmSnapshotTests {
   TestOmSnapshotFsoWithNativeLib() throws Exception {
     super(FILE_SYSTEM_OPTIMIZED, false, false, false, false);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithoutNativeLib.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithoutNativeLib.java
@@ -22,7 +22,7 @@ import static org.apache.hadoop.ozone.om.helpers.BucketLayout.FILE_SYSTEM_OPTIMI
 /**
  * Test OmSnapshot for FSO bucket type when native lib is disabled.
  */
-public class TestOmSnapshotFsoWithoutNativeLib extends TestOmSnapshot {
+public class TestOmSnapshotFsoWithoutNativeLib extends OmSnapshotTests {
 
   public TestOmSnapshotFsoWithoutNativeLib() throws Exception {
     super(FILE_SYSTEM_OPTIMIZED, false, false, true, false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithoutNativeLibWithLinkedBuckets.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotFsoWithoutNativeLibWithLinkedBuckets.java
@@ -22,7 +22,7 @@ import static org.apache.hadoop.ozone.om.helpers.BucketLayout.FILE_SYSTEM_OPTIMI
 /**
  * Test OmSnapshot for FSO bucket type when native lib is disabled.
  */
-public class TestOmSnapshotFsoWithoutNativeLibWithLinkedBuckets extends TestOmSnapshot {
+public class TestOmSnapshotFsoWithoutNativeLibWithLinkedBuckets extends OmSnapshotTests {
 
   public TestOmSnapshotFsoWithoutNativeLibWithLinkedBuckets() throws Exception {
     super(FILE_SYSTEM_OPTIMIZED, false, false, true, true);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotObjectStore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotObjectStore.java
@@ -22,7 +22,7 @@ import static org.apache.hadoop.ozone.om.helpers.BucketLayout.OBJECT_STORE;
 /**
  * Test OmSnapshot for Object Store bucket type.
  */
-public class TestOmSnapshotObjectStore extends TestOmSnapshot {
+public class TestOmSnapshotObjectStore extends OmSnapshotTests {
 
   public TestOmSnapshotObjectStore() throws Exception {
     super(OBJECT_STORE, false, false, false, false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotWithoutBucketLinkingLegacy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotWithoutBucketLinkingLegacy.java
@@ -22,7 +22,7 @@ import static org.apache.hadoop.ozone.om.helpers.BucketLayout.LEGACY;
 /**
  * Test OmSnapshot for Legacy bucket type.
  */
-public class TestOmSnapshotWithoutBucketLinkingLegacy extends TestOmSnapshot {
+public class TestOmSnapshotWithoutBucketLinkingLegacy extends OmSnapshotTests {
 
   public TestOmSnapshotWithoutBucketLinkingLegacy() throws Exception {
     super(LEGACY, false, false, false, false);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Abstract test parent classes should not be named `Test...`, rather `...Tests` (or similar).

This PR renames:

* `TestCoderBase/TestRawCoderBase` to `CoderTests/RawCoderTests`
* `TestConfigurationFieldsBase` to `ConfigurationFieldsTests`
* `TestContainerScannersAbstract` to `ContainerScannerTests`
* `TestContainerScannerIntegrationAbstract` to `ContainerScannerIntegrationTests`
* `TestContainerStateMachine` to `ContainerStateMachineTests`
* `TestDataValidate` to `DataValidateTests`
* `TestInputStreamBase` to `InputStreamTests`
* `TestMisReplicationHandler` to `MisReplicationHandlerTests`
* `TestOmSnapshot` to `OmSnapshotTests`
* `TestOzoneManagerHA` to `OzoneManagerHATests`
* `TestOzoneManagerHAFollowerRead` to `OzoneManagerHAFollowerReadTests`

https://issues.apache.org/jira/browse/HDDS-15751

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/29097353220
