### PR TITLE
HDDS-15782. [Recon] Poll DN pending-deletion scan to completion when Auto Refresh is off

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -25,7 +25,13 @@ import { capacityServer } from '@tests/mocks/capacityMocks/capacityServer';
 import * as mockResponses from '@tests/mocks/capacityMocks/capacityResponseMocks';
 
 vi.mock('@/components/autoReloadPanel/autoReloadPanel', () => ({
-  default: () => <div data-testid="auto-reload-panel" />,
+  default: (props: { onReload?: () => void }) => (
+    <div data-testid="auto-reload-panel">
+      <button data-testid="manual-reload" onClick={() => props.onReload?.()}>
+        reload
+      </button>
+    </div>
+  ),
 }));
 vi.mock('@/components/eChart/eChart', () => ({
   EChart: () => <div data-testid="echart" />,
@@ -49,9 +55,9 @@ describe('Capacity Page', () => {
       return;
     }
     await waitFor(() =>
-      expect(ozoneCapacityCard).toHaveTextContent(/TOTAL\s*10\s*KB/i)
+      expect(ozoneCapacityCard).toHaveTextContent(/TOTAL CAPACITY\s*10\s*KB/i)
     );
-    expect(ozoneCapacityCard).toHaveTextContent(/OZONE USED SPACE\s*4\s*KB/i);
+    expect(ozoneCapacityCard).toHaveTextContent(/USED SPACE\s*4\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/OTHER USED SPACE\s*2\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/CONTAINER PRE-ALLOCATED\s*1\s*KB/i);
     expect(ozoneCapacityCard).toHaveTextContent(/REMAINING SPACE\s*4\s*KB/i);
@@ -63,7 +69,7 @@ describe('Capacity Page', () => {
       return;
     }
     await waitFor(() =>
-      expect(ozoneUsedSpaceCard).toHaveTextContent(/PENDING DELETION\s*6\s*KB/i)
+      expect(ozoneUsedSpaceCard).toHaveTextContent(/PENDING DELETION\s*7\s*KB/i)
     );
   });
 
@@ -80,7 +86,7 @@ describe('Capacity Page', () => {
       expect(pendingDeletionCard).toHaveTextContent(/OZONE MANAGER\s*2\s*KB/i)
     );
     expect(pendingDeletionCard)
-      .toHaveTextContent(/STORAGE CONTAINER MANAGER\s*1\s*KB/i);
+      .toHaveTextContent(/STORAGE CONTAINER MANAGER\s*2\s*KB/i);
     expect(pendingDeletionCard).toHaveTextContent(/DATANODES\s*3\s*KB/i);
 
     const downloadLink = await screen.findByText('Download Insights');
@@ -308,53 +314,128 @@ describe('Capacity Page', () => {
     expect(screen.queryByRole('option', { name: 'dn-17' })).not.toBeInTheDocument();
   });
 
-  test('keeps polling the DN scan to completion even when Auto Refresh is off', async () => {
-    // Auto Refresh disabled before mount, so useAutoReload never starts its timer.
-    sessionStorage.setItem('autoReloadEnabled', 'false');
+  // Interval constants mirrored from capacity.tsx / autoReload.constants.
+  const PENDING_POLL_INTERVAL = 5* 1000;
+  const AUTO_RELOAD_INTERVAL = 60 * 1000;
 
-    let dnCallCount = 0;
-    // Report an in-progress scan on the first two reads, then FINISHED.
-    const dnStatuses = ['IN_PROGRESS', 'IN_PROGRESS', 'FINISHED'];
+  type EndpointCounts = { storage: number; scm: number; om: number; dn: number };
+
+  // Installs handlers that count how often each endpoint is hit and serves the
+  // supplied DN scan statuses in order (clamped to the last entry afterwards).
+  const setupCountingHandlers = (dnStatuses: string[]) => {
+    const counts: EndpointCounts = { storage: 0, scm: 0, om: 0, dn: 0 };
     capacityServer.use(
+      rest.get('api/v1/storageDistribution', (_req, res, ctx) => {
+        counts.storage++;
+        return res(ctx.status(200), ctx.json(mockResponses.StorageDistribution));
+      }),
       rest.get('api/v1/pendingDeletion', (req, res, ctx) => {
         const component = req.url.searchParams.get('component');
         if (component === 'dn') {
-          const status = dnStatuses[Math.min(dnCallCount, dnStatuses.length - 1)];
-          dnCallCount++;
+          const status = dnStatuses[Math.min(counts.dn, dnStatuses.length - 1)];
+          counts.dn++;
           return res(
             ctx.status(200),
             ctx.json({ ...mockResponses.DnPendingDeletion, status })
           );
         }
-        const map: Record<string, object> = {
-          scm: mockResponses.ScmPendingDeletion,
-          om: mockResponses.OmPendingDeletion
-        };
-        const body = component ? map[component] : undefined;
-        return body
-          ? res(ctx.status(200), ctx.json(body))
-          : res(ctx.status(400), ctx.json({ message: 'Unsupported pending deletion component.' }));
+        if (component === 'scm') {
+          counts.scm++;
+          return res(ctx.status(200), ctx.json(mockResponses.ScmPendingDeletion));
+        }
+        if (component === 'om') {
+          counts.om++;
+          return res(ctx.status(200), ctx.json(mockResponses.OmPendingDeletion));
+        }
+        return res(ctx.status(400), ctx.json({ message: 'Unsupported pending deletion component.' }));
       })
     );
+    return counts;
+  };
+
+  test('Auto Refresh off: a manual refresh drives the DN scan, polling only the DN endpoint until it finishes, then syncs the other endpoints', async () => {
+    // Auto Refresh disabled before mount, so useAutoReload never starts its timer.
+    sessionStorage.setItem('autoReloadEnabled', 'false');
+
+    // Mount read is FINISHED (no scan running). The manual refresh kicks off a
+    // scan: the next reads are IN_PROGRESS, IN_PROGRESS, then FINISHED.
+    const counts = setupCountingHandlers([
+      'FINISHED',      // mount
+      'IN_PROGRESS',   // manual refresh
+      'IN_PROGRESS',   // poll #1
+      'FINISHED'       // poll #2
+    ]);
 
     vi.useFakeTimers();
     try {
       render(<Capacity />);
 
-      // Flush the initial mount fetch (dn read #1 -> IN_PROGRESS).
+      // Flush the initial mount fetch: everything fetched exactly once.
       await vi.advanceTimersByTimeAsync(50);
-      expect(dnCallCount).toBe(1);
+      expect(counts).toEqual({ storage: 1, scm: 1, om: 1, dn: 1 });
 
-      // With the toggle off, an in-progress scan still polls every 5s. Advancing
-      // the timer drives further reads (#2 IN_PROGRESS, #3 FINISHED).
-      await vi.advanceTimersByTimeAsync(5000);
-      expect(dnCallCount).toBe(2);
-      await vi.advanceTimersByTimeAsync(5000);
-      expect(dnCallCount).toBe(3);
+      // Scan is FINISHED, so nothing is polled while idle.
+      await vi.advanceTimersByTimeAsync(AUTO_RELOAD_INTERVAL * 2);
+      expect(counts).toEqual({ storage: 1, scm: 1, om: 1, dn: 1 });
 
-      // Once FINISHED, polling stops even though Auto Refresh remains off.
-      await vi.advanceTimersByTimeAsync(15000);
-      expect(dnCallCount).toBe(3);
+      // Manual reload -> full refresh of all four endpoints; DN comes back
+      // IN_PROGRESS, which starts the DN-only poll.
+      fireEvent.click(screen.getByTestId('manual-reload'));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(counts).toEqual({ storage: 2, scm: 2, om: 2, dn: 2 });
+
+      // While IN_PROGRESS only the DN endpoint is polled; the others stay put.
+      await vi.advanceTimersByTimeAsync(PENDING_POLL_INTERVAL);
+      expect(counts).toEqual({ storage: 2, scm: 2, om: 2, dn: 3 });
+
+      // Next poll returns FINISHED -> DN polling stops and the other three
+      // endpoints are synced exactly once.
+      await vi.advanceTimersByTimeAsync(PENDING_POLL_INTERVAL);
+      expect(counts).toEqual({ storage: 3, scm: 3, om: 3, dn: 4 });
+
+      // No further polling once finished, and no periodic refresh while off.
+      await vi.advanceTimersByTimeAsync(AUTO_RELOAD_INTERVAL * 2);
+      expect(counts).toEqual({ storage: 3, scm: 3, om: 3, dn: 4 });
+    } finally {
+      vi.useRealTimers();
+      sessionStorage.removeItem('autoReloadEnabled');
+    }
+  });
+
+  test('Auto Refresh on: refreshes all endpoints on the interval, polls only the DN endpoint while a scan runs, and syncs the others when it finishes', async () => {
+    // Auto Refresh enabled (default). useAutoReload runs a full refresh every 60s.
+    sessionStorage.setItem('autoReloadEnabled', 'true');
+
+    // A scan is already running at mount: IN_PROGRESS, IN_PROGRESS, then FINISHED.
+    const counts = setupCountingHandlers([
+      'IN_PROGRESS',   // mount
+      'IN_PROGRESS',   // poll #1
+      'FINISHED'       // poll #2
+    ]);
+
+    vi.useFakeTimers();
+    try {
+      render(<Capacity />);
+
+      // Flush the initial mount fetch: everything fetched once, scan IN_PROGRESS.
+      await vi.advanceTimersByTimeAsync(50);
+      expect(counts).toEqual({ storage: 1, scm: 1, om: 1, dn: 1 });
+
+      // While IN_PROGRESS only the DN endpoint is polled.
+      await vi.advanceTimersByTimeAsync(PENDING_POLL_INTERVAL);
+      expect(counts).toEqual({ storage: 1, scm: 1, om: 1, dn: 2 });
+
+      // Next poll returns FINISHED -> DN polling stops and the others sync once.
+      await vi.advanceTimersByTimeAsync(PENDING_POLL_INTERVAL);
+      expect(counts).toEqual({ storage: 2, scm: 2, om: 2, dn: 3 });
+
+      // No DN-only polling once finished.
+      await vi.advanceTimersByTimeAsync(PENDING_POLL_INTERVAL * 4);
+      expect(counts).toEqual({ storage: 2, scm: 2, om: 2, dn: 3 });
+
+      // At the auto-refresh interval, all four endpoints are refreshed together.
+      await vi.advanceTimersByTimeAsync(AUTO_RELOAD_INTERVAL);
+      expect(counts).toEqual({ storage: 3, scm: 3, om: 3, dn: 4 });
     } finally {
       vi.useRealTimers();
       sessionStorage.removeItem('autoReloadEnabled');

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -315,7 +315,7 @@ describe('Capacity Page', () => {
   });
 
   // Interval constants mirrored from capacity.tsx / autoReload.constants.
-  const PENDING_POLL_INTERVAL = 5* 1000;
+  const PENDING_POLL_INTERVAL = 5 * 1000;
   const AUTO_RELOAD_INTERVAL = 60 * 1000;
 
   type EndpointCounts = { storage: number; scm: number; om: number; dn: number };

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -307,4 +307,57 @@ describe('Capacity Page', () => {
     );
     expect(screen.queryByRole('option', { name: 'dn-17' })).not.toBeInTheDocument();
   });
+
+  test('keeps polling the DN scan to completion even when Auto Refresh is off', async () => {
+    // Auto Refresh disabled before mount, so useAutoReload never starts its timer.
+    sessionStorage.setItem('autoReloadEnabled', 'false');
+
+    let dnCallCount = 0;
+    // Report an in-progress scan on the first two reads, then FINISHED.
+    const dnStatuses = ['IN_PROGRESS', 'IN_PROGRESS', 'FINISHED'];
+    capacityServer.use(
+      rest.get('api/v1/pendingDeletion', (req, res, ctx) => {
+        const component = req.url.searchParams.get('component');
+        if (component === 'dn') {
+          const status = dnStatuses[Math.min(dnCallCount, dnStatuses.length - 1)];
+          dnCallCount++;
+          return res(
+            ctx.status(200),
+            ctx.json({ ...mockResponses.DnPendingDeletion, status })
+          );
+        }
+        const map: Record<string, object> = {
+          scm: mockResponses.ScmPendingDeletion,
+          om: mockResponses.OmPendingDeletion
+        };
+        const body = component ? map[component] : undefined;
+        return body
+          ? res(ctx.status(200), ctx.json(body))
+          : res(ctx.status(400), ctx.json({ message: 'Unsupported pending deletion component.' }));
+      })
+    );
+
+    vi.useFakeTimers();
+    try {
+      render(<Capacity />);
+
+      // Flush the initial mount fetch (dn read #1 -> IN_PROGRESS).
+      await vi.advanceTimersByTimeAsync(50);
+      expect(dnCallCount).toBe(1);
+
+      // With the toggle off, an in-progress scan still polls every 5s. Advancing
+      // the timer drives further reads (#2 IN_PROGRESS, #3 FINISHED).
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(dnCallCount).toBe(2);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(dnCallCount).toBe(3);
+
+      // Once FINISHED, polling stops even though Auto Refresh remains off.
+      await vi.advanceTimersByTimeAsync(15000);
+      expect(dnCallCount).toBe(3);
+    } finally {
+      vi.useRealTimers();
+      sessionStorage.removeItem('autoReloadEnabled');
+    }
+  });
 });

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -38,7 +38,6 @@ import { useApiData } from '@/v2/hooks/useAPIData.hook';
 import * as CONSTANTS from '@/v2/constants/capacity.constants';
 import { UtilizationResponse, SCMPendingDeletion, OMPendingDeletion, DNPendingDeletion, DataNodeUsage } from '@/v2/types/capacity.types';
 import { useAutoReload } from '@/v2/hooks/useAutoReload.hook';
-import { AUTO_RELOAD_INTERVAL_DEFAULT } from '@/constants/autoReload.constants';
 
 type CapacityState = {
   lastUpdated: number;
@@ -202,28 +201,58 @@ const Capacity: React.FC<object> = () => {
     }
   };
 
-  // Keep the latest refresh callback in a ref so the interval below always calls
-  // the current closure instead of a stale one captured when the effect last ran.
-  const loadDataIfIdleRef = React.useRef(loadDataIfIdle);
-  loadDataIfIdleRef.current = loadDataIfIdle;
+  // --- DN pending-deletion scan polling --------------------------------------
+  // The periodic full refresh (all four endpoints) is driven by useAutoReload
+  // when Auto Refresh is enabled, and by the manual reload button otherwise.
+  // On top of that, whenever a DN scan is reported IN_PROGRESS we poll ONLY the
+  // DN endpoint at a fast cadence until it finishes, then refetch the other
+  // endpoints once so the aggregate pending-deletion numbers reflect the final
+  // DN data. This runs regardless of the Auto Refresh toggle, because a running
+  // scan must be driven to completion either way.
 
-  // Drive the DN pending-deletion scan through to completion:
-  // fast (5s) while a scan is running, normal (60s) once finished.
-  // A running scan must be polled to completion and refresh the whole page even
-  // when Auto Refresh is off, otherwise the datanode sections stay stuck loading
-  // after the toggle is disabled. The toggle only governs the steady-state
-  // periodic reload once the scan has FINISHED.
-  React.useEffect(() => {
-    const scanInProgress = dnPendingDeletes.data.status !== "FINISHED";
-    if (autoReload.isPolling) {
-      autoReload.startPolling(scanInProgress ? PENDING_POLL_INTERVAL : AUTO_RELOAD_INTERVAL_DEFAULT);
-      return;
+  // Refetch only the DN endpoint. Kept in a ref so the interval below always
+  // reads the current `loading` value instead of a stale closure (the effect
+  // does not re-run while the status stays IN_PROGRESS).
+  const pollDnScanRef = React.useRef<() => void>(() => {});
+  pollDnScanRef.current = () => {
+    if (!dnPendingDeletes.loading) {
+      dnPendingDeletes.refetch();
     }
+  };
+
+  // Refetch everything except the DN endpoint, to re-sync the OM / SCM / storage
+  // numbers with the DN data once the scan has finished.
+  const syncNonDnDataRef = React.useRef<() => void>(() => {});
+  syncNonDnDataRef.current = () => {
+    storageDistribution.refetch();
+    scmPendingDeletes.refetch();
+    omPendingDeletes.refetch();
+    setState({ lastUpdated: Number(moment()) });
+  };
+
+  // True while we are actively driving a DN scan, so that we sync the other
+  // endpoints exactly once when it transitions to FINISHED — and not on the
+  // initial load, where all four endpoints were already fetched together.
+  const isDrivingDnScanRef = React.useRef(false);
+
+  React.useEffect(() => {
+    const scanInProgress = dnPendingDeletes.data.status === "IN_PROGRESS";
+
     if (scanInProgress) {
-      const timer = window.setInterval(() => loadDataIfIdleRef.current(), PENDING_POLL_INTERVAL);
+      isDrivingDnScanRef.current = true;
+      const timer = window.setInterval(() => pollDnScanRef.current(), PENDING_POLL_INTERVAL);
       return () => clearInterval(timer);
     }
-  }, [dnPendingDeletes.data.status, autoReload.isPolling]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Reached a terminal state (FINISHED / FAILED). If we were driving a scan,
+    // sync the other endpoints once (only on success) and stop tracking it.
+    if (isDrivingDnScanRef.current) {
+      isDrivingDnScanRef.current = false;
+      if (dnPendingDeletes.data.status === "FINISHED") {
+        syncNonDnDataRef.current();
+      }
+    }
+  }, [dnPendingDeletes.data.status]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const dnReportStatus = (
     (dnPendingDeletes.data.totalNodeQueriesFailed ?? 0) > 0

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -202,18 +202,27 @@ const Capacity: React.FC<object> = () => {
     }
   };
 
-  // Adjust the polling interval based on DN scan status:
+  // Keep the latest refresh callback in a ref so the interval below always calls
+  // the current closure instead of a stale one captured when the effect last ran.
+  const loadDataIfIdleRef = React.useRef(loadDataIfIdle);
+  loadDataIfIdleRef.current = loadDataIfIdle;
+
+  // Drive the DN pending-deletion scan through to completion:
   // fast (5s) while a scan is running, normal (60s) once finished.
-  // Honors the auto-reload toggle: if polling is OFF, do nothing.
+  // A running scan must be polled to completion and refresh the whole page even
+  // when Auto Refresh is off, otherwise the datanode sections stay stuck loading
+  // after the toggle is disabled. The toggle only governs the steady-state
+  // periodic reload once the scan has FINISHED.
   React.useEffect(() => {
-    if (!autoReload.isPolling) {
+    const scanInProgress = dnPendingDeletes.data.status !== "FINISHED";
+    if (autoReload.isPolling) {
+      autoReload.startPolling(scanInProgress ? PENDING_POLL_INTERVAL : AUTO_RELOAD_INTERVAL_DEFAULT);
       return;
     }
-    autoReload.startPolling(
-      dnPendingDeletes.data.status === "FINISHED"
-        ? AUTO_RELOAD_INTERVAL_DEFAULT
-        : PENDING_POLL_INTERVAL
-    );
+    if (scanInProgress) {
+      const timer = window.setInterval(() => loadDataIfIdleRef.current(), PENDING_POLL_INTERVAL);
+      return () => clearInterval(timer);
+    }
   }, [dnPendingDeletes.data.status, autoReload.isPolling]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const dnReportStatus = (


### PR DESCRIPTION

## What changes were proposed in this pull request?

The Capacity page showed the datanode sections as loading based on the pending-deletion scan status. That status only changed to **FINISHED** through the auto-refresh polling loop.

The problem was that if Auto Refresh was turned off while a scan was still running, polling stopped completely. As a result, the scan status never updated to **FINISHED** on the page, even though it had completed on the backend, leaving the datanode sections stuck in a loading state.

This change separates scan completion polling from the Auto Refresh setting. While a scan is in progress, the page now continues polling every 5 seconds and refreshes until the scan reaches **FINISHED**, regardless of whether Auto Refresh is enabled. Once the scan is complete, the Auto Refresh toggle resumes controlling the normal periodic refresh behavior. A separate `setInterval` handles polling when Auto Refresh is off, and a ref ensures it always calls the latest refresh function instead of an outdated one.

A new Capacity test has also been added to verify this behavior. With Auto Refresh turned off, the test confirms that polling continues while the scan is in progress (`IN_PROGRESS → IN_PROGRESS → FINISHED`) and stops once the scan finishes.

## What is the link to the Apache JIRA

 HDDS-15782

## How was this patch tested?

Made with Cursor Composer 2.5.
Tested manually and using unit test.
