### PR TITLE
HDDS-15822. Fix flaky TestStorageVolumeChecker#testNumScansSkipped

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -274,8 +274,22 @@ public class TestStorageVolumeChecker {
     final List<HddsVolume> volumes = makeVolumes(3, expectedVolumeHealth);
 
     FakeTimer timer = new FakeTimer();
+    // Configure diskCheckTimeout=0 so checkAllVolumes uses latch.await(0, ...) which
+    // returns immediately once the synchronous checks below have already fired the latch.
+    OzoneConfiguration testConf = new OzoneConfiguration();
+    DatanodeConfiguration dnConf = testConf.getObject(DatanodeConfiguration.class);
+    dnConf.setDiskCheckTimeout(Duration.ZERO);
+    testConf.setFromObject(dnConf);
     final StorageVolumeChecker checker =
-        new StorageVolumeChecker(new OzoneConfiguration(), timer, "");
+        new StorageVolumeChecker(testConf, timer, "");
+    // Use a synchronous (direct-executor) ThrottledAsyncChecker so that
+    // completedChecks is always fully updated before checkAllVolumes returns,
+    // eliminating the race between async callback completion and timer.advance().
+    checker.setDelegateChecker(new ThrottledAsyncChecker<>(
+        timer,
+        dnConf.getDiskCheckMinGap().toMillis(),
+        0L,
+        MoreExecutors.newDirectExecutorService()));
 
     VolumeInfoMetrics metrics1 = new VolumeInfoMetrics("test-volume-1", volumes.get(0));
     VolumeInfoMetrics metrics2 = new VolumeInfoMetrics("test-volume-2", volumes.get(1));


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.8)

## What changes were proposed in this pull request?

`TestStorageVolumeChecker#testNumScansSkipped` fails intermittently with `expected: <1> but was: <2>` (seen in upstream CI on 2026-07-09).

The test uses the real `ThrottledAsyncChecker`, which runs volume checks on a background executor and wraps them with `Futures.withTimeout`. The callback that records each check's `completedAt` runs on those executor threads. On a busy JVM this races with the test's `timer.advance()`, so a check's `completedAt` is occasionally recorded against a later timer value. On the third `checkAllVolumes` call the affected volume then looks like it is still within `minMsBetweenChecks` and is skipped, which inflates `numScansSkipped` from 1 to 2.

This PR makes the check synchronous for this test by installing a `ThrottledAsyncChecker` backed by a direct executor service, and by setting `diskCheckTimeout` to zero so no `Futures.withTimeout` wrapper is created. `completedChecks` is then fully populated before `checkAllVolumes` returns, which removes the race. The throttling gap (`getDiskCheckMinGap`) is unchanged, so the test still verifies skip counting, and the asynchronous per volume timeout path stays covered by the dedicated test added in HDDS-14871. The change is limited to the test.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15822

## How was this patch tested?

Ran `testNumScansSkipped` 100 times locally with 0 failures. Ran the full `TestStorageVolumeChecker` class (20 tests) multiple times with no failures. Checkstyle clean.
