### PR TITLE
HDDS-15823. Fix flaky TestFailureHandlingByClient#testContainerExclusionWithClosedContainerException

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -400,7 +400,12 @@ public class TestFailureHandlingByClient {
       // level is configurable via RatisClientConfig watchType, HDDS-2887).
       // Watch-level datanode exclusion is covered by
       // testDatanodeExclusionWithMajorityCommit.
-      assertThat(keyOutputStream.getExcludeList().getPipelineIds()).isEmpty();
+      // Pipeline IDs are also not asserted here. Under ALL_COMMITTED a WATCH
+      // RaftRetryFailureException can fire (retryFailure=true) before the
+      // ClosedContainerException path runs; that takes the else-branch in
+      // KeyOutputStream.handleException and adds the pipeline to the exclude
+      // list, so an empty pipeline set is not an invariant for this config.
+      // The container-id assertion above is the actual property under test.
 
       // The close will just write to the buffer
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -394,18 +394,14 @@ public class TestFailureHandlingByClient {
 
       assertThat(keyOutputStream.getExcludeList().getContainerIds())
           .contains(ContainerID.valueOf(containerId));
-      // Datanodes are not asserted here. Under the default ALL_COMMITTED watch
-      // level a slow-but-healthy follower can be recorded in the exclude list, so
-      // an empty datanode set is not an invariant for this config (the watch
-      // level is configurable via RatisClientConfig watchType, HDDS-2887).
-      // Watch-level datanode exclusion is covered by
-      // testDatanodeExclusionWithMajorityCommit.
-      // Pipeline IDs are also not asserted here. Under ALL_COMMITTED a WATCH
-      // RaftRetryFailureException can fire (retryFailure=true) before the
-      // ClosedContainerException path runs; that takes the else-branch in
-      // KeyOutputStream.handleException and adds the pipeline to the exclude
-      // list, so an empty pipeline set is not an invariant for this config.
       // The container-id assertion above is the actual property under test.
+      // Under the default ALL_COMMITTED watch level neither the datanode nor the
+      // pipeline set is an invariant: a slow-but-healthy follower can be recorded
+      // as a failed datanode, and a WATCH RaftRetryFailureException takes the
+      // else-branch in KeyOutputStream.handleException and excludes the pipeline.
+      // The watch level is configurable via RatisClientConfig watchType
+      // (HDDS-2887); watch-level exclusion is covered by
+      // testDatanodeExclusionWithMajorityCommit.
 
       // The close will just write to the buffer
     }


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.8)

## What changes were proposed in this pull request?

`TestFailureHandlingByClient#testContainerExclusionWithClosedContainerException` fails intermittently with `Expecting empty but was: [Pipeline-...]` on the assertion that the client exclude list holds no pipeline IDs (seen in upstream CI on 2026-07-06, after HDDS-15605 removed the analogous datanodes assertion).

The test forces a container to close and writes again, expecting a `ClosedContainerException` that adds only the container to the exclude list. Under the default `ALL_COMMITTED` watch level, a slow or unavailable follower can instead surface a WATCH `RaftRetryFailureException`. In `KeyOutputStream.handleException`, `checkForRetryFailure` returns true for that exception, so the container exclusion branch is skipped and the else branch adds the pipeline to the exclude list. That is intended client behavior, so an empty pipeline set is not an invariant for this configuration.

This PR removes the `getPipelineIds().isEmpty()` assertion, consistent with how HDDS-15605 handled the datanodes case, and adds a comment explaining why the pipeline set is not an invariant here. The container ID exclusion assertion, which is the actual property under test, is retained. The change is limited to the test.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15823

## How was this patch tested?

Ran the test 100 times locally with 0 failures, each run confirmed to execute the method (`Tests run: 1, Failures: 0, Errors: 0`). Ran the full `TestFailureHandlingByClient` class (6 tests, 0 failures). Checkstyle clean.
