### PR TITLE
HDDS-15827. Wait for SCM pipelines in TestDnRatisLogParser

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
@@ -70,6 +70,10 @@ public class TestDnRatisLogParser {
     OzoneConfiguration conf = cluster.getHddsDatanodes().get(0).getConf();
     String path =
         conf.get(OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATANODE_STORAGE_DIR);
+    GenericTestUtils.waitFor(
+        () -> !cluster.getStorageContainerManager().getPipelineManager()
+            .getPipelines().isEmpty(),
+        100, 60000);
     UUID pid = cluster.getStorageContainerManager().getPipelineManager()
         .getPipelines().get(0).getId().getId();
     File pipelineDir = new File(path, pid.toString());


### PR DESCRIPTION
## Summary
- Wait for SCM to report at least one pipeline before `TestDnRatisLogParser` reads `getPipelines().get(0)`.
- Avoids intermittent `IndexOutOfBoundsException: Index 0 out of bounds for length 0` when pipeline creation lags behind `waitForClusterToBeReady()`.

## Jira
https://issues.apache.org/jira/browse/HDDS-15827

## Problem
`testRatisLogParsing` uses a single-datanode mini-cluster and immediately indexes the first SCM pipeline. In CI, the pipeline list can still be empty when the test runs, even though the cluster is marked ready.

## Test plan
- [x] checkstyle on `ozone-integration-test` module
- [ ] `mvn -pl :ozone-integration-test test -Dtest=TestDnRatisLogParser -DskipShade -DskipRecon -DskipDocs`