### PR TITLE
HDDS-15832. Wait for healthy KDC before starting S3G

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/s3-haproxy.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/s3-haproxy.yaml
@@ -24,6 +24,9 @@ x-common-config:
     - ./krb5.conf:/etc/krb5.conf
   env_file:
     - docker-config
+  depends_on:
+    kdc:
+      condition: service_healthy
 
 services:
   s3g1:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add "wait for healthy KDC" condition to S3G HA setup, which #10256 missed.  This should prevent startup errors like:

```
s3g3-1  | failure to login: for principal: s3g/s3g@EXAMPLE.COM from keytab /etc/security/keytabs/s3g.keytab javax.security.auth.login.LoginException: Unable to obtain password from user
```

https://issues.apache.org/jira/browse/HDDS-15832

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/29151068339/job/86541440943
