### PR TITLE
HDDS-15831. CompleteMultipartUpload with no parts returns MalformedXML

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -66,7 +66,7 @@ Test Multipart Upload Complete With Chunked Transfer Encoding
     [Documentation]    Regression test for HDDS-14760. When CompleteMultipartUpload
     ...                is sent with chunked transfer encoding (no Content-Length, as
     ...                e.g. the AWS C++ SDK does with Expect: 100-continue), it must
-    ...                not be rejected with "You must specify at least one part".
+    ...                not be rejected as an empty part list (MalformedXML).
     ${access_key} =     Execute    aws configure get aws_access_key_id
     ${secret_key} =     Execute    aws configure get aws_secret_access_key
     ${key} =            Set Variable    ${PREFIX}/chunkedCompleteKey
@@ -84,11 +84,11 @@ Test Multipart Upload Complete With Chunked Transfer Encoding
     ${result} =         Execute    curl -sS -v -X POST -H "Transfer-Encoding: chunked" -H "Content-Length:" -H "Content-Type: application/xml" --data-binary @/tmp/${PREFIX}-complete.xml "${presigned_url}" 2>&1
     Should Contain      ${result}    > Transfer-Encoding: chunked
     Should Not Contain  ${result}    > Content-Length:
-    # A success response carries <CompleteMultipartUploadResult>/<ETag>; the
-    # error response would instead contain the "must specify at least one part"
-    # message (the bucket/key alone are not success discriminators, since the
-    # key also appears in the <Resource> element of an error response).
-    Should Not Contain  ${result}    must specify at least one part
+    # A success response carries <CompleteMultipartUploadResult>/<ETag>; an empty
+    # part list would instead be rejected with MalformedXML (the bucket/key alone
+    # are not success discriminators, since the key also appears in the
+    # <Resource> element of an error response).
+    Should Not Contain  ${result}    MalformedXML
     Should Contain      ${result}    CompleteMultipartUploadResult
     Should Contain      ${result}    ETag
     [Teardown]          Run Keywords    Remove File    /tmp/${PREFIX}-complete.xml
@@ -122,8 +122,7 @@ Test Multipart Upload Complete
 
 #complete multipart upload without any parts
     ${result} =         Execute AWSS3APICli and checkrc    complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/multipartKey1    255
-                        Should contain    ${result}    InvalidRequest
-                        Should contain    ${result}    must specify at least one part
+                        Should contain    ${result}    MalformedXML
 
 #complete multipart upload
     ${resultETag} =     Complete MPU    ${BUCKET}    ${PREFIX}/multipartKey1    ${uploadID}    {ETag=${eTag1},PartNumber=1},{ETag=${eTag2},PartNumber=2}

--- a/hadoop-ozone/integration-test-s3/pom.xml
+++ b/hadoop-ozone/integration-test-s3/pom.xml
@@ -84,6 +84,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kerby</groupId>
       <artifactId>kerby-util</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.MB;
 import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.calculateDigest;
 import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.createFile;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.stripQuotes;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -769,6 +770,28 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
         b -> b.bucket(bucketName).key(keyName)
     );
     assertEquals(part1Content, objectBytes.asUtf8String());
+  }
+
+  @Test
+  public void testCompleteMultipartUploadWithNoParts() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    // Initiate multipart upload
+    CreateMultipartUploadResponse createResponse = s3Client.createMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName));
+    String uploadId = createResponse.uploadId();
+
+    S3Exception exception = assertThrows(S3Exception.class, () -> s3Client.completeMultipartUpload(b -> b
+        .bucket(bucketName)
+        .key(keyName)
+        .uploadId(uploadId)
+        .multipartUpload(CompletedMultipartUpload.builder().build())));
+
+    assertThat(exception.statusCode()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(exception.awsErrorDetails().errorCode()).isEqualTo("MalformedXML");
   }
 
   @ParameterizedTest

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_XML;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
@@ -58,8 +59,8 @@ public class CompleteMultipartUploadRequestUnmarshaller
       PushbackInputStream pushbackStream = new PushbackInputStream(inputStream);
       int firstByte = pushbackStream.read();
       if (firstByte == -1) {
-        throw wrapOS3Exception(newError(INVALID_REQUEST)
-            .withMessage("You must specify at least one part"));
+        // An empty body is a malformed CompleteMultipartUpload request.
+        throw wrapOS3Exception(newError(MALFORMED_XML));
       }
       pushbackStream.unread(firstByte);
       return super.readFrom(aClass, type, annotations, mediaType, multivaluedMap, pushbackStream);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIREC
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_XML;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_UPLOAD;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
@@ -759,11 +760,17 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     final String uploadID = queryParams().get(QueryParams.UPLOAD_ID, "");
     long startNanos = Time.monotonicNowNanos();
     S3GAction s3GAction = S3GAction.COMPLETE_MULTIPART_UPLOAD;
+    List<CompleteMultipartUploadRequest.Part> partList =
+        multipartUploadRequest.getPartList();
+
+    // Reject an empty part list before contacting OM.
+    if (partList == null || partList.isEmpty()) {
+      throw newError(MALFORMED_XML, key);
+    }
+
     OzoneVolume volume = getVolume();
     // Using LinkedHashMap to preserve ordering of parts list.
     Map<Integer, String> partsMap = new LinkedHashMap<>();
-    List<CompleteMultipartUploadRequest.Part> partList =
-        multipartUploadRequest.getPartList();
 
     S3ConditionalRequest.WriteConditions writeConditions =
         S3ConditionalRequest.parseWriteConditions(getHeaders(), key);
@@ -807,12 +814,6 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       getMetrics().updateCompleteMultipartUploadFailureStats(startNanos);
       if (ex.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
         throw newError(NO_SUCH_UPLOAD, uploadID, ex);
-      } else if (ex.getResult() == ResultCodes.INVALID_REQUEST) {
-        OS3Exception os3Exception = newError(INVALID_REQUEST, key, ex);
-        os3Exception.setErrorMessage("An error occurred (InvalidRequest) " +
-            "when calling the CompleteMultipartUpload operation: You must " +
-            "specify at least one part");
-        throw os3Exception;
       } else if (ex.getResult() == ResultCodes.NOT_A_FILE) {
         OS3Exception os3Exception = newError(INVALID_REQUEST, key, ex);
         os3Exception.setErrorMessage("An error occurred (InvalidRequest) " +

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -762,13 +762,6 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     S3GAction s3GAction = S3GAction.COMPLETE_MULTIPART_UPLOAD;
     List<CompleteMultipartUploadRequest.Part> partList =
         multipartUploadRequest.getPartList();
-
-    // Reject an empty part list before contacting OM.
-    if (partList == null || partList.isEmpty()) {
-      throw newError(MALFORMED_XML, key);
-    }
-
-    OzoneVolume volume = getVolume();
     // Using LinkedHashMap to preserve ordering of parts list.
     Map<Integer, String> partsMap = new LinkedHashMap<>();
 
@@ -777,6 +770,12 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
     OmMultipartUploadCompleteInfo omMultipartUploadCompleteInfo;
     try {
+      // Reject an empty part list before contacting OM.
+      if (partList == null || partList.isEmpty()) {
+        throw newError(MALFORMED_XML, key);
+      }
+
+      OzoneVolume volume = getVolume();
       OzoneBucket ozoneBucket = volume.getBucket(bucket);
       S3Owner.verifyBucketOwnerCondition(getHeaders(), bucket, ozoneBucket.getOwner());
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCompleteMultipartUploadRequestUnmarshaller.java
@@ -93,7 +93,7 @@ public class TestCompleteMultipartUploadRequestUnmarshaller {
   }
 
   @Test
-  public void emptyBodyIsRejectedAsInvalidRequest() {
+  public void emptyBodyIsRejectedAsMalformedXml() {
     InputStream emptyBody = new ByteArrayInputStream(new byte[0]);
 
     WebApplicationException ex = assertThrows(WebApplicationException.class,
@@ -102,7 +102,7 @@ public class TestCompleteMultipartUploadRequestUnmarshaller {
 
     // Assert on the stable S3 error code rather than the human-readable message.
     OS3Exception cause = assertInstanceOf(OS3Exception.class, ex.getCause());
-    assertEquals(S3ErrorTable.INVALID_REQUEST.getCode(), cause.getCode());
+    assertEquals(S3ErrorTable.MALFORMED_XML.getCode(), cause.getCode());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -18,8 +18,10 @@
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import static java.util.Collections.singletonList;
+import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.completeMultipartUpload;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.uploadPart;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_XML;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_HEADER_PREFIX;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.X_AMZ_CONTENT_SHA256;
@@ -45,6 +47,7 @@ import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadRequest.Part;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
+import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -185,5 +188,19 @@ public class TestMultipartUploadComplete {
     OS3Exception ex = assertThrows(OS3Exception.class,
         () -> completeMultipartUpload(rest, OzoneConsts.S3_BUCKET, key, uploadID, partsList));
     assertEquals(ex.getCode(), S3ErrorTable.INVALID_PART.getCode());
+  }
+
+  @Test
+  public void testMultipartEmptyPartListError() throws Exception {
+    // Initiate multipart upload
+    String key = UUID.randomUUID().toString();
+    String uploadID = initiateMultipartUpload(key);
+
+    // A CompleteMultipartUpload request with an empty part list must fail.
+    CompleteMultipartUploadRequest request = new CompleteMultipartUploadRequest();
+    rest.queryParamsForTest().set(S3Consts.QueryParams.UPLOAD_ID, uploadID);
+
+    assertErrorResponse(MALFORMED_XML,
+        () -> rest.completeMultipartUpload(OzoneConsts.S3_BUCKET, key, request));
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.s3.metrics;
 
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.abortMultipartUpload;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertStatus;
@@ -35,6 +35,7 @@ import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.listParts;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.put;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.putBucketTagging;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.putTagging;
+import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.uploadPart;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
@@ -59,6 +60,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint;
+import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadRequest.Part;
 import org.apache.hadoop.ozone.s3.endpoint.EndpointBuilder;
 import org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils;
 import org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint;
@@ -411,8 +413,9 @@ public class TestS3GatewayMetrics {
   public void testCompleteMultiPartUploadSuccess() throws Exception {
     long oriMetric = metrics.getCompleteMultiPartUploadSuccess();
     String uploadID = initiateMultipartUpload(bucketName, keyName);
+    Part part = uploadPart(keyEndpoint, bucketName, keyName, 1, uploadID, CONTENT);
 
-    completeMultipartUpload(keyEndpoint, bucketName, keyName, uploadID, emptyList());
+    completeMultipartUpload(keyEndpoint, bucketName, keyName, uploadID, singletonList(part));
 
     long curMetric = metrics.getCompleteMultiPartUploadSuccess();
     assertEquals(1L, curMetric - oriMetric);
@@ -422,8 +425,11 @@ public class TestS3GatewayMetrics {
   public void testCompleteMultiPartUploadFailure() {
     long oriMetric = metrics.getCompleteMultiPartUploadFailure();
 
+    Part part = new Part();
+    part.setPartNumber(1);
+    part.setETag("etag");
     assertErrorResponse(S3ErrorTable.NO_SUCH_UPLOAD,
-        () -> completeMultipartUpload(keyEndpoint, bucketName, "key2", "random", emptyList()));
+        () -> completeMultipartUpload(keyEndpoint, bucketName, "key2", "random", singletonList(part)));
 
     long curMetric = metrics.getCompleteMultiPartUploadFailure();
     assertEquals(1L, curMetric - oriMetric);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CompleteMultipartUpload` with no parts returned the S3 error code
`InvalidRequest`; AWS S3 returns **`MalformedXML`** (HTTP 400 in both cases).

A partless request reaches the gateway in two shapes, and both are now aligned to
`MalformedXML`:

- **Empty request body** e.g. `aws s3api complete-multipart-upload` without`--multipart-upload`. `CompleteMultipartUploadRequestUnmarshaller` detects the  empty body (added in HDDS-14760) and previously threw `InvalidRequest` ("You must specify at least one part"); it now throws `MalformedXML`.
- **Well-formed body with no `<Part>` elements**  e.g. a chunked SDK, or `CompletedMultipartUpload.builder().build()`. `ObjectEndpoint.completeMultipartUpload` now rejects an empty/absent part list up front with `MalformedXML`, before
  contacting OM. Because the gateway now rejects an empty part list before the OM call, the OM `INVALID_REQUEST` mapping in the gateway (the "must specify at least one part" message) is unreachable and has been removed.

`S3ErrorTable.MALFORMED_XML` already exists, so no new error code or wire change
is introduced.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15831


## How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/29151193111