### PR TITLE
HDDS-15836. Add Archiver.appendFile for incremental TAR writes

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
@@ -27,11 +27,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
-import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
@@ -52,8 +52,9 @@ public final class Archiver {
 
   static final int MIN_BUFFER_SIZE = 8 * (int) OzoneConsts.KB; // same as IOUtils.DEFAULT_BUFFER_SIZE
   static final int MAX_BUFFER_SIZE = (int) OzoneConsts.MB;
-  private static final int TAR_SIZE_OFFSET = 124;
-  private static final int TAR_SIZE_LENGTH = 12;
+  private static final byte[] TAR_ZERO_BLOCK = new byte[TarConstants.DEFAULT_RCDSIZE];
+  private static final int TAR_SIZE_OFFSET = TarConstants.NAMELEN + TarConstants.MODELEN
+      + TarConstants.UIDLEN + TarConstants.GIDLEN;
   private static final Logger LOG = LoggerFactory.getLogger(Archiver.class);
 
   private Archiver() {
@@ -68,22 +69,11 @@ public final class Archiver {
   }
 
   /**
-   * Append a single file as a new entry to an existing tarball, or create the
-   * tarball if it does not exist yet.
+   * Opens a tarball for incremental appends. The stream stays open until
+   * {@link AppendableTar#close()} writes the end-of-archive marker.
    */
-  public static void appendFile(File tarFile, File file, String entryName)
-      throws IOException {
-    if (tarFile.exists() && tarFile.length() > 0) {
-      stripTarEofMarker(tarFile);
-    }
-    OpenOption[] options = tarFile.exists() && tarFile.length() > 0
-        ? new OpenOption[] {StandardOpenOption.WRITE, StandardOpenOption.APPEND}
-        : new OpenOption[] {StandardOpenOption.WRITE, StandardOpenOption.CREATE};
-    try (OutputStream fos = Files.newOutputStream(tarFile.toPath(), options);
-         ArchiveOutputStream<TarArchiveEntry> out = simpleTar(fos)) {
-      includeSimpleFile(file, entryName, out);
-      out.finish();
-    }
+  public static AppendableTar openForAppend(File tarFile) throws IOException {
+    return new AppendableTar(tarFile);
   }
 
   /**
@@ -97,7 +87,7 @@ public final class Archiver {
       while (position + TarConstants.DEFAULT_RCDSIZE <= fileLength) {
         raf.seek(position);
         raf.readFully(header);
-        if (isZeroBlock(header)) {
+        if (Arrays.equals(header, TAR_ZERO_BLOCK)) {
           raf.setLength(position);
           return;
         }
@@ -108,18 +98,9 @@ public final class Archiver {
     }
   }
 
-  private static boolean isZeroBlock(byte[] block) {
-    for (byte b : block) {
-      if (b != 0) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   private static long parseTarEntrySize(byte[] header) throws IOException {
     try {
-      return TarUtils.parseOctalOrBinary(header, TAR_SIZE_OFFSET, TAR_SIZE_LENGTH);
+      return TarUtils.parseOctalOrBinary(header, TAR_SIZE_OFFSET, TarConstants.SIZELEN);
     } catch (IllegalArgumentException e) {
       throw new IOException("Invalid tar entry size.", e);
     }
@@ -148,32 +129,6 @@ public final class Archiver {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     IOUtils.copy(input, output, getBufferSize(size));
     return output.toByteArray();
-  }
-
-  private static TarArchiveEntry createSimpleTarArchiveEntry(File file, String entryName)
-      throws IOException {
-    TarArchiveEntry entry = new TarArchiveEntry(entryName);
-    entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
-    entry.setSize(Files.size(file.toPath()));
-    entry.setModTime(file.lastModified());
-    return entry;
-  }
-
-  private static long includeSimpleFile(File file, String entryName,
-      ArchiveOutputStream<TarArchiveEntry> archiveOutput) throws IOException {
-    TarArchiveEntry entry = createSimpleTarArchiveEntry(file, entryName);
-    archiveOutput.putArchiveEntry(entry);
-    try (InputStream input = Files.newInputStream(file.toPath())) {
-      return IOUtils.copy(input, archiveOutput, getBufferSize(file.length()));
-    } finally {
-      archiveOutput.closeArchiveEntry();
-    }
-  }
-
-  private static ArchiveOutputStream<TarArchiveEntry> simpleTar(OutputStream output) {
-    TarArchiveOutputStream os = new TarArchiveOutputStream(output);
-    os.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
-    return os;
   }
 
   private static TarArchiveEntry createBasicTarArchiveEntry(File file, String entryName)
@@ -313,6 +268,32 @@ public final class Archiver {
 
   static int getBufferSize(long fileSize) {
     return Math.toIntExact(Math.min(MAX_BUFFER_SIZE, Math.max(fileSize, MIN_BUFFER_SIZE)));
+  }
+
+  /** Incrementally append entries to a tarball. */
+  public static final class AppendableTar implements AutoCloseable {
+    private final ArchiveOutputStream<TarArchiveEntry> out;
+
+    private AppendableTar(File tarFile) throws IOException {
+      OutputStream fos;
+      if (tarFile.exists() && tarFile.length() > 0) {
+        stripTarEofMarker(tarFile);
+        fos = Files.newOutputStream(tarFile.toPath(), StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+      } else {
+        fos = Files.newOutputStream(tarFile.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+      }
+      out = tar(fos);
+    }
+
+    public void appendFile(File file, String entryName) throws IOException {
+      includeFile(file, entryName, out);
+    }
+
+    @Override
+    public void close() throws IOException {
+      out.finish();
+      out.close();
+    }
   }
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/Archiver.java
@@ -25,9 +25,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -37,6 +40,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarConstants;
+import org.apache.commons.compress.archivers.tar.TarUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -48,6 +52,8 @@ public final class Archiver {
 
   static final int MIN_BUFFER_SIZE = 8 * (int) OzoneConsts.KB; // same as IOUtils.DEFAULT_BUFFER_SIZE
   static final int MAX_BUFFER_SIZE = (int) OzoneConsts.MB;
+  private static final int TAR_SIZE_OFFSET = 124;
+  private static final int TAR_SIZE_LENGTH = 12;
   private static final Logger LOG = LoggerFactory.getLogger(Archiver.class);
 
   private Archiver() {
@@ -59,6 +65,69 @@ public final class Archiver {
     try (ArchiveOutputStream<TarArchiveEntry> out = tar(Files.newOutputStream(tarFile.toPath()))) {
       includePath(from, "", out);
     }
+  }
+
+  /**
+   * Append a single file as a new entry to an existing tarball, or create the
+   * tarball if it does not exist yet.
+   */
+  public static void appendFile(File tarFile, File file, String entryName)
+      throws IOException {
+    if (tarFile.exists() && tarFile.length() > 0) {
+      stripTarEofMarker(tarFile);
+    }
+    OpenOption[] options = tarFile.exists() && tarFile.length() > 0
+        ? new OpenOption[] {StandardOpenOption.WRITE, StandardOpenOption.APPEND}
+        : new OpenOption[] {StandardOpenOption.WRITE, StandardOpenOption.CREATE};
+    try (OutputStream fos = Files.newOutputStream(tarFile.toPath(), options);
+         ArchiveOutputStream<TarArchiveEntry> out = simpleTar(fos)) {
+      includeSimpleFile(file, entryName, out);
+      out.finish();
+    }
+  }
+
+  /**
+   * Remove the tar end-of-archive marker so new entries can be appended.
+   */
+  private static void stripTarEofMarker(File tarFile) throws IOException {
+    try (RandomAccessFile raf = new RandomAccessFile(tarFile, "rw")) {
+      long position = 0;
+      long fileLength = raf.length();
+      byte[] header = new byte[TarConstants.DEFAULT_RCDSIZE];
+      while (position + TarConstants.DEFAULT_RCDSIZE <= fileLength) {
+        raf.seek(position);
+        raf.readFully(header);
+        if (isZeroBlock(header)) {
+          raf.setLength(position);
+          return;
+        }
+        long entrySize = parseTarEntrySize(header);
+        position += TarConstants.DEFAULT_RCDSIZE + paddedTarEntrySize(entrySize);
+      }
+      throw new IOException("Invalid tar archive without an end-of-archive marker: " + tarFile);
+    }
+  }
+
+  private static boolean isZeroBlock(byte[] block) {
+    for (byte b : block) {
+      if (b != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static long parseTarEntrySize(byte[] header) throws IOException {
+    try {
+      return TarUtils.parseOctalOrBinary(header, TAR_SIZE_OFFSET, TAR_SIZE_LENGTH);
+    } catch (IllegalArgumentException e) {
+      throw new IOException("Invalid tar entry size.", e);
+    }
+  }
+
+  private static long paddedTarEntrySize(long size) {
+    long recordSize = TarConstants.DEFAULT_RCDSIZE;
+    return ((size + recordSize - 1) / recordSize) * recordSize;
   }
 
   /** Extract {@code tarFile} to {@code dir}. */
@@ -79,6 +148,32 @@ public final class Archiver {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     IOUtils.copy(input, output, getBufferSize(size));
     return output.toByteArray();
+  }
+
+  private static TarArchiveEntry createSimpleTarArchiveEntry(File file, String entryName)
+      throws IOException {
+    TarArchiveEntry entry = new TarArchiveEntry(entryName);
+    entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+    entry.setSize(Files.size(file.toPath()));
+    entry.setModTime(file.lastModified());
+    return entry;
+  }
+
+  private static long includeSimpleFile(File file, String entryName,
+      ArchiveOutputStream<TarArchiveEntry> archiveOutput) throws IOException {
+    TarArchiveEntry entry = createSimpleTarArchiveEntry(file, entryName);
+    archiveOutput.putArchiveEntry(entry);
+    try (InputStream input = Files.newInputStream(file.toPath())) {
+      return IOUtils.copy(input, archiveOutput, getBufferSize(file.length()));
+    } finally {
+      archiveOutput.closeArchiveEntry();
+    }
+  }
+
+  private static ArchiveOutputStream<TarArchiveEntry> simpleTar(OutputStream output) {
+    TarArchiveOutputStream os = new TarArchiveOutputStream(output);
+    os.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+    return os;
   }
 
   private static TarArchiveEntry createBasicTarArchiveEntry(File file, String entryName)

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestArchiver.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestArchiver.java
@@ -133,4 +133,44 @@ class TestArchiver {
     Files.deleteIfExists(tmpDir);
   }
 
+  @Test
+  void appendFileCreatesAndExtendsTar() throws IOException {
+    Path tmpDir = Files.createTempDirectory("archiver-append");
+    File tarFile = tmpDir.resolve("export.tar").toFile();
+    File part1 = tmpDir.resolve("part001.txt").toFile();
+    File part2 = tmpDir.resolve("part002.txt").toFile();
+    Files.write(part1.toPath(), "1\n2\n".getBytes(StandardCharsets.UTF_8));
+    Files.write(part2.toPath(), "3\n".getBytes(StandardCharsets.UTF_8));
+
+    Archiver.appendFile(tarFile, part1, "part001.txt");
+    Archiver.appendFile(tarFile, part2, "part002.txt");
+
+    Path extractDir = tmpDir.resolve("extract");
+    Archiver.extract(tarFile, extractDir);
+    assertThat(new String(Files.readAllBytes(extractDir.resolve("part001.txt")),
+        StandardCharsets.UTF_8)).isEqualTo("1\n2\n");
+    assertThat(new String(Files.readAllBytes(extractDir.resolve("part002.txt")),
+        StandardCharsets.UTF_8)).isEqualTo("3\n");
+  }
+
+  @Test
+  void appendFilePreservesZeroBlocksAtEndOfEntry() throws IOException {
+    Path tmpDir = Files.createTempDirectory("archiver-append-zero-block");
+    File tarFile = tmpDir.resolve("export.tar").toFile();
+    File part1 = tmpDir.resolve("part001.bin").toFile();
+    File part2 = tmpDir.resolve("part002.txt").toFile();
+    byte[] zeroBlockPayload = new byte[1024];
+    Files.write(part1.toPath(), zeroBlockPayload);
+    Files.write(part2.toPath(), "next\n".getBytes(StandardCharsets.UTF_8));
+
+    Archiver.appendFile(tarFile, part1, "part001.bin");
+    Archiver.appendFile(tarFile, part2, "part002.txt");
+
+    Path extractDir = tmpDir.resolve("extract");
+    Archiver.extract(tarFile, extractDir);
+    assertThat(Files.readAllBytes(extractDir.resolve("part001.bin")))
+        .isEqualTo(zeroBlockPayload);
+    assertThat(new String(Files.readAllBytes(extractDir.resolve("part002.txt")),
+        StandardCharsets.UTF_8)).isEqualTo("next\n");
+  }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestArchiver.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestArchiver.java
@@ -142,15 +142,15 @@ class TestArchiver {
     Files.write(part1.toPath(), "1\n2\n".getBytes(StandardCharsets.UTF_8));
     Files.write(part2.toPath(), "3\n".getBytes(StandardCharsets.UTF_8));
 
-    Archiver.appendFile(tarFile, part1, "part001.txt");
-    Archiver.appendFile(tarFile, part2, "part002.txt");
+    try (Archiver.AppendableTar tar = Archiver.openForAppend(tarFile)) {
+      tar.appendFile(part1, "part001.txt");
+      tar.appendFile(part2, "part002.txt");
+    }
 
     Path extractDir = tmpDir.resolve("extract");
     Archiver.extract(tarFile, extractDir);
-    assertThat(new String(Files.readAllBytes(extractDir.resolve("part001.txt")),
-        StandardCharsets.UTF_8)).isEqualTo("1\n2\n");
-    assertThat(new String(Files.readAllBytes(extractDir.resolve("part002.txt")),
-        StandardCharsets.UTF_8)).isEqualTo("3\n");
+    assertThat(extractDir.resolve("part001.txt")).hasSameBinaryContentAs(part1.toPath());
+    assertThat(extractDir.resolve("part002.txt")).hasSameBinaryContentAs(part2.toPath());
   }
 
   @Test
@@ -163,14 +163,14 @@ class TestArchiver {
     Files.write(part1.toPath(), zeroBlockPayload);
     Files.write(part2.toPath(), "next\n".getBytes(StandardCharsets.UTF_8));
 
-    Archiver.appendFile(tarFile, part1, "part001.bin");
-    Archiver.appendFile(tarFile, part2, "part002.txt");
+    try (Archiver.AppendableTar tar = Archiver.openForAppend(tarFile)) {
+      tar.appendFile(part1, "part001.bin");
+      tar.appendFile(part2, "part002.txt");
+    }
 
     Path extractDir = tmpDir.resolve("extract");
     Archiver.extract(tarFile, extractDir);
-    assertThat(Files.readAllBytes(extractDir.resolve("part001.bin")))
-        .isEqualTo(zeroBlockPayload);
-    assertThat(new String(Files.readAllBytes(extractDir.resolve("part002.txt")),
-        StandardCharsets.UTF_8)).isEqualTo("next\n");
+    assertThat(extractDir.resolve("part001.bin")).hasSameBinaryContentAs(part1.toPath());
+    assertThat(extractDir.resolve("part002.txt")).hasSameBinaryContentAs(part2.toPath());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Adds `Archiver.appendFile()` to append a single file entry to an existing TAR (or create a new archive).
- Strips the TAR end-of-archive marker before append so multi-shard exports can build one archive incrementally.

Part **1** in splitting [HDDS-15496](https://issues.apache.org/jira/browse/HDDS-15496) https://github.com/apache/ozone/pull/10673 container ID export.

## What is the link to the Apache JIRA
[HDDS-15836](https://issues.apache.org/jira/browse/HDDS-15836)

## How was this patch tested?
Adds unit tests for multi-part append and entries containing zero-byte blocks.

Made with [Cursor](https://cursor.com) to help split the container ID export.