### PR TITLE
HDDS-15838. Add container export shared types, config, and proto

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -641,6 +641,13 @@ public final class ScmConfigKeys {
       "ozone.scm.ratis.events.max.limit";
   public static final int OZONE_SCM_RATIS_EVENTS_MAX_LIMIT_DEFAULT = 100;
 
+  public static final String OZONE_SCM_CONTAINER_EXPORT_DIR =
+      "ozone.scm.container.export.dir";
+
+  public static final String OZONE_SCM_CONTAINER_EXPORT_MAX_TERMINAL_JOBS =
+      "ozone.scm.container.export.max.terminal.jobs";
+  public static final int OZONE_SCM_CONTAINER_EXPORT_MAX_TERMINAL_JOBS_DEFAULT = 10;
+
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/export/ContainerExportLimits.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/export/ContainerExportLimits.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.export;
+
+/**
+ * Shared limits and defaults for container ID export (CLI and SCM server).
+ */
+public final class ContainerExportLimits {
+
+  public static final String EXPORT_SUBDIR = "exports";
+
+  public static final int DEFAULT_PAGE_SIZE = 100_000;
+  public static final int DEFAULT_SHARD_SIZE = 500_000;
+  public static final int MAX_PAGE_SIZE = 1_000_000;
+  public static final int MAX_SHARD_SIZE = 5_000_000;
+
+  private ContainerExportLimits() {
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/export/ContainerExportStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/export/ContainerExportStatus.java
@@ -17,6 +17,9 @@
 
 package org.apache.hadoop.hdds.scm.container.export;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
+
 /**
  * Client-side view of a container ID export job on the SCM leader.
  */
@@ -24,8 +27,8 @@ public final class ContainerExportStatus {
 
   private final String jobId;
   private final State state;
-  private final String lifecycleState;
-  private final String healthState;
+  private final LifeCycleState lifecycleState;
+  private final ContainerHealthState healthState;
   private final long totalRows;
   private final long elapsedMs;
   private final String tarPath;
@@ -41,8 +44,8 @@ public final class ContainerExportStatus {
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
-  public ContainerExportStatus(String jobId, State state, String lifecycleState, String healthState,
-      long totalRows, long elapsedMs, String tarPath, String errorMessage) {
+  public ContainerExportStatus(String jobId, State state, LifeCycleState lifecycleState, 
+      ContainerHealthState healthState, long totalRows, long elapsedMs, String tarPath, String errorMessage) {
     this.jobId = jobId;
     this.state = state;
     this.lifecycleState = lifecycleState;
@@ -61,11 +64,11 @@ public final class ContainerExportStatus {
     return state;
   }
 
-  public String getLifecycleState() {
+  public LifeCycleState getLifecycleState() {
     return lifecycleState;
   }
 
-  public String getHealthState() {
+  public ContainerHealthState getHealthState() {
     return healthState;
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/export/ContainerExportStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/export/ContainerExportStatus.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.export;
+
+/**
+ * Client-side view of a container ID export job on the SCM leader.
+ */
+public final class ContainerExportStatus {
+
+  private final String jobId;
+  private final State state;
+  private final String lifecycleState;
+  private final String healthState;
+  private final long totalRows;
+  private final long elapsedMs;
+  private final String tarPath;
+  private final String errorMessage;
+
+  /**
+   * States of export job.
+   */
+  public enum State {
+    RUNNING,
+    SUCCEEDED,
+    FAILED
+  }
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public ContainerExportStatus(String jobId, State state, String lifecycleState, String healthState,
+      long totalRows, long elapsedMs, String tarPath, String errorMessage) {
+    this.jobId = jobId;
+    this.state = state;
+    this.lifecycleState = lifecycleState;
+    this.healthState = healthState;
+    this.totalRows = totalRows;
+    this.elapsedMs = elapsedMs;
+    this.tarPath = tarPath;
+    this.errorMessage = errorMessage;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public State getState() {
+    return state;
+  }
+
+  public String getLifecycleState() {
+    return lifecycleState;
+  }
+
+  public String getHealthState() {
+    return healthState;
+  }
+
+  public long getTotalRows() {
+    return totalRows;
+  }
+
+  public long getElapsedMs() {
+    return elapsedMs;
+  }
+
+  public String getTarPath() {
+    return tarPath;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public boolean isTerminal() {
+    return state == State.SUCCEEDED || state == State.FAILED;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/export/package-info.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/export/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains classes related to container export.
+ */
+package org.apache.hadoop.hdds.scm.container.export;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -764,6 +764,25 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.container.export.dir</name>
+    <value/>
+    <tag>OZONE, SCM, STORAGE</tag>
+    <description>
+      Directory where the SCM leader writes container ID export TAR files.
+      When unset, exports are stored under {ozone.scm.db.dirs}/exports.
+      Use a separate volume in production to avoid filling the SCM metadata disk.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.container.export.max.terminal.jobs</name>
+    <value>10</value>
+    <tag>OZONE, SCM</tag>
+    <description>
+      Maximum number of completed (SUCCEEDED or FAILED) export jobs retained in
+      SCM memory for status lookup. Older terminal jobs are evicted on new submits.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.block.client.address</name>
     <value/>
     <tag>OZONE, SCM</tag>

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -89,6 +89,8 @@ message ScmContainerLocationRequest {
   optional GetDeletedBlocksTxnSummaryRequestProto getDeletedBlocksTxnSummaryRequest = 50;
   optional SCMListContainerIDsRequestProto scmListContainerIDsRequest = 51;
   optional SuppressContainerRequestProto suppressContainerRequest = 52;
+  optional SubmitContainerIdExportRequestProto submitContainerIdExportRequest = 53;
+  optional GetContainerIdExportStatusRequestProto getContainerIdExportStatusRequest = 54;
 }
 
 message ScmContainerLocationResponse {
@@ -149,6 +151,8 @@ message ScmContainerLocationResponse {
   optional GetDeletedBlocksTxnSummaryResponseProto getDeletedBlocksTxnSummaryResponse = 50;
   optional SCMListContainerIDsResponseProto scmListContainerIDsResponse = 51;
   optional SuppressContainerResponseProto suppressContainerResponse = 52;
+  optional SubmitContainerIdExportResponseProto submitContainerIdExportResponse = 53;
+  optional GetContainerIdExportStatusResponseProto getContainerIdExportStatusResponse = 54;
 
   enum Status {
     OK = 1;
@@ -208,6 +212,8 @@ enum Type {
   GetDeletedBlocksTransactionSummary = 46;
   ListContainerIDs = 47;
   SuppressContainer = 48;
+  SubmitContainerIdExport = 49;
+  GetContainerIdExportStatus = 50;
 }
 
 /**
@@ -724,6 +730,40 @@ message SuppressContainerRequestProto {
 message SuppressContainerResponseProto {
   // Container IDs that failed to suppress or unsuppress. Empty if all succeeded.
   repeated int64 failedContainerIDs = 1;
+}
+
+enum ContainerExportStateProto {
+  RUNNING = 1;
+  SUCCEEDED = 2;
+  FAILED = 3;
+}
+
+message SubmitContainerIdExportRequestProto {
+  optional ContainerID startContainerID = 1;
+  optional LifeCycleState lifecycleState = 2;
+  optional string healthState = 3;
+  optional int64 maxRows = 4;
+  optional int32 pageSize = 5;
+  optional int32 shardSize = 6;
+}
+
+message SubmitContainerIdExportResponseProto {
+  optional string jobId = 1;
+}
+
+message GetContainerIdExportStatusRequestProto {
+  required string jobId = 1;
+}
+
+message GetContainerIdExportStatusResponseProto {
+  optional string jobId = 1;
+  optional ContainerExportStateProto state = 2;
+  optional LifeCycleState lifecycleState = 3;
+  optional string healthState = 4;
+  optional int64 totalRows = 5;
+  optional int64 elapsedMs = 6;
+  optional string tarPath = 7;
+  optional string errorMessage = 8;
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds shared types, SCM configuration, and SCM client protocol messages for async export. No server implementation, client wiring, or CLI in this PR.

Part **3 of 5** in splitting [HDDS-15496](https://issues.apache.org/jira/browse/HDDS-15496) https://github.com/apache/ozone/pull/10673 container ID export. 

## What is the link to the Apache JIRA
[HDDS-15838](https://issues.apache.org/jira/browse/HDDS-15838)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/29226836517

Made with [Cursor](https://cursor.com) to help split the container ID export.