### PR TITLE
HDDS-15786. Intermittent pipeline limit exceeded in debug tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/replicas-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/replicas-test.sh
@@ -66,6 +66,8 @@ for dn_container in ${datanodes}; do
   wait_for_datanode "${dn_container}" HEALTHY 60
 done
 
+wait_for_pipeline
+
 execute_robot_test ${SCM} -v "PREFIX:${prefix}" debug/ozone-debug-tests.robot
 
 # get block locations for key

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -126,6 +126,19 @@ wait_for_safemode_exit(){
   execute_commands_in_container ${SCM} "$cmd"
 }
 
+## @description wait until RATIS/THREE pipeline exists (or 180 seconds)
+wait_for_pipeline() {
+  RETRY_ATTEMPTS=60 retry assert_pipeline_exists
+}
+
+## @description check if RATIS/THREE pipeline exists; note: does not kinit
+assert_pipeline_exists() {
+  local cmd="ozone admin pipeline list --state OPEN --filter-by-factor THREE --json | jq -r 'length'"
+  local -i count
+  count=$(execute_commands_in_container ${SCM} "${cmd}")
+  [[ $count -gt 0 ]]
+}
+
 ## @description wait until OM leader is elected (or 120 seconds)
 wait_for_om_leader() {
   if [[ -z "${OM_SERVICE_ID:-}" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-14225 added new steps in debug acceptance test to restart datanodes, which caused intermittent failure:

```
Stopping datanodes for a consistent container.db backup
Restarting datanodes after backup
ozonesecure-ha-datanode1-1 is HEALTHY
ozonesecure-ha-datanode2-1 is HEALTHY
ozonesecure-ha-datanode3-1 is HEALTHY
ozonesecure-ha-datanode4-1 is HEALTHY
ozonesecure-ha-datanode5-1 is HEALTHY
==============================================================================
Ozone-Debug-Tests :: Test ozone debug CLI                                     
==============================================================================
Test ozone debug replicas verify checksums, block-existence and co... | FAIL |
Parent suite setup failed:
255 != 0
```

We need to wait for pipeline to be opened before proceeding with the test.  Same as #10722, but with reusable function (taken from `hadoop-ozone/dist/src/main/k8s/examples/testlib.sh`).

https://issues.apache.org/jira/browse/HDDS-15786

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/29234299846

Tried to reproduce using `repeat-acceptance-test`, but did not encounter the problem with/without the patch:
- https://github.com/adoroszlai/ozone/actions/runs/29230561004
- https://github.com/adoroszlai/ozone/actions/runs/29232058791
