### PR TITLE
HDDS-15843. Update upgrade/xcompat tests to use 2.1.1

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -33,7 +33,7 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
+run_test ha     non-rolling-upgrade 2.1.1 "$OZONE_CURRENT_VERSION"
 # run_test ha     non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
 #run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 #run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -69,8 +69,8 @@ services:
     image: ${OZONE_IMAGE}:2.0.0${OZONE_IMAGE_FLAVOR}
     <<: *old-config
 
-  old_client_2_1_0:
-    image: ${OZONE_IMAGE}:2.1.0${OZONE_IMAGE_FLAVOR}
+  old_client_2_1_1:
+    image: ${OZONE_IMAGE}:2.1.1${OZONE_IMAGE_FLAVOR}
     <<: *old-config
 
   new_client:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
@@ -24,7 +24,7 @@ source "${COMPOSE_DIR}/../testlib.sh"
 
 current_version="${OZONE_CURRENT_VERSION}"
 # TODO: debug acceptance test failures for client versions 1.0.0 on secure clusters
-old_versions="1.1.0 1.2.1 1.3.0 1.4.1 2.0.0 2.1.0" # container is needed for each version in clients.yaml
+old_versions="1.1.0 1.2.1 1.3.0 1.4.1 2.0.0 2.1.1" # container is needed for each version in clients.yaml
 
 export SECURITY_ENABLED=true
 : ${OZONE_BUCKET_KEY_NAME:=key1}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test compatibility/upgrade with 2.1.1 instead of 2.1.0.

https://issues.apache.org/jira/browse/HDDS-15843

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/29236956314
