### PR TITLE
HDDS-15842. Speed up TestDuplicateContainerDirScannerIntegration

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/container/TestDuplicateContainerDirScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/container/TestDuplicateContainerDirScannerIntegration.java
@@ -86,6 +86,7 @@ class TestDuplicateContainerDirScannerIntegration {
     conf.setStorageSize(ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN,
         0, StorageUnit.MB);
     conf.setInt(OzoneConfigKeys.OZONE_REPLICATION, ONE.getValue());
+    conf.set(ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL, "3s");
 
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(1)


### PR DESCRIPTION
## What changes were proposed in this pull request?
The test in `TestDuplicateContainerDirScannerIntegration` verifies functionality of ContainerDirectoryScanner before and after a Datanode restart.  Restarting a datanode in the MiniOzoneCluster first stops the datanode, waits for SCM to move the datanode to STALE state and then starts the datanode. 

The default value for `ozone.scm.stale.node.interval` is 100s, resulting in a test runtime > 2mins. This value is reduced to 3s to improve test execution time.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15842

## How was this patch tested?
1. Integration Test

Time taken post changes:  `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 45.19 s -- in org.apache.hadoop.ozone.dn.container.TestDuplicateContainerDirScannerIntegration`