### PR TITLE
HDDS-15851. Return 403 for expired or out-of-range pre-signed S3 URLs

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AWSSignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AWSSignatureProcessor.java
@@ -80,12 +80,12 @@ public class AWSSignatureProcessor implements SignatureProcessor {
     for (SignatureParser parser : signatureParsers) {
       try {
         signatureInfo = parser.parseSignature();
+      } catch (AccessDeniedResourceException e) {
+        AUDIT.logAuthFailure(buildAuthFailureMessage(e));
+        throw S3ErrorTable.newError(ACCESS_DENIED, e.getResource());
       } catch (MalformedResourceException e) {
-        AuditMessage message = buildAuthFailureMessage(e);
-        AUDIT.logAuthFailure(message);
-        throw S3ErrorTable.newError(
-            e.isAccessDenied() ? ACCESS_DENIED : MALFORMED_HEADER,
-            e.getResource());
+        AUDIT.logAuthFailure(buildAuthFailureMessage(e));
+        throw S3ErrorTable.newError(MALFORMED_HEADER, e.getResource());
       }
       if (signatureInfo != null) {
         break;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AWSSignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AWSSignatureProcessor.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.s3.signature;
 
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ACCESS_DENIED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_HEADER;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -82,7 +83,9 @@ public class AWSSignatureProcessor implements SignatureProcessor {
       } catch (MalformedResourceException e) {
         AuditMessage message = buildAuthFailureMessage(e);
         AUDIT.logAuthFailure(message);
-        throw S3ErrorTable.newError(MALFORMED_HEADER, e.getResource());
+        throw S3ErrorTable.newError(
+            e.isAccessDenied() ? ACCESS_DENIED : MALFORMED_HEADER,
+            e.getResource());
       }
       if (signatureInfo != null) {
         break;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AccessDeniedResourceException.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AccessDeniedResourceException.java
@@ -18,22 +18,11 @@
 package org.apache.hadoop.ozone.s3.signature;
 
 /**
- * This exception is used to communicate validation errors when parsing
- * signatures.
+ * Signals a signature validation failure that AWS reports as 403 AccessDenied
+ * rather than 400 (e.g. an expired or out-of-range pre-signed URL).
  */
-public class MalformedResourceException extends Exception {
-  private final String resource;
-
-  public MalformedResourceException(String resource) {
-    this.resource = resource;
-  }
-
-  public MalformedResourceException(String message, String resource) {
-    super(message);
-    this.resource = resource;
-  }
-
-  public String getResource() {
-    return resource;
+public class AccessDeniedResourceException extends MalformedResourceException {
+  public AccessDeniedResourceException(String resource) {
+    super(resource);
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AuthorizationV4QueryParser.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AuthorizationV4QueryParser.java
@@ -137,15 +137,15 @@ public class AuthorizationV4QueryParser implements SignatureParser {
           .plus(expires, SECONDS).isBefore(ZonedDateTime.now())) {
         // An expired pre-signed URL is an authorization failure (403), not a
         // malformed header (400).
-        throw new MalformedResourceException("Pre-signed S3 url is expired. "
+        throw new AccessDeniedResourceException("Pre-signed S3 url is expired. "
             + "dateString:" + dateString
-            + " expiresString:" + expiresString, true);
+            + " expiresString:" + expiresString);
       }
     } else {
       // An out-of-range X-Amz-Expires is rejected by AWS with 403, not 400.
-      throw new MalformedResourceException("Invalid expiry duration. "
+      throw new AccessDeniedResourceException("Invalid expiry duration. "
           + "X-Amz-Expires should be between " + X_AMZ_EXPIRES_MIN
-          + "and" + X_AMZ_EXPIRES_MAX + " expiresString:" + expiresString, true);
+          + "and" + X_AMZ_EXPIRES_MAX + " expiresString:" + expiresString);
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AuthorizationV4QueryParser.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/AuthorizationV4QueryParser.java
@@ -135,14 +135,17 @@ public class AuthorizationV4QueryParser implements SignatureParser {
     if (expires >= X_AMZ_EXPIRES_MIN && expires <= X_AMZ_EXPIRES_MAX) {
       if (ZonedDateTime.parse(dateString, StringToSignProducer.TIME_FORMATTER)
           .plus(expires, SECONDS).isBefore(ZonedDateTime.now())) {
+        // An expired pre-signed URL is an authorization failure (403), not a
+        // malformed header (400).
         throw new MalformedResourceException("Pre-signed S3 url is expired. "
             + "dateString:" + dateString
-            + " expiresString:" + expiresString);
+            + " expiresString:" + expiresString, true);
       }
     } else {
+      // An out-of-range X-Amz-Expires is rejected by AWS with 403, not 400.
       throw new MalformedResourceException("Invalid expiry duration. "
           + "X-Amz-Expires should be between " + X_AMZ_EXPIRES_MIN
-          + "and" + X_AMZ_EXPIRES_MAX + " expiresString:" + expiresString);
+          + "and" + X_AMZ_EXPIRES_MAX + " expiresString:" + expiresString, true);
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/MalformedResourceException.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/MalformedResourceException.java
@@ -23,17 +23,32 @@ package org.apache.hadoop.ozone.s3.signature;
  */
 public class MalformedResourceException extends Exception {
   private final String resource;
+  private final boolean accessDenied;
 
   public MalformedResourceException(String resource) {
+    this(resource, false);
+  }
+
+  public MalformedResourceException(String resource, boolean accessDenied) {
     this.resource = resource;
+    this.accessDenied = accessDenied;
   }
 
   public MalformedResourceException(String message, String resource) {
     super(message);
     this.resource = resource;
+    this.accessDenied = false;
   }
 
   public String getResource() {
     return resource;
+  }
+
+  /**
+   * @return true if the failure should be reported as 403 AccessDenied instead
+   * of 400 (e.g. an expired or out-of-range pre-signed URL).
+   */
+  public boolean isAccessDenied() {
+    return accessDenied;
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAWSSignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAWSSignatureProcessor.java
@@ -17,9 +17,9 @@
 
 package org.apache.hadoop.ozone.s3.signature;
 
+import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,8 +27,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
-import org.apache.hadoop.ozone.s3.exception.OS3Exception;
-import org.apache.http.HttpStatus;
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -73,8 +72,6 @@ public class TestAWSSignatureProcessor {
     AWSSignatureProcessor processor = new AWSSignatureProcessor();
     processor.setContext(context);
 
-    OS3Exception ex = assertThrows(OS3Exception.class, processor::parseSignature);
-    assertEquals(HttpStatus.SC_FORBIDDEN, ex.getHttpCode());
-    assertEquals("AccessDenied", ex.getCode());
+    assertErrorResponse(S3ErrorTable.ACCESS_DENIED, processor::parseSignature);
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAWSSignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAWSSignatureProcessor.java
@@ -19,7 +19,16 @@ package org.apache.hadoop.ozone.s3.signature;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,5 +45,36 @@ public class TestAWSSignatureProcessor {
     assertEquals("AWS4-HMAC-SHA256 value",
         headers.remove("AUTHORIZATION"));
     assertFalse(headers.containsKey("authorization"));
+  }
+
+  @Test
+  public void testOutOfRangeExpiresPreSignedUrlReturns403() throws Exception {
+    // A pre-signed URL whose X-Amz-Expires is out of range must be rejected
+    // with 403 AccessDenied, not 400 MalformedHeader.
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    queryParams.putSingle("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+    queryParams.putSingle("X-Amz-Credential",
+        "AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request");
+    queryParams.putSingle("X-Amz-Date", "20130524T000000Z");
+    queryParams.putSingle("X-Amz-Expires", "604801");
+    queryParams.putSingle("X-Amz-SignedHeaders", "host");
+    queryParams.putSingle("X-Amz-Signature",
+        "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
+
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getQueryParameters()).thenReturn(queryParams);
+    when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>());
+    when(uriInfo.getPath()).thenReturn("key");
+    ContainerRequestContext context = mock(ContainerRequestContext.class);
+    when(context.getUriInfo()).thenReturn(uriInfo);
+    when(context.getHeaders()).thenReturn(new MultivaluedHashMap<>());
+    when(context.getMethod()).thenReturn("GET");
+
+    AWSSignatureProcessor processor = new AWSSignatureProcessor();
+    processor.setContext(context);
+
+    OS3Exception ex = assertThrows(OS3Exception.class, processor::parseSignature);
+    assertEquals(HttpStatus.SC_FORBIDDEN, ex.getHttpCode());
+    assertEquals("AccessDenied", ex.getCode());
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.s3.signature;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -81,7 +80,7 @@ public class TestAuthorizationV4QueryParser {
     MalformedResourceException missingDate = assertThrows(
         MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
-    assertFalse(missingDate.isAccessDenied());
+    assertFalse(missingDate instanceof AccessDeniedResourceException);
 
     // Empty date
     parameters.put("X-Amz-Date", "");
@@ -106,23 +105,17 @@ public class TestAuthorizationV4QueryParser {
 
     // Out-of-range expires -> 403 (AccessDenied), not 400.
     parameters.put("X-Amz-Expires", "0");
-    MalformedResourceException tooSmall = assertThrows(
-        MalformedResourceException.class,
+    assertThrows(AccessDeniedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
-    assertTrue(tooSmall.isAccessDenied());
     parameters.put("X-Amz-Expires", "604801");
-    MalformedResourceException tooLarge = assertThrows(
-        MalformedResourceException.class,
+    assertThrows(AccessDeniedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
-    assertTrue(tooLarge.isAccessDenied());
 
     // Expired request -> 403 (AccessDenied), not 400.
     parameters.put("X-Amz-Date", "20160801T083241Z");
     parameters.put("X-Amz-Expires", "10000");
-    MalformedResourceException expired = assertThrows(
-        MalformedResourceException.class,
+    assertThrows(AccessDeniedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
-    assertTrue(expired.isAccessDenied());
 
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
@@ -18,7 +18,9 @@
 package org.apache.hadoop.ozone.s3.signature;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -75,8 +77,11 @@ public class TestAuthorizationV4QueryParser {
     parameters.put("X-Amz-SignedHeaders", "host");
     parameters.put("X-Amz-Signature",
         "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
-    assertThrows(MalformedResourceException.class,
+    // A genuinely malformed request (missing date) stays a 400, not 403.
+    MalformedResourceException missingDate = assertThrows(
+        MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
+    assertFalse(missingDate.isAccessDenied());
 
     // Empty date
     parameters.put("X-Amz-Date", "");
@@ -99,19 +104,25 @@ public class TestAuthorizationV4QueryParser {
     assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
-    // Invalid expires
+    // Out-of-range expires -> 403 (AccessDenied), not 400.
     parameters.put("X-Amz-Expires", "0");
-    assertThrows(MalformedResourceException.class,
+    MalformedResourceException tooSmall = assertThrows(
+        MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
+    assertTrue(tooSmall.isAccessDenied());
     parameters.put("X-Amz-Expires", "604801");
-    assertThrows(MalformedResourceException.class,
+    MalformedResourceException tooLarge = assertThrows(
+        MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
+    assertTrue(tooLarge.isAccessDenied());
 
-    // Expired request
+    // Expired request -> 403 (AccessDenied), not 400.
     parameters.put("X-Amz-Date", "20160801T083241Z");
     parameters.put("X-Amz-Expires", "10000");
-    assertThrows(MalformedResourceException.class,
+    MalformedResourceException expired = assertThrows(
+        MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
+    assertTrue(expired.isAccessDenied());
 
   }
 


### PR DESCRIPTION
What changes were proposed in this pull request?

The S3 Gateway reports an expired or out-of-range pre-signed URL as 400 MalformedHeader. AWS S3 returns 403 AccessDenied for both. This maps only those two pre-signed expiry failures to 403 AccessDenied, leaving genuinely malformed signatures at 400.

- MalformedResourceException gains an accessDenied
- AuthorizationV4QueryParser.validateDateAndExpires() sets the flag for (a) an expired pre-signed URL and (b) an out-of-range
X-Amz-Expires.
- AWSSignatureProcessor maps the flag to ACCESS_DENIED (403) instead of MALFORMED_HEADER (400). It is the single catch site for
MalformedResourceException, so all parsers route th

What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15851

How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/29302072421