### PR TITLE
HDDS-15389. Top-level delete entry retention utilities for snapshot diff.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -96,6 +96,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.management.ObjectName;
 import org.apache.commons.io.file.PathUtils;
@@ -1352,6 +1353,53 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
     }
     return OzoneConsts.ROOT_PATH.resolve(key).toString()
         .substring(1);
+  }
+
+  /**
+   * Returns whether any ancestor of the given parent is a deleted directory.
+   */
+  @VisibleForTesting
+  boolean hasDeletedAncestor(long parentObjectId, Set<Long> deletedDirectoryIds,
+      Map<Long, Long> objectIdToParentId, long bucketObjectId) {
+    long currentParent = parentObjectId;
+    while (currentParent != bucketObjectId) {
+      if (deletedDirectoryIds.contains(currentParent)) {
+        return true;
+      }
+      Long nextParent = objectIdToParentId.get(currentParent);
+      if (nextParent == null) {
+        throw new IllegalStateException(
+            "Missing parent for object ID: " + currentParent);
+      }
+      currentParent = nextParent;
+    }
+    return false;
+  }
+
+  /**
+   * Filters mixed directory and file delete entries, retaining only those without
+   * a deleted directory ancestor. FSO buckets only.
+   */
+  @VisibleForTesting
+  <T extends WithParentObjectId> List<T> filterTopLevelDeletedEntries(
+      Collection<T> deletedEntries,
+      Predicate<T> isDirectory,
+      Map<Long, Long> objectIdToParentId,
+      long bucketObjectId) {
+    Set<Long> deletedDirectoryIds = new HashSet<>();
+    for (T deletedEntry : deletedEntries) {
+      if (isDirectory.test(deletedEntry)) {
+        deletedDirectoryIds.add(deletedEntry.getObjectID());
+      }
+    }
+    List<T> filteredDeletes = new ArrayList<>();
+    for (T deletedEntry : deletedEntries) {
+      if (!hasDeletedAncestor(deletedEntry.getParentObjectID(), deletedDirectoryIds,
+          objectIdToParentId, bucketObjectId)) {
+        filteredDeletes.add(deletedEntry);
+      }
+    }
+    return filteredDeletes;
   }
 
   @SuppressWarnings({"checkstyle:ParameterNumber", "checkstyle:MethodLength"})

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -1359,7 +1359,9 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
   /**
    * Returns whether any ancestor of the given parent is a deleted directory.
    * The walk stops at renamed directories because their descendant deletes are
-   * not subsumed by a deleted ancestor above them.
+   * not subsumed by a deleted ancestor above them. Returns true when the parent
+   * chain cannot be resolved in the live from-snapshot directory graph, so the
+   * delete entry can be skipped from the final report.
    *
    * @param objectIdToParentId from-snapshot directory parent graph keyed by stable
    *     objectId; must not be the to-snapshot graph
@@ -1406,8 +1408,8 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
       }
       Long nextParent = objectIdToParentId.get(current);
       if (nextParent == null) {
-        result = false;
-        ancestorMemo.put(current, false);
+        result = true;
+        ancestorMemo.put(current, true);
         break;
       }
       path.add(current);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -80,6 +80,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1357,45 +1358,96 @@ public class SnapshotDiffManager implements AutoCloseable, SnapshotDiffManagerMX
 
   /**
    * Returns whether any ancestor of the given parent is a deleted directory.
+   * The walk stops at renamed directories because their descendant deletes are
+   * not subsumed by a deleted ancestor above them.
+   *
+   * @param objectIdToParentId from-snapshot directory parent graph keyed by stable
+   *     objectId; must not be the to-snapshot graph
+   * @param renamedDirectoryIds objectIds of directories renamed in the diff (from
+   *     snapshot objectIds, not destination paths)
    */
   @VisibleForTesting
   boolean hasDeletedAncestor(long parentObjectId, Set<Long> deletedDirectoryIds,
-      Map<Long, Long> objectIdToParentId, long bucketObjectId) {
-    long currentParent = parentObjectId;
-    while (currentParent != bucketObjectId) {
-      if (deletedDirectoryIds.contains(currentParent)) {
-        return true;
-      }
-      Long nextParent = objectIdToParentId.get(currentParent);
-      if (nextParent == null) {
-        throw new IllegalStateException(
-            "Missing parent for object ID: " + currentParent);
-      }
-      currentParent = nextParent;
+      Set<Long> renamedDirectoryIds, Map<Long, Long> objectIdToParentId,
+      long bucketObjectId, Map<Long, Boolean> ancestorMemo) {
+    Objects.requireNonNull(objectIdToParentId, "objectIdToParentId must not be null");
+    Objects.requireNonNull(renamedDirectoryIds, "renamedDirectoryIds must not be null");
+
+    if (parentObjectId == bucketObjectId) {
+      return false;
     }
-    return false;
+    Boolean cached = ancestorMemo.get(parentObjectId);
+    if (cached != null) {
+      return cached;
+    }
+
+    List<Long> path = new ArrayList<>();
+    long current = parentObjectId;
+    boolean result;
+    while (true) {
+      if (current == bucketObjectId) {
+        result = false;
+        break;
+      }
+      cached = ancestorMemo.get(current);
+      if (cached != null) {
+        result = cached;
+        break;
+      }
+      if (renamedDirectoryIds.contains(current)) {
+        result = false;
+        ancestorMemo.put(current, false);
+        break;
+      }
+      if (deletedDirectoryIds.contains(current)) {
+        result = true;
+        ancestorMemo.put(current, true);
+        break;
+      }
+      Long nextParent = objectIdToParentId.get(current);
+      if (nextParent == null) {
+        result = false;
+        ancestorMemo.put(current, false);
+        break;
+      }
+      path.add(current);
+      current = nextParent;
+    }
+    for (Long node : path) {
+      ancestorMemo.put(node, result);
+    }
+    return result;
   }
 
   /**
    * Filters mixed directory and file delete entries, retaining only those without
    * a deleted directory ancestor. FSO buckets only.
+   *
+   * @param objectIdToParentId from-snapshot directory parent graph keyed by stable
+   *     objectId, built from a full fromSnapshot directoryTable scan
+   * @param renamedDirectoryIds objectIds of directories renamed in the diff (from
+   *     snapshot objectIds); pass an empty set when there are no renames
    */
   @VisibleForTesting
   <T extends WithParentObjectId> List<T> filterTopLevelDeletedEntries(
       Collection<T> deletedEntries,
       Predicate<T> isDirectory,
       Map<Long, Long> objectIdToParentId,
+      Set<Long> renamedDirectoryIds,
       long bucketObjectId) {
+    Objects.requireNonNull(objectIdToParentId, "objectIdToParentId must not be null");
+    Objects.requireNonNull(renamedDirectoryIds, "renamedDirectoryIds must not be null");
     Set<Long> deletedDirectoryIds = new HashSet<>();
     for (T deletedEntry : deletedEntries) {
       if (isDirectory.test(deletedEntry)) {
         deletedDirectoryIds.add(deletedEntry.getObjectID());
       }
     }
+    Map<Long, Boolean> ancestorMemo = new HashMap<>();
     List<T> filteredDeletes = new ArrayList<>();
     for (T deletedEntry : deletedEntries) {
       if (!hasDeletedAncestor(deletedEntry.getParentObjectID(), deletedDirectoryIds,
-          objectIdToParentId, bucketObjectId)) {
+          renamedDirectoryIds, objectIdToParentId, bucketObjectId, ancestorMemo)) {
         filteredDeletes.add(deletedEntry);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -1665,6 +1665,57 @@ public class TestSnapshotDiffManager {
         .containsExactlyElementsOf(expectedEntries);
   }
 
+  @ParameterizedTest
+  @MethodSource("filterTopLevelDeletedEntryScenarios")
+  public void testFilterTopLevelDeletedEntriesMixed(
+      List<WithParentObjectId> deletedEntries, Set<Long> expectedObjectIds) {
+    long bucketObjectId = 0L;
+    Map<Long, Long> objectIdToParentId = buildDirATreeParentMap(bucketObjectId);
+
+    List<WithParentObjectId> filteredDeletes = snapshotDiffManager
+        .filterTopLevelDeletedEntries(deletedEntries, OmDirectoryInfo.class::isInstance,
+            objectIdToParentId, bucketObjectId);
+
+    assertThat(filteredDeletes)
+        .extracting(WithParentObjectId::getObjectID)
+        .containsExactlyInAnyOrderElementsOf(expectedObjectIds);
+  }
+
+  private static Stream<Arguments> filterTopLevelDeletedEntryScenarios() {
+    long bucketObjectId = 0L;
+    OmDirectoryInfo dirA = newDeletedDir(100L, bucketObjectId);
+    OmDirectoryInfo dirB = newDeletedDir(101L, 100L);
+    OmDirectoryInfo dirC = newDeletedDir(102L, 101L);
+    OmDirectoryInfo dirD = newDeletedDir(103L, 101L);
+    OmKeyInfo fileA = newDeletedFile(104L, 102L);
+    return Stream.of(
+        Arguments.of(
+            Arrays.asList(dirA, dirB, dirC, fileA, dirD),
+            Sets.newHashSet(dirA.getObjectID())),
+        Arguments.of(
+            Arrays.asList(dirA, dirD, fileA),
+            Sets.newHashSet(dirA.getObjectID())),
+        Arguments.of(
+            Arrays.asList(dirB, dirD, fileA),
+            Sets.newHashSet(dirB.getObjectID())),
+        Arguments.of(
+            Arrays.asList(dirD, dirC, fileA),
+            Sets.newHashSet(dirD.getObjectID(), dirC.getObjectID())),
+        Arguments.of(
+            Arrays.asList(dirD, fileA),
+            Sets.newHashSet(dirD.getObjectID(), fileA.getObjectID())));
+  }
+
+  private static Map<Long, Long> buildDirATreeParentMap(long bucketObjectId) {
+    return ImmutableMap.<Long, Long>builder()
+        .put(100L, bucketObjectId)
+        .put(101L, 100L)
+        .put(102L, 101L)
+        .put(103L, 101L)
+        .put(104L, 102L)
+        .build();
+  }
+
   @Test
   public void testGetSnapshotDiffReportReportOnlyInProgressIncludesProgressDetails()
       throws IOException {
@@ -1678,4 +1729,27 @@ public class TestSnapshotDiffManager {
         ctx.volumeName, ctx.bucketName, ctx.fromSnapshotName, ctx.toSnapshotName, "", 1000);
     assertEquals(IN_PROGRESS, response.getJobStatus());
   }
+
+  private static OmDirectoryInfo newDeletedDir(long objectId, long parentId) {
+    return OmDirectoryInfo.newBuilder()
+        .setObjectID(objectId)
+        .setParentObjectID(parentId)
+        .setName("dir-" + objectId)
+        .setOwner("test")
+        .setCreationTime(0L)
+        .setModificationTime(0L)
+        .build();
+  }
+
+  private static OmKeyInfo newDeletedFile(long objectId, long parentId) {
+    return new OmKeyInfo.Builder()
+        .setObjectID(objectId)
+        .setParentObjectID(parentId)
+        .setVolumeName(VOLUME_NAME)
+        .setBucketName(BUCKET_NAME)
+        .setKeyName("file-" + objectId)
+        .setReplicationConfig(new ECReplicationConfig(3, 2))
+        .build();
+  }
+
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -1665,16 +1665,22 @@ public class TestSnapshotDiffManager {
         .containsExactlyElementsOf(expectedEntries);
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @MethodSource("filterTopLevelDeletedEntryScenarios")
-  public void testFilterTopLevelDeletedEntriesMixed(
-      List<WithParentObjectId> deletedEntries, Set<Long> expectedObjectIds) {
+  public void testFilterTopLevelDeletedEntries(
+      String scenarioDescription,
+      List<WithParentObjectId> deletedEntries,
+      Set<Long> renamedDirectoryIds,
+      Map<Long, Long> objectIdToParentId,
+      Set<Long> expectedObjectIds) {
     long bucketObjectId = 0L;
-    Map<Long, Long> objectIdToParentId = buildDirATreeParentMap(bucketObjectId);
+    Map<Long, Long> parentMap = objectIdToParentId != null
+        ? objectIdToParentId
+        : buildDirATreeParentMap(bucketObjectId);
 
     List<WithParentObjectId> filteredDeletes = snapshotDiffManager
         .filterTopLevelDeletedEntries(deletedEntries, OmDirectoryInfo.class::isInstance,
-            objectIdToParentId, bucketObjectId);
+            parentMap, renamedDirectoryIds, bucketObjectId);
 
     assertThat(filteredDeletes)
         .extracting(WithParentObjectId::getObjectID)
@@ -1688,22 +1694,64 @@ public class TestSnapshotDiffManager {
     OmDirectoryInfo dirC = newDeletedDir(102L, 101L);
     OmDirectoryInfo dirD = newDeletedDir(103L, 101L);
     OmKeyInfo fileA = newDeletedFile(104L, 102L);
+    OmKeyInfo fileUnderDirB = newDeletedFile(105L, 101L);
     return Stream.of(
         Arguments.of(
+            "full candidate set keeps only top-level deleted dirA",
             Arrays.asList(dirA, dirB, dirC, fileA, dirD),
+            Collections.emptySet(),
+            null,
             Sets.newHashSet(dirA.getObjectID())),
         Arguments.of(
+            "partial DAG candidates with dirA dirD and fileA keep only dirA",
             Arrays.asList(dirA, dirD, fileA),
+            Collections.emptySet(),
+            null,
             Sets.newHashSet(dirA.getObjectID())),
         Arguments.of(
+            "deleted dirB with partial candidates keeps only dirB",
             Arrays.asList(dirB, dirD, fileA),
+            Collections.emptySet(),
+            null,
             Sets.newHashSet(dirB.getObjectID())),
         Arguments.of(
+            "sibling deleted dirs dirD and dirC suppress fileA under deleted dirC",
             Arrays.asList(dirD, dirC, fileA),
+            Collections.emptySet(),
+            null,
             Sets.newHashSet(dirD.getObjectID(), dirC.getObjectID())),
         Arguments.of(
+            "unrelated deleted dirD and fileA are both kept",
             Arrays.asList(dirD, fileA),
-            Sets.newHashSet(dirD.getObjectID(), fileA.getObjectID())));
+            Collections.emptySet(),
+            null,
+            Sets.newHashSet(dirD.getObjectID(), fileA.getObjectID())),
+        Arguments.of(
+            "renamed dirB retains file delete when dirA is also deleted",
+            Arrays.asList(dirA, fileUnderDirB),
+            Sets.newHashSet(dirB.getObjectID()),
+            null,
+            Sets.newHashSet(dirA.getObjectID(), fileUnderDirB.getObjectID())),
+        Arguments.of(
+            "missing parent in map retains delete when ancestor chain is broken",
+            Collections.singletonList(fileA),
+            Collections.emptySet(),
+            ImmutableMap.of(102L, 101L),
+            Sets.newHashSet(fileA.getObjectID())));
+  }
+
+  @Test
+  public void testFilterTopLevelDeletedEntriesRejectsNullArguments() {
+    long bucketObjectId = 0L;
+    OmDirectoryInfo dirA = newDeletedDir(100L, bucketObjectId);
+    List<OmDirectoryInfo> deletedEntries = Collections.singletonList(dirA);
+
+    assertThrows(NullPointerException.class, () -> snapshotDiffManager
+        .filterTopLevelDeletedEntries(deletedEntries, OmDirectoryInfo.class::isInstance,
+            null, Collections.emptySet(), bucketObjectId));
+    assertThrows(NullPointerException.class, () -> snapshotDiffManager
+        .filterTopLevelDeletedEntries(deletedEntries, OmDirectoryInfo.class::isInstance,
+            Collections.emptyMap(), null, bucketObjectId));
   }
 
   private static Map<Long, Long> buildDirATreeParentMap(long bucketObjectId) {
@@ -1713,6 +1761,7 @@ public class TestSnapshotDiffManager {
         .put(102L, 101L)
         .put(103L, 101L)
         .put(104L, 102L)
+        .put(105L, 101L)
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -1733,11 +1733,17 @@ public class TestSnapshotDiffManager {
             null,
             Sets.newHashSet(dirA.getObjectID(), fileUnderDirB.getObjectID())),
         Arguments.of(
-            "missing parent in map retains delete when ancestor chain is broken",
+            "broken parent chain in live directory graph skips delete from report",
             Collections.singletonList(fileA),
             Collections.emptySet(),
             ImmutableMap.of(102L, 101L),
-            Sets.newHashSet(fileA.getObjectID())));
+            Collections.emptySet()),
+        Arguments.of(
+            "delete with parent absent from live directory graph is skipped",
+            Collections.singletonList(newDeletedFile(104L, 999L)),
+            Collections.emptySet(),
+            null,
+            Collections.emptySet()));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Developed with the help of Cursor AI.

This PR is intended as the foundation for a more efficient snapshot diff ([HDDS-9154](https://issues.apache.org/jira/browse/HDDS-9154)).

Baseline snapshot diff can report descendant deletes inconsistently when a top-level directory is removed. Depending on deep-cleaning progress and diff mode(full or DAG based diff), the report may include child directories and files in addition to the top-level directory delete. The efficient diff design requires stable, top-level-only delete reporting for FSO buckets.

This change adds isolated delete-retention helpers in `SnapshotDiffManager` for the efficient snapshot diff. It introduces ancestor-based suppression of delete entries so that snapshot diff reports only surface top-level deletes, not redundant descendant directory or file deletes under a deleted directory tree.

- Adds `hasDeletedAncestor` to walk the `from-snapshot` parent graph and detect whether a delete entry falls under a deleted directory.
- Adds `filterTopLevelDeletedEntries` to filter mixed directory/file DELETE candidates, keeping only entries without a deleted directory ancestor.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15389

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Unit tests covering multiple FSO hierarchy scenarios (e.g. dirA/dirB/dirC/fileA and dirA/dirB/dirD).
