### PR TITLE
HDDS-15852. Allow CopyObject to the same key when the metadata directive is REPLACE

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -1230,6 +1230,12 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     CopyObjectResponse copyObjectResponse = assertDoesNotThrow(() -> s3Client.copyObject(copyReq));
     assertNotNull(copyObjectResponse.copyObjectResult().eTag());
 
+    // The metadata was replaced in place: the new entry is present and the old one is gone.
+    HeadObjectResponse head = s3Client.headObject(b -> b.bucket(bucketName).key(key));
+    assertThat(head.metadata())
+        .containsEntry("meta2", "v2")
+        .doesNotContainKey("meta1");
+
     // The object is still readable with its original content after the in-place copy.
     ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(
         b -> b.bucket(bucketName).key(key));

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -168,7 +168,6 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
-import software.amazon.awssdk.services.s3.model.TaggingDirective;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
@@ -1240,35 +1239,6 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(
         b -> b.bucket(bucketName).key(key));
     assertEquals(content, objectBytes.asUtf8String());
-  }
-
-  @Test
-  public void testCopyObjectToSelfWithTaggingReplace() {
-    final String bucketName = getBucketName();
-    final String key = getKeyName();
-    final String content = "bar";
-    s3Client.createBucket(b -> b.bucket(bucketName));
-    s3Client.putObject(b -> b.bucket(bucketName).key(key).tagging("tag1=value1"),
-        RequestBody.fromString(content));
-
-    // Copying an object onto itself is allowed when the tag set is replaced.
-    CopyObjectRequest copyReq = CopyObjectRequest.builder()
-        .sourceBucket(bucketName)
-        .sourceKey(key)
-        .destinationBucket(bucketName)
-        .destinationKey(key)
-        .taggingDirective(TaggingDirective.REPLACE)
-        .tagging("tag2=value2")
-        .build();
-
-    CopyObjectResponse copyObjectResponse = assertDoesNotThrow(() -> s3Client.copyObject(copyReq));
-    assertNotNull(copyObjectResponse.copyObjectResult().eTag());
-
-    // The tag set was replaced in place.
-    GetObjectTaggingResponse tagging = s3Client.getObjectTagging(b -> b.bucket(bucketName).key(key));
-    assertEquals(1, tagging.tagSet().size());
-    assertEquals("tag2", tagging.tagSet().get(0).key());
-    assertEquals("value2", tagging.tagSet().get(0).value());
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -156,6 +156,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.ListPartsRequest;
+import software.amazon.awssdk.services.s3.model.MetadataDirective;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutBucketAclRequest;
@@ -167,6 +168,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
+import software.amazon.awssdk.services.s3.model.TaggingDirective;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
@@ -1204,6 +1206,63 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
 
     CopyObjectResponse copyObjectResponse = s3Client.copyObject(copyReq);
     assertEquals("\"37b51d194a7513e45b56f6524f2d51f2\"", copyObjectResponse.copyObjectResult().eTag());
+  }
+
+  @Test
+  public void testCopyObjectToSelfWithMetadataReplace() {
+    final String bucketName = getBucketName();
+    final String key = getKeyName();
+    final String content = "bar";
+    s3Client.createBucket(b -> b.bucket(bucketName));
+    s3Client.putObject(b -> b.bucket(bucketName).key(key).metadata(Collections.singletonMap("meta1", "v1")),
+        RequestBody.fromString(content));
+
+    // Copying an object onto itself is allowed when the metadata is replaced.
+    CopyObjectRequest copyReq = CopyObjectRequest.builder()
+        .sourceBucket(bucketName)
+        .sourceKey(key)
+        .destinationBucket(bucketName)
+        .destinationKey(key)
+        .metadataDirective(MetadataDirective.REPLACE)
+        .metadata(Collections.singletonMap("meta2", "v2"))
+        .build();
+
+    CopyObjectResponse copyObjectResponse = assertDoesNotThrow(() -> s3Client.copyObject(copyReq));
+    assertNotNull(copyObjectResponse.copyObjectResult().eTag());
+
+    // The object is still readable with its original content after the in-place copy.
+    ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(
+        b -> b.bucket(bucketName).key(key));
+    assertEquals(content, objectBytes.asUtf8String());
+  }
+
+  @Test
+  public void testCopyObjectToSelfWithTaggingReplace() {
+    final String bucketName = getBucketName();
+    final String key = getKeyName();
+    final String content = "bar";
+    s3Client.createBucket(b -> b.bucket(bucketName));
+    s3Client.putObject(b -> b.bucket(bucketName).key(key).tagging("tag1=value1"),
+        RequestBody.fromString(content));
+
+    // Copying an object onto itself is allowed when the tag set is replaced.
+    CopyObjectRequest copyReq = CopyObjectRequest.builder()
+        .sourceBucket(bucketName)
+        .sourceKey(key)
+        .destinationBucket(bucketName)
+        .destinationKey(key)
+        .taggingDirective(TaggingDirective.REPLACE)
+        .tagging("tag2=value2")
+        .build();
+
+    CopyObjectResponse copyObjectResponse = assertDoesNotThrow(() -> s3Client.copyObject(copyReq));
+    assertNotNull(copyObjectResponse.copyObjectResult().eTag());
+
+    // The tag set was replaced in place.
+    GetObjectTaggingResponse tagging = s3Client.getObjectTagging(b -> b.bucket(bucketName).key(key));
+    assertEquals(1, tagging.tagSet().size());
+    assertEquals("tag2", tagging.tagSet().get(0).key());
+    assertEquals("value2", tagging.tagSet().get(0).value());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -1096,17 +1096,15 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     try {
       OzoneKeyDetails sourceKeyDetails = getClientProtocol().getKeyDetails(
           volume.getName(), sourceBucket, sourceKey);
-      // The tagging and metadata directives are read up front because a
-      // self-copy is only legal when at least one attribute is being changed.
-      String tagCopyDirective = getHeaders().getHeaderString(TAG_DIRECTIVE_HEADER);
+      // Metadata directive is read up front: a self-copy is legal when metadata
+      // is being replaced (x-amz-metadata-directive: REPLACE).
       String metadataCopyDirective = getHeaders().getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER);
-      boolean replacingTags = CopyDirective.REPLACE.name().equals(tagCopyDirective);
       boolean replacingMetadata = CopyDirective.REPLACE.name().equals(metadataCopyDirective);
 
       // Checking whether we trying to copying to it self.
       if (sourceBucket.equals(destBucket) && sourceKey.equals(destkey)
-          && !replacingTags && !replacingMetadata) {
-        // Self-copy without a metadata or tag replacement. AWS still allows it
+          && !replacingMetadata) {
+        // Self-copy without a metadata replacement. AWS still allows it
         // when a storage class is provided (aws cli passes storage type), so
         // only the default-storage-type case is rejected.
         if (storageTypeDefault) {
@@ -1139,6 +1137,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       // Object tagging in copyObject with tagging directive
       Map<String, String> tags;
+      String tagCopyDirective = getHeaders().getHeaderString(TAG_DIRECTIVE_HEADER);
       if (StringUtils.isEmpty(tagCopyDirective) || tagCopyDirective.equals(CopyDirective.COPY.name())) {
         // Tag-set will be copied from the source directly
         tags = sourceKeyDetails.getTags();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -1096,13 +1096,19 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     try {
       OzoneKeyDetails sourceKeyDetails = getClientProtocol().getKeyDetails(
           volume.getName(), sourceBucket, sourceKey);
+      // The tagging and metadata directives are read up front because a
+      // self-copy is only legal when at least one attribute is being changed.
+      String tagCopyDirective = getHeaders().getHeaderString(TAG_DIRECTIVE_HEADER);
+      String metadataCopyDirective = getHeaders().getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER);
+      boolean replacingTags = CopyDirective.REPLACE.name().equals(tagCopyDirective);
+      boolean replacingMetadata = CopyDirective.REPLACE.name().equals(metadataCopyDirective);
+
       // Checking whether we trying to copying to it self.
-      if (sourceBucket.equals(destBucket) && sourceKey
-          .equals(destkey)) {
-        // When copying to same storage type when storage type is provided,
-        // we should not throw exception, as aws cli checks if any of the
-        // options like storage type are provided or not when source and
-        // dest are given same
+      if (sourceBucket.equals(destBucket) && sourceKey.equals(destkey)
+          && !replacingTags && !replacingMetadata) {
+        // Self-copy without a metadata or tag replacement. AWS still allows it
+        // when a storage class is provided (aws cli passes storage type), so
+        // only the default-storage-type case is rejected.
         if (storageTypeDefault) {
           OS3Exception ex = newError(S3ErrorTable.INVALID_REQUEST, copyHeader);
           ex.setErrorMessage("This copy request is illegal because it is " +
@@ -1133,7 +1139,6 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       // Object tagging in copyObject with tagging directive
       Map<String, String> tags;
-      String tagCopyDirective = getHeaders().getHeaderString(TAG_DIRECTIVE_HEADER);
       if (StringUtils.isEmpty(tagCopyDirective) || tagCopyDirective.equals(CopyDirective.COPY.name())) {
         // Tag-set will be copied from the source directly
         tags = sourceKeyDetails.getTags();
@@ -1150,7 +1155,6 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       // Custom metadata in copyObject with metadata directive
       Map<String, String> customMetadata;
-      String metadataCopyDirective = getHeaders().getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER);
       if (StringUtils.isEmpty(metadataCopyDirective) || metadataCopyDirective.equals(CopyDirective.COPY.name())) {
         // The custom metadata will be copied from the source key
         customMetadata = sourceKeyDetails.getMetadata();

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -383,6 +383,57 @@ class TestObjectPut {
   }
 
   @Test
+  void testCopyObjectToSelfWithMetadataReplace() throws Exception {
+    // Put the source object with some custom metadata.
+    Map<String, String> sourceMetadata = ImmutableMap.of(
+        "custom-key-1", "custom-value-1",
+        "custom-key-2", "custom-value-2");
+    MultivaluedMap<String, String> metadataHeaders = new MultivaluedHashMap<>();
+    sourceMetadata.forEach((k, v) -> metadataHeaders.putSingle(CUSTOM_METADATA_HEADER_PREFIX + k, v));
+    when(headers.getRequestHeaders()).thenReturn(metadataHeaders);
+    when(headers.getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER)).thenReturn("COPY");
+    assertSucceeds(() -> putObject(CONTENT));
+    assertThat(bucket.getKey(KEY_NAME).getMetadata()).containsAllEntriesOf(sourceMetadata);
+
+    // Copy the object onto itself with x-amz-metadata-directive: REPLACE and a
+    // new metadata set. AWS allows this as an in-place metadata update.
+    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
+        BUCKET_NAME + "/" + urlEncode(KEY_NAME));
+    when(headers.getHeaderString(CUSTOM_METADATA_COPY_DIRECTIVE_HEADER)).thenReturn("REPLACE");
+    metadataHeaders.clear();
+    metadataHeaders.putSingle(CUSTOM_METADATA_HEADER_PREFIX + "custom-key-3", "custom-value-3");
+
+    assertSucceeds(() -> putObject(CONTENT));
+
+    OzoneKeyDetails keyDetails = assertKeyContent(bucket, KEY_NAME, CONTENT);
+    assertThat(keyDetails.getMetadata())
+        .containsEntry("custom-key-3", "custom-value-3")
+        .doesNotContainKeys("custom-key-1", "custom-key-2");
+  }
+
+  @Test
+  void testCopyObjectToSelfWithTaggingReplace() throws Exception {
+    // Put the source object with some tags.
+    when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
+    assertSucceeds(() -> putObject(CONTENT));
+    assertThat(bucket.getKey(KEY_NAME).getTags()).hasSize(2);
+
+    // Copy the object onto itself with x-amz-tagging-directive: REPLACE and a
+    // new tag set. AWS allows this as an in-place tag update.
+    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
+        BUCKET_NAME + "/" + urlEncode(KEY_NAME));
+    when(headers.getHeaderString(TAG_DIRECTIVE_HEADER)).thenReturn("REPLACE");
+    when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag3=value3");
+
+    assertSucceeds(() -> putObject(CONTENT));
+
+    Map<String, String> tags = assertKeyContent(bucket, KEY_NAME, CONTENT).getTags();
+    assertThat(tags)
+        .containsEntry("tag3", "value3")
+        .doesNotContainKeys("tag1", "tag2");
+  }
+
+  @Test
   void testContentTypeStoredAndCopied() throws Exception {
     // PUT with an explicit Content-Type (preserved by HeaderPreprocessor).
     when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -412,28 +412,6 @@ class TestObjectPut {
   }
 
   @Test
-  void testCopyObjectToSelfWithTaggingReplace() throws Exception {
-    // Put the source object with some tags.
-    when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
-    assertSucceeds(() -> putObject(CONTENT));
-    assertThat(bucket.getKey(KEY_NAME).getTags()).hasSize(2);
-
-    // Copy the object onto itself with x-amz-tagging-directive: REPLACE and a
-    // new tag set. AWS allows this as an in-place tag update.
-    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
-        BUCKET_NAME + "/" + urlEncode(KEY_NAME));
-    when(headers.getHeaderString(TAG_DIRECTIVE_HEADER)).thenReturn("REPLACE");
-    when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag3=value3");
-
-    assertSucceeds(() -> putObject(CONTENT));
-
-    Map<String, String> tags = assertKeyContent(bucket, KEY_NAME, CONTENT).getTags();
-    assertThat(tags)
-        .containsEntry("tag3", "value3")
-        .doesNotContainKeys("tag1", "tag2");
-  }
-
-  @Test
   void testContentTypeStoredAndCopied() throws Exception {
     // PUT with an explicit Content-Type (preserved by HeaderPreprocessor).
     when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -412,6 +412,19 @@ class TestObjectPut {
   }
 
   @Test
+  void testCopyObjectToSelfWithoutMetadataReplaceRejected() throws Exception {
+    // Seed the source object.
+    assertSucceeds(() -> putObject(CONTENT));
+
+    // Self-copy without x-amz-metadata-directive: REPLACE (and no storage-class
+    // change) is not a real update, so it stays InvalidRequest.
+    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
+        BUCKET_NAME + "/" + urlEncode(KEY_NAME));
+
+    assertErrorResponse(INVALID_REQUEST, () -> putObject(CONTENT));
+  }
+
+  @Test
   void testContentTypeStoredAndCopied() throws Exception {
     // PUT with an explicit Content-Type (preserved by HeaderPreprocessor).
     when(headers.getHeaderString(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE))


### PR DESCRIPTION
## What changes were proposed in this pull request?

A CopyObject request whose source and destination are the same key was rejected with 400 InvalidRequest ("This copy request is illegal because it is trying to copy an object to it self ...") whenever no x-amz-storage-class header was present. This ignored the metadata directive.

AWS S3 permits a self-copy when metadata is replaced (`x-amz-metadata-directive: REPLACE`). That in-place metadata update is the canonical way to change an object's user metadata.

The self-copy guard in ObjectEndpoint only accounted for the storage-class case. This change reads the metadata directive up front and only rejects the self-copy when it is not REPLACE (and the storage type is default). When metadata is REPLACE, the request falls through to the normal copy path, which replaces the metadata in place. The storage-class-only self-copy behaviour is unchanged.

Tagging-only self-copy (`x-amz-tagging-directive: REPLACE` without a metadata REPLACE) is intentionally out of scope for this change: AWS's InvalidRequest message and AWS-validated compatible implementations treat metadata / storage class / encryption / redirect as the attributes that make a same-key copy legal, not tagging alone. Cross-key CopyObject tagging REPLACE, and tagging REPLACE together with metadata REPLACE on a self-copy, continue to work via the existing copy path. Use PutObjectTagging to update tags without a copy.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15852

## How was this patch tested?

- Unit: `TestObjectPut#testCopyObjectToSelfWithMetadataReplace`
- Integration: `AbstractS3SDKV2Tests#testCopyObjectToSelfWithMetadataReplace` (asserts replaced metadata via HeadObject and preserved content)