### PR TITLE
HDDS-14932. Optional Recon and Httpfs Start Up

### DIFF
--- a/hadoop-hdds/docs/content/tools/_index.md
+++ b/hadoop-hdds/docs/content/tools/_index.md
@@ -43,8 +43,8 @@ Client commands:
 
    * **sh** -  Primary command line interface for ozone to manage volumes/buckets/keys.
    * **fs** - Runs a command on ozone file system (similar to `hdfs dfs`)
-   * **local** - Runs a single-node local Ozone cluster (SCM, OM, and datanodes)
-   in one process for development.
+   * **local** - Runs a single-node local Ozone cluster (SCM, OM, datanodes,
+   and optional S3 Gateway) in one process for development.
    * **version** - Prints the version of Ozone and HDDS.
 
 

--- a/hadoop-hdds/docs/content/tools/_index.md
+++ b/hadoop-hdds/docs/content/tools/_index.md
@@ -44,7 +44,7 @@ Client commands:
    * **sh** -  Primary command line interface for ozone to manage volumes/buckets/keys.
    * **fs** - Runs a command on ozone file system (similar to `hdfs dfs`)
    * **local** - Runs a single-node local Ozone cluster (SCM, OM, datanodes,
-   and optional S3 Gateway) in one process for development.
+   and optional S3 Gateway and Recon) in one process for development.
    * **version** - Prints the version of Ozone and HDDS.
 
 

--- a/hadoop-ozone/integration-test-recon/pom.xml
+++ b/hadoop-ozone/integration-test-recon/pom.xml
@@ -181,6 +181,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-tools</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-common</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneRecon.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneRecon.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.local;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration tests for Recon in the {@code ozone local} runtime.
+ */
+class TestLocalOzoneRecon {
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  void reconServesRequestsWhenEnabled() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone-recon"))
+        .setS3gEnabled(false)
+        .setReconEnabled(true)
+        .setStartupTimeout(Duration.ofMinutes(2))
+        .build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, new OzoneConfiguration())) {
+      cluster.start();
+
+      assertTrue(cluster.getReconPort() > 0);
+      assertHttpEndpointResponds(cluster.getReconEndpoint());
+    }
+  }
+
+  private static void assertHttpEndpointResponds(String endpoint) throws Exception {
+    HttpURLConnection connection = (HttpURLConnection) new URL(endpoint).openConnection();
+    try {
+      connection.setConnectTimeout(1_000);
+      connection.setReadTimeout(1_000);
+      // Any HTTP response proves Recon is serving requests.
+      assertTrue(connection.getResponseCode() > 0, endpoint);
+    } finally {
+      connection.disconnect();
+    }
+  }
+}

--- a/hadoop-ozone/integration-test-s3/pom.xml
+++ b/hadoop-ozone/integration-test-s3/pom.xml
@@ -155,6 +155,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-tools</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-common</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneS3.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneS3.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.local;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.UUID;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Integration tests for the S3 Gateway of the {@code ozone local} runtime.
+ */
+class TestLocalOzoneS3 {
+
+  @TempDir
+  private Path tempDir;
+
+  /**
+   * The gateway serves signed S3 requests on a loopback-only listener, and accepts any
+   * credentials because the local runtime leaves security off. Regression guard rather than a
+   * fix: non-secure OM has always skipped signature validation, so these assertions do not go red
+   * against a runtime that also stores a secret in OM.
+   */
+  @Test
+  void s3GatewayServesRequests() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(tempDir.resolve("local-ozone-s3")).build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, new OzoneConfiguration())) {
+      cluster.start();
+
+      assertTrue(cluster.getS3gPort() > 0);
+      assertTrue(cluster.getS3gBoundAddress().getAddress().isLoopbackAddress(),
+          () -> cluster.getS3gBoundAddress().toString());
+
+      assertBucketRoundTrip(cluster.getS3Endpoint(), "local-smoke",
+          LocalOzoneClusterConfig.LOCAL_S3_ACCESS_KEY, LocalOzoneClusterConfig.LOCAL_S3_SECRET_KEY);
+      // Credentials the runtime never saw work the same, for the reason given on this test.
+      String unknown = UUID.randomUUID().toString().replace("-", "");
+      assertBucketRoundTrip(cluster.getS3Endpoint(), "local-smoke-" + unknown, unknown, unknown);
+    }
+  }
+
+  /**
+   * The SDK sends a SigV4-signed request, which is what AuthorizationFilter requires of every
+   * caller; whether that signature verifies is decided separately, in OM.
+   */
+  private static void assertBucketRoundTrip(String endpoint, String bucket,
+      String accessKey, String secretKey) {
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+    try (S3Client s3 = S3Client.builder()
+        .endpointOverride(URI.create(endpoint))
+        .region(Region.of(LocalOzoneClusterConfig.LOCAL_S3_REGION))
+        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .forcePathStyle(true)
+        .build()) {
+      s3.createBucket(request -> request.bucket(bucket));
+      assertTrue(s3.listBuckets().buckets().stream().anyMatch(b -> bucket.equals(b.name())));
+    }
+  }
+}

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneS3.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneS3.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.local;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.nio.file.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Integration tests for the S3 Gateway of the {@code ozone local} runtime.
+ */
+class TestLocalOzoneS3 {
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  void s3GatewayServesRequests() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(tempDir.resolve("local-ozone-s3")).build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, new OzoneConfiguration())) {
+      cluster.start();
+
+      assertTrue(cluster.getS3gPort() > 0);
+      // Loopback-only by default: the credentials above are fixed and well known, so binding a
+      // wider interface must stay an explicit --bind-host choice.
+      assertTrue(cluster.getS3gBoundAddress().getAddress().isLoopbackAddress(),
+          () -> cluster.getS3gBoundAddress().toString());
+      assertPreProvisionedCredentialsAccepted(cluster.getS3Endpoint());
+    }
+  }
+
+  /**
+   * A signed bucket round-trip through the endpoint the runtime advertises: proves the suggested
+   * AWS settings (endpoint, pre-provisioned credentials, path-style addressing) work against the
+   * local gateway.
+   */
+  private static void assertPreProvisionedCredentialsAccepted(String endpoint) {
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(
+        LocalOzoneClusterConfig.DEFAULT_S3_ACCESS_KEY, LocalOzoneClusterConfig.DEFAULT_S3_SECRET_KEY);
+    try (S3Client s3 = S3Client.builder()
+        .endpointOverride(URI.create(endpoint))
+        .region(Region.of(LocalOzoneClusterConfig.DEFAULT_S3_REGION))
+        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .forcePathStyle(true)
+        .build()) {
+      s3.createBucket(request -> request.bucket("local-smoke"));
+      assertTrue(s3.listBuckets().buckets().stream().anyMatch(bucket -> "local-smoke".equals(bucket.name())));
+    }
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ConfigurationProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ConfigurationProvider.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.recon;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Provider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configuration.DeprecationDelta;
@@ -50,16 +49,14 @@ public class ConfigurationProvider implements
     });
   }
 
-  @VisibleForTesting
   public static void setConfiguration(OzoneConfiguration conf) {
-    // Nullity check is used in case the configuration was already set
-    // in the MiniOzoneCluster
+    // Nullity check is used in case the configuration was already set by a
+    // same-JVM launcher (MiniOzoneCluster or ozone local)
     if (configuration == null) {
       ConfigurationProvider.configuration = conf;
     }
   }
 
-  @VisibleForTesting
   public static void resetConfiguration() {
     configuration = null;
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ConfigurationProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ConfigurationProvider.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.recon;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Provider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configuration.DeprecationDelta;
@@ -50,16 +49,14 @@ public class ConfigurationProvider implements
     });
   }
 
-  @VisibleForTesting
   public static void setConfiguration(OzoneConfiguration conf) {
-    // Nullity check is used in case the configuration was already set
-    // in the MiniOzoneCluster
+    // First writer wins: ReconService and LocalOzoneCluster set this before ReconServer#call()
+    // reaches it, and their configuration is the one the in-JVM server has to run with.
     if (configuration == null) {
       ConfigurationProvider.configuration = conf;
     }
   }
 
-  @VisibleForTesting
   public static void resetConfiguration() {
     configuration = null;
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -65,6 +65,12 @@ public class Gateway extends GenericCli implements Callable<Void> {
   private BaseHttpServer contentServer;
   private S3GatewayMetrics metrics;
   private NettyMetrics nettyMetrics;
+  /**
+   * Withdrawn by {@link #stop()}: a hook left behind keeps a stopped gateway reachable for the
+   * life of the JVM and would still run {@link S3GatewayMetrics#unRegister()}, a static global
+   * shared with whichever gateway is current when several start in turn in one JVM.
+   */
+  private Runnable shutdownHook;
 
   private final JvmPauseMonitor jvmPauseMonitor = newJvmPauseMonitor("S3G");
 
@@ -95,13 +101,14 @@ public class Gateway extends GenericCli implements Callable<Void> {
     nettyMetrics = NettyMetrics.create();
     start();
 
-    ShutdownHookManager.get().addShutdownHook(() -> {
+    shutdownHook = () -> {
       try {
         stop();
       } catch (Exception e) {
         LOG.error("Error during stop S3Gateway", e);
       }
-    }, DEFAULT_SHUTDOWN_HOOK_PRIORITY);
+    };
+    ShutdownHookManager.get().addShutdownHook(shutdownHook, DEFAULT_SHUTDOWN_HOOK_PRIORITY);
     return null;
   }
 
@@ -120,6 +127,15 @@ public class Gateway extends GenericCli implements Callable<Void> {
 
   public void stop() throws Exception {
     LOG.info("Stopping Ozone S3 gateway");
+    if (shutdownHook != null) {
+      // Withdrawn before the stop runs, so the hook firing during JVM shutdown does not repeat
+      // a stop that already happened. Skipped while the hook itself is running, since
+      // ShutdownHookManager rejects removal once shutdown is in progress.
+      if (!ShutdownHookManager.get().isShutdownInProgress()) {
+        ShutdownHookManager.get().removeShutdownHook(shutdownHook);
+      }
+      shutdownHook = null;
+    }
     IOUtils.closeQuietly(httpServer, contentServer);
     jvmPauseMonitor.stop();
     S3GatewayMetrics.unRegister();
@@ -151,7 +167,6 @@ public class Gateway extends GenericCli implements Callable<Void> {
     }
   }
 
-  @VisibleForTesting
   public InetSocketAddress getHttpAddress() {
     return this.httpServer.getHttpAddress();
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -143,7 +143,6 @@ public class Gateway extends GenericCli implements Callable<Void> {
     }
   }
 
-  @VisibleForTesting
   public InetSocketAddress getHttpAddress() {
     return this.httpServer.getHttpAddress();
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneConfigurationHolder.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneConfigurationHolder.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.s3;
 
-import com.google.common.annotations.VisibleForTesting;
 import javax.enterprise.inject.Produces;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
@@ -39,17 +38,15 @@ public final class OzoneConfigurationHolder {
     return configuration;
   }
 
-  @VisibleForTesting
   public static void setConfiguration(
       OzoneConfiguration conf) {
-    // Nullity check is used in case the configuration was already set
-    // in the MiniOzoneCluster
+    // Nullity check is used in case the configuration was already set by a
+    // same-JVM launcher (MiniOzoneCluster or ozone local)
     if (configuration == null) {
       OzoneConfigurationHolder.configuration = conf;
     }
   }
 
-  @VisibleForTesting
   public static void resetConfiguration() {
     configuration = null;
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneConfigurationHolder.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneConfigurationHolder.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.s3;
 
-import com.google.common.annotations.VisibleForTesting;
 import javax.enterprise.inject.Produces;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
@@ -39,17 +38,15 @@ public final class OzoneConfigurationHolder {
     return configuration;
   }
 
-  @VisibleForTesting
   public static void setConfiguration(
       OzoneConfiguration conf) {
-    // Nullity check is used in case the configuration was already set
-    // in the MiniOzoneCluster
+    // First writer wins: S3GatewayService and LocalOzoneCluster set this before Gateway#call()
+    // reaches it, and their configuration is the one the in-JVM gateway has to run with.
     if (configuration == null) {
       OzoneConfigurationHolder.configuration = conf;
     }
   }
 
-  @VisibleForTesting
   public static void resetConfiguration() {
     configuration = null;
   }

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -88,6 +88,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-recon</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-s3gateway</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -89,6 +89,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-recon</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-s3gateway</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -87,6 +87,10 @@
       <artifactId>ozone-manager</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-s3gateway</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-common</artifactId>
     </dependency>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -47,6 +47,10 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -69,6 +69,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-admin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-server-framework</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>ozone-manager</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-s3gateway</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-common</artifactId>
     </dependency>

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -72,10 +72,20 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DB_DIR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ENABLED_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_BIND_HOST_KEY;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -90,6 +100,11 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -111,13 +126,13 @@ import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.s3.Gateway;
+import org.apache.hadoop.ozone.s3.OzoneConfigurationHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Starts the SCM, OM, and datanode portion of the {@code ozone local} runtime.
- *
- * <p>S3 Gateway and Recon are added by later local runtime tickets.</p>
+ * Starts the SCM, OM, datanode, and optional S3 Gateway portion of the {@code ozone local} runtime.
  */
 public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
@@ -145,6 +160,8 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private static final String OM_HTTP_PORT_KEY = "om.http";
   private static final String OM_HTTPS_PORT_KEY = "om.https";
   private static final String OM_RATIS_PORT_KEY = "om.ratis";
+  private static final String S3G_HTTP_PORT_KEY = "s3g.http";
+  private static final String S3G_WEBADMIN_HTTP_PORT_KEY = "s3g.web.http";
   private static final String DATANODE_PORT_KEY_PREFIX = "dn.";
   private static final String DATANODE_HTTP_PORT_KEY_SUFFIX = "http";
   private static final String DATANODE_CLIENT_PORT_KEY_SUFFIX = "client";
@@ -205,6 +222,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private PreparedConfiguration preparedConfiguration;
   private StorageContainerManager scm;
   private OzoneManager om;
+  private Gateway s3Gateway;
   private final List<HddsDatanodeService> datanodes = new ArrayList<>();
   private boolean previousMetricsMiniClusterMode;
   private boolean metricsMiniClusterModeEnabled;
@@ -236,6 +254,9 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       startOm(prepared.getConfiguration());
       startDatanodes(prepared.getDatanodeConfigurations());
       waitForClusterReadiness(config.getStartupTimeout());
+      if (config.isS3gEnabled()) {
+        startS3Gateway(prepared.getConfiguration());
+      }
     } catch (Exception ex) {
       // Roll back without latching closed: the caller's close() still owns the
       // ephemeral data dir lifecycle.
@@ -262,6 +283,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     PortAllocator portAllocator = new PortAllocator();
     int scmPort = configureScm(conf, persistedPorts, portAllocator);
     int omPort = configureOm(conf, persistedPorts, portAllocator);
+    int s3gPort = configureS3Gateway(conf, persistedPorts, portAllocator);
     List<OzoneConfiguration> datanodeConfigurations =
         configureDatanodes(conf, persistedPorts, portAllocator);
 
@@ -269,13 +291,13 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     createServiceDirectories();
     persistedPorts.store();
     preparedConfiguration = new PreparedConfiguration(conf, scmPort, omPort,
-        datanodeConfigurations);
+        s3gPort, datanodeConfigurations);
     return preparedConfiguration;
   }
 
   @Override
   public String getDisplayHost() {
-    return LocalOzoneClusterConfig.DEFAULT_BIND_HOST.equals(config.getHost())
+    return LocalOzoneClusterConfig.WILDCARD_HOST.equals(config.getHost())
         ? LocalOzoneClusterConfig.DEFAULT_HOST : config.getHost();
   }
 
@@ -298,12 +320,23 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
   @Override
   public int getS3gPort() {
-    return -1;
+    InetSocketAddress address = getS3gBoundAddress();
+    return address != null ? address.getPort() : -1;
   }
 
   @Override
   public String getS3Endpoint() {
-    return "";
+    int port = getS3gPort();
+    return port > 0 ? "http://" + getDisplayHost() + ":" + port : "";
+  }
+
+  /**
+   * Returns the address the S3 Gateway HTTP listener is bound to, or null when there is none to
+   * report: {@code BaseHttpServer} assigns an address only for a server it enables. Keyed off the
+   * field rather than {@code isS3gEnabled()}, which says what was asked for, not what is running.
+   */
+  InetSocketAddress getS3gBoundAddress() {
+    return s3Gateway != null ? s3Gateway.getHttpAddress() : null;
   }
 
   @Override
@@ -333,9 +366,17 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       // Shutdown is best-effort so one failed service cannot leak the others,
       // but the failures are logged: stopServices() also runs as start()
       // rollback, where a silent failure hides leaked threads and ports.
-      IOUtils.close(LOG, this::stopDatanodes, this::stopOm, this::stopScm);
+      IOUtils.close(LOG, this::stopS3Gateway, this::stopDatanodes, this::stopOm, this::stopScm);
     } finally {
       restoreSameJvmMetricsMode();
+    }
+  }
+
+  private void stopS3Gateway() throws Exception {
+    Gateway service = s3Gateway;
+    s3Gateway = null;
+    if (service != null) {
+      service.stop();
     }
   }
 
@@ -371,7 +412,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
   private void configureLocalDefaults(OzoneConfiguration conf) throws IOException {
     conf.set(OZONE_METADATA_DIRS, metadataDir().toString());
-    // SCM and OM share one configuration and JVM, so the Jetty base dir is a
+    // SCM, OM, and the S3 Gateway share one configuration and JVM, so the Jetty base dir is a
     // single service-neutral location; Jetty keeps per-context temp dirs.
     conf.setIfUnset(OZONE_HTTP_BASEDIR, metadataDir() + SERVER_DIR);
     setLocalOverrideReplication(conf, OZONE_REPLICATION, ReplicationFactor.ONE);
@@ -641,6 +682,41 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
         omMetadataDir.toString());
   }
 
+  private int configureS3Gateway(OzoneConfiguration conf,
+      PersistedPortState persistedPorts, PortAllocator portAllocator)
+      throws IOException {
+    if (!config.isS3gEnabled()) {
+      return -1;
+    }
+    // The runtime advertises an http:// endpoint and reads the bound port back off this
+    // listener, so a configuration that switches it off leaves nothing to report.
+    setLocalOverride(conf, OZONE_S3G_HTTP_ENABLED_KEY, true);
+
+    int s3gHttpPort = reservePort(portAllocator, persistedPorts,
+        S3G_HTTP_PORT_KEY, config.getS3gPort());
+    int s3gWebHttpPort = reservePort(portAllocator, persistedPorts,
+        S3G_WEBADMIN_HTTP_PORT_KEY, 0);
+    // Port 0, not a reservation: the local runtime runs the default HTTP-only policy, so these
+    // connectors never bind, and a port reserved for a listener that never claims it is a window
+    // for another process rather than a stable endpoint.
+    int s3gHttpsPort = 0;
+    int s3gWebHttpsPort = 0;
+
+    conf.set(OZONE_S3G_HTTP_ADDRESS_KEY,
+        address(config.getHost(), s3gHttpPort));
+    conf.set(OZONE_S3G_HTTP_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_S3G_HTTPS_ADDRESS_KEY,
+        address(config.getHost(), s3gHttpsPort));
+    conf.set(OZONE_S3G_HTTPS_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY,
+        address(config.getHost(), s3gWebHttpPort));
+    conf.set(OZONE_S3G_WEBADMIN_HTTP_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY,
+        address(config.getHost(), s3gWebHttpsPort));
+    conf.set(OZONE_S3G_WEBADMIN_HTTPS_BIND_HOST_KEY, config.getBindHost());
+    return s3gHttpPort;
+  }
+
   private List<OzoneConfiguration> configureDatanodes(OzoneConfiguration conf,
       PersistedPortState persistedPorts, PortAllocator portAllocator)
       throws IOException {
@@ -793,6 +869,61 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       HddsDatanodeService datanode = new HddsDatanodeService(NO_ARGS);
       datanodes.add(datanode);
       datanode.start(dnConf);
+    }
+  }
+
+  private void startS3Gateway(OzoneConfiguration conf) throws Exception {
+    // Gateway reads its configuration from the static holder, and the reset is what lets a second
+    // in-JVM start win: setConfiguration() keeps the first value. Same pair as S3GatewayService.
+    OzoneConfigurationHolder.resetConfiguration();
+    OzoneConfigurationHolder.setConfiguration(new OzoneConfiguration(conf));
+    Gateway gateway = new Gateway();
+    // Start through call(), not execute(): GenericCli's execution-exception handler reduces the
+    // startup failure cause to a bare exit code and can even System.exit the JVM on an
+    // AccessControlException. parseArgs() primes the picocli state that Gateway.start() reads.
+    gateway.getCmd().parseArgs();
+    // call() returns only after Jetty has bound the gateway's ports and serves requests, so no
+    // readiness poll follows.
+    executeWithinStartupTimeout("S3 Gateway", gateway::call, gateway::stop, config.getStartupTimeout());
+    s3Gateway = gateway;
+  }
+
+  /**
+   * Runs a blocking in-JVM service startup under {@code timeout}, so the launcher fails fast and
+   * rolls back instead of hanging if a startup ever blocks. {@code startupCleanup} is the only
+   * stopper for an attempt that did not finish: a startup that ignores the interrupt keeps running
+   * after {@code stopServices()} has rolled back, so on a timeout or an interrupt the cleanup is
+   * queued behind it on the same single thread rather than run here. The caller assigns its field
+   * only after this returns, so a failed attempt is never reachable from the rollback.
+   */
+  static void executeWithinStartupTimeout(String serviceName, Callable<Void> startup,
+      AutoCloseable startupCleanup, Duration timeout) throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+      Thread thread = new Thread(runnable, "local-startup-" + serviceName);
+      thread.setDaemon(true);
+      return thread;
+    });
+    Future<Void> future = executor.submit(startup);
+    try {
+      future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (TimeoutException ex) {
+      future.cancel(true);
+      executor.submit(() -> IOUtils.close(LOG, startupCleanup));
+      throw new IOException("Local " + serviceName + " did not start within " + timeout + ".", ex);
+    } catch (InterruptedException ex) {
+      // Queued, not run here, for the reason given on this method: the startup may finish late.
+      future.cancel(true);
+      executor.submit(() -> IOUtils.close(LOG, startupCleanup));
+      Thread.currentThread().interrupt();
+      throw ex;
+    } catch (ExecutionException ex) {
+      IOUtils.close(LOG, startupCleanup);
+      Throwable cause = ex.getCause();
+      throw cause instanceof Exception ? (Exception) cause : ex;
+    } finally {
+      // shutdown(), not shutdownNow(): the timeout path queues the cleanup, which shutdownNow()
+      // would discard. The worker is a daemon thread, so it cannot keep the JVM alive.
+      executor.shutdown();
     }
   }
 
@@ -980,6 +1111,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private String[] requiredPersistedPortKeys() {
     List<String> keys =
         new ArrayList<>(Arrays.asList(REQUIRED_PERSISTED_PORT_KEYS));
+    if (config.isS3gEnabled()) {
+      keys.add(S3G_HTTP_PORT_KEY);
+      keys.add(S3G_WEBADMIN_HTTP_PORT_KEY);
+    }
     for (int index = 0; index < config.getDatanodes(); index++) {
       for (String suffix : DATANODE_PORT_KEY_SUFFIXES) {
         keys.add(datanodePortKey(index, suffix));
@@ -1042,14 +1177,16 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     private final OzoneConfiguration configuration;
     private final int scmPort;
     private final int omPort;
+    private final int s3gPort;
     private final List<OzoneConfiguration> datanodeConfigurations;
 
-    PreparedConfiguration(OzoneConfiguration configuration, int scmPort,
-        int omPort, List<OzoneConfiguration> datanodeConfigurations) {
+    PreparedConfiguration(OzoneConfiguration configuration, int scmPort, int omPort, int s3gPort,
+        List<OzoneConfiguration> datanodeConfigurations) {
       this.configuration = Objects.requireNonNull(configuration,
           "configuration");
       this.scmPort = scmPort;
       this.omPort = omPort;
+      this.s3gPort = s3gPort;
       this.datanodeConfigurations = Collections.unmodifiableList(
           new ArrayList<>(Objects.requireNonNull(datanodeConfigurations,
               "datanodeConfigurations")));
@@ -1065,6 +1202,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
     int getOmPort() {
       return omPort;
+    }
+
+    int getS3gPort() {
+      return s3gPort;
     }
 
     List<OzoneConfiguration> getDatanodeConfigurations() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -25,6 +25,12 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY;
@@ -72,6 +78,11 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DB_DIR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_BIND_HOST_KEY;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY;
@@ -84,8 +95,10 @@ import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -124,15 +137,17 @@ import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.recon.ConfigurationProvider;
+import org.apache.hadoop.ozone.recon.ReconServer;
+import org.apache.hadoop.ozone.recon.ReconSqlDbConfig;
 import org.apache.hadoop.ozone.s3.Gateway;
 import org.apache.hadoop.ozone.s3.OzoneConfigurationHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Starts the SCM, OM, datanode, and optional S3 Gateway portion of the {@code ozone local} runtime.
- *
- * <p>Recon is added by a later local runtime ticket.</p>
+ * Starts the SCM, OM, datanode, and optional S3 Gateway and Recon portion of the {@code ozone local}
+ * runtime.
  */
 public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
@@ -164,6 +179,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private static final String S3G_HTTPS_PORT_KEY = "s3g.https";
   private static final String S3G_WEBADMIN_HTTP_PORT_KEY = "s3g.web.http";
   private static final String S3G_WEBADMIN_HTTPS_PORT_KEY = "s3g.web.https";
+  private static final String RECON_HTTP_PORT_KEY = "recon.http";
+  private static final String RECON_HTTPS_PORT_KEY = "recon.https";
+  private static final String RECON_DATANODE_PORT_KEY = "recon.datanode";
+  private static final String RECON_DIR_NAME = "recon";
   private static final String DATANODE_PORT_KEY_PREFIX = "dn.";
   private static final String DATANODE_HTTP_PORT_KEY_SUFFIX = "http";
   private static final String DATANODE_CLIENT_PORT_KEY_SUFFIX = "client";
@@ -210,7 +229,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   // local ports, so an unbounded count would exhaust local ports; cap it.
   static final int MAX_DATANODES = 20;
 
-  private static final String OZONE_DEFAULT_XML = "ozone-default.xml";
+  // OzoneConfiguration loads ozone-default.xml plus a generated <module>-default.xml for every
+  // module (see OzoneConfiguration.getConfigurationResourceFiles), so match the suffix: Recon's
+  // default for OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD ships in ozone-recon-default.xml.
+  private static final String DEFAULT_XML_SUFFIX = "-default.xml";
 
   private static final String[] NO_ARGS = new String[0];
 
@@ -222,6 +244,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private StorageContainerManager scm;
   private OzoneManager om;
   private Gateway s3Gateway;
+  private ReconServer reconServer;
   private final List<HddsDatanodeService> datanodes = new ArrayList<>();
   private final List<String> discardedUserConfigKeys = new ArrayList<>();
   private boolean previousMetricsMiniClusterMode;
@@ -254,6 +277,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       startOm(prepared.getConfiguration());
       startDatanodes(prepared.getDatanodeConfigurations());
       waitForClusterReadiness(config.getStartupTimeout());
+      if (config.isReconEnabled()) {
+        startRecon(prepared.getConfiguration());
+        waitForHttpEndpointReadiness(getReconEndpoint(), "Recon",
+            config.getStartupTimeout());
+      }
       if (config.isS3gEnabled()) {
         provisionS3Credentials();
         startS3Gateway(prepared.getConfiguration());
@@ -286,12 +314,13 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     int scmPort = configureScm(conf, persistedPorts, portAllocator);
     int omPort = configureOm(conf, persistedPorts, portAllocator);
     int s3gPort = configureS3Gateway(conf, persistedPorts, portAllocator);
+    int reconPort = configureRecon(conf, persistedPorts, portAllocator);
     List<OzoneConfiguration> datanodeConfigurations =
         configureDatanodes(conf, persistedPorts, portAllocator);
 
     persistedPorts.store();
     preparedConfiguration = new PreparedConfiguration(conf, scmPort, omPort,
-        s3gPort, datanodeConfigurations);
+        s3gPort, reconPort, datanodeConfigurations);
     return preparedConfiguration;
   }
 
@@ -337,6 +366,23 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   @Override
+  public int getReconPort() {
+    if (!config.isReconEnabled()) {
+      return -1;
+    }
+    return preparedConfiguration == null ? config.getReconPort()
+        : preparedConfiguration.getReconPort();
+  }
+
+  @Override
+  public String getReconEndpoint() {
+    if (!config.isReconEnabled()) {
+      return "";
+    }
+    return "http://" + getDisplayHost() + ":" + getReconPort();
+  }
+
+  @Override
   public List<String> getDiscardedUserConfigKeys() {
     return Collections.unmodifiableList(discardedUserConfigKeys);
   }
@@ -368,7 +414,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       // Shutdown is best-effort so one failed service cannot leak the others,
       // but the failures are logged: stopServices() also runs as start()
       // rollback, where a silent failure hides leaked threads and ports.
-      IOUtils.close(LOG, this::stopS3Gateway, this::stopDatanodes, this::stopOm, this::stopScm);
+      IOUtils.close(LOG, this::stopS3Gateway, this::stopRecon, this::stopDatanodes, this::stopOm, this::stopScm);
     } finally {
       restoreSameJvmMetricsMode();
     }
@@ -379,6 +425,15 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     s3Gateway = null;
     if (service != null) {
       service.stop();
+    }
+  }
+
+  private void stopRecon() {
+    ReconServer service = reconServer;
+    reconServer = null;
+    if (service != null) {
+      service.stop();
+      service.join();
     }
   }
 
@@ -457,13 +512,13 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   /**
-   * Whether {@code key} carries a value the user chose. A value whose last source is
-   * ozone-default.xml is a shipped default, not a user choice.
+   * Whether {@code key} carries a value the user chose. A value whose last source is one of the
+   * shipped {@code *-default.xml} resources is a default, not a user choice.
    */
   private static boolean isUserConfigured(OzoneConfiguration conf, String key) {
     String[] sources = conf.getPropertySources(key);
     return sources != null && sources.length > 0
-        && !sources[sources.length - 1].contains(OZONE_DEFAULT_XML);
+        && !sources[sources.length - 1].endsWith(DEFAULT_XML_SUFFIX);
   }
 
   private int configureScm(OzoneConfiguration conf,
@@ -590,6 +645,50 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
         address(config.getHost(), s3gWebHttpsPort));
     conf.set(OZONE_S3G_WEBADMIN_HTTPS_BIND_HOST_KEY, config.getBindHost());
     return s3gHttpPort;
+  }
+
+  private int configureRecon(OzoneConfiguration conf,
+      PersistedPortState persistedPorts, PortAllocator portAllocator)
+      throws IOException {
+    if (!config.isReconEnabled()) {
+      return -1;
+    }
+    Path reconDir = config.getDataDir().resolve(RECON_DIR_NAME);
+    Files.createDirectories(reconDir);
+    conf.setIfUnset(OZONE_RECON_DB_DIR, reconDir.toString());
+    conf.setIfUnset(OZONE_RECON_OM_SNAPSHOT_DB_DIR, reconDir.toString());
+    conf.setIfUnset(OZONE_RECON_SCM_DB_DIR, reconDir.toString());
+
+    ReconSqlDbConfig dbConfig = conf.getObject(ReconSqlDbConfig.class);
+    dbConfig.setJdbcUrl("jdbc:derby:"
+        + reconDir.resolve("ozone_recon_derby.db"));
+    conf.setFromObject(dbConfig);
+
+    int reconHttpPort = reservePort(portAllocator, persistedPorts,
+        RECON_HTTP_PORT_KEY, config.getReconPort());
+    int reconHttpsPort = reservePort(portAllocator, persistedPorts,
+        RECON_HTTPS_PORT_KEY, 0);
+    int reconDatanodePort = reservePort(portAllocator, persistedPorts,
+        RECON_DATANODE_PORT_KEY, 0);
+
+    conf.set(OZONE_RECON_ADDRESS_KEY,
+        address(config.getHost(), reconDatanodePort));
+    conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY,
+        address(config.getHost(), reconDatanodePort));
+    conf.set(OZONE_RECON_DATANODE_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_RECON_HTTP_ADDRESS_KEY,
+        address(config.getHost(), reconHttpPort));
+    conf.set(OZONE_RECON_HTTP_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_RECON_HTTPS_ADDRESS_KEY,
+        address(config.getHost(), reconHttpsPort));
+    conf.set(OZONE_RECON_HTTPS_BIND_HOST_KEY, config.getBindHost());
+    // Recon's start-up blocks until it leaves safe mode, and an empty local
+    // cluster never leaves it on its own, so keep the fallback wait short.
+    // Use set(), not setIfUnset(): the generated ozone-recon-default.xml
+    // already supplies the 300s default, so setIfUnset() would do nothing here
+    // and Recon would block start-up for 5 minutes.
+    setLocalOverride(conf, OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "10s");
+    return reconHttpPort;
   }
 
   private List<OzoneConfiguration> configureDatanodes(OzoneConfiguration conf,
@@ -789,16 +888,16 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
    * {@link #stopServices()} has run. The queued cleanup is that abandoned attempt's only stopper,
    * and the shared thread runs it after every write the attempt made.
    */
-  static void executeWithinStartupTimeout(String serviceName, Callable<Void> startup,
+  static <V> V executeWithinStartupTimeout(String serviceName, Callable<V> startup,
       AutoCloseable startupCleanup, Duration timeout) throws Exception {
     ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
       Thread thread = new Thread(runnable, "local-startup-" + serviceName);
       thread.setDaemon(true);
       return thread;
     });
-    Future<Void> future = executor.submit(startup);
+    Future<V> future = executor.submit(startup);
     try {
-      future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+      return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (TimeoutException ex) {
       future.cancel(true);
       executor.submit(() -> IOUtils.close(LOG, startupCleanup));
@@ -811,6 +910,58 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       // shutdown(), not shutdownNow(): the timeout path queues the cleanup, which shutdownNow()
       // would discard. The worker is a daemon thread, so it cannot keep the JVM alive.
       executor.shutdown();
+    }
+  }
+
+  private void startRecon(OzoneConfiguration conf) throws Exception {
+    // ReconServer reads its configuration from the static provider, like
+    // MiniOzoneCluster does when running Recon in the same JVM.
+    ConfigurationProvider.resetConfiguration();
+    ConfigurationProvider.setConfiguration(new OzoneConfiguration(conf));
+    ReconServer recon = new ReconServer();
+    // The field holds only a successfully launched server: a failed or timed-out launch is
+    // stopped by executeWithinStartupTimeout, never by the rollback in stopServices(), which
+    // could otherwise race a launch that is still running.
+    int exitCode = executeWithinStartupTimeout("Recon", () -> recon.execute(NO_ARGS),
+        recon::stop, config.getStartupTimeout());
+    if (exitCode != 0) {
+      // execute() has returned, so stopping the partially started server cannot race it.
+      IOUtils.close(LOG, recon::stop);
+      throw new IOException("Failed to start local Recon. Exit code "
+          + exitCode + ".");
+    }
+    reconServer = recon;
+  }
+
+  private void waitForHttpEndpointReadiness(String endpoint,
+      String serviceName, Duration timeout) throws Exception {
+    waitForReadiness(() -> httpEndpointBlocker(endpoint, serviceName),
+        serviceName, timeout);
+  }
+
+  /**
+   * Returns why {@code endpoint} is not serving yet, or null once it is. Unlike SCM and OM, Recon
+   * exposes no in-process readiness API to this package, and ReconServer even reports success
+   * while its initialization failed; an HTTP response from the endpoint is the service-level
+   * signal that requests are being served. A failed probe is expected while the service starts,
+   * but the reason is kept: a refused connection, a wrong port and a hung listener are otherwise
+   * indistinguishable once the wait times out.
+   */
+  private static String httpEndpointBlocker(String endpoint, String serviceName) {
+    HttpURLConnection connection = null;
+    try {
+      connection = (HttpURLConnection) new URL(endpoint).openConnection();
+      connection.setConnectTimeout((int) READINESS_POLL_INTERVAL_MILLIS);
+      connection.setReadTimeout((int) READINESS_POLL_INTERVAL_MILLIS);
+      connection.getResponseCode();
+      return null;
+    } catch (IOException ex) {
+      LOG.debug("{} readiness probe of {} failed.", serviceName, endpoint, ex);
+      return endpoint + " is not answering (" + ex + ")";
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
     }
   }
 
@@ -975,6 +1126,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       keys.add(S3G_WEBADMIN_HTTP_PORT_KEY);
       keys.add(S3G_WEBADMIN_HTTPS_PORT_KEY);
     }
+    if (config.isReconEnabled()) {
+      keys.add(RECON_HTTP_PORT_KEY);
+      keys.add(RECON_HTTPS_PORT_KEY);
+      keys.add(RECON_DATANODE_PORT_KEY);
+    }
     for (int index = 0; index < config.getDatanodes(); index++) {
       for (String suffix : DATANODE_PORT_KEY_SUFFIXES) {
         keys.add(datanodePortKey(index, suffix));
@@ -1038,15 +1194,17 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     private final int scmPort;
     private final int omPort;
     private final int s3gPort;
+    private final int reconPort;
     private final List<OzoneConfiguration> datanodeConfigurations;
 
-    PreparedConfiguration(OzoneConfiguration configuration, int scmPort, int omPort, int s3gPort,
+    PreparedConfiguration(OzoneConfiguration configuration, int scmPort, int omPort, int s3gPort, int reconPort,
         List<OzoneConfiguration> datanodeConfigurations) {
       this.configuration = Objects.requireNonNull(configuration,
           "configuration");
       this.scmPort = scmPort;
       this.omPort = omPort;
       this.s3gPort = s3gPort;
+      this.reconPort = reconPort;
       this.datanodeConfigurations = Collections.unmodifiableList(
           new ArrayList<>(Objects.requireNonNull(datanodeConfigurations,
               "datanodeConfigurations")));
@@ -1066,6 +1224,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
     int getS3gPort() {
       return s3gPort;
+    }
+
+    int getReconPort() {
+      return reconPort;
     }
 
     List<OzoneConfiguration> getDatanodeConfigurations() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -92,6 +92,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -153,6 +155,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private static final int LOCAL_RATIS_RPC_TIMEOUT_SECONDS = 1;
   private static final long SCM_CLIENT_MAX_RETRY_TIMEOUT_MILLIS = 30_000;
   private static final long READINESS_POLL_INTERVAL_MILLIS = 500;
+  private static final long READINESS_LOG_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(5);
 
   private static final int MAX_PORT = 65_535;
 
@@ -186,6 +189,8 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   // local ports, so an unbounded count would exhaust local ports; cap it.
   static final int MAX_DATANODES = 20;
 
+  private static final String OZONE_DEFAULT_XML = "ozone-default.xml";
+
   private static final String[] NO_ARGS = new String[0];
 
   private final LocalOzoneClusterConfig config;
@@ -196,6 +201,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private StorageContainerManager scm;
   private OzoneManager om;
   private final List<HddsDatanodeService> datanodes = new ArrayList<>();
+  private final List<String> discardedUserConfigKeys = new ArrayList<>();
   private boolean previousMetricsMiniClusterMode;
   private boolean metricsMiniClusterModeEnabled;
 
@@ -239,6 +245,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       return preparedConfiguration;
     }
 
+    // preparedConfiguration is assigned only on success, so a failed attempt can be retried on this
+    // instance; start from an empty list so a retry does not report an override twice.
+    discardedUserConfigKeys.clear();
+
+    requireSupportedDatanodeCount();
     prepareStorageLayout();
 
     OzoneConfiguration conf = new OzoneConfiguration(seedConfiguration);
@@ -291,6 +302,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   @Override
+  public List<String> getDiscardedUserConfigKeys() {
+    return Collections.unmodifiableList(discardedUserConfigKeys);
+  }
+
+  @Override
   public void close() throws IOException {
     if (closed) {
       return;
@@ -314,8 +330,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
   private void stopServices() {
     try {
-      // Shutdown is best-effort so one failed service cannot leak the others.
-      IOUtils.closeQuietly(this::stopDatanodes, this::stopOm, this::stopScm);
+      // Shutdown is best-effort so one failed service cannot leak the others,
+      // but the failures are logged: stopServices() also runs as start()
+      // rollback, where a silent failure hides leaked threads and ports.
+      IOUtils.close(LOG, this::stopDatanodes, this::stopOm, this::stopScm);
     } finally {
       restoreSameJvmMetricsMode();
     }
@@ -331,7 +349,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       });
     }
     datanodes.clear();
-    IOUtils.closeQuietly(stoppers);
+    IOUtils.close(LOG, stoppers);
   }
 
   private void stopOm() {
@@ -352,33 +370,57 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   private void configureLocalDefaults(OzoneConfiguration conf) {
-    conf.set(OZONE_METADATA_DIRS, metadataDir().toString());
+    setLocalOverride(conf, OZONE_METADATA_DIRS, metadataDir().toString());
     // SCM and OM share one configuration and JVM, so the Jetty base dir is a
     // single service-neutral location; Jetty keeps per-context temp dirs.
     conf.setIfUnset(OZONE_HTTP_BASEDIR, metadataDir() + SERVER_DIR);
-    conf.set(OZONE_REPLICATION, ReplicationFactor.ONE.name());
-    conf.set(OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE.name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
+    setLocalOverride(conf, OZONE_REPLICATION, ReplicationFactor.ONE.name());
+    setLocalOverride(conf, OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
+    setLocalOverride(conf, OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE.name());
+    setLocalOverride(conf, OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
         ReplicationType.STAND_ALONE.name());
-    conf.setBoolean(HDDS_CONTAINER_RATIS_ENABLED_KEY, false);
+    setLocalOverride(conf, HDDS_CONTAINER_RATIS_ENABLED_KEY, "false");
     // A single-node local cluster can heartbeat aggressively; this speeds
-    // datanode registration and safe-mode exit. Use set(), not setIfUnset():
-    // ozone-default.xml supplies the 30s default that would otherwise defeat
-    // the override.
-    conf.set(HDDS_HEARTBEAT_INTERVAL, "1s");
-    conf.setBoolean(HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
-    conf.setInt(HDDS_SCM_SAFEMODE_MIN_DATANODE,
-        Math.max(1, config.getDatanodes()));
-    conf.setTimeDuration(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
-        LOCAL_RATIS_RPC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    conf.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
+    // datanode registration and safe-mode exit.
+    setLocalOverride(conf, HDDS_HEARTBEAT_INTERVAL, "1s");
+    setLocalOverride(conf, HDDS_SCM_SAFEMODE_PIPELINE_CREATION, "false");
+    setLocalOverride(conf, HDDS_SCM_SAFEMODE_MIN_DATANODE,
+        String.valueOf(Math.max(1, config.getDatanodes())));
+    setLocalOverride(conf, OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+        LOCAL_RATIS_RPC_TIMEOUT_SECONDS + "s");
+    setLocalOverride(conf, HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
     conf.setIfUnset(OZONE_SCM_HA_RATIS_SERVER_RPC_FIRST_ELECTION_TIMEOUT,
         "1s");
 
     SCMClientConfig scmClientConfig = conf.getObject(SCMClientConfig.class);
     scmClientConfig.setMaxRetryTimeout(SCM_CLIENT_MAX_RETRY_TIMEOUT_MILLIS);
     conf.setFromObject(scmClientConfig);
+  }
+
+  /**
+   * Applies a value the local runtime requires, reporting the value it replaces. These keys are
+   * set rather than {@code setIfUnset} because ozone-default.xml would otherwise win, so a value
+   * the user put in ozone-site.xml or passed with -D is discarded; reporting happens here, at the
+   * point of the override, so a new override cannot be added without being reported.
+   */
+  private void setLocalOverride(OzoneConfiguration conf, String key, String value) {
+    String configured = conf.get(key);
+    if (!value.equals(configured) && isUserConfigured(conf, key)) {
+      discardedUserConfigKeys.add(key);
+      LOG.warn("ozone local requires {}={}; the configured value {} is ignored.",
+          key, value, configured);
+    }
+    conf.set(key, value);
+  }
+
+  /**
+   * Whether {@code key} carries a value the user chose. A value whose last source is
+   * ozone-default.xml is a shipped default, not a user choice.
+   */
+  private static boolean isUserConfigured(OzoneConfiguration conf, String key) {
+    String[] sources = conf.getPropertySources(key);
+    return sources != null && sources.length > 0
+        && !sources[sources.length - 1].contains(OZONE_DEFAULT_XML);
   }
 
   private int configureScm(OzoneConfiguration conf,
@@ -480,13 +522,6 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private List<OzoneConfiguration> configureDatanodes(OzoneConfiguration conf,
       PersistedPortState persistedPorts, PortAllocator portAllocator)
       throws IOException {
-    int datanodeCount = config.getDatanodes();
-    if (datanodeCount > MAX_DATANODES) {
-      throw new IOException("Datanode count " + datanodeCount
-          + " exceeds the local maximum of " + MAX_DATANODES
-          + "; each datanode reserves " + DATANODE_PORT_KEY_SUFFIXES.length
-          + " local ports.");
-    }
     List<OzoneConfiguration> datanodeConfigurations =
         new ArrayList<>(config.getDatanodes());
     for (int index = 0; index < config.getDatanodes(); index++) {
@@ -643,30 +678,66 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   private void waitForClusterReadiness(Duration timeout) throws Exception {
+    waitForReadiness(this::clusterReadinessBlocker, "Ozone cluster", timeout);
+  }
+
+  /**
+   * Polls {@code blocker} until it reports ready. {@code blocker} returns why {@code subject} is
+   * not ready yet, so the wait can name the unmet condition instead of reporting a bare timeout
+   * that cannot distinguish a slow start from a stuck one.
+   */
+  static void waitForReadiness(Supplier<String> blocker, String subject, Duration timeout)
+      throws InterruptedException, TimeoutException {
     long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    long nextLogNanos = System.nanoTime() + READINESS_LOG_INTERVAL_NANOS;
     while (true) {
-      if (isClusterReady()) {
+      String reason = blocker.get();
+      if (reason == null) {
         return;
       }
       if (System.nanoTime() >= deadlineNanos) {
-        throw new TimeoutException("Timed out waiting " + timeout
-            + " for the local Ozone cluster to become ready.");
+        throw new TimeoutException("Timed out waiting " + timeout + " for the local " + subject
+            + " to become ready: " + reason + ".");
+      }
+      if (System.nanoTime() >= nextLogNanos) {
+        LOG.info("Waiting for the local {} to become ready: {}.", subject, reason);
+        nextLogNanos = System.nanoTime() + READINESS_LOG_INTERVAL_NANOS;
       }
       Thread.sleep(READINESS_POLL_INTERVAL_MILLIS);
     }
   }
 
-  private boolean isClusterReady() {
-    if (!scm.checkLeader() || !om.isLeaderReady()) {
-      return false;
+  /**
+   * Returns why the cluster is not usable yet, or null once it is ready. The cluster is usable
+   * once SCM and OM are leader-ready, every datanode has registered with SCM, and SCM has left
+   * safe mode.
+   */
+  private String clusterReadinessBlocker() {
+    if (!scm.checkLeader()) {
+      return "SCM has no Ratis leader yet";
     }
-    if (config.getDatanodes() == 0) {
-      return true;
+    if (!om.isLeaderReady()) {
+      return "OM is not leader-ready yet";
     }
-    // The cluster is usable once every datanode has registered with SCM and
-    // SCM has left safe mode.
-    return scm.getScmNodeManager().getAllNodes().size() >= config.getDatanodes()
-        && !scm.isInSafeMode();
+    int registered = scm.getScmNodeManager().getAllNodes().size();
+    if (registered < config.getDatanodes()) {
+      return "only " + registered + " of " + config.getDatanodes()
+          + " datanodes have registered with SCM";
+    }
+    // Safe mode is checked even for a zero-datanode cluster: configureLocalDefaults() still
+    // requires one datanode there, so skipping the check would report a cluster that can never
+    // serve requests as ready.
+    if (scm.isInSafeMode()) {
+      return "SCM is still in safe mode (" + unmetSafeModeRules() + ")";
+    }
+    return null;
+  }
+
+  private String unmetSafeModeRules() {
+    return scm.getScmSafeModeManager().getRuleStatus().entrySet().stream()
+        .filter(rule -> !rule.getValue().getLeft())
+        .map(rule -> rule.getKey() + ": " + rule.getValue().getRight())
+        .collect(Collectors.joining("; "));
   }
 
   private void enableSameJvmMetricsMode() {
@@ -684,6 +755,21 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     }
   }
 
+  /**
+   * Rejects a datanode count this host cannot serve. Called before {@link #prepareStorageLayout()}
+   * because format mode ALWAYS deletes the data dir: validating afterwards would destroy local
+   * state for a run that cannot start anyway.
+   */
+  private void requireSupportedDatanodeCount() throws IOException {
+    int datanodeCount = config.getDatanodes();
+    if (datanodeCount > MAX_DATANODES) {
+      throw new IOException("Datanode count " + datanodeCount
+          + " exceeds the local maximum of " + MAX_DATANODES
+          + "; each datanode reserves " + DATANODE_PORT_KEY_SUFFIXES.length
+          + " local ports.");
+    }
+  }
+
   private void prepareStorageLayout() throws IOException {
     Path dataDir = config.getDataDir();
     if (Files.exists(dataDir) && !Files.isDirectory(dataDir)) {
@@ -693,6 +779,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
     switch (config.getFormatMode()) {
     case ALWAYS:
+      LOG.info("Removing local Ozone data dir {} (format mode ALWAYS).", dataDir);
       deleteDirectory(dataDir);
       createBaseLayout();
       break;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -92,10 +92,14 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.TimeDurationUtil;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -153,6 +157,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private static final int LOCAL_RATIS_RPC_TIMEOUT_SECONDS = 1;
   private static final long SCM_CLIENT_MAX_RETRY_TIMEOUT_MILLIS = 30_000;
   private static final long READINESS_POLL_INTERVAL_MILLIS = 500;
+  private static final long READINESS_LOG_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(5);
 
   private static final int MAX_PORT = 65_535;
 
@@ -185,6 +190,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   // Every datanode runs in this JVM and reserves DATANODE_PORT_KEY_SUFFIXES.length
   // local ports, so an unbounded count would exhaust local ports; cap it.
   static final int MAX_DATANODES = 20;
+
+  private static final Set<String> SHIPPED_DEFAULT_RESOURCES = Collections.unmodifiableSet(
+      OzoneConfiguration.getConfigurationResourceFiles().stream()
+          .filter(resource -> resource.endsWith("-default.xml"))
+          .collect(Collectors.toSet()));
 
   private static final String[] NO_ARGS = new String[0];
 
@@ -239,8 +249,12 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       return preparedConfiguration;
     }
 
-    prepareStorageLayout();
-
+    // Every rejection of user input runs before prepareStorageLayout(), which deletes the data
+    // dir in format mode ALWAYS: a run that cannot start must not destroy local state first. The
+    // configure* steps only compute configuration and validate ports; directories are created
+    // afterwards by createServiceDirectories().
+    requireSupportedDatanodeCount();
+    validateStorageLayout();
     OzoneConfiguration conf = new OzoneConfiguration(seedConfiguration);
     configureLocalDefaults(conf);
 
@@ -251,6 +265,8 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     List<OzoneConfiguration> datanodeConfigurations =
         configureDatanodes(conf, persistedPorts, portAllocator);
 
+    prepareStorageLayout();
+    createServiceDirectories();
     persistedPorts.store();
     preparedConfiguration = new PreparedConfiguration(conf, scmPort, omPort,
         datanodeConfigurations);
@@ -314,8 +330,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
   private void stopServices() {
     try {
-      // Shutdown is best-effort so one failed service cannot leak the others.
-      IOUtils.closeQuietly(this::stopDatanodes, this::stopOm, this::stopScm);
+      // Shutdown is best-effort so one failed service cannot leak the others,
+      // but the failures are logged: stopServices() also runs as start()
+      // rollback, where a silent failure hides leaked threads and ports.
+      IOUtils.close(LOG, this::stopDatanodes, this::stopOm, this::stopScm);
     } finally {
       restoreSameJvmMetricsMode();
     }
@@ -331,7 +349,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       });
     }
     datanodes.clear();
-    IOUtils.closeQuietly(stoppers);
+    IOUtils.close(LOG, stoppers);
   }
 
   private void stopOm() {
@@ -351,34 +369,182 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     }
   }
 
-  private void configureLocalDefaults(OzoneConfiguration conf) {
+  private void configureLocalDefaults(OzoneConfiguration conf) throws IOException {
     conf.set(OZONE_METADATA_DIRS, metadataDir().toString());
     // SCM and OM share one configuration and JVM, so the Jetty base dir is a
     // single service-neutral location; Jetty keeps per-context temp dirs.
     conf.setIfUnset(OZONE_HTTP_BASEDIR, metadataDir() + SERVER_DIR);
-    conf.set(OZONE_REPLICATION, ReplicationFactor.ONE.name());
-    conf.set(OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE.name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
+    setLocalOverrideReplication(conf, OZONE_REPLICATION, ReplicationFactor.ONE);
+    setLocalOverride(conf, OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
+    setLocalOverrideReplication(conf, OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE);
+    setLocalOverride(conf, OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
         ReplicationType.STAND_ALONE.name());
-    conf.setBoolean(HDDS_CONTAINER_RATIS_ENABLED_KEY, false);
+    setLocalOverride(conf, HDDS_CONTAINER_RATIS_ENABLED_KEY, false);
     // A single-node local cluster can heartbeat aggressively; this speeds
-    // datanode registration and safe-mode exit. Use set(), not setIfUnset():
-    // ozone-default.xml supplies the 30s default that would otherwise defeat
-    // the override.
-    conf.set(HDDS_HEARTBEAT_INTERVAL, "1s");
-    conf.setBoolean(HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
-    conf.setInt(HDDS_SCM_SAFEMODE_MIN_DATANODE,
-        Math.max(1, config.getDatanodes()));
-    conf.setTimeDuration(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
-        LOCAL_RATIS_RPC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    conf.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
+    // datanode registration and safe-mode exit.
+    setLocalOverrideDuration(conf, HDDS_HEARTBEAT_INTERVAL, "1s");
+    setLocalOverride(conf, HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
+    setLocalOverride(conf, HDDS_SCM_SAFEMODE_MIN_DATANODE, config.getDatanodes());
+    setLocalOverrideDuration(conf, OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+        LOCAL_RATIS_RPC_TIMEOUT_SECONDS + "s");
+    setLocalOverrideDuration(conf, HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
     conf.setIfUnset(OZONE_SCM_HA_RATIS_SERVER_RPC_FIRST_ELECTION_TIMEOUT,
         "1s");
 
     SCMClientConfig scmClientConfig = conf.getObject(SCMClientConfig.class);
     scmClientConfig.setMaxRetryTimeout(SCM_CLIENT_MAX_RETRY_TIMEOUT_MILLIS);
     conf.setFromObject(scmClientConfig);
+  }
+
+  /**
+   * Applies a value the local runtime requires. Set rather than {@code setIfUnset} because
+   * ozone-default.xml would otherwise win.
+   *
+   * <p>This overload compares text. The typed overloads compare through the accessor the services
+   * read the key with, so a value that already means what the runtime requires is kept.</p>
+   *
+   * @throws IOException if the user configured {@code key} with a value other than {@code value}
+   */
+  private void setLocalOverride(OzoneConfiguration conf, String key, String value)
+      throws IOException {
+    // Configuration#unset() leaves the key in updatingResource, so a source can outlive its
+    // value; there is nothing to reject when no value is configured. The comparison trims:
+    // Hadoop never trims XML values on load and the services read these keys through
+    // getTrimmed(), so a padded value already means what the runtime requires.
+    String configured = conf.get(key);
+    if (configured != null && !value.equals(configured.trim())) {
+      rejectUserConfigured(conf, key, value);
+    }
+    conf.set(key, value);
+  }
+
+  private void setLocalOverride(OzoneConfiguration conf, String key, boolean value)
+      throws IOException {
+    // Defaulting to the negation keeps a value getBoolean() cannot read from matching by accident.
+    String configured = conf.get(key);
+    if (configured != null && conf.getBoolean(key, !value) != value) {
+      rejectUserConfigured(conf, key, String.valueOf(value));
+    }
+    conf.setBoolean(key, value);
+  }
+
+  private void setLocalOverride(OzoneConfiguration conf, String key, int value)
+      throws IOException {
+    String configured = conf.get(key);
+    if (configured != null && !matchesInt(conf, key, value)) {
+      rejectUserConfigured(conf, key, String.valueOf(value));
+    }
+    conf.setInt(key, value);
+  }
+
+  /**
+   * Compares the configured value as a duration rather than as text, so the same length written
+   * in another unit is not treated as a conflict. An explicit unit is required to avoid silently
+   * interpreting a bare number differently from the user intended.
+   *
+   * @throws IOException if the user configured {@code key} with a different duration
+   */
+  private void setLocalOverrideDuration(OzoneConfiguration conf, String key, String value)
+      throws IOException {
+    long requiredMillis = TimeDurationUtil.getTimeDurationHelper(key, value, TimeUnit.MILLISECONDS);
+    String configured = conf.get(key);
+    if (configured != null && !matchesDuration(conf, key, configured, requiredMillis)) {
+      rejectUserConfigured(conf, key, value);
+    }
+    conf.set(key, value);
+  }
+
+  /**
+   * Applies a replication factor the local runtime requires, reading the configured value the way
+   * {@link org.apache.hadoop.hdds.client.ReplicationConfig#parse} does, which accepts both the
+   * numeric and the named spelling.
+   *
+   * @throws IOException if the user configured {@code key} with a different factor
+   */
+  private void setLocalOverrideReplication(OzoneConfiguration conf, String key,
+      ReplicationFactor value) throws IOException {
+    String configured = conf.get(key);
+    if (configured != null && parseReplicationFactor(configured) != value) {
+      rejectUserConfigured(conf, key, value.name());
+    }
+    conf.set(key, value.name());
+  }
+
+  /**
+   * Throws when the value {@code conf} carries for {@code key} is the user's choice rather than a
+   * shipped default. The message names the source because the user has to find the value to
+   * remove it.
+   */
+  private static void rejectUserConfigured(OzoneConfiguration conf, String key, String required)
+      throws IOException {
+    String source = userConfiguredSource(conf, key);
+    if (source == null) {
+      return;
+    }
+    throw new IOException("ozone local requires " + key + "=" + required
+        + ", but it is set to " + conf.get(key) + " (source: " + source
+        + "). Remove or change that setting.");
+  }
+
+  private static boolean matchesInt(OzoneConfiguration conf, String key, int value) {
+    try {
+      return conf.getInt(key, value) == value;
+    } catch (NumberFormatException unreadable) {
+      // A value the accessor cannot read is a conflict; the caller reports it by key.
+      return false;
+    }
+  }
+
+  private static boolean matchesDuration(OzoneConfiguration conf, String key, String configured,
+      long requiredMillis) {
+    if (lacksTimeUnit(configured)) {
+      return false;
+    }
+    try {
+      return conf.getTimeDuration(key, requiredMillis, TimeUnit.MILLISECONDS) == requiredMillis;
+    } catch (NumberFormatException unreadable) {
+      return false;
+    }
+  }
+
+  /**
+   * {@link TimeDurationUtil} only warns about a missing unit and then assumes the caller's,
+   * silently reinterpreting a bare number (for example "120" as 120 milliseconds). Every unit
+   * suffix it accepts ends in a letter, so a trailing digit means the unit is missing.
+   */
+  static boolean lacksTimeUnit(String value) {
+    String trimmed = value.trim();
+    return !trimmed.isEmpty() && Character.isDigit(trimmed.charAt(trimmed.length() - 1));
+  }
+
+  /** Returns the factor {@code value} names in either spelling, or null if it names neither. */
+  private static ReplicationFactor parseReplicationFactor(String value) {
+    String trimmed = value.trim();
+    try {
+      return ReplicationFactor.valueOf(Integer.parseInt(trimmed));
+    } catch (IllegalArgumentException notNumeric) {
+      try {
+        return ReplicationFactor.valueOf(trimmed);
+      } catch (IllegalArgumentException notNamed) {
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Returns where {@code key} got the value the user chose, or null if the user chose none. A
+   * value whose last source is one of Ozone's shipped {@code *-default.xml} resources is a default,
+   * not a user choice. The comparison is exact: Configuration records a classpath resource by its
+   * bare name, while {@link OzoneLocal} qualifies a file named with {@code --conf} so it stays a
+   * user choice however that file is called.
+   */
+  private static String userConfiguredSource(OzoneConfiguration conf, String key) {
+    String[] sources = conf.getPropertySources(key);
+    if (sources == null || sources.length == 0) {
+      return null;
+    }
+    String source = sources[sources.length - 1];
+    return SHIPPED_DEFAULT_RESOURCES.contains(source) ? null : source;
   }
 
   private int configureScm(OzoneConfiguration conf,
@@ -427,10 +593,9 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     return scmClientPort;
   }
 
-  private void configureScmStorage(OzoneConfiguration conf) throws IOException {
+  private void configureScmStorage(OzoneConfiguration conf) {
     Path scmDir = config.getDataDir().resolve(SCM_DIR_NAME);
     Path scmMetadataDir = scmDir.resolve(OZONE_METADATA_DIR_NAME);
-    Files.createDirectories(scmDir.resolve(DATA_DIR_NAME));
 
     conf.setIfUnset(OZONE_SCM_DB_DIRS,
         scmDir.resolve(DATA_DIR_NAME).toString());
@@ -463,10 +628,9 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     return omRpcPort;
   }
 
-  private void configureOmStorage(OzoneConfiguration conf) throws IOException {
+  private void configureOmStorage(OzoneConfiguration conf) {
     Path omDir = config.getDataDir().resolve(OM_DIR_NAME);
     Path omMetadataDir = omDir.resolve(OZONE_METADATA_DIR_NAME);
-    Files.createDirectories(omDir.resolve(DATA_DIR_NAME));
 
     conf.setIfUnset(OZONE_OM_DB_DIRS, omDir.resolve(DATA_DIR_NAME).toString());
     conf.setIfUnset(OZONE_OM_RATIS_STORAGE_DIR,
@@ -480,13 +644,6 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private List<OzoneConfiguration> configureDatanodes(OzoneConfiguration conf,
       PersistedPortState persistedPorts, PortAllocator portAllocator)
       throws IOException {
-    int datanodeCount = config.getDatanodes();
-    if (datanodeCount > MAX_DATANODES) {
-      throw new IOException("Datanode count " + datanodeCount
-          + " exceeds the local maximum of " + MAX_DATANODES
-          + "; each datanode reserves " + DATANODE_PORT_KEY_SUFFIXES.length
-          + " local ports.");
-    }
     List<OzoneConfiguration> datanodeConfigurations =
         new ArrayList<>(config.getDatanodes());
     for (int index = 0; index < config.getDatanodes(); index++) {
@@ -534,13 +691,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     return dnConf;
   }
 
-  private void configureDatanodeStorage(OzoneConfiguration dnConf, int index)
-      throws IOException {
+  private void configureDatanodeStorage(OzoneConfiguration dnConf, int index) {
     Path datanodeDir = config.getDataDir()
         .resolve(DATANODE_DIR_PREFIX + index);
     Path datanodeMetadataDir = datanodeDir.resolve(OZONE_METADATA_DIR_NAME);
-    Files.createDirectories(datanodeMetadataDir);
-    Files.createDirectories(datanodeDir.resolve(DATA_DIR_NAME));
 
     dnConf.set(OZONE_METADATA_DIRS, datanodeMetadataDir.toString());
     // Each datanode gets its own Jetty base dir so same-JVM HTTP servers do
@@ -643,30 +797,74 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   private void waitForClusterReadiness(Duration timeout) throws Exception {
-    long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    waitForReadiness(this::clusterReadinessBlocker, "Ozone cluster", timeout);
+  }
+
+  /**
+   * Polls {@code blocker} until it reports ready. {@code blocker} returns why {@code subject} is
+   * not ready yet, so the wait can name the unmet condition instead of reporting a bare timeout
+   * that cannot distinguish a slow start from a stuck one.
+   */
+  static void waitForReadiness(Supplier<String> blocker, String subject, Duration timeout)
+      throws InterruptedException, TimeoutException {
+    long startNanos = System.nanoTime();
+    long nextLogNanos = startNanos + READINESS_LOG_INTERVAL_NANOS;
     while (true) {
-      if (isClusterReady()) {
+      String reason = blocker.get();
+      if (reason == null) {
         return;
       }
-      if (System.nanoTime() >= deadlineNanos) {
-        throw new TimeoutException("Timed out waiting " + timeout
-            + " for the local Ozone cluster to become ready.");
+      long now = System.nanoTime();
+      // Compared as elapsed Duration: timeout.toNanos() throws for very long timeouts, and an
+      // absolute nano deadline can wrap negative on a long-uptime host.
+      if (Duration.ofNanos(now - startNanos).compareTo(timeout) >= 0) {
+        throw new TimeoutException("Timed out waiting " + timeout + " for the local " + subject
+            + " to become ready: " + reason + ".");
+      }
+      if (now >= nextLogNanos) {
+        LOG.info("Waiting for the local {} to become ready: {}.", subject, reason);
+        nextLogNanos = now + READINESS_LOG_INTERVAL_NANOS;
       }
       Thread.sleep(READINESS_POLL_INTERVAL_MILLIS);
     }
   }
 
-  private boolean isClusterReady() {
-    if (!scm.checkLeader() || !om.isLeaderReady()) {
-      return false;
+  /**
+   * Returns why the cluster is not usable yet, or null once it is ready.
+   */
+  private String clusterReadinessBlocker() {
+    if (!scm.checkLeader()) {
+      return "SCM has no Ratis leader yet";
     }
-    if (config.getDatanodes() == 0) {
-      return true;
+    if (!om.isLeaderReady()) {
+      return "OM is not leader-ready yet";
     }
-    // The cluster is usable once every datanode has registered with SCM and
-    // SCM has left safe mode.
-    return scm.getScmNodeManager().getAllNodes().size() >= config.getDatanodes()
-        && !scm.isInSafeMode();
+    int registered = scm.getScmNodeManager().getAllNodeCount();
+    if (registered < config.getDatanodes()) {
+      return "only " + registered + " of " + config.getDatanodes()
+          + " datanodes have registered with SCM";
+    }
+    // Registration alone is not enough: SCM refuses block allocation until it leaves safe mode.
+    if (scm.isInSafeMode()) {
+      return "SCM is still in safe mode ("
+          + formatSafeModeRuleBlocker(scm.getRuleStatus()) + ")";
+    }
+    return null;
+  }
+
+  static String formatSafeModeRuleBlocker(List<SafeModeRuleStatusProto> rules) {
+    if (rules.isEmpty()) {
+      return "safe-mode rule status is not available yet";
+    }
+    String unmetRules = joinSafeModeRules(rules.stream().filter(rule -> !rule.getValidate()));
+    return unmetRules.isEmpty()
+        ? "all rules currently report satisfied: " + joinSafeModeRules(rules.stream())
+        : unmetRules;
+  }
+
+  private static String joinSafeModeRules(Stream<SafeModeRuleStatusProto> rules) {
+    return rules.map(rule -> rule.getRuleName() + ": " + rule.getStatusText())
+        .collect(Collectors.joining("; "));
   }
 
   private void enableSameJvmMetricsMode() {
@@ -684,20 +882,41 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     }
   }
 
-  private void prepareStorageLayout() throws IOException {
+  private void requireSupportedDatanodeCount() throws IOException {
+    int datanodeCount = config.getDatanodes();
+    if (datanodeCount < 1) {
+      throw new IOException("Datanode count " + datanodeCount
+          + " is below the local minimum of 1; a local cluster requires at least one datanode.");
+    }
+    if (datanodeCount > MAX_DATANODES) {
+      throw new IOException("Datanode count " + datanodeCount
+          + " exceeds the local maximum of " + MAX_DATANODES
+          + "; each datanode reserves " + DATANODE_PORT_KEY_SUFFIXES.length
+          + " local ports.");
+    }
+  }
+
+  /** The read-only half of the layout checks, run before any user input can be rejected. */
+  private void validateStorageLayout() throws IOException {
     Path dataDir = config.getDataDir();
     if (Files.exists(dataDir) && !Files.isDirectory(dataDir)) {
       throw new IOException("Local Ozone data dir " + dataDir
           + " is not a directory.");
     }
+    if (config.getFormatMode() == LocalOzoneClusterConfig.FormatMode.NEVER) {
+      requireExistingLayout();
+    }
+  }
 
+  private void prepareStorageLayout() throws IOException {
     switch (config.getFormatMode()) {
     case ALWAYS:
-      deleteDirectory(dataDir);
+      LOG.info("Removing local Ozone data dir {} (format mode ALWAYS).", config.getDataDir());
+      deleteDirectory(config.getDataDir());
       createBaseLayout();
       break;
     case NEVER:
-      requireExistingLayout();
+      // validateStorageLayout() already required the existing layout.
       break;
     case IF_NEEDED:
       createBaseLayout();
@@ -705,6 +924,17 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     default:
       throw new IOException("Unsupported format mode "
           + config.getFormatMode() + ".");
+    }
+  }
+
+  private void createServiceDirectories() throws IOException {
+    Path dataDir = config.getDataDir();
+    Files.createDirectories(dataDir.resolve(SCM_DIR_NAME).resolve(DATA_DIR_NAME));
+    Files.createDirectories(dataDir.resolve(OM_DIR_NAME).resolve(DATA_DIR_NAME));
+    for (int index = 0; index < config.getDatanodes(); index++) {
+      Path datanodeDir = dataDir.resolve(DATANODE_DIR_PREFIX + index);
+      Files.createDirectories(datanodeDir.resolve(OZONE_METADATA_DIR_NAME));
+      Files.createDirectories(datanodeDir.resolve(DATA_DIR_NAME));
     }
   }
 
@@ -734,6 +964,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   private PersistedPortState loadPersistedPortState() throws IOException {
+    if (config.getFormatMode() == LocalOzoneClusterConfig.FormatMode.ALWAYS) {
+      // prepareStorageLayout() deletes the data dir after the ports are validated, so the
+      // persisted ports are stale; start from an empty state without reading the doomed file.
+      return PersistedPortState.empty(portStateFile());
+    }
     PersistedPortState persistedPorts =
         PersistedPortState.load(portStateFile());
     if (config.getFormatMode() == LocalOzoneClusterConfig.FormatMode.NEVER) {
@@ -886,6 +1121,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
     private PersistedPortState(Path path) {
       this.path = path;
+    }
+
+    static PersistedPortState empty(Path path) {
+      return new PersistedPortState(path);
     }
 
     static PersistedPortState load(Path path) throws IOException {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -25,6 +25,12 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY;
@@ -72,6 +78,11 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DB_DIR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_BIND_HOST_KEY;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY;
@@ -85,8 +96,10 @@ import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -126,13 +139,17 @@ import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.recon.ConfigurationProvider;
+import org.apache.hadoop.ozone.recon.ReconServer;
+import org.apache.hadoop.ozone.recon.ReconSqlDbConfig;
 import org.apache.hadoop.ozone.s3.Gateway;
 import org.apache.hadoop.ozone.s3.OzoneConfigurationHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Starts the SCM, OM, datanode, and optional S3 Gateway portion of the {@code ozone local} runtime.
+ * Starts the SCM, OM, datanode, and optional S3 Gateway and Recon portion of the {@code ozone local}
+ * runtime.
  */
 public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
@@ -162,6 +179,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private static final String OM_RATIS_PORT_KEY = "om.ratis";
   private static final String S3G_HTTP_PORT_KEY = "s3g.http";
   private static final String S3G_WEBADMIN_HTTP_PORT_KEY = "s3g.web.http";
+  private static final String RECON_HTTP_PORT_KEY = "recon.http";
+  private static final String RECON_HTTPS_PORT_KEY = "recon.https";
+  private static final String RECON_DATANODE_PORT_KEY = "recon.datanode";
+  private static final String RECON_DIR_NAME = "recon";
   private static final String DATANODE_PORT_KEY_PREFIX = "dn.";
   private static final String DATANODE_HTTP_PORT_KEY_SUFFIX = "http";
   private static final String DATANODE_CLIENT_PORT_KEY_SUFFIX = "client";
@@ -223,6 +244,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private StorageContainerManager scm;
   private OzoneManager om;
   private Gateway s3Gateway;
+  private ReconServer reconServer;
   private final List<HddsDatanodeService> datanodes = new ArrayList<>();
   private boolean previousMetricsMiniClusterMode;
   private boolean metricsMiniClusterModeEnabled;
@@ -254,6 +276,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       startOm(prepared.getConfiguration());
       startDatanodes(prepared.getDatanodeConfigurations());
       waitForClusterReadiness(config.getStartupTimeout());
+      if (config.isReconEnabled()) {
+        startRecon(prepared.getConfiguration());
+        waitForHttpEndpointReadiness(getReconEndpoint(), "Recon",
+            config.getStartupTimeout());
+      }
       if (config.isS3gEnabled()) {
         startS3Gateway(prepared.getConfiguration());
       }
@@ -284,6 +311,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     int scmPort = configureScm(conf, persistedPorts, portAllocator);
     int omPort = configureOm(conf, persistedPorts, portAllocator);
     int s3gPort = configureS3Gateway(conf, persistedPorts, portAllocator);
+    int reconPort = configureRecon(conf, persistedPorts, portAllocator);
     List<OzoneConfiguration> datanodeConfigurations =
         configureDatanodes(conf, persistedPorts, portAllocator);
 
@@ -291,7 +319,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     createServiceDirectories();
     persistedPorts.store();
     preparedConfiguration = new PreparedConfiguration(conf, scmPort, omPort,
-        s3gPort, datanodeConfigurations);
+        s3gPort, reconPort, datanodeConfigurations);
     return preparedConfiguration;
   }
 
@@ -340,6 +368,23 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   @Override
+  public int getReconPort() {
+    if (!config.isReconEnabled()) {
+      return -1;
+    }
+    return preparedConfiguration == null ? config.getReconPort()
+        : preparedConfiguration.getReconPort();
+  }
+
+  @Override
+  public String getReconEndpoint() {
+    if (!config.isReconEnabled()) {
+      return "";
+    }
+    return "http://" + getDisplayHost() + ":" + getReconPort();
+  }
+
+  @Override
   public void close() throws IOException {
     if (closed) {
       return;
@@ -366,7 +411,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       // Shutdown is best-effort so one failed service cannot leak the others,
       // but the failures are logged: stopServices() also runs as start()
       // rollback, where a silent failure hides leaked threads and ports.
-      IOUtils.close(LOG, this::stopS3Gateway, this::stopDatanodes, this::stopOm, this::stopScm);
+      IOUtils.close(LOG, this::stopS3Gateway, this::stopRecon, this::stopDatanodes, this::stopOm, this::stopScm);
     } finally {
       restoreSameJvmMetricsMode();
     }
@@ -377,6 +422,15 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     s3Gateway = null;
     if (service != null) {
       service.stop();
+    }
+  }
+
+  private void stopRecon() {
+    ReconServer service = reconServer;
+    reconServer = null;
+    if (service != null) {
+      service.stop();
+      service.join();
     }
   }
 
@@ -717,6 +771,46 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     return s3gHttpPort;
   }
 
+  private int configureRecon(OzoneConfiguration conf,
+      PersistedPortState persistedPorts, PortAllocator portAllocator)
+      throws IOException {
+    if (!config.isReconEnabled()) {
+      return -1;
+    }
+    Path reconDir = config.getDataDir().resolve(RECON_DIR_NAME);
+    conf.setIfUnset(OZONE_RECON_DB_DIR, reconDir.toString());
+    conf.setIfUnset(OZONE_RECON_OM_SNAPSHOT_DB_DIR, reconDir.toString());
+    conf.setIfUnset(OZONE_RECON_SCM_DB_DIR, reconDir.toString());
+
+    ReconSqlDbConfig dbConfig = conf.getObject(ReconSqlDbConfig.class);
+    dbConfig.setJdbcUrl("jdbc:derby:"
+        + reconDir.resolve("ozone_recon_derby.db"));
+    conf.setFromObject(dbConfig);
+
+    int reconHttpPort = reservePort(portAllocator, persistedPorts,
+        RECON_HTTP_PORT_KEY, config.getReconPort());
+    int reconHttpsPort = reservePort(portAllocator, persistedPorts,
+        RECON_HTTPS_PORT_KEY, 0);
+    int reconDatanodePort = reservePort(portAllocator, persistedPorts,
+        RECON_DATANODE_PORT_KEY, 0);
+
+    conf.set(OZONE_RECON_ADDRESS_KEY,
+        address(config.getHost(), reconDatanodePort));
+    conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY,
+        address(config.getHost(), reconDatanodePort));
+    conf.set(OZONE_RECON_DATANODE_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_RECON_HTTP_ADDRESS_KEY,
+        address(config.getHost(), reconHttpPort));
+    conf.set(OZONE_RECON_HTTP_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_RECON_HTTPS_ADDRESS_KEY,
+        address(config.getHost(), reconHttpsPort));
+    conf.set(OZONE_RECON_HTTPS_BIND_HOST_KEY, config.getBindHost());
+    // Recon's start-up blocks until it leaves safe mode and an empty local cluster never leaves
+    // it on its own, so the shipped 300s default would stall every start for five minutes.
+    setLocalOverrideDuration(conf, OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "10s");
+    return reconHttpPort;
+  }
+
   private List<OzoneConfiguration> configureDatanodes(OzoneConfiguration conf,
       PersistedPortState persistedPorts, PortAllocator portAllocator)
       throws IOException {
@@ -896,16 +990,16 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
    * queued behind it on the same single thread rather than run here. The caller assigns its field
    * only after this returns, so a failed attempt is never reachable from the rollback.
    */
-  static void executeWithinStartupTimeout(String serviceName, Callable<Void> startup,
+  static <V> V executeWithinStartupTimeout(String serviceName, Callable<V> startup,
       AutoCloseable startupCleanup, Duration timeout) throws Exception {
     ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
       Thread thread = new Thread(runnable, "local-startup-" + serviceName);
       thread.setDaemon(true);
       return thread;
     });
-    Future<Void> future = executor.submit(startup);
+    Future<V> future = executor.submit(startup);
     try {
-      future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+      return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (TimeoutException ex) {
       future.cancel(true);
       executor.submit(() -> IOUtils.close(LOG, startupCleanup));
@@ -924,6 +1018,53 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       // shutdown(), not shutdownNow(): the timeout path queues the cleanup, which shutdownNow()
       // would discard. The worker is a daemon thread, so it cannot keep the JVM alive.
       executor.shutdown();
+    }
+  }
+
+  private void startRecon(OzoneConfiguration conf) throws Exception {
+    // ReconServer reads its configuration from the static provider, and the reset is what lets a
+    // second in-JVM start win: setConfiguration() keeps the first value. Same pair as ReconService.
+    ConfigurationProvider.resetConfiguration();
+    ConfigurationProvider.setConfiguration(new OzoneConfiguration(conf));
+    ReconServer recon = new ReconServer();
+    int exitCode = executeWithinStartupTimeout("Recon", () -> recon.execute(NO_ARGS),
+        recon::stop, config.getStartupTimeout());
+    if (exitCode != 0) {
+      // execute() has returned, so stopping the partially started server cannot race it.
+      IOUtils.close(LOG, recon::stop);
+      throw new IOException("Failed to start local Recon. Exit code "
+          + exitCode + ".");
+    }
+    reconServer = recon;
+  }
+
+  private void waitForHttpEndpointReadiness(String endpoint,
+      String serviceName, Duration timeout) throws Exception {
+    waitForReadiness(() -> httpEndpointBlocker(endpoint, serviceName),
+        serviceName, timeout);
+  }
+
+  /**
+   * Returns why {@code endpoint} is not serving yet, or null once it is. {@code ReconServer#call()}
+   * returns success even when its initialization threw, so an HTTP response is the only readiness
+   * signal; the reason is kept because a refused connection, a wrong port and a hung listener are
+   * indistinguishable once the wait times out.
+   */
+  private static String httpEndpointBlocker(String endpoint, String serviceName) {
+    HttpURLConnection connection = null;
+    try {
+      connection = (HttpURLConnection) new URL(endpoint).openConnection();
+      connection.setConnectTimeout((int) READINESS_POLL_INTERVAL_MILLIS);
+      connection.setReadTimeout((int) READINESS_POLL_INTERVAL_MILLIS);
+      connection.getResponseCode();
+      return null;
+    } catch (IOException ex) {
+      LOG.debug("{} readiness probe of {} failed.", serviceName, endpoint, ex);
+      return endpoint + " is not answering (" + ex + ")";
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
     }
   }
 
@@ -1067,6 +1208,9 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       Files.createDirectories(datanodeDir.resolve(OZONE_METADATA_DIR_NAME));
       Files.createDirectories(datanodeDir.resolve(DATA_DIR_NAME));
     }
+    if (config.isReconEnabled()) {
+      Files.createDirectories(dataDir.resolve(RECON_DIR_NAME));
+    }
   }
 
   private void createBaseLayout() throws IOException {
@@ -1114,6 +1258,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     if (config.isS3gEnabled()) {
       keys.add(S3G_HTTP_PORT_KEY);
       keys.add(S3G_WEBADMIN_HTTP_PORT_KEY);
+    }
+    if (config.isReconEnabled()) {
+      keys.add(RECON_HTTP_PORT_KEY);
+      keys.add(RECON_HTTPS_PORT_KEY);
+      keys.add(RECON_DATANODE_PORT_KEY);
     }
     for (int index = 0; index < config.getDatanodes(); index++) {
       for (String suffix : DATANODE_PORT_KEY_SUFFIXES) {
@@ -1178,15 +1327,17 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     private final int scmPort;
     private final int omPort;
     private final int s3gPort;
+    private final int reconPort;
     private final List<OzoneConfiguration> datanodeConfigurations;
 
-    PreparedConfiguration(OzoneConfiguration configuration, int scmPort, int omPort, int s3gPort,
+    PreparedConfiguration(OzoneConfiguration configuration, int scmPort, int omPort, int s3gPort, int reconPort,
         List<OzoneConfiguration> datanodeConfigurations) {
       this.configuration = Objects.requireNonNull(configuration,
           "configuration");
       this.scmPort = scmPort;
       this.omPort = omPort;
       this.s3gPort = s3gPort;
+      this.reconPort = reconPort;
       this.datanodeConfigurations = Collections.unmodifiableList(
           new ArrayList<>(Objects.requireNonNull(datanodeConfigurations,
               "datanodeConfigurations")));
@@ -1206,6 +1357,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
     int getS3gPort() {
       return s3gPort;
+    }
+
+    int getReconPort() {
+      return reconPort;
     }
 
     List<OzoneConfiguration> getDatanodeConfigurations() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -72,10 +72,19 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DB_DIR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_BIND_HOST_KEY;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -90,6 +99,11 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -109,13 +123,16 @@ import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.s3.Gateway;
+import org.apache.hadoop.ozone.s3.OzoneConfigurationHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Starts the SCM, OM, and datanode portion of the {@code ozone local} runtime.
+ * Starts the SCM, OM, datanode, and optional S3 Gateway portion of the {@code ozone local} runtime.
  *
- * <p>S3 Gateway and Recon are added by later local runtime tickets.</p>
+ * <p>Recon is added by a later local runtime ticket.</p>
  */
 public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
@@ -143,6 +160,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private static final String OM_HTTP_PORT_KEY = "om.http";
   private static final String OM_HTTPS_PORT_KEY = "om.https";
   private static final String OM_RATIS_PORT_KEY = "om.ratis";
+  private static final String S3G_HTTP_PORT_KEY = "s3g.http";
+  private static final String S3G_HTTPS_PORT_KEY = "s3g.https";
+  private static final String S3G_WEBADMIN_HTTP_PORT_KEY = "s3g.web.http";
+  private static final String S3G_WEBADMIN_HTTPS_PORT_KEY = "s3g.web.https";
   private static final String DATANODE_PORT_KEY_PREFIX = "dn.";
   private static final String DATANODE_HTTP_PORT_KEY_SUFFIX = "http";
   private static final String DATANODE_CLIENT_PORT_KEY_SUFFIX = "client";
@@ -200,6 +221,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private PreparedConfiguration preparedConfiguration;
   private StorageContainerManager scm;
   private OzoneManager om;
+  private Gateway s3Gateway;
   private final List<HddsDatanodeService> datanodes = new ArrayList<>();
   private final List<String> discardedUserConfigKeys = new ArrayList<>();
   private boolean previousMetricsMiniClusterMode;
@@ -232,6 +254,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       startOm(prepared.getConfiguration());
       startDatanodes(prepared.getDatanodeConfigurations());
       waitForClusterReadiness(config.getStartupTimeout());
+      if (config.isS3gEnabled()) {
+        provisionS3Credentials();
+        startS3Gateway(prepared.getConfiguration());
+      }
     } catch (Exception ex) {
       // Roll back without latching closed: the caller's close() still owns the
       // ephemeral data dir lifecycle.
@@ -259,18 +285,19 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     PortAllocator portAllocator = new PortAllocator();
     int scmPort = configureScm(conf, persistedPorts, portAllocator);
     int omPort = configureOm(conf, persistedPorts, portAllocator);
+    int s3gPort = configureS3Gateway(conf, persistedPorts, portAllocator);
     List<OzoneConfiguration> datanodeConfigurations =
         configureDatanodes(conf, persistedPorts, portAllocator);
 
     persistedPorts.store();
     preparedConfiguration = new PreparedConfiguration(conf, scmPort, omPort,
-        datanodeConfigurations);
+        s3gPort, datanodeConfigurations);
     return preparedConfiguration;
   }
 
   @Override
   public String getDisplayHost() {
-    return LocalOzoneClusterConfig.DEFAULT_BIND_HOST.equals(config.getHost())
+    return LocalOzoneClusterConfig.WILDCARD_HOST.equals(config.getHost())
         ? LocalOzoneClusterConfig.DEFAULT_HOST : config.getHost();
   }
 
@@ -293,12 +320,20 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
   @Override
   public int getS3gPort() {
-    return -1;
+    return config.isS3gEnabled() ? s3Gateway.getHttpAddress().getPort() : -1;
   }
 
   @Override
   public String getS3Endpoint() {
-    return "";
+    return config.isS3gEnabled() ? "http://" + getDisplayHost() + ":" + getS3gPort() : "";
+  }
+
+  /**
+   * Returns the address the S3 Gateway HTTP listener is bound to, for tests
+   * that pin the bind host.
+   */
+  InetSocketAddress getS3gBoundAddress() {
+    return s3Gateway.getHttpAddress();
   }
 
   @Override
@@ -333,9 +368,17 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       // Shutdown is best-effort so one failed service cannot leak the others,
       // but the failures are logged: stopServices() also runs as start()
       // rollback, where a silent failure hides leaked threads and ports.
-      IOUtils.close(LOG, this::stopDatanodes, this::stopOm, this::stopScm);
+      IOUtils.close(LOG, this::stopS3Gateway, this::stopDatanodes, this::stopOm, this::stopScm);
     } finally {
       restoreSameJvmMetricsMode();
+    }
+  }
+
+  private void stopS3Gateway() throws Exception {
+    Gateway service = s3Gateway;
+    s3Gateway = null;
+    if (service != null) {
+      service.stop();
     }
   }
 
@@ -371,7 +414,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
   private void configureLocalDefaults(OzoneConfiguration conf) {
     setLocalOverride(conf, OZONE_METADATA_DIRS, metadataDir().toString());
-    // SCM and OM share one configuration and JVM, so the Jetty base dir is a
+    // SCM, OM, and the S3 Gateway share one configuration and JVM, so the Jetty base dir is a
     // single service-neutral location; Jetty keeps per-context temp dirs.
     conf.setIfUnset(OZONE_HTTP_BASEDIR, metadataDir() + SERVER_DIR);
     setLocalOverride(conf, OZONE_REPLICATION, ReplicationFactor.ONE.name());
@@ -517,6 +560,36 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
         omMetadataDir.resolve(OZONE_RATIS_SNAPSHOT_DIR).toString());
     conf.setIfUnset(OZONE_OM_SNAPSHOT_DIFF_DB_DIR,
         omMetadataDir.toString());
+  }
+
+  private int configureS3Gateway(OzoneConfiguration conf,
+      PersistedPortState persistedPorts, PortAllocator portAllocator)
+      throws IOException {
+    if (!config.isS3gEnabled()) {
+      return -1;
+    }
+    int s3gHttpPort = reservePort(portAllocator, persistedPorts,
+        S3G_HTTP_PORT_KEY, config.getS3gPort());
+    int s3gHttpsPort = reservePort(portAllocator, persistedPorts,
+        S3G_HTTPS_PORT_KEY, 0);
+    int s3gWebHttpPort = reservePort(portAllocator, persistedPorts,
+        S3G_WEBADMIN_HTTP_PORT_KEY, 0);
+    int s3gWebHttpsPort = reservePort(portAllocator, persistedPorts,
+        S3G_WEBADMIN_HTTPS_PORT_KEY, 0);
+
+    conf.set(OZONE_S3G_HTTP_ADDRESS_KEY,
+        address(config.getHost(), s3gHttpPort));
+    conf.set(OZONE_S3G_HTTP_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_S3G_HTTPS_ADDRESS_KEY,
+        address(config.getHost(), s3gHttpsPort));
+    conf.set(OZONE_S3G_HTTPS_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY,
+        address(config.getHost(), s3gWebHttpPort));
+    conf.set(OZONE_S3G_WEBADMIN_HTTP_BIND_HOST_KEY, config.getBindHost());
+    conf.set(OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY,
+        address(config.getHost(), s3gWebHttpsPort));
+    conf.set(OZONE_S3G_WEBADMIN_HTTPS_BIND_HOST_KEY, config.getBindHost());
+    return s3gHttpPort;
   }
 
   private List<OzoneConfiguration> configureDatanodes(OzoneConfiguration conf,
@@ -677,6 +750,70 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     }
   }
 
+  /**
+   * Stores the recommended local credentials in OM so S3 clients can sign requests without a
+   * separate {@code ozone s3 getsecret} bootstrap step. The write goes to the secret store
+   * directly rather than through the OM request pipeline: the local runtime is single-node and
+   * non-HA, the same fixed credentials are re-provisioned on every start, and a dev-only
+   * bootstrap credential needs neither Ratis replication nor an audit trail.
+   */
+  private void provisionS3Credentials() throws IOException {
+    om.getS3SecretManager().storeSecret(config.getS3AccessKey(),
+        S3SecretValue.of(config.getS3AccessKey(), config.getS3SecretKey()));
+  }
+
+  private void startS3Gateway(OzoneConfiguration conf) throws Exception {
+    // Gateway reads its configuration from the static holder, like MiniOzoneCluster does when
+    // running S3 Gateway in the same JVM.
+    OzoneConfigurationHolder.resetConfiguration();
+    OzoneConfigurationHolder.setConfiguration(new OzoneConfiguration(conf));
+    Gateway gateway = new Gateway();
+    // Start through call(), not execute(): GenericCli's execution-exception handler reduces the
+    // startup failure cause to a bare exit code and can even System.exit the JVM on an
+    // AccessControlException. parseArgs() primes the picocli state that Gateway.start() reads.
+    gateway.getCmd().parseArgs();
+    // call() returns only after Jetty has bound the gateway's ports and serves requests, so no
+    // readiness poll follows. The field holds only a fully started gateway: a failed or timed-out
+    // startup is stopped by executeWithinStartupTimeout, never by the rollback in stopServices(),
+    // which could otherwise race a startup attempt that is still running.
+    executeWithinStartupTimeout("S3 Gateway", gateway::call, gateway::stop, config.getStartupTimeout());
+    s3Gateway = gateway;
+  }
+
+  /**
+   * Runs a blocking in-JVM service startup under {@code timeout}, so the launcher fails fast and
+   * rolls back instead of hanging if a startup ever blocks. {@code startupCleanup} stops whatever
+   * a startup that did not finish cleanly managed to bring up: it runs in place when the startup
+   * throws, and on a timeout it is queued behind the startup on the same single thread, because a
+   * timed-out startup can ignore the interrupt and still finish after the rollback in
+   * {@link #stopServices()} has run. The queued cleanup is that abandoned attempt's only stopper,
+   * and the shared thread runs it after every write the attempt made.
+   */
+  static void executeWithinStartupTimeout(String serviceName, Callable<Void> startup,
+      AutoCloseable startupCleanup, Duration timeout) throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+      Thread thread = new Thread(runnable, "local-startup-" + serviceName);
+      thread.setDaemon(true);
+      return thread;
+    });
+    Future<Void> future = executor.submit(startup);
+    try {
+      future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (TimeoutException ex) {
+      future.cancel(true);
+      executor.submit(() -> IOUtils.close(LOG, startupCleanup));
+      throw new IOException("Local " + serviceName + " did not start within " + timeout + ".", ex);
+    } catch (ExecutionException ex) {
+      IOUtils.close(LOG, startupCleanup);
+      Throwable cause = ex.getCause();
+      throw cause instanceof Exception ? (Exception) cause : ex;
+    } finally {
+      // shutdown(), not shutdownNow(): the timeout path queues the cleanup, which shutdownNow()
+      // would discard. The worker is a daemon thread, so it cannot keep the JVM alive.
+      executor.shutdown();
+    }
+  }
+
   private void waitForClusterReadiness(Duration timeout) throws Exception {
     waitForReadiness(this::clusterReadinessBlocker, "Ozone cluster", timeout);
   }
@@ -832,6 +969,12 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private String[] requiredPersistedPortKeys() {
     List<String> keys =
         new ArrayList<>(Arrays.asList(REQUIRED_PERSISTED_PORT_KEYS));
+    if (config.isS3gEnabled()) {
+      keys.add(S3G_HTTP_PORT_KEY);
+      keys.add(S3G_HTTPS_PORT_KEY);
+      keys.add(S3G_WEBADMIN_HTTP_PORT_KEY);
+      keys.add(S3G_WEBADMIN_HTTPS_PORT_KEY);
+    }
     for (int index = 0; index < config.getDatanodes(); index++) {
       for (String suffix : DATANODE_PORT_KEY_SUFFIXES) {
         keys.add(datanodePortKey(index, suffix));
@@ -894,14 +1037,16 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     private final OzoneConfiguration configuration;
     private final int scmPort;
     private final int omPort;
+    private final int s3gPort;
     private final List<OzoneConfiguration> datanodeConfigurations;
 
-    PreparedConfiguration(OzoneConfiguration configuration, int scmPort,
-        int omPort, List<OzoneConfiguration> datanodeConfigurations) {
+    PreparedConfiguration(OzoneConfiguration configuration, int scmPort, int omPort, int s3gPort,
+        List<OzoneConfiguration> datanodeConfigurations) {
       this.configuration = Objects.requireNonNull(configuration,
           "configuration");
       this.scmPort = scmPort;
       this.omPort = omPort;
+      this.s3gPort = s3gPort;
       this.datanodeConfigurations = Collections.unmodifiableList(
           new ArrayList<>(Objects.requireNonNull(datanodeConfigurations,
               "datanodeConfigurations")));
@@ -917,6 +1062,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
     int getOmPort() {
       return omPort;
+    }
+
+    int getS3gPort() {
+      return s3gPort;
     }
 
     List<OzoneConfiguration> getDatanodeConfigurations() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
@@ -43,6 +43,7 @@ public final class LocalOzoneClusterConfig {
   static final String DEFAULT_DATANODES_VALUE = "1";
   static final String DEFAULT_PORT_VALUE = "0";
   static final String DEFAULT_S3G_ENABLED_VALUE = "true";
+  static final String DEFAULT_RECON_ENABLED_VALUE = "false";
   static final String DEFAULT_EPHEMERAL_VALUE = "false";
   static final String DEFAULT_STARTUP_TIMEOUT_VALUE = "PT2M";
 
@@ -64,6 +65,8 @@ public final class LocalOzoneClusterConfig {
   static final int DEFAULT_PORT = Integer.parseInt(DEFAULT_PORT_VALUE);
   static final boolean DEFAULT_S3G_ENABLED =
       Boolean.parseBoolean(DEFAULT_S3G_ENABLED_VALUE);
+  static final boolean DEFAULT_RECON_ENABLED =
+      Boolean.parseBoolean(DEFAULT_RECON_ENABLED_VALUE);
   static final boolean DEFAULT_EPHEMERAL =
       Boolean.parseBoolean(DEFAULT_EPHEMERAL_VALUE);
   static final Duration DEFAULT_STARTUP_TIMEOUT =
@@ -81,6 +84,8 @@ public final class LocalOzoneClusterConfig {
   private final int omPort;
   private final int s3gPort;
   private final boolean s3gEnabled;
+  private final int reconPort;
+  private final boolean reconEnabled;
   private final boolean ephemeral;
   private final Duration startupTimeout;
   private final String s3AccessKey;
@@ -99,6 +104,8 @@ public final class LocalOzoneClusterConfig {
     omPort = builder.omPort;
     s3gPort = builder.s3gPort;
     s3gEnabled = builder.s3gEnabled;
+    reconPort = builder.reconPort;
+    reconEnabled = builder.reconEnabled;
     ephemeral = builder.ephemeral;
     startupTimeout = Objects.requireNonNull(builder.startupTimeout,
         "startupTimeout");
@@ -156,6 +163,21 @@ public final class LocalOzoneClusterConfig {
    */
   public boolean isS3gEnabled() {
     return s3gEnabled;
+  }
+
+  /**
+   * Returns the Recon HTTP port. Port {@code 0} asks the runtime to choose an
+   * available local port.
+   */
+  public int getReconPort() {
+    return reconPort;
+  }
+
+  /**
+   * Returns whether the local runtime should include Recon.
+   */
+  public boolean isReconEnabled() {
+    return reconEnabled;
   }
 
   /**
@@ -249,6 +271,8 @@ public final class LocalOzoneClusterConfig {
     private int omPort = DEFAULT_PORT;
     private int s3gPort = DEFAULT_PORT;
     private boolean s3gEnabled = DEFAULT_S3G_ENABLED;
+    private int reconPort = DEFAULT_PORT;
+    private boolean reconEnabled = DEFAULT_RECON_ENABLED;
     private boolean ephemeral = DEFAULT_EPHEMERAL;
     private Duration startupTimeout = DEFAULT_STARTUP_TIMEOUT;
     private String s3AccessKey = DEFAULT_S3_ACCESS_KEY;
@@ -296,6 +320,16 @@ public final class LocalOzoneClusterConfig {
 
     public Builder setS3gEnabled(boolean value) {
       s3gEnabled = value;
+      return this;
+    }
+
+    public Builder setReconPort(int value) {
+      reconPort = value;
+      return this;
+    }
+
+    public Builder setReconEnabled(boolean value) {
+      reconEnabled = value;
       return this;
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
@@ -56,7 +56,11 @@ public final class LocalOzoneClusterConfig {
   static final int DEFAULT_DATANODES =
       Integer.parseInt(DEFAULT_DATANODES_VALUE);
   static final String DEFAULT_HOST = "127.0.0.1";
-  static final String DEFAULT_BIND_HOST = "0.0.0.0";
+  // Loopback, not the wildcard address: the local runtime leaves security off, and
+  // S3SecurityUtil#validateS3Credential only checks a signature when it is on, so listening on
+  // every interface would serve a writable S3 endpoint to anyone who can reach the port.
+  static final String DEFAULT_BIND_HOST = "127.0.0.1";
+  static final String WILDCARD_HOST = "0.0.0.0";
   static final int DEFAULT_PORT = Integer.parseInt(DEFAULT_PORT_VALUE);
   static final boolean DEFAULT_S3G_ENABLED =
       Boolean.parseBoolean(DEFAULT_S3G_ENABLED_VALUE);
@@ -64,9 +68,13 @@ public final class LocalOzoneClusterConfig {
       Boolean.parseBoolean(DEFAULT_EPHEMERAL_VALUE);
   static final Duration DEFAULT_STARTUP_TIMEOUT =
       Duration.parse(DEFAULT_STARTUP_TIMEOUT_VALUE);
-  static final String DEFAULT_S3_ACCESS_KEY = "admin";
-  static final String DEFAULT_S3_SECRET_KEY = "admin123";
-  static final String DEFAULT_S3_REGION = "us-east-1";
+  // Printed for client setup, not enforced: with security off any credentials are accepted. The
+  // access key id still names the caller, so OMClientRequest records it as the request user and
+  // RpcClient stores it as the owner of buckets created through the gateway. Keeping one fixed
+  // value keeps that ownership stable across restarts.
+  static final String LOCAL_S3_ACCESS_KEY = "admin";
+  static final String LOCAL_S3_SECRET_KEY = "admin123";
+  static final String LOCAL_S3_REGION = "us-east-1";
 
   private final Path dataDir;
   private final FormatMode formatMode;
@@ -79,9 +87,6 @@ public final class LocalOzoneClusterConfig {
   private final boolean s3gEnabled;
   private final boolean ephemeral;
   private final Duration startupTimeout;
-  private final String s3AccessKey;
-  private final String s3SecretKey;
-  private final String s3Region;
 
   private LocalOzoneClusterConfig(Builder builder) {
     dataDir = Objects.requireNonNull(builder.dataDir, "dataDir")
@@ -98,9 +103,6 @@ public final class LocalOzoneClusterConfig {
     ephemeral = builder.ephemeral;
     startupTimeout = Objects.requireNonNull(builder.startupTimeout,
         "startupTimeout");
-    s3AccessKey = Objects.requireNonNull(builder.s3AccessKey, "s3AccessKey");
-    s3SecretKey = Objects.requireNonNull(builder.s3SecretKey, "s3SecretKey");
-    s3Region = Objects.requireNonNull(builder.s3Region, "s3Region");
   }
 
   public Path getDataDir() {
@@ -170,27 +172,6 @@ public final class LocalOzoneClusterConfig {
     return startupTimeout;
   }
 
-  /**
-   * Returns the suggested local-only S3 access key printed for client setup.
-   */
-  public String getS3AccessKey() {
-    return s3AccessKey;
-  }
-
-  /**
-   * Returns the suggested local-only S3 secret key printed for client setup.
-   */
-  public String getS3SecretKey() {
-    return s3SecretKey;
-  }
-
-  /**
-   * Returns the suggested local-only S3 region printed for client setup.
-   */
-  public String getS3Region() {
-    return s3Region;
-  }
-
   public static Builder builder() {
     return new Builder(DEFAULT_DATA_DIR);
   }
@@ -247,9 +228,6 @@ public final class LocalOzoneClusterConfig {
     private boolean s3gEnabled = DEFAULT_S3G_ENABLED;
     private boolean ephemeral = DEFAULT_EPHEMERAL;
     private Duration startupTimeout = DEFAULT_STARTUP_TIMEOUT;
-    private String s3AccessKey = DEFAULT_S3_ACCESS_KEY;
-    private String s3SecretKey = DEFAULT_S3_SECRET_KEY;
-    private String s3Region = DEFAULT_S3_REGION;
 
     private Builder(Path dataDir) {
       this.dataDir = dataDir;
@@ -302,21 +280,6 @@ public final class LocalOzoneClusterConfig {
 
     public Builder setStartupTimeout(Duration value) {
       startupTimeout = value;
-      return this;
-    }
-
-    public Builder setS3AccessKey(String value) {
-      s3AccessKey = value;
-      return this;
-    }
-
-    public Builder setS3SecretKey(String value) {
-      s3SecretKey = value;
-      return this;
-    }
-
-    public Builder setS3Region(String value) {
-      s3Region = value;
       return this;
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
@@ -56,7 +56,11 @@ public final class LocalOzoneClusterConfig {
   static final int DEFAULT_DATANODES =
       Integer.parseInt(DEFAULT_DATANODES_VALUE);
   static final String DEFAULT_HOST = "127.0.0.1";
-  static final String DEFAULT_BIND_HOST = "0.0.0.0";
+  // Loopback, not the wildcard address: the pre-provisioned S3 credentials are fixed and well
+  // known, so listening on every interface by default would serve a remotely writable S3
+  // endpoint. Widening the bind is an explicit --bind-host choice.
+  static final String DEFAULT_BIND_HOST = "127.0.0.1";
+  static final String WILDCARD_HOST = "0.0.0.0";
   static final int DEFAULT_PORT = Integer.parseInt(DEFAULT_PORT_VALUE);
   static final boolean DEFAULT_S3G_ENABLED =
       Boolean.parseBoolean(DEFAULT_S3G_ENABLED_VALUE);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneClusterConfig.java
@@ -43,6 +43,7 @@ public final class LocalOzoneClusterConfig {
   static final String DEFAULT_DATANODES_VALUE = "1";
   static final String DEFAULT_PORT_VALUE = "0";
   static final String DEFAULT_S3G_ENABLED_VALUE = "true";
+  static final String DEFAULT_RECON_ENABLED_VALUE = "false";
   static final String DEFAULT_EPHEMERAL_VALUE = "false";
   static final String DEFAULT_STARTUP_TIMEOUT_VALUE = "PT2M";
 
@@ -64,6 +65,8 @@ public final class LocalOzoneClusterConfig {
   static final int DEFAULT_PORT = Integer.parseInt(DEFAULT_PORT_VALUE);
   static final boolean DEFAULT_S3G_ENABLED =
       Boolean.parseBoolean(DEFAULT_S3G_ENABLED_VALUE);
+  static final boolean DEFAULT_RECON_ENABLED =
+      Boolean.parseBoolean(DEFAULT_RECON_ENABLED_VALUE);
   static final boolean DEFAULT_EPHEMERAL =
       Boolean.parseBoolean(DEFAULT_EPHEMERAL_VALUE);
   static final Duration DEFAULT_STARTUP_TIMEOUT =
@@ -85,6 +88,8 @@ public final class LocalOzoneClusterConfig {
   private final int omPort;
   private final int s3gPort;
   private final boolean s3gEnabled;
+  private final int reconPort;
+  private final boolean reconEnabled;
   private final boolean ephemeral;
   private final Duration startupTimeout;
 
@@ -100,6 +105,8 @@ public final class LocalOzoneClusterConfig {
     omPort = builder.omPort;
     s3gPort = builder.s3gPort;
     s3gEnabled = builder.s3gEnabled;
+    reconPort = builder.reconPort;
+    reconEnabled = builder.reconEnabled;
     ephemeral = builder.ephemeral;
     startupTimeout = Objects.requireNonNull(builder.startupTimeout,
         "startupTimeout");
@@ -154,6 +161,18 @@ public final class LocalOzoneClusterConfig {
    */
   public boolean isS3gEnabled() {
     return s3gEnabled;
+  }
+
+  /**
+   * Returns the Recon HTTP port. Port {@code 0} asks the runtime to choose an
+   * available local port.
+   */
+  public int getReconPort() {
+    return reconPort;
+  }
+
+  public boolean isReconEnabled() {
+    return reconEnabled;
   }
 
   /**
@@ -226,6 +245,8 @@ public final class LocalOzoneClusterConfig {
     private int omPort = DEFAULT_PORT;
     private int s3gPort = DEFAULT_PORT;
     private boolean s3gEnabled = DEFAULT_S3G_ENABLED;
+    private int reconPort = DEFAULT_PORT;
+    private boolean reconEnabled = DEFAULT_RECON_ENABLED;
     private boolean ephemeral = DEFAULT_EPHEMERAL;
     private Duration startupTimeout = DEFAULT_STARTUP_TIMEOUT;
 
@@ -270,6 +291,16 @@ public final class LocalOzoneClusterConfig {
 
     public Builder setS3gEnabled(boolean value) {
       s3gEnabled = value;
+      return this;
+    }
+
+    public Builder setReconPort(int value) {
+      reconPort = value;
+      return this;
+    }
+
+    public Builder setReconEnabled(boolean value) {
+      reconEnabled = value;
       return this;
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
@@ -62,14 +62,14 @@ public interface LocalOzoneRuntime extends AutoCloseable {
   /**
    * Returns the S3 Gateway HTTP port for this local runtime.
    *
-   * @return S3 Gateway port
+   * @return S3 Gateway port, or -1 when the S3 Gateway is disabled
    */
   int getS3gPort();
 
   /**
    * Returns the full S3 Gateway endpoint shown to users.
    *
-   * @return S3 Gateway endpoint, including scheme, host, and port
+   * @return S3 Gateway endpoint, including scheme, host, and port; empty when the S3 Gateway is disabled
    */
   String getS3Endpoint();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
@@ -74,6 +74,20 @@ public interface LocalOzoneRuntime extends AutoCloseable {
   String getS3Endpoint();
 
   /**
+   * Returns the Recon HTTP port for this local runtime.
+   *
+   * @return Recon port
+   */
+  int getReconPort();
+
+  /**
+   * Returns the full Recon endpoint shown to users.
+   *
+   * @return Recon endpoint, including scheme, host, and port
+   */
+  String getReconEndpoint();
+
+  /**
    * Returns the configuration keys whose user-supplied value the local runtime had to replace.
    *
    * <p>Callers report these: {@code ozone local} runs with service logging off, so a warning that

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
@@ -60,14 +60,14 @@ public interface LocalOzoneRuntime extends AutoCloseable {
   /**
    * Returns the S3 Gateway HTTP port for this local runtime.
    *
-   * @return S3 Gateway port
+   * @return S3 Gateway port, or -1 when the S3 Gateway is disabled
    */
   int getS3gPort();
 
   /**
    * Returns the full S3 Gateway endpoint shown to users.
    *
-   * @return S3 Gateway endpoint, including scheme, host, and port
+   * @return S3 Gateway endpoint, including scheme, host, and port; empty when the S3 Gateway is disabled
    */
   String getS3Endpoint();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
@@ -72,6 +72,20 @@ public interface LocalOzoneRuntime extends AutoCloseable {
   String getS3Endpoint();
 
   /**
+   * Returns the Recon HTTP port for this local runtime.
+   *
+   * @return Recon port, or -1 when Recon is disabled
+   */
+  int getReconPort();
+
+  /**
+   * Returns the full Recon endpoint shown to users.
+   *
+   * @return Recon endpoint, including scheme, host, and port; empty when Recon is disabled
+   */
+  String getReconEndpoint();
+
+  /**
    * Stops the local runtime and releases resources created during startup.
    *
    * @throws Exception if shutdown fails

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.local;
 
+import java.util.List;
+
 /**
  * Runtime contract for local Ozone cluster commands.
  */
@@ -70,6 +72,16 @@ public interface LocalOzoneRuntime extends AutoCloseable {
    * @return S3 Gateway endpoint, including scheme, host, and port
    */
   String getS3Endpoint();
+
+  /**
+   * Returns the configuration keys whose user-supplied value the local runtime had to replace.
+   *
+   * <p>Callers report these: {@code ozone local} runs with service logging off, so a warning that
+   * only reaches the log is invisible by default.</p>
+   *
+   * @return overridden keys, empty if the user configured none of them
+   */
+  List<String> getDiscardedUserConfigKeys();
 
   /**
    * Stops the local runtime and releases resources created during startup.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -62,9 +62,6 @@ public class OzoneLocal extends GenericCli {
   static final String ENV_S3G_PORT = "OZONE_LOCAL_S3G_PORT";
   static final String ENV_EPHEMERAL = "OZONE_LOCAL_EPHEMERAL";
   static final String ENV_STARTUP_TIMEOUT = "OZONE_LOCAL_STARTUP_TIMEOUT";
-  static final String ENV_S3_ACCESS_KEY = "OZONE_LOCAL_S3_ACCESS_KEY";
-  static final String ENV_S3_SECRET_KEY = "OZONE_LOCAL_S3_SECRET_KEY";
-  static final String ENV_S3_REGION = "OZONE_LOCAL_S3_REGION";
 
   private static final String DEFAULT_DATA_DIR_VALUE = "${env:" + ENV_DATA_DIR
       + ":-" + LocalOzoneClusterConfig.DEFAULT_DATA_DIR_VALUE + "}";
@@ -93,14 +90,6 @@ public class OzoneLocal extends GenericCli {
   private static final String DEFAULT_STARTUP_TIMEOUT_VALUE = "${env:"
       + ENV_STARTUP_TIMEOUT + ":-"
       + LocalOzoneClusterConfig.DEFAULT_STARTUP_TIMEOUT_VALUE + "}";
-  private static final String DEFAULT_S3_ACCESS_KEY_VALUE = "${env:"
-      + ENV_S3_ACCESS_KEY + ":-"
-      + LocalOzoneClusterConfig.DEFAULT_S3_ACCESS_KEY + "}";
-  private static final String DEFAULT_S3_SECRET_KEY_VALUE = "${env:"
-      + ENV_S3_SECRET_KEY + ":-"
-      + LocalOzoneClusterConfig.DEFAULT_S3_SECRET_KEY + "}";
-  private static final String DEFAULT_S3_REGION_VALUE = "${env:"
-      + ENV_S3_REGION + ":-" + LocalOzoneClusterConfig.DEFAULT_S3_REGION + "}";
 
   public OzoneLocal() {
     super();
@@ -164,7 +153,7 @@ public class OzoneLocal extends GenericCli {
   }
 
   @Command(name = "run",
-      description = "Start SCM, OM, and datanodes in one local process")
+      description = "Start SCM, OM, datanodes, and optional S3 Gateway in one local process")
   static class RunCommand extends AbstractSubcommand implements Callable<Void> {
 
     @Option(names = "--data-dir",
@@ -190,7 +179,7 @@ public class OzoneLocal extends GenericCli {
 
     @Option(names = "--bind-host",
         defaultValue = DEFAULT_BIND_HOST_VALUE,
-        description = "Bind host for HTTP and RPC listeners")
+        description = "Bind host for HTTP and RPC listeners (use 0.0.0.0 to listen on all interfaces)")
     private String bindHost;
 
     @Option(names = "--scm-port",
@@ -228,21 +217,6 @@ public class OzoneLocal extends GenericCli {
         description = "How long to wait for the local cluster to become ready")
     private Duration startupTimeout;
 
-    @Option(names = "--s3-access-key",
-        defaultValue = DEFAULT_S3_ACCESS_KEY_VALUE,
-        description = "Suggested local AWS access key to print on startup")
-    private String s3AccessKey;
-
-    @Option(names = "--s3-secret-key",
-        defaultValue = DEFAULT_S3_SECRET_KEY_VALUE,
-        description = "Suggested local AWS secret key to print on startup")
-    private String s3SecretKey;
-
-    @Option(names = "--s3-region",
-        defaultValue = DEFAULT_S3_REGION_VALUE,
-        description = "Suggested local AWS region to print on startup")
-    private String s3Region;
-
     @Override
     public Void call() throws Exception {
       LocalOzoneClusterConfig config = resolveConfig();
@@ -272,6 +246,17 @@ public class OzoneLocal extends GenericCli {
       writer.println("Local Ozone is running from " + config.getDataDir());
       writer.println("SCM RPC: " + runtime.getDisplayHost() + ":" + runtime.getScmPort());
       writer.println("OM RPC: " + runtime.getDisplayHost() + ":" + runtime.getOmPort());
+      if (config.isS3gEnabled()) {
+        writer.println("S3 endpoint: " + runtime.getS3Endpoint());
+        writer.println("Suggested local AWS settings:");
+        writer.println("AWS_ACCESS_KEY_ID=" + LocalOzoneClusterConfig.LOCAL_S3_ACCESS_KEY);
+        writer.println("AWS_SECRET_ACCESS_KEY=" + LocalOzoneClusterConfig.LOCAL_S3_SECRET_KEY);
+        writer.println("AWS_REGION=" + LocalOzoneClusterConfig.LOCAL_S3_REGION);
+        writer.println("AWS_ENDPOINT_URL_S3=" + runtime.getS3Endpoint());
+        writer.println("Use path-style addressing (AWS CLI: aws configure set default.s3.addressing_style path).");
+        writer.println("Local Ozone runs without security, so the S3 Gateway accepts any credentials;");
+        writer.println("the access key id is the identity buckets are created under.");
+      }
       writer.println("Press Ctrl+C to stop.");
       writer.flush();
     }
@@ -324,9 +309,6 @@ public class OzoneLocal extends GenericCli {
           .setS3gEnabled(s3gEnabled)
           .setEphemeral(ephemeral)
           .setStartupTimeout(startupTimeout)
-          .setS3AccessKey(s3AccessKey)
-          .setS3SecretKey(s3SecretKey)
-          .setS3Region(s3Region)
           .build();
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -61,6 +61,8 @@ public class OzoneLocal extends GenericCli {
   static final String ENV_OM_PORT = "OZONE_LOCAL_OM_PORT";
   static final String ENV_S3G_ENABLED = "OZONE_LOCAL_S3G_ENABLED";
   static final String ENV_S3G_PORT = "OZONE_LOCAL_S3G_PORT";
+  static final String ENV_RECON_ENABLED = "OZONE_LOCAL_RECON_ENABLED";
+  static final String ENV_RECON_PORT = "OZONE_LOCAL_RECON_PORT";
   static final String ENV_EPHEMERAL = "OZONE_LOCAL_EPHEMERAL";
   static final String ENV_STARTUP_TIMEOUT = "OZONE_LOCAL_STARTUP_TIMEOUT";
   static final String ENV_S3_ACCESS_KEY = "OZONE_LOCAL_S3_ACCESS_KEY";
@@ -88,6 +90,12 @@ public class OzoneLocal extends GenericCli {
       + LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED_VALUE + "}";
   private static final String DEFAULT_S3G_PORT_VALUE = "${env:" + ENV_S3G_PORT
       + ":-" + LocalOzoneClusterConfig.DEFAULT_PORT_VALUE + "}";
+  private static final String DEFAULT_RECON_ENABLED_VALUE = "${env:"
+      + ENV_RECON_ENABLED + ":-"
+      + LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED_VALUE + "}";
+  private static final String DEFAULT_RECON_PORT_VALUE = "${env:"
+      + ENV_RECON_PORT + ":-" + LocalOzoneClusterConfig.DEFAULT_PORT_VALUE
+      + "}";
   private static final String DEFAULT_EPHEMERAL_VALUE = "${env:"
       + ENV_EPHEMERAL + ":-"
       + LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE + "}";
@@ -116,7 +124,7 @@ public class OzoneLocal extends GenericCli {
   }
 
   @Command(name = "run",
-      description = "Start SCM, OM, datanodes, and optional S3 Gateway in one local process")
+      description = "Start SCM, OM, datanodes, and optional S3 Gateway and Recon in one local process")
   static class RunCommand extends AbstractSubcommand implements Callable<Void> {
 
     @Option(names = "--data-dir",
@@ -166,6 +174,18 @@ public class OzoneLocal extends GenericCli {
         fallbackValue = "true",
         description = "Enable S3 Gateway")
     private boolean s3gEnabled;
+
+    @Option(names = "--recon-port",
+        defaultValue = DEFAULT_RECON_PORT_VALUE,
+        description = "Recon HTTP port (0 means auto-allocate)")
+    private int reconPort;
+
+    @Option(names = "--recon",
+        negatable = true,
+        defaultValue = DEFAULT_RECON_ENABLED_VALUE,
+        fallbackValue = "true",
+        description = "Enable Recon")
+    private boolean reconEnabled;
 
     @Option(names = "--ephemeral",
         negatable = true,
@@ -271,6 +291,9 @@ public class OzoneLocal extends GenericCli {
         writer.println("Use path-style addressing (AWS CLI: aws configure set default.s3.addressing_style path).");
         writer.println("These credentials are pre-provisioned for the local S3 Gateway.");
       }
+      if (config.isReconEnabled()) {
+        writer.println("Recon endpoint: " + runtime.getReconEndpoint());
+      }
       writer.println("Press Ctrl+C to stop.");
       writer.flush();
     }
@@ -310,6 +333,7 @@ public class OzoneLocal extends GenericCli {
       validatePort(scmPort, "--scm-port");
       validatePort(omPort, "--om-port");
       validatePort(s3gPort, "--s3g-port");
+      validatePort(reconPort, "--recon-port");
       validateStartupTimeout();
 
       return LocalOzoneClusterConfig.builder(dataDir)
@@ -321,6 +345,8 @@ public class OzoneLocal extends GenericCli {
           .setOmPort(omPort)
           .setS3gPort(s3gPort)
           .setS3gEnabled(s3gEnabled)
+          .setReconPort(reconPort)
+          .setReconEnabled(reconEnabled)
           .setEphemeral(ephemeral)
           .setStartupTimeout(startupTimeout)
           .setS3AccessKey(s3AccessKey)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.local;
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.concurrent.Callable;
@@ -109,8 +110,57 @@ public class OzoneLocal extends GenericCli {
     super(factory);
   }
 
+  @Override
+  public void setConfigurationPath(String configPath) {
+    // LocalOzoneCluster.userConfiguredSource() tells a --conf file from a shipped classpath
+    // default by exact source-name comparison, and Configuration records a classpath resource by
+    // its bare name, so a scheme-less path is absolutized before GenericCli records it. A value
+    // carrying a scheme (file:, hdfs:) already cannot collide with a bare resource name and
+    // java.nio would misparse it into a CWD-relative literal path, so it passes through; the
+    // fs.Path parse also keeps rejecting an empty value at option parse time.
+    if (new org.apache.hadoop.fs.Path(configPath).toUri().getScheme() == null) {
+      configPath = Paths.get(configPath).toAbsolutePath().normalize().toString();
+    }
+    super.setConfigurationPath(configPath);
+  }
+
+  @Override
+  public void printError(Throwable error) {
+    if (!(error instanceof StartupFailureException)) {
+      super.printError(error);
+      return;
+    }
+
+    super.printError(error.getCause());
+    String hint = startupFailureHint(LOG.isInfoEnabled(), isVerbose());
+    if (hint != null) {
+      err().println(hint);
+    }
+  }
+
+  static String startupFailureHint(boolean infoEnabled, boolean verbose) {
+    if (infoEnabled && verbose) {
+      return null;
+    }
+    if (!infoEnabled && !verbose) {
+      return "For more detail, re-run with `ozone --loglevel INFO local run` for service logs,"
+          + " or add --verbose for the full stack trace.";
+    }
+    if (!infoEnabled) {
+      return "For service logs, re-run with `ozone --loglevel INFO local run`.";
+    }
+    return "For the full stack trace, add --verbose.";
+  }
+
   public static void main(String[] args) {
     new OzoneLocal().run(args);
+  }
+
+  private static final class StartupFailureException extends Exception {
+
+    private StartupFailureException(Throwable cause) {
+      super(cause);
+    }
   }
 
   @Command(name = "run",
@@ -197,11 +247,20 @@ public class OzoneLocal extends GenericCli {
     public Void call() throws Exception {
       LocalOzoneClusterConfig config = resolveConfig();
       try (LocalOzoneRuntime runtime = createRuntime(config, getOzoneConf())) {
-        runtime.start();
+        start(runtime);
         printSummary(runtime, config);
         awaitShutdown(runtime);
       }
       return null;
+    }
+
+    /** Marks startup failures so the root command can print the cause before any useful hints. */
+    private void start(LocalOzoneRuntime runtime) throws Exception {
+      try {
+        runtime.start();
+      } catch (Exception ex) {
+        throw new StartupFailureException(ex);
+      }
     }
 
     LocalOzoneRuntime createRuntime(LocalOzoneClusterConfig config, OzoneConfiguration seedConfiguration) {
@@ -293,8 +352,11 @@ public class OzoneLocal extends GenericCli {
         try {
           return LocalOzoneClusterConfig.FormatMode.fromString(value);
         } catch (IllegalArgumentException ex) {
-          throw new CommandLine.TypeConversionException(
-              "Expected one of: if-needed, always, never.");
+          // The value can come from OZONE_LOCAL_FORMAT, so name it: the user may not realize the
+          // environment supplied it. picocli's conversion-error line names the option but not the
+          // value, so the message has to carry it.
+          throw new CommandLine.TypeConversionException("Invalid format mode '" + value
+              + "'. Expected one of: if-needed, always, never.");
         }
       }
     }
@@ -304,19 +366,27 @@ public class OzoneLocal extends GenericCli {
 
       @Override
       public Duration convert(String value) {
+        String trimmed = value.trim();
         try {
-          return Duration.parse(value.trim());
+          return Duration.parse(trimmed);
         } catch (DateTimeParseException ignored) {
-          return parseHadoopStyleDuration(value);
+          return parseHadoopStyleDuration(trimmed);
         }
       }
 
       private static Duration parseHadoopStyleDuration(String value) {
+        // Rejected instead of silently interpreting the value a thousand times smaller than the
+        // user meant; the rationale lives on LocalOzoneCluster#lacksTimeUnit.
+        if (LocalOzoneCluster.lacksTimeUnit(value)) {
+          throw new CommandLine.TypeConversionException("Missing time unit in '" + value
+              + "'. " + durationMessage());
+        }
         try {
           return TimeDurationUtil.getDuration("--startup-timeout", value,
               TimeUnit.MILLISECONDS);
         } catch (RuntimeException ex) {
-          throw new CommandLine.TypeConversionException(durationMessage());
+          throw new CommandLine.TypeConversionException("Invalid duration '" + value
+              + "'. " + durationMessage());
         }
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -17,10 +17,12 @@
 
 package org.apache.hadoop.ozone.local;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -197,11 +199,56 @@ public class OzoneLocal extends GenericCli {
     public Void call() throws Exception {
       LocalOzoneClusterConfig config = resolveConfig();
       try (LocalOzoneRuntime runtime = createRuntime(config, getOzoneConf())) {
-        runtime.start();
+        start(runtime);
         printSummary(runtime, config);
         awaitShutdown(runtime);
       }
       return null;
+    }
+
+    /**
+     * Starts {@code runtime}, restating a failure in a form the user can act on. Service logs are
+     * off by default for this command, so the detail goes to the log for {@code --loglevel INFO}
+     * while the message keeps {@link GenericCli}'s single-line path: an exception with no message
+     * would otherwise print a raw stack trace.
+     */
+    private void start(LocalOzoneRuntime runtime) throws Exception {
+      try {
+        runtime.start();
+      } catch (Exception ex) {
+        LOG.error("Local Ozone cluster failed to start.", ex);
+        throw new IOException("Local Ozone failed to start: " + failureMessage(ex)
+            + " Re-run with `ozone --loglevel INFO local run` for service logs,"
+            + " or add --verbose for the full stack trace.", ex);
+      } finally {
+        reportDiscardedConfig(runtime);
+      }
+    }
+
+    /**
+     * Reports configuration the local runtime had to replace. The runtime also logs each
+     * replacement, but service logging is off by default for this command, so the keys are
+     * repeated here where the user will actually see them. Reported even when startup fails:
+     * a discarded override can be the very setting the user is debugging.
+     */
+    private void reportDiscardedConfig(LocalOzoneRuntime runtime) {
+      List<String> discarded = runtime.getDiscardedUserConfigKeys();
+      if (!discarded.isEmpty()) {
+        err().println("Ignoring configured " + String.join(", ", discarded)
+            + ": ozone local requires its own values for these."
+            + " Re-run with `ozone --loglevel INFO local run` to see them.");
+      }
+    }
+
+    /** Returns the nearest message in {@code error}'s cause chain, since the outermost may be null. */
+    private static String failureMessage(Throwable error) {
+      for (Throwable cause = error; cause != null; cause = cause.getCause()) {
+        String message = cause.getMessage();
+        if (message != null && !message.isEmpty()) {
+          return message.endsWith(".") ? message : message + ".";
+        }
+      }
+      return error.getClass().getSimpleName() + ".";
     }
 
     LocalOzoneRuntime createRuntime(LocalOzoneClusterConfig config, OzoneConfiguration seedConfiguration) {
@@ -213,6 +260,7 @@ public class OzoneLocal extends GenericCli {
       writer.println("Local Ozone is running from " + config.getDataDir());
       writer.println("SCM RPC: " + runtime.getDisplayHost() + ":" + runtime.getScmPort());
       writer.println("OM RPC: " + runtime.getDisplayHost() + ":" + runtime.getOmPort());
+      writer.println("Datanodes: " + config.getDatanodes());
       writer.println("Press Ctrl+C to stop.");
       writer.flush();
     }
@@ -293,8 +341,11 @@ public class OzoneLocal extends GenericCli {
         try {
           return LocalOzoneClusterConfig.FormatMode.fromString(value);
         } catch (IllegalArgumentException ex) {
-          throw new CommandLine.TypeConversionException(
-              "Expected one of: if-needed, always, never.");
+          // The value can come from OZONE_LOCAL_FORMAT, so name it: the user may not realize the
+          // environment supplied it. picocli's conversion-error line names the option but not the
+          // value, so the message has to carry it.
+          throw new CommandLine.TypeConversionException("Invalid format mode '" + value
+              + "'. Expected one of: if-needed, always, never.");
         }
       }
     }
@@ -304,19 +355,29 @@ public class OzoneLocal extends GenericCli {
 
       @Override
       public Duration convert(String value) {
+        String trimmed = value.trim();
         try {
-          return Duration.parse(value.trim());
+          return Duration.parse(trimmed);
         } catch (DateTimeParseException ignored) {
-          return parseHadoopStyleDuration(value);
+          return parseHadoopStyleDuration(trimmed);
         }
       }
 
       private static Duration parseHadoopStyleDuration(String value) {
+        // TimeDurationUtil.getDuration() only warns about a missing unit and then assumes the one
+        // it is given, which would read "120" as 120 milliseconds. Reject it instead of silently
+        // interpreting the value a thousand times smaller than the user meant. Every unit suffix
+        // TimeDurationUtil accepts ends in a letter, so a trailing digit means the unit is missing.
+        if (!value.isEmpty() && Character.isDigit(value.charAt(value.length() - 1))) {
+          throw new CommandLine.TypeConversionException("Missing time unit in '" + value
+              + "'. " + durationMessage());
+        }
         try {
           return TimeDurationUtil.getDuration("--startup-timeout", value,
               TimeUnit.MILLISECONDS);
         } catch (RuntimeException ex) {
-          throw new CommandLine.TypeConversionException(durationMessage());
+          throw new CommandLine.TypeConversionException("Invalid duration '" + value
+              + "'. " + durationMessage());
         }
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -60,6 +60,8 @@ public class OzoneLocal extends GenericCli {
   static final String ENV_OM_PORT = "OZONE_LOCAL_OM_PORT";
   static final String ENV_S3G_ENABLED = "OZONE_LOCAL_S3G_ENABLED";
   static final String ENV_S3G_PORT = "OZONE_LOCAL_S3G_PORT";
+  static final String ENV_RECON_ENABLED = "OZONE_LOCAL_RECON_ENABLED";
+  static final String ENV_RECON_PORT = "OZONE_LOCAL_RECON_PORT";
   static final String ENV_EPHEMERAL = "OZONE_LOCAL_EPHEMERAL";
   static final String ENV_STARTUP_TIMEOUT = "OZONE_LOCAL_STARTUP_TIMEOUT";
 
@@ -84,6 +86,12 @@ public class OzoneLocal extends GenericCli {
       + LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED_VALUE + "}";
   private static final String DEFAULT_S3G_PORT_VALUE = "${env:" + ENV_S3G_PORT
       + ":-" + LocalOzoneClusterConfig.DEFAULT_PORT_VALUE + "}";
+  private static final String DEFAULT_RECON_ENABLED_VALUE = "${env:"
+      + ENV_RECON_ENABLED + ":-"
+      + LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED_VALUE + "}";
+  private static final String DEFAULT_RECON_PORT_VALUE = "${env:"
+      + ENV_RECON_PORT + ":-" + LocalOzoneClusterConfig.DEFAULT_PORT_VALUE
+      + "}";
   private static final String DEFAULT_EPHEMERAL_VALUE = "${env:"
       + ENV_EPHEMERAL + ":-"
       + LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE + "}";
@@ -153,7 +161,7 @@ public class OzoneLocal extends GenericCli {
   }
 
   @Command(name = "run",
-      description = "Start SCM, OM, datanodes, and optional S3 Gateway in one local process")
+      description = "Start SCM, OM, datanodes, and optional S3 Gateway and Recon in one local process")
   static class RunCommand extends AbstractSubcommand implements Callable<Void> {
 
     @Option(names = "--data-dir",
@@ -203,6 +211,18 @@ public class OzoneLocal extends GenericCli {
         fallbackValue = "true",
         description = "Enable S3 Gateway")
     private boolean s3gEnabled;
+
+    @Option(names = "--recon-port",
+        defaultValue = DEFAULT_RECON_PORT_VALUE,
+        description = "Recon HTTP port (0 means auto-allocate)")
+    private int reconPort;
+
+    @Option(names = "--recon",
+        negatable = true,
+        defaultValue = DEFAULT_RECON_ENABLED_VALUE,
+        fallbackValue = "true",
+        description = "Enable Recon")
+    private boolean reconEnabled;
 
     @Option(names = "--ephemeral",
         negatable = true,
@@ -257,6 +277,9 @@ public class OzoneLocal extends GenericCli {
         writer.println("Local Ozone runs without security, so the S3 Gateway accepts any credentials;");
         writer.println("the access key id is the identity buckets are created under.");
       }
+      if (config.isReconEnabled()) {
+        writer.println("Recon endpoint: " + runtime.getReconEndpoint());
+      }
       writer.println("Press Ctrl+C to stop.");
       writer.flush();
     }
@@ -296,6 +319,7 @@ public class OzoneLocal extends GenericCli {
       validatePort(scmPort, "--scm-port");
       validatePort(omPort, "--om-port");
       validatePort(s3gPort, "--s3g-port");
+      validatePort(reconPort, "--recon-port");
       validateStartupTimeout();
 
       return LocalOzoneClusterConfig.builder(dataDir)
@@ -307,6 +331,8 @@ public class OzoneLocal extends GenericCli {
           .setOmPort(omPort)
           .setS3gPort(s3gPort)
           .setS3gEnabled(s3gEnabled)
+          .setReconPort(reconPort)
+          .setReconEnabled(reconEnabled)
           .setEphemeral(ephemeral)
           .setStartupTimeout(startupTimeout)
           .build();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -116,7 +116,7 @@ public class OzoneLocal extends GenericCli {
   }
 
   @Command(name = "run",
-      description = "Start SCM, OM, and datanodes in one local process")
+      description = "Start SCM, OM, datanodes, and optional S3 Gateway in one local process")
   static class RunCommand extends AbstractSubcommand implements Callable<Void> {
 
     @Option(names = "--data-dir",
@@ -142,7 +142,7 @@ public class OzoneLocal extends GenericCli {
 
     @Option(names = "--bind-host",
         defaultValue = DEFAULT_BIND_HOST_VALUE,
-        description = "Bind host for HTTP and RPC listeners")
+        description = "Bind host for HTTP and RPC listeners (use 0.0.0.0 to listen on all interfaces)")
     private String bindHost;
 
     @Option(names = "--scm-port",
@@ -261,6 +261,16 @@ public class OzoneLocal extends GenericCli {
       writer.println("SCM RPC: " + runtime.getDisplayHost() + ":" + runtime.getScmPort());
       writer.println("OM RPC: " + runtime.getDisplayHost() + ":" + runtime.getOmPort());
       writer.println("Datanodes: " + config.getDatanodes());
+      if (config.isS3gEnabled()) {
+        writer.println("S3 endpoint: " + runtime.getS3Endpoint());
+        writer.println("Suggested local AWS settings:");
+        writer.println("AWS_ACCESS_KEY_ID=" + config.getS3AccessKey());
+        writer.println("AWS_SECRET_ACCESS_KEY=" + config.getS3SecretKey());
+        writer.println("AWS_REGION=" + config.getS3Region());
+        writer.println("AWS_ENDPOINT_URL_S3=" + runtime.getS3Endpoint());
+        writer.println("Use path-style addressing (AWS CLI: aws configure set default.s3.addressing_style path).");
+        writer.println("These credentials are pre-provisioned for the local S3 Gateway.");
+      }
       writer.println("Press Ctrl+C to stop.");
       writer.flush();
     }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_BIND_HOST_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
@@ -25,22 +26,32 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAF
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_IPC_PORT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_BIND_HOST_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ENABLED_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -48,13 +59,20 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
+import org.apache.hadoop.net.NetUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -83,9 +101,26 @@ class TestLocalOzoneCluster {
       assertTrue(Files.isRegularFile(portStateFile(dataDir)));
       assertTrue(prepared.getScmPort() > 0);
       assertTrue(prepared.getOmPort() > 0);
+      assertTrue(prepared.getS3gPort() > 0);
+    }
+  }
+
+  @Test
+  void prepareConfigurationSkipsS3GatewayWhenDisabled() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setS3gEnabled(false)
+        .build();
+
+    try (LocalOzoneCluster cluster = newCluster(config)) {
+      LocalOzoneCluster.PreparedConfiguration prepared =
+          cluster.prepareConfiguration();
+
+      assertEquals(-1, prepared.getS3gPort());
       assertEquals(-1, cluster.getS3gPort());
       assertEquals("", cluster.getS3Endpoint());
     }
+    assertFalse(loadPortState(dataDir).stringPropertyNames().stream().anyMatch(key -> key.startsWith("s3g.")));
   }
 
   @Test
@@ -95,6 +130,7 @@ class TestLocalOzoneCluster {
     LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
         .setScmPort(9860)
         .setOmPort(9862)
+        .setS3gPort(9878)
         .setDatanodes(2)
         .build();
 
@@ -116,10 +152,91 @@ class TestLocalOzoneCluster {
     assertEquals(2, conf.getInt(HDDS_SCM_SAFEMODE_MIN_DATANODE, 0));
     assertTrue(conf.get(OZONE_SCM_CLIENT_ADDRESS_KEY).endsWith(":9860"));
     assertTrue(conf.get(OZONE_OM_ADDRESS_KEY).endsWith(":9862"));
+    assertTrue(conf.get(OZONE_S3G_HTTP_ADDRESS_KEY).endsWith(":9878"));
     assertTrue(conf.getTrimmedStringCollection(OZONE_SCM_NAMES).iterator()
         .next().contains(":"));
     assertEquals(9860, prepared.getScmPort());
     assertEquals(9862, prepared.getOmPort());
+    assertEquals(9878, prepared.getS3gPort());
+  }
+
+  /**
+   * The S3 accessors answer for the gateway that is running, not the one that was asked for. An
+   * enabled but unstarted gateway has no port to report, and reporting it must not require the
+   * caller to know the lifecycle: the runtime contract is -1 and an empty endpoint.
+   */
+  @Test
+  void s3AccessorsReportNoListenerBeforeStart() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    try (LocalOzoneCluster cluster = newCluster(config)) {
+      assertTrue(config.isS3gEnabled());
+      assertEquals(-1, cluster.getS3gPort());
+      assertEquals("", cluster.getS3Endpoint());
+      assertNull(cluster.getS3gBoundAddress());
+    }
+  }
+
+  /**
+   * The runtime reads the advertised port back off the S3 Gateway HTTP listener, so a
+   * configuration that switches the listener off is rejected up front, with the message naming
+   * the key. Without this the cluster starts fully and then fails while printing its summary.
+   */
+  @Test
+  void prepareConfigurationRejectsDisabledS3GatewayHttpListener() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.setBoolean(OZONE_S3G_HTTP_ENABLED_KEY, false);
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    IOException error = assertPrepareFails(config, seed);
+
+    assertMessageContains(error, OZONE_S3G_HTTP_ENABLED_KEY);
+  }
+
+  /**
+   * One bind-host key per service binds loopback unless {@code --bind-host} widens it, for the
+   * reason stated on {@code LocalOzoneClusterConfig#DEFAULT_BIND_HOST}.
+   */
+  @Test
+  void prepareConfigurationBindsListenersToLoopbackByDefault() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    LocalOzoneCluster.PreparedConfiguration prepared = prepare(config);
+    OzoneConfiguration conf = prepared.getConfiguration();
+
+    assertEquals("127.0.0.1", conf.get(OZONE_SCM_CLIENT_BIND_HOST_KEY));
+    assertEquals("127.0.0.1", conf.get(OZONE_OM_HTTP_BIND_HOST_KEY));
+    assertEquals("127.0.0.1", conf.get(OZONE_S3G_HTTP_BIND_HOST_KEY));
+    assertEquals("127.0.0.1", prepared.getDatanodeConfigurations().get(0)
+        .get(HDDS_DATANODE_CLIENT_BIND_HOST_KEY));
+  }
+
+  /**
+   * The two listeners the local runtime actually binds get distinct reserved ports. The HTTPS
+   * addresses stay on port 0: the default HTTP-only policy never binds them, and a reserved port
+   * that no listener claims is only a window for another process to take it.
+   */
+  @Test
+  void prepareConfigurationAllocatesDistinctS3GatewayPorts() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setS3gPort(9878)
+        .build();
+
+    OzoneConfiguration conf = prepare(config).getConfiguration();
+
+    int httpPort = parsePort(conf.get(OZONE_S3G_HTTP_ADDRESS_KEY));
+    int httpsPort = parsePort(conf.get(OZONE_S3G_HTTPS_ADDRESS_KEY));
+    int webHttpPort = parsePort(conf.get(OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY));
+    int webHttpsPort = parsePort(conf.get(OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY));
+
+    assertEquals(9878, httpPort);
+    assertEquals(0, httpsPort);
+    assertEquals(0, webHttpsPort);
+    assertEquals(2, new HashSet<>(Arrays.asList(httpPort, webHttpPort)).size());
   }
 
   @Test
@@ -312,8 +429,28 @@ class TestLocalOzoneCluster {
     assertPositivePort(properties, "om.rpc");
     assertPositivePort(properties, "om.http");
     assertPositivePort(properties, "om.ratis");
+    assertPositivePort(properties, "s3g.http");
+    assertPositivePort(properties, "s3g.web.http");
+    // Not persisted: nothing binds them, so there is no endpoint to keep stable across restarts.
+    assertFalse(properties.containsKey("s3g.https"), properties::toString);
+    assertFalse(properties.containsKey("s3g.web.https"), properties::toString);
     assertNotEquals(properties.getProperty("scm.client"),
         properties.getProperty("om.rpc"));
+  }
+
+  @Test
+  void formatNeverRejectsPortStateMissingS3GatewayPorts() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    prepare(LocalOzoneClusterConfig.builder(dataDir)
+        .setS3gEnabled(false)
+        .build());
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.NEVER)
+        .build();
+
+    IOException error = assertPrepareFails(config);
+
+    assertMessageContains(error, "s3g.");
   }
 
   @Test
@@ -642,6 +779,93 @@ class TestLocalOzoneCluster {
     assertEquals(2, attempts.get());
   }
 
+  /**
+   * Pins the timeout contract of executeWithinStartupTimeout: Gateway.call() ignores interruption,
+   * so a timed-out startup can still finish after the launcher has rolled back. Without the queued
+   * cleanup running after the abandoned attempt returns, the late-started service leaks until JVM
+   * exit.
+   */
+  @Test
+  void timedOutStartupIsStoppedOnceItFinishes() throws Exception {
+    CountDownLatch startupBlocked = new CountDownLatch(1);
+    List<String> events = new CopyOnWriteArrayList<>();
+    CountDownLatch cleanupRan = new CountDownLatch(1);
+
+    IOException error = assertThrows(IOException.class, () ->
+        LocalOzoneCluster.executeWithinStartupTimeout("S3 Gateway", () -> {
+          Uninterruptibles.awaitUninterruptibly(startupBlocked);
+          events.add("startup finished");
+          return null;
+        }, () -> {
+          events.add("cleanup");
+          cleanupRan.countDown();
+        }, Duration.ofMillis(50)));
+
+    assertTrue(error.getMessage().contains("did not start within"), error.getMessage());
+    startupBlocked.countDown();
+    assertTrue(cleanupRan.await(30, TimeUnit.SECONDS));
+    assertEquals(Arrays.asList("startup finished", "cleanup"), events);
+  }
+
+  /**
+   * Same contract as timedOutStartupIsStoppedOnceItFinishes, reached the other way: an interrupted
+   * launcher thread never assigns s3Gateway, so stopServices() has nothing to stop and the queued
+   * cleanup is the only thing that can release the started listeners.
+   */
+  @Test
+  void interruptedStartupIsStoppedOnceItFinishes() throws Exception {
+    CountDownLatch startupRunning = new CountDownLatch(1);
+    CountDownLatch startupBlocked = new CountDownLatch(1);
+    CountDownLatch cleanupRan = new CountDownLatch(1);
+
+    Thread caller = new Thread(() -> assertThrows(InterruptedException.class, () ->
+        LocalOzoneCluster.executeWithinStartupTimeout("S3 Gateway", () -> {
+          startupRunning.countDown();
+          Uninterruptibles.awaitUninterruptibly(startupBlocked);
+          return null;
+        }, cleanupRan::countDown, Duration.ofMinutes(5))));
+    caller.start();
+    // The interrupt must land while the caller is parked in future.get(), which cannot happen
+    // before the startup it submitted is running. A generous timeout keeps this from racing.
+    assertTrue(startupRunning.await(30, TimeUnit.SECONDS));
+    caller.interrupt();
+    caller.join(TimeUnit.SECONDS.toMillis(30));
+    assertFalse(caller.isAlive());
+
+    assertEquals(1, cleanupRan.getCount());
+    startupBlocked.countDown();
+    assertTrue(cleanupRan.await(30, TimeUnit.SECONDS));
+  }
+
+  /**
+   * A startup that throws may have started some of its servers first; the cleanup stops them
+   * before the failure propagates to the launcher.
+   */
+  @Test
+  void failedStartupIsStoppedInPlace() {
+    AtomicBoolean cleaned = new AtomicBoolean();
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        LocalOzoneCluster.executeWithinStartupTimeout("S3 Gateway",
+            () -> {
+              throw new IllegalStateException("startup failed");
+            },
+            () -> cleaned.set(true), Duration.ofSeconds(30)));
+
+    assertEquals("startup failed", error.getMessage());
+    assertTrue(cleaned.get());
+  }
+
+  @Test
+  void successfulStartupIsNotCleanedUp() throws Exception {
+    AtomicBoolean cleaned = new AtomicBoolean();
+
+    LocalOzoneCluster.executeWithinStartupTimeout("S3 Gateway", () -> null,
+        () -> cleaned.set(true), Duration.ofSeconds(30));
+
+    assertFalse(cleaned.get());
+  }
+
   @Test
   void persistedPortFileContainsDatanodePorts() throws Exception {
     Path dataDir = tempDir.resolve("local-ozone");
@@ -787,6 +1011,10 @@ class TestLocalOzoneCluster {
         .setValidate(validated)
         .setStatusText(status)
         .build();
+  }
+
+  private static int parsePort(String address) {
+    return NetUtils.createSocketAddr(address).getPort();
   }
 
   private Path metadataDir(Path dataDir) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -23,6 +23,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
@@ -436,6 +438,114 @@ class TestLocalOzoneCluster {
     assertFalse(properties.containsKey("s3g.web.https"), properties::toString);
     assertNotEquals(properties.getProperty("scm.client"),
         properties.getProperty("om.rpc"));
+  }
+
+  @Test
+  void reconOverrideRejectsConflictingUserValue() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "9m", "test-ozone-site.xml");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setReconEnabled(true)
+        .build();
+
+    IOException error = assertPrepareFails(config, seed);
+
+    // configureRecon() runs after configureLocalDefaults(), so the value has to be rejected where
+    // it is applied rather than by a check that only covers the keys set earlier.
+    String message = error.getMessage();
+    assertTrue(message.contains(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD), message);
+    assertTrue(message.contains("9m"), message);
+  }
+
+  @Test
+  void reconOverrideAcceptsEquivalentDurationSpelling() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "10000ms", "test-ozone-site.xml");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setReconEnabled(true)
+        .build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+      assertEquals("10s", cluster.prepareConfiguration().getConfiguration()
+          .get(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD));
+    }
+  }
+
+  /**
+   * Regression guard: the Recon default ships in ozone-recon-default.xml, so counting only
+   * ozone-default.xml as shipped would reject every run with Recon enabled.
+   */
+  @Test
+  void reconDefaultFromModuleXmlIsNotTreatedAsUserConfig() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setReconEnabled(true)
+        .build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config,
+        new OzoneConfiguration())) {
+      assertEquals("10s", cluster.prepareConfiguration().getConfiguration()
+          .get(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD));
+    }
+  }
+
+  @Test
+  void prepareConfigurationReservesReconPortsWhenEnabled() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setReconEnabled(true)
+        .setReconPort(9888)
+        .build();
+
+    try (LocalOzoneCluster cluster = newCluster(config)) {
+      LocalOzoneCluster.PreparedConfiguration prepared =
+          cluster.prepareConfiguration();
+      OzoneConfiguration conf = prepared.getConfiguration();
+
+      assertEquals(9888, prepared.getReconPort());
+      assertEquals(9888, cluster.getReconPort());
+      assertEquals("http://127.0.0.1:9888", cluster.getReconEndpoint());
+      assertTrue(conf.get(OZONE_RECON_HTTP_ADDRESS_KEY).endsWith(":9888"));
+      assertTrue(Files.isDirectory(dataDir.resolve("recon")));
+    }
+    Properties properties = loadPortState(dataDir);
+    assertPositivePort(properties, "recon.http");
+    assertPositivePort(properties, "recon.https");
+    assertPositivePort(properties, "recon.datanode");
+  }
+
+  @Test
+  void prepareConfigurationSkipsReconWhenDisabled() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    LocalOzoneClusterConfig config =
+        LocalOzoneClusterConfig.builder(dataDir).build();
+
+    try (LocalOzoneCluster cluster = newCluster(config)) {
+      LocalOzoneCluster.PreparedConfiguration prepared =
+          cluster.prepareConfiguration();
+
+      assertEquals(-1, prepared.getReconPort());
+      assertEquals(-1, cluster.getReconPort());
+      assertEquals("", cluster.getReconEndpoint());
+    }
+    assertFalse(loadPortState(dataDir).stringPropertyNames().stream()
+        .anyMatch(key -> key.startsWith("recon.")));
+  }
+
+  @Test
+  void formatNeverRejectsPortStateMissingReconPorts() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    prepare(LocalOzoneClusterConfig.builder(dataDir).build());
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.NEVER)
+        .setReconEnabled(true)
+        .build();
+
+    IOException error = assertPrepareFails(config);
+
+    assertMessageContains(error, "recon.");
   }
 
   @Test
@@ -929,6 +1039,46 @@ class TestLocalOzoneCluster {
 
       assertEquals(0, cluster.getDatanodeCount());
     }
+  }
+
+  @Test
+  void executeWithinStartupTimeoutReturnsStartupResult() throws Exception {
+    assertEquals(0, LocalOzoneCluster.executeWithinStartupTimeout("Recon", () -> 0,
+        () -> { }, Duration.ofSeconds(30)));
+  }
+
+  @Test
+  void executeWithinStartupTimeoutFailsFastWhenStartupBlocks() throws Exception {
+    CountDownLatch interrupted = new CountDownLatch(1);
+
+    IOException error =
+        assertThrows(IOException.class, () -> LocalOzoneCluster.executeWithinStartupTimeout(
+            "Recon", () -> {
+              try {
+                // Simulate an in-JVM startup that blocks until it leaves safe
+                // mode; the deadline must interrupt it rather than hang.
+                Thread.sleep(TimeUnit.MINUTES.toMillis(5));
+              } catch (InterruptedException e) {
+                interrupted.countDown();
+                Thread.currentThread().interrupt();
+              }
+              return 0;
+            }, () -> { }, Duration.ofMillis(200)));
+
+    assertMessageContains(error, "did not start within");
+    assertTrue(interrupted.await(30, TimeUnit.SECONDS),
+        "blocked startup should be interrupted on timeout");
+  }
+
+  @Test
+  void executeWithinStartupTimeoutPropagatesStartupFailure() {
+    IOException error =
+        assertThrows(IOException.class, () -> LocalOzoneCluster.executeWithinStartupTimeout(
+            "Recon", () -> {
+              throw new IOException("startup boom");
+            }, () -> { }, Duration.ofSeconds(30)));
+
+    assertMessageContains(error, "startup boom");
   }
 
   private LocalOzoneCluster.PreparedConfiguration prepare(

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
@@ -42,10 +43,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -143,6 +148,27 @@ class TestLocalOzoneCluster {
       assertSame(first, second);
       assertEquals(first.getScmPort(), second.getScmPort());
       assertEquals(first.getOmPort(), second.getOmPort());
+    }
+  }
+
+  @Test
+  void retryAfterFailedPrepareDoesNotRepeatDiscardedKeys() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name());
+    // Duplicate ports fail in configureOm(), after configureLocalDefaults() has recorded the
+    // override, so the second attempt re-runs the recording.
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setScmPort(9860)
+        .setOmPort(9860)
+        .build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+      assertThrows(IOException.class, cluster::prepareConfiguration);
+      assertThrows(IOException.class, cluster::prepareConfiguration);
+
+      assertEquals(singletonList(OZONE_REPLICATION),
+          cluster.getDiscardedUserConfigKeys());
     }
   }
 
@@ -347,6 +373,79 @@ class TestLocalOzoneCluster {
     assertEquals("Datanode count " + (LocalOzoneCluster.MAX_DATANODES + 1)
         + " exceeds the local maximum of " + LocalOzoneCluster.MAX_DATANODES
         + "; each datanode reserves 8 local ports.", error.getMessage());
+  }
+
+  @Test
+  void tooManyDatanodesIsRejectedBeforeFormatDeletesDataDir() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    Path marker = writeMarker(dataDir, "keep me");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.ALWAYS)
+        .setDatanodes(LocalOzoneCluster.MAX_DATANODES + 1)
+        .build();
+
+    assertPrepareFails(config);
+
+    assertTrue(Files.exists(marker),
+        "format ALWAYS must not delete the data dir for a run that cannot start");
+  }
+
+  @Test
+  void forcedLocalDefaultWarnsAboutDiscardedUserValue() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name());
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    LogCapturer logs = LogCapturer.captureLogs(LocalOzoneCluster.class);
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+      cluster.prepareConfiguration();
+
+      assertTrue(logs.getOutput().contains(OZONE_REPLICATION), logs.getOutput());
+      assertTrue(logs.getOutput().contains(ReplicationFactor.THREE.name()),
+          logs.getOutput());
+      // The CLI repeats these, because the log above is off by default for ozone local.
+      assertEquals(singletonList(OZONE_REPLICATION),
+          cluster.getDiscardedUserConfigKeys());
+    } finally {
+      logs.stopCapturing();
+    }
+  }
+
+  @Test
+  void forcedLocalDefaultIsQuietWhenUserConfiguredNothing() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config,
+        new OzoneConfiguration())) {
+      cluster.prepareConfiguration();
+
+      assertTrue(cluster.getDiscardedUserConfigKeys().isEmpty(),
+          cluster.getDiscardedUserConfigKeys().toString());
+    }
+  }
+
+  @Test
+  void readinessTimeoutNamesTheUnmetCondition() {
+    TimeoutException error = assertThrows(TimeoutException.class,
+        () -> LocalOzoneCluster.waitForReadiness(() -> "only 1 of 3 datanodes have registered",
+            "Ozone cluster", Duration.ofMillis(1)));
+
+    assertTrue(error.getMessage().contains("only 1 of 3 datanodes have registered"),
+        error.getMessage());
+    assertTrue(error.getMessage().contains("Ozone cluster"), error.getMessage());
+  }
+
+  @Test
+  void readinessReturnsOnceBlockerReportsReady() throws Exception {
+    AtomicInteger attempts = new AtomicInteger();
+
+    LocalOzoneCluster.waitForReadiness(
+        () -> attempts.incrementAndGet() < 2 ? "not yet" : null, "Ozone cluster",
+        Duration.ofSeconds(30));
+
+    assertEquals(2, attempts.get());
   }
 
   @Test

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -18,8 +18,10 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
@@ -29,6 +31,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,10 +45,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -349,6 +358,290 @@ class TestLocalOzoneCluster {
         + "; each datanode reserves 8 local ports.", error.getMessage());
   }
 
+  /** A local cluster with no datanodes is unusable and would otherwise time out during readiness. */
+  @Test
+  void zeroDatanodesIsRejected() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setDatanodes(0)
+        .build();
+
+    IOException error = assertPrepareFails(config);
+
+    assertMessageContains(error, "Datanode count 0");
+  }
+
+  /**
+   * A key unset after being configured still reports a source with no value behind it, so
+   * setLocalOverride has to treat it as unconfigured rather than as a conflict.
+   */
+  @Test
+  void keyUnsetAfterBeingConfiguredIsNotRejected() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "test-ozone-site.xml");
+    seed.unset(OZONE_REPLICATION);
+
+    assertEquals(ReplicationFactor.ONE.name(), prepared(seed).get(OZONE_REPLICATION));
+  }
+
+  @Test
+  void configuredMetadataDirIsReplacedByTheLocalDataDir() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_METADATA_DIRS, "/real/cluster/metadata", "test-ozone-site.xml");
+
+    assertEquals(metadataDir(tempDir.resolve("local-ozone")).toString(),
+        prepared(seed).get(OZONE_METADATA_DIRS));
+  }
+
+  /**
+   * A file named with --conf is the user's choice however it is called, so a path ending in
+   * ozone-default.xml stays a conflict rather than counting as a shipped default.
+   */
+  @Test
+  void defaultsFileNamedByPathCountsAsUserConfig() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "/home/me/ozone-default.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, OZONE_REPLICATION);
+  }
+
+  @Test
+  void tooManyDatanodesIsRejectedBeforeFormatDeletesDataDir() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    Path marker = writeMarker(dataDir, "keep me");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.ALWAYS)
+        .setDatanodes(LocalOzoneCluster.MAX_DATANODES + 1)
+        .build();
+
+    assertPrepareFails(config);
+
+    assertTrue(Files.exists(marker),
+        "format ALWAYS must not delete the data dir for a run that cannot start");
+  }
+
+  /**
+   * The rejection message has to carry enough for the user to locate and remove the value.
+   */
+  @Test
+  void conflictingUserConfigIsRejected() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "test-ozone-site.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, OZONE_REPLICATION);
+    assertMessageContains(error, ReplicationFactor.ONE.name());
+    assertMessageContains(error, ReplicationFactor.THREE.name());
+    assertMessageContains(error, "test-ozone-site.xml");
+  }
+
+  @Test
+  void userConfigMatchingTheLocalRequirementIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.ONE.name(), "test-ozone-site.xml");
+
+    assertEquals(ReplicationFactor.ONE.name(), prepared(seed).get(OZONE_REPLICATION));
+  }
+
+  @Test
+  void conflictingUserConfigIsRejectedBeforeFormatDeletesDataDir() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    Path marker = writeMarker(dataDir, "keep me");
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "test-ozone-site.xml");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.ALWAYS)
+        .build();
+
+    assertPrepareFails(config, seed);
+
+    assertTrue(Files.exists(marker),
+        "format ALWAYS must not delete the data dir for a run that cannot start");
+  }
+
+  /**
+   * A duplicate configured port is a user-input error PortAllocator detects deterministically, so
+   * it must be rejected before format mode ALWAYS deletes the data dir.
+   */
+  @Test
+  void duplicateConfiguredPortsAreRejectedBeforeFormatDeletesDataDir() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    Path marker = writeMarker(dataDir, "keep me");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.ALWAYS)
+        .setScmPort(9860)
+        .setOmPort(9860)
+        .build();
+
+    IOException error = assertPrepareFails(config);
+
+    assertMessageContains(error, "more than once");
+    assertTrue(Files.exists(marker),
+        "format ALWAYS must not delete the data dir for a run that cannot start");
+  }
+
+  /**
+   * Hadoop never trims XML values on load and the services read these keys through getTrimmed(),
+   * so a padded value that names the required setting already means what the runtime requires.
+   */
+  @Test
+  void paddedValueMatchingTheLocalRequirementIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION_TYPE, "\n  STAND_ALONE\n", "test-ozone-site.xml");
+
+    assertEquals(ReplicationType.STAND_ALONE.name(), prepared(seed).get(OZONE_REPLICATION_TYPE));
+  }
+
+  /** Duration#toNanos overflows for very long timeouts, so the wait must not read it. */
+  @Test
+  void readinessAcceptsTimeoutBeyondNanoTimeRange() throws Exception {
+    LocalOzoneCluster.waitForReadiness(() -> null, "Ozone cluster",
+        Duration.ofDays(999_999_999L));
+  }
+
+  /**
+   * The same interval written in another unit means what the runtime requires, so comparing as a
+   * duration rather than as text has to accept it instead of refusing to start.
+   */
+  @Test
+  void equivalentDurationSpellingIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(HDDS_HEARTBEAT_INTERVAL, "1000ms", "test-ozone-site.xml");
+    seed.set(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY, "1000ms", "test-ozone-site.xml");
+    seed.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3000ms", "test-ozone-site.xml");
+
+    OzoneConfiguration conf = prepared(seed);
+
+    assertEquals("1s", conf.get(HDDS_HEARTBEAT_INTERVAL));
+    assertEquals("1s", conf.get(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY));
+    assertEquals("3s", conf.get(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT));
+  }
+
+  /** ozone local requires explicit units even though the service accessors accept bare numbers. */
+  @Test
+  void unitlessConfigurationDurationsAreRejected() {
+    assertUnitlessDurationRejected(HDDS_HEARTBEAT_INTERVAL, "1000");
+    assertUnitlessDurationRejected(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY, "1");
+    assertUnitlessDurationRejected(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3000");
+  }
+
+  @Test
+  void equivalentBooleanSpellingIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(HDDS_CONTAINER_RATIS_ENABLED_KEY, "FALSE", "test-ozone-site.xml");
+
+    assertFalse(prepared(seed).getBoolean(HDDS_CONTAINER_RATIS_ENABLED_KEY, true));
+  }
+
+  /**
+   * ReplicationConfig.parse() reads both "1" and "ONE", and compose environments in this repo
+   * write the numeric form, so it has to be accepted as the value the runtime requires.
+   */
+  @Test
+  void numericReplicationIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_SERVER_DEFAULT_REPLICATION_KEY, "1", "test-ozone-site.xml");
+
+    assertEquals(ReplicationFactor.ONE.name(),
+        prepared(seed).get(OZONE_SERVER_DEFAULT_REPLICATION_KEY));
+  }
+
+  /**
+   * Comparing durations by value must not swallow a genuine conflict.
+   */
+  @Test
+  void conflictingDurationIsRejected() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(HDDS_HEARTBEAT_INTERVAL, "30s", "test-ozone-site.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, HDDS_HEARTBEAT_INTERVAL);
+    assertMessageContains(error, "30s");
+  }
+
+  /**
+   * A value the accessor cannot parse is a conflict, reported by the same message rather than
+   * escaping as a NumberFormatException from the comparison itself.
+   */
+  @Test
+  void unparseableValueIsRejected() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(HDDS_HEARTBEAT_INTERVAL, "banana", "test-ozone-site.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, HDDS_HEARTBEAT_INTERVAL);
+    assertMessageContains(error, "banana");
+  }
+
+  /**
+   * Regression guard: ozone-default.xml ships a value for most keys the local runtime requires
+   * (hdds.heartbeat.interval=30s, and so on) and is always on the classpath, so counting a shipped
+   * default as a user choice would reject every run.
+   */
+  @Test
+  void shippedDefaultIsNotTreatedAsUserConfig() throws Exception {
+    assertEquals("1s", prepared(new OzoneConfiguration()).get(HDDS_HEARTBEAT_INTERVAL));
+    assertNotEquals("1s", new OzoneConfiguration().get(HDDS_HEARTBEAT_INTERVAL),
+        "the shipped default must differ from the local value, or this guards nothing");
+  }
+
+  @Test
+  void generatedShippedDefaultIsNotTreatedAsUserConfig() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "hdds-server-scm-default.xml");
+
+    assertEquals(ReplicationFactor.ONE.name(), prepared(seed).get(OZONE_REPLICATION));
+  }
+
+  @Test
+  void safeModeRuleBlockerListsOnlyUnmetRules() {
+    String blocker = LocalOzoneCluster.formatSafeModeRuleBlocker(Arrays.asList(
+        safeModeRule("registered datanodes", true, "registered"),
+        safeModeRule("healthy containers", false, "1 of 3 reported")));
+
+    assertEquals("healthy containers: 1 of 3 reported", blocker);
+  }
+
+  @Test
+  void safeModeRuleBlockerFallsBackToSatisfiedRuleStatuses() {
+    String blocker = LocalOzoneCluster.formatSafeModeRuleBlocker(Collections.singletonList(
+        safeModeRule("registered datanodes", true, "registered")));
+
+    assertEquals("all rules currently report satisfied: registered datanodes: registered", blocker);
+  }
+
+  @Test
+  void safeModeRuleBlockerExplainsUnavailableRuleStatus() {
+    assertEquals("safe-mode rule status is not available yet",
+        LocalOzoneCluster.formatSafeModeRuleBlocker(Collections.emptyList()));
+  }
+
+  @Test
+  void readinessTimeoutNamesTheUnmetCondition() {
+    TimeoutException error = assertThrows(TimeoutException.class,
+        () -> LocalOzoneCluster.waitForReadiness(() -> "only 1 of 3 datanodes have registered",
+            "Ozone cluster", Duration.ZERO));
+
+    assertMessageContains(error, "only 1 of 3 datanodes have registered");
+    assertMessageContains(error, "Ozone cluster");
+  }
+
+  @Test
+  void readinessReturnsOnceBlockerReportsReady() throws Exception {
+    AtomicInteger attempts = new AtomicInteger();
+
+    LocalOzoneCluster.waitForReadiness(
+        () -> attempts.incrementAndGet() < 2 ? "not yet" : null, "Ozone cluster",
+        Duration.ofSeconds(30));
+
+    assertEquals(2, attempts.get());
+  }
+
   @Test
   void persistedPortFileContainsDatanodePorts() throws Exception {
     Path dataDir = tempDir.resolve("local-ozone");
@@ -425,15 +718,47 @@ class TestLocalOzoneCluster {
     return new LocalOzoneCluster(config, new OzoneConfiguration());
   }
 
+  /** Prepares a default-config cluster over {@code seed} and returns the prepared configuration. */
+  private OzoneConfiguration prepared(OzoneConfiguration seed) throws IOException {
+    LocalOzoneClusterConfig config = defaultConfig();
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+      return cluster.prepareConfiguration().getConfiguration();
+    }
+  }
+
+  private LocalOzoneClusterConfig defaultConfig() {
+    return LocalOzoneClusterConfig.builder(tempDir.resolve("local-ozone")).build();
+  }
+
   private IOException assertPrepareFails(LocalOzoneClusterConfig config) {
+    return assertPrepareFails(config, new OzoneConfiguration());
+  }
+
+  private IOException assertPrepareFails(OzoneConfiguration seed) {
+    return assertPrepareFails(defaultConfig(), seed);
+  }
+
+  private IOException assertPrepareFails(LocalOzoneClusterConfig config,
+      OzoneConfiguration seed) {
     return assertThrows(IOException.class, () -> {
-      try (LocalOzoneCluster cluster = newCluster(config)) {
+      try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
         cluster.prepareConfiguration();
       }
     });
   }
 
-  private void assertMessageContains(IOException error, String expectedText) {
+  private void assertUnitlessDurationRejected(String key, String value) {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(key, value, "test-ozone-site.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, key);
+    assertMessageContains(error, value);
+    assertMessageContains(error, "test-ozone-site.xml");
+  }
+
+  private void assertMessageContains(Exception error, String expectedText) {
     assertTrue(error.getMessage().contains(expectedText), error.getMessage());
   }
 
@@ -454,6 +779,14 @@ class TestLocalOzoneCluster {
 
   private void assertPositivePort(Properties properties, String key) {
     assertTrue(Integer.parseInt(properties.getProperty(key)) > 0, key);
+  }
+
+  private static SafeModeRuleStatusProto safeModeRule(String name, boolean validated, String status) {
+    return SafeModeRuleStatusProto.newBuilder()
+        .setRuleName(name)
+        .setValidate(validated)
+        .setStatusText(status)
+        .build();
   }
 
   private Path metadataDir(Path dataDir) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -22,6 +22,8 @@ import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_BIND_HOST_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
@@ -413,6 +415,100 @@ class TestLocalOzoneCluster {
   }
 
   @Test
+  void reconOverrideReportsDiscardedUserValue() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "9m");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setReconEnabled(true)
+        .build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+      cluster.prepareConfiguration();
+
+      // configureRecon() runs after configureLocalDefaults(), so the override has to be reported
+      // where it is applied rather than from a list checked earlier.
+      assertTrue(cluster.getDiscardedUserConfigKeys()
+              .contains(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD),
+          cluster.getDiscardedUserConfigKeys().toString());
+    }
+  }
+
+  @Test
+  void reconDefaultFromModuleXmlIsNotReportedAsUserConfigured() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setReconEnabled(true)
+        .build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config,
+        new OzoneConfiguration())) {
+      cluster.prepareConfiguration();
+
+      // The Recon default ships in ozone-recon-default.xml, not ozone-default.xml.
+      assertTrue(cluster.getDiscardedUserConfigKeys().isEmpty(),
+          cluster.getDiscardedUserConfigKeys().toString());
+    }
+  }
+
+  @Test
+  void prepareConfigurationReservesReconPortsWhenEnabled() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setReconEnabled(true)
+        .setReconPort(9888)
+        .build();
+
+    try (LocalOzoneCluster cluster = newCluster(config)) {
+      LocalOzoneCluster.PreparedConfiguration prepared =
+          cluster.prepareConfiguration();
+      OzoneConfiguration conf = prepared.getConfiguration();
+
+      assertEquals(9888, prepared.getReconPort());
+      assertEquals(9888, cluster.getReconPort());
+      assertEquals("http://127.0.0.1:9888", cluster.getReconEndpoint());
+      assertTrue(conf.get(OZONE_RECON_HTTP_ADDRESS_KEY).endsWith(":9888"));
+      assertTrue(Files.isDirectory(dataDir.resolve("recon")));
+    }
+    Properties properties = loadPortState(dataDir);
+    assertPositivePort(properties, "recon.http");
+    assertPositivePort(properties, "recon.https");
+    assertPositivePort(properties, "recon.datanode");
+  }
+
+  @Test
+  void prepareConfigurationSkipsReconWhenDisabled() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    LocalOzoneClusterConfig config =
+        LocalOzoneClusterConfig.builder(dataDir).build();
+
+    try (LocalOzoneCluster cluster = newCluster(config)) {
+      LocalOzoneCluster.PreparedConfiguration prepared =
+          cluster.prepareConfiguration();
+
+      assertEquals(-1, prepared.getReconPort());
+      assertEquals(-1, cluster.getReconPort());
+      assertEquals("", cluster.getReconEndpoint());
+    }
+    assertFalse(loadPortState(dataDir).stringPropertyNames().stream()
+        .anyMatch(key -> key.startsWith("recon.")));
+  }
+
+  @Test
+  void formatNeverRejectsPortStateMissingReconPorts() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    prepare(LocalOzoneClusterConfig.builder(dataDir).build());
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.NEVER)
+        .setReconEnabled(true)
+        .build();
+
+    IOException error = assertPrepareFails(config);
+
+    assertMessageContains(error, "recon.");
+  }
+
+  @Test
   void formatNeverRejectsPortStateMissingS3GatewayPorts() throws Exception {
     Path dataDir = tempDir.resolve("local-ozone");
     prepare(LocalOzoneClusterConfig.builder(dataDir)
@@ -658,6 +754,46 @@ class TestLocalOzoneCluster {
 
       assertEquals(0, cluster.getDatanodeCount());
     }
+  }
+
+  @Test
+  void executeWithinStartupTimeoutReturnsStartupResult() throws Exception {
+    assertEquals(0, LocalOzoneCluster.executeWithinStartupTimeout("Recon", () -> 0,
+        () -> { }, Duration.ofSeconds(30)));
+  }
+
+  @Test
+  void executeWithinStartupTimeoutFailsFastWhenStartupBlocks() throws Exception {
+    CountDownLatch interrupted = new CountDownLatch(1);
+
+    IOException error =
+        assertThrows(IOException.class, () -> LocalOzoneCluster.executeWithinStartupTimeout(
+            "Recon", () -> {
+              try {
+                // Simulate an in-JVM startup that blocks until it leaves safe
+                // mode; the deadline must interrupt it rather than hang.
+                Thread.sleep(TimeUnit.MINUTES.toMillis(5));
+              } catch (InterruptedException e) {
+                interrupted.countDown();
+                Thread.currentThread().interrupt();
+              }
+              return 0;
+            }, () -> { }, Duration.ofMillis(200)));
+
+    assertMessageContains(error, "did not start within");
+    assertTrue(interrupted.await(30, TimeUnit.SECONDS),
+        "blocked startup should be interrupted on timeout");
+  }
+
+  @Test
+  void executeWithinStartupTimeoutPropagatesStartupFailure() {
+    IOException error =
+        assertThrows(IOException.class, () -> LocalOzoneCluster.executeWithinStartupTimeout(
+            "Recon", () -> {
+              throw new IOException("startup boom");
+            }, () -> { }, Duration.ofSeconds(30)));
+
+    assertMessageContains(error, "startup boom");
   }
 
   private LocalOzoneCluster.PreparedConfiguration prepare(

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -19,19 +19,27 @@ package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_BIND_HOST_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_IPC_PORT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_BIND_HOST_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -39,17 +47,26 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -79,9 +96,26 @@ class TestLocalOzoneCluster {
       assertTrue(Files.isRegularFile(portStateFile(dataDir)));
       assertTrue(prepared.getScmPort() > 0);
       assertTrue(prepared.getOmPort() > 0);
+      assertTrue(prepared.getS3gPort() > 0);
+    }
+  }
+
+  @Test
+  void prepareConfigurationSkipsS3GatewayWhenDisabled() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setS3gEnabled(false)
+        .build();
+
+    try (LocalOzoneCluster cluster = newCluster(config)) {
+      LocalOzoneCluster.PreparedConfiguration prepared =
+          cluster.prepareConfiguration();
+
+      assertEquals(-1, prepared.getS3gPort());
       assertEquals(-1, cluster.getS3gPort());
       assertEquals("", cluster.getS3Endpoint());
     }
+    assertFalse(loadPortState(dataDir).stringPropertyNames().stream().anyMatch(key -> key.startsWith("s3g.")));
   }
 
   @Test
@@ -91,6 +125,7 @@ class TestLocalOzoneCluster {
     LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
         .setScmPort(9860)
         .setOmPort(9862)
+        .setS3gPort(9878)
         .setDatanodes(2)
         .build();
 
@@ -112,10 +147,50 @@ class TestLocalOzoneCluster {
     assertEquals(2, conf.getInt(HDDS_SCM_SAFEMODE_MIN_DATANODE, 0));
     assertTrue(conf.get(OZONE_SCM_CLIENT_ADDRESS_KEY).endsWith(":9860"));
     assertTrue(conf.get(OZONE_OM_ADDRESS_KEY).endsWith(":9862"));
+    assertTrue(conf.get(OZONE_S3G_HTTP_ADDRESS_KEY).endsWith(":9878"));
     assertTrue(conf.getTrimmedStringCollection(OZONE_SCM_NAMES).iterator()
         .next().contains(":"));
     assertEquals(9860, prepared.getScmPort());
     assertEquals(9862, prepared.getOmPort());
+    assertEquals(9878, prepared.getS3gPort());
+  }
+
+  /**
+   * Every listener with a bind-host key binds loopback unless the user widens it with
+   * {@code --bind-host}: the pre-provisioned S3 credentials are fixed and well known, so a
+   * wildcard default would serve a remotely writable S3 endpoint on every interface.
+   */
+  @Test
+  void prepareConfigurationBindsListenersToLoopbackByDefault() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    LocalOzoneCluster.PreparedConfiguration prepared = prepare(config);
+    OzoneConfiguration conf = prepared.getConfiguration();
+
+    assertEquals("127.0.0.1", conf.get(OZONE_SCM_CLIENT_BIND_HOST_KEY));
+    assertEquals("127.0.0.1", conf.get(OZONE_OM_HTTP_BIND_HOST_KEY));
+    assertEquals("127.0.0.1", conf.get(OZONE_S3G_HTTP_BIND_HOST_KEY));
+    assertEquals("127.0.0.1", prepared.getDatanodeConfigurations().get(0)
+        .get(HDDS_DATANODE_CLIENT_BIND_HOST_KEY));
+  }
+
+  @Test
+  void prepareConfigurationAllocatesDistinctS3GatewayPorts() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setS3gPort(9878)
+        .build();
+
+    OzoneConfiguration conf = prepare(config).getConfiguration();
+
+    int httpPort = parsePort(conf.get(OZONE_S3G_HTTP_ADDRESS_KEY));
+    int httpsPort = parsePort(conf.get(OZONE_S3G_HTTPS_ADDRESS_KEY));
+    int webHttpPort = parsePort(conf.get(OZONE_S3G_WEBADMIN_HTTP_ADDRESS_KEY));
+    int webHttpsPort = parsePort(conf.get(OZONE_S3G_WEBADMIN_HTTPS_ADDRESS_KEY));
+
+    assertEquals(9878, httpPort);
+    assertEquals(4, new HashSet<>(Arrays.asList(httpPort, httpsPort, webHttpPort, webHttpsPort)).size());
   }
 
   @Test
@@ -329,8 +404,27 @@ class TestLocalOzoneCluster {
     assertPositivePort(properties, "om.rpc");
     assertPositivePort(properties, "om.http");
     assertPositivePort(properties, "om.ratis");
+    assertPositivePort(properties, "s3g.http");
+    assertPositivePort(properties, "s3g.https");
+    assertPositivePort(properties, "s3g.web.http");
+    assertPositivePort(properties, "s3g.web.https");
     assertNotEquals(properties.getProperty("scm.client"),
         properties.getProperty("om.rpc"));
+  }
+
+  @Test
+  void formatNeverRejectsPortStateMissingS3GatewayPorts() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    prepare(LocalOzoneClusterConfig.builder(dataDir)
+        .setS3gEnabled(false)
+        .build());
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.NEVER)
+        .build();
+
+    IOException error = assertPrepareFails(config);
+
+    assertMessageContains(error, "s3g.");
   }
 
   @Test
@@ -449,6 +543,59 @@ class TestLocalOzoneCluster {
   }
 
   @Test
+  void timedOutStartupIsStoppedOnceItFinishes() throws Exception {
+    // Pins the timeout contract of executeWithinStartupTimeout: Gateway.call() ignores
+    // interruption, so a timed-out startup can still finish after the launcher has rolled back.
+    // The cleanup must run after the abandoned attempt returns, as its only stopper; without the
+    // queued cleanup the late-started service leaks until JVM exit.
+    CountDownLatch startupBlocked = new CountDownLatch(1);
+    List<String> events = new CopyOnWriteArrayList<>();
+    CountDownLatch cleanupRan = new CountDownLatch(1);
+
+    IOException error = assertThrows(IOException.class, () ->
+        LocalOzoneCluster.executeWithinStartupTimeout("S3 Gateway", () -> {
+          Uninterruptibles.awaitUninterruptibly(startupBlocked);
+          events.add("startup finished");
+          return null;
+        }, () -> {
+          events.add("cleanup");
+          cleanupRan.countDown();
+        }, Duration.ofMillis(50)));
+
+    assertTrue(error.getMessage().contains("did not start within"), error.getMessage());
+    startupBlocked.countDown();
+    assertTrue(cleanupRan.await(30, TimeUnit.SECONDS));
+    assertEquals(Arrays.asList("startup finished", "cleanup"), events);
+  }
+
+  @Test
+  void failedStartupIsStoppedInPlace() {
+    // A startup that throws may have started some of its servers first; the cleanup stops them
+    // before the failure propagates to the launcher.
+    AtomicBoolean cleaned = new AtomicBoolean();
+
+    IllegalStateException error = assertThrows(IllegalStateException.class, () ->
+        LocalOzoneCluster.executeWithinStartupTimeout("S3 Gateway",
+            () -> {
+              throw new IllegalStateException("startup failed");
+            },
+            () -> cleaned.set(true), Duration.ofSeconds(30)));
+
+    assertEquals("startup failed", error.getMessage());
+    assertTrue(cleaned.get());
+  }
+
+  @Test
+  void successfulStartupIsNotCleanedUp() throws Exception {
+    AtomicBoolean cleaned = new AtomicBoolean();
+
+    LocalOzoneCluster.executeWithinStartupTimeout("S3 Gateway", () -> null,
+        () -> cleaned.set(true), Duration.ofSeconds(30));
+
+    assertFalse(cleaned.get());
+  }
+
+  @Test
   void persistedPortFileContainsDatanodePorts() throws Exception {
     Path dataDir = tempDir.resolve("local-ozone");
     LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
@@ -553,6 +700,10 @@ class TestLocalOzoneCluster {
 
   private void assertPositivePort(Properties properties, String key) {
     assertTrue(Integer.parseInt(properties.getProperty(key)) > 0, key);
+  }
+
+  private static int parsePort(String address) {
+    return NetUtils.createSocketAddr(address).getPort();
   }
 
   private Path metadataDir(Path dataDir) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneClusterConfig.java
@@ -46,6 +46,8 @@ class TestLocalOzoneClusterConfig {
     assertEquals(0, config.getOmPort());
     assertEquals(0, config.getS3gPort());
     assertTrue(config.isS3gEnabled());
+    assertEquals(0, config.getReconPort());
+    assertFalse(config.isReconEnabled());
     assertFalse(config.isEphemeral());
     assertEquals(Duration.ofMinutes(2), config.getStartupTimeout());
     assertEquals("admin", config.getS3AccessKey());
@@ -67,6 +69,9 @@ class TestLocalOzoneClusterConfig {
         LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED_VALUE),
         LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED);
     assertEquals(Boolean.parseBoolean(
+        LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED_VALUE),
+        LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED);
+    assertEquals(Boolean.parseBoolean(
         LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE),
         LocalOzoneClusterConfig.DEFAULT_EPHEMERAL);
     assertEquals(Duration.parse(
@@ -86,6 +91,8 @@ class TestLocalOzoneClusterConfig {
         .setOmPort(9862)
         .setS3gPort(9878)
         .setS3gEnabled(false)
+        .setReconPort(9888)
+        .setReconEnabled(true)
         .setEphemeral(true)
         .setStartupTimeout(Duration.ofSeconds(45))
         .setS3AccessKey("dev")
@@ -104,6 +111,8 @@ class TestLocalOzoneClusterConfig {
     assertEquals(9862, config.getOmPort());
     assertEquals(9878, config.getS3gPort());
     assertFalse(config.isS3gEnabled());
+    assertEquals(9888, config.getReconPort());
+    assertTrue(config.isReconEnabled());
     assertTrue(config.isEphemeral());
     assertEquals(Duration.ofSeconds(45), config.getStartupTimeout());
     assertEquals("dev", config.getS3AccessKey());

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneClusterConfig.java
@@ -41,7 +41,7 @@ class TestLocalOzoneClusterConfig {
         config.getFormatMode());
     assertEquals(1, config.getDatanodes());
     assertEquals("127.0.0.1", config.getHost());
-    assertEquals("0.0.0.0", config.getBindHost());
+    assertEquals("127.0.0.1", config.getBindHost());
     assertEquals(0, config.getScmPort());
     assertEquals(0, config.getOmPort());
     assertEquals(0, config.getS3gPort());

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneClusterConfig.java
@@ -46,6 +46,8 @@ class TestLocalOzoneClusterConfig {
     assertEquals(0, config.getOmPort());
     assertEquals(0, config.getS3gPort());
     assertTrue(config.isS3gEnabled());
+    assertEquals(0, config.getReconPort());
+    assertFalse(config.isReconEnabled());
     assertFalse(config.isEphemeral());
     assertEquals(Duration.ofMinutes(2), config.getStartupTimeout());
   }
@@ -63,6 +65,9 @@ class TestLocalOzoneClusterConfig {
     assertEquals(Boolean.parseBoolean(
         LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED_VALUE),
         LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED);
+    assertEquals(Boolean.parseBoolean(
+        LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED_VALUE),
+        LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED);
     assertEquals(Boolean.parseBoolean(
         LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE),
         LocalOzoneClusterConfig.DEFAULT_EPHEMERAL);
@@ -83,6 +88,8 @@ class TestLocalOzoneClusterConfig {
         .setOmPort(9862)
         .setS3gPort(9878)
         .setS3gEnabled(false)
+        .setReconPort(9888)
+        .setReconEnabled(true)
         .setEphemeral(true)
         .setStartupTimeout(Duration.ofSeconds(45))
         .build();
@@ -98,6 +105,8 @@ class TestLocalOzoneClusterConfig {
     assertEquals(9862, config.getOmPort());
     assertEquals(9878, config.getS3gPort());
     assertFalse(config.isS3gEnabled());
+    assertEquals(9888, config.getReconPort());
+    assertTrue(config.isReconEnabled());
     assertTrue(config.isEphemeral());
     assertEquals(Duration.ofSeconds(45), config.getStartupTimeout());
   }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneClusterConfig.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneClusterConfig.java
@@ -41,16 +41,13 @@ class TestLocalOzoneClusterConfig {
         config.getFormatMode());
     assertEquals(1, config.getDatanodes());
     assertEquals("127.0.0.1", config.getHost());
-    assertEquals("0.0.0.0", config.getBindHost());
+    assertEquals("127.0.0.1", config.getBindHost());
     assertEquals(0, config.getScmPort());
     assertEquals(0, config.getOmPort());
     assertEquals(0, config.getS3gPort());
     assertTrue(config.isS3gEnabled());
     assertFalse(config.isEphemeral());
     assertEquals(Duration.ofMinutes(2), config.getStartupTimeout());
-    assertEquals("admin", config.getS3AccessKey());
-    assertEquals("admin123", config.getS3SecretKey());
-    assertEquals("us-east-1", config.getS3Region());
   }
 
   @Test
@@ -88,9 +85,6 @@ class TestLocalOzoneClusterConfig {
         .setS3gEnabled(false)
         .setEphemeral(true)
         .setStartupTimeout(Duration.ofSeconds(45))
-        .setS3AccessKey("dev")
-        .setS3SecretKey("secret")
-        .setS3Region("ap-south-1")
         .build();
 
     assertEquals(Paths.get("target", "custom-local-ozone")
@@ -106,9 +100,6 @@ class TestLocalOzoneClusterConfig {
     assertFalse(config.isS3gEnabled());
     assertTrue(config.isEphemeral());
     assertEquals(Duration.ofSeconds(45), config.getStartupTimeout());
-    assertEquals("dev", config.getS3AccessKey());
-    assertEquals("secret", config.getS3SecretKey());
-    assertEquals("ap-south-1", config.getS3Region());
   }
 
   @Test

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -98,7 +98,7 @@ class TestOzoneLocal {
   @Test
   void runCommandStartsRuntimeAndPrintsStartupSummary() throws Exception {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "http://localhost:9878");
     TestableRunCommand command = new TestableRunCommand(runtime);
     CommandLine commandLine = new CommandLine(command);
     commandLine.setOut(new PrintWriter(new OutputStreamWriter(out, UTF_8),
@@ -113,12 +113,36 @@ class TestOzoneLocal {
     assertTrue(text.contains("Local Ozone is running from"), text);
     assertTrue(text.contains("SCM RPC: localhost:9860"), text);
     assertTrue(text.contains("OM RPC: localhost:9862"), text);
+    assertTrue(text.contains("S3 endpoint: http://localhost:9878"), text);
+    assertTrue(text.contains("AWS_ACCESS_KEY_ID=" + LocalOzoneClusterConfig.DEFAULT_S3_ACCESS_KEY), text);
+    assertTrue(text.contains("AWS_SECRET_ACCESS_KEY=" + LocalOzoneClusterConfig.DEFAULT_S3_SECRET_KEY), text);
+    assertTrue(text.contains("AWS_REGION=" + LocalOzoneClusterConfig.DEFAULT_S3_REGION), text);
+    assertTrue(text.contains("AWS_ENDPOINT_URL_S3=http://localhost:9878"), text);
+    assertTrue(text.contains("aws configure set default.s3.addressing_style path"), text);
+    assertTrue(text.contains("Press Ctrl+C to stop."), text);
+  }
+
+  @Test
+  void runCommandOmitsS3SummaryWhenS3gDisabled() throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setOut(new PrintWriter(new OutputStreamWriter(out, UTF_8),
+        true));
+
+    int exitCode = commandLine.execute("--no-s3g");
+
+    assertEquals(0, exitCode);
+    String text = out.toString(UTF_8.name());
+    assertFalse(text.contains("S3 endpoint:"), text);
+    assertFalse(text.contains("AWS_ACCESS_KEY_ID="), text);
     assertTrue(text.contains("Press Ctrl+C to stop."), text);
   }
 
   @Test
   void runCommandClosesRuntimeWhenStartupFails() {
-    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
     runtime.failStart = true;
     TestableRunCommand command = new TestableRunCommand(runtime);
 
@@ -131,7 +155,7 @@ class TestOzoneLocal {
   @Test
   void runCommandReportsDiscardedConfigToStdErr() throws Exception {
     ByteArrayOutputStream err = new ByteArrayOutputStream();
-    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
     runtime.discardedUserConfigKeys = singletonList("ozone.replication");
     TestableRunCommand command = new TestableRunCommand(runtime);
     CommandLine commandLine = new CommandLine(command);
@@ -148,7 +172,7 @@ class TestOzoneLocal {
   @Test
   void runCommandReportsDiscardedConfigWhenStartupFails() throws Exception {
     ByteArrayOutputStream err = new ByteArrayOutputStream();
-    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
     runtime.failStart = true;
     runtime.discardedUserConfigKeys = singletonList("ozone.replication");
     TestableRunCommand command = new TestableRunCommand(runtime);
@@ -166,7 +190,7 @@ class TestOzoneLocal {
 
   @Test
   void runCommandStartupFailureReportsCauseAndHowToGetDetail() {
-    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
     runtime.failStart = true;
     TestableRunCommand command = new TestableRunCommand(runtime);
     new CommandLine(command).parseArgs();
@@ -224,7 +248,7 @@ class TestOzoneLocal {
         config.getFormatMode());
     assertEquals(1, config.getDatanodes());
     assertEquals("127.0.0.1", config.getHost());
-    assertEquals("0.0.0.0", config.getBindHost());
+    assertEquals("127.0.0.1", config.getBindHost());
     assertEquals(0, config.getScmPort());
     assertEquals(0, config.getOmPort());
     assertEquals(0, config.getS3gPort());
@@ -243,7 +267,7 @@ class TestOzoneLocal {
         "--format", "always",
         "--datanodes", "3",
         "--host", "cli-host",
-        "--bind-host", "127.0.0.1",
+        "--bind-host", "0.0.0.0",
         "--scm-port", "200",
         "--om-port", "201",
         "--s3g-port", "202",
@@ -260,7 +284,7 @@ class TestOzoneLocal {
         config.getFormatMode());
     assertEquals(3, config.getDatanodes());
     assertEquals("cli-host", config.getHost());
-    assertEquals("127.0.0.1", config.getBindHost());
+    assertEquals("0.0.0.0", config.getBindHost());
     assertEquals(200, config.getScmPort());
     assertEquals(201, config.getOmPort());
     assertEquals(202, config.getS3gPort());
@@ -442,15 +466,17 @@ class TestOzoneLocal {
     private final String displayHost;
     private final int scmPort;
     private final int omPort;
+    private final String s3Endpoint;
     private boolean failStart;
     private boolean started;
     private List<String> discardedUserConfigKeys = emptyList();
     private boolean closed;
 
-    private StubRuntime(String displayHost, int scmPort, int omPort) {
+    private StubRuntime(String displayHost, int scmPort, int omPort, String s3Endpoint) {
       this.displayHost = displayHost;
       this.scmPort = scmPort;
       this.omPort = omPort;
+      this.s3Endpoint = s3Endpoint;
     }
 
     @Override
@@ -483,7 +509,7 @@ class TestOzoneLocal {
 
     @Override
     public String getS3Endpoint() {
-      return "";
+      return s3Endpoint;
     }
 
     @Override

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -101,7 +101,7 @@ class TestOzoneLocal {
   @Test
   void runCommandStartsRuntimeAndPrintsStartupSummary() throws Exception {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "http://localhost:9878");
     TestableRunCommand command = new TestableRunCommand(runtime);
     CommandLine commandLine = new CommandLine(command);
     commandLine.setOut(new PrintWriter(new OutputStreamWriter(out, UTF_8),
@@ -117,12 +117,39 @@ class TestOzoneLocal {
     assertTrue(text.contains("SCM RPC: localhost:9860"), text);
     assertTrue(text.contains("OM RPC: localhost:9862"), text);
     assertFalse(text.contains("Datanodes:"), text);
+    assertTrue(text.contains("S3 endpoint: http://localhost:9878"), text);
+    assertTrue(text.contains("AWS_ACCESS_KEY_ID=" + LocalOzoneClusterConfig.LOCAL_S3_ACCESS_KEY), text);
+    assertTrue(text.contains("AWS_SECRET_ACCESS_KEY=" + LocalOzoneClusterConfig.LOCAL_S3_SECRET_KEY), text);
+    assertTrue(text.contains("AWS_REGION=" + LocalOzoneClusterConfig.LOCAL_S3_REGION), text);
+    assertTrue(text.contains("AWS_ENDPOINT_URL_S3=http://localhost:9878"), text);
+    assertTrue(text.contains("aws configure set default.s3.addressing_style path"), text);
+    // The printed pair is an example, not a credential the gateway enforces. Saying so is what
+    // keeps a reader from treating the local endpoint as access-controlled.
+    assertTrue(text.contains("accepts any credentials"), text);
+    assertTrue(text.contains("Press Ctrl+C to stop."), text);
+  }
+
+  @Test
+  void runCommandOmitsS3SummaryWhenS3gDisabled() throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setOut(new PrintWriter(new OutputStreamWriter(out, UTF_8),
+        true));
+
+    int exitCode = commandLine.execute("--no-s3g");
+
+    assertEquals(0, exitCode);
+    String text = out.toString(UTF_8.name());
+    assertFalse(text.contains("S3 endpoint:"), text);
+    assertFalse(text.contains("AWS_ACCESS_KEY_ID="), text);
     assertTrue(text.contains("Press Ctrl+C to stop."), text);
   }
 
   @Test
   void runCommandClosesRuntimeWhenStartupFails() {
-    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
     runtime.failStart = true;
     TestableRunCommand command = new TestableRunCommand(runtime);
 
@@ -136,7 +163,7 @@ class TestOzoneLocal {
   @Test
   void runCommandPreservesStartupFailureAsTheCause() throws Exception {
     ByteArrayOutputStream err = new ByteArrayOutputStream();
-    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
     runtime.failStart = true;
     TestableRunCommand command = new TestableRunCommand(runtime);
     CommandLine commandLine = new CommandLine(command);
@@ -273,12 +300,6 @@ class TestOzoneLocal {
         LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE);
     assertEnvDefault("startupTimeout", OzoneLocal.ENV_STARTUP_TIMEOUT,
         LocalOzoneClusterConfig.DEFAULT_STARTUP_TIMEOUT_VALUE);
-    assertEnvDefault("s3AccessKey", OzoneLocal.ENV_S3_ACCESS_KEY,
-        LocalOzoneClusterConfig.DEFAULT_S3_ACCESS_KEY);
-    assertEnvDefault("s3SecretKey", OzoneLocal.ENV_S3_SECRET_KEY,
-        LocalOzoneClusterConfig.DEFAULT_S3_SECRET_KEY);
-    assertEnvDefault("s3Region", OzoneLocal.ENV_S3_REGION,
-        LocalOzoneClusterConfig.DEFAULT_S3_REGION);
   }
 
   @Test
@@ -291,16 +312,13 @@ class TestOzoneLocal {
         config.getFormatMode());
     assertEquals(1, config.getDatanodes());
     assertEquals("127.0.0.1", config.getHost());
-    assertEquals("0.0.0.0", config.getBindHost());
+    assertEquals("127.0.0.1", config.getBindHost());
     assertEquals(0, config.getScmPort());
     assertEquals(0, config.getOmPort());
     assertEquals(0, config.getS3gPort());
     assertTrue(config.isS3gEnabled());
     assertFalse(config.isEphemeral());
     assertEquals(Duration.ofMinutes(2), config.getStartupTimeout());
-    assertEquals("admin", config.getS3AccessKey());
-    assertEquals("admin123", config.getS3SecretKey());
-    assertEquals("us-east-1", config.getS3Region());
   }
 
   @Test
@@ -310,16 +328,13 @@ class TestOzoneLocal {
         "--format", "always",
         "--datanodes", "3",
         "--host", "cli-host",
-        "--bind-host", "127.0.0.1",
+        "--bind-host", "0.0.0.0",
         "--scm-port", "200",
         "--om-port", "201",
         "--s3g-port", "202",
         "--no-s3g",
         "--ephemeral",
-        "--startup-timeout", "45s",
-        "--s3-access-key", "cli-access",
-        "--s3-secret-key", "cli-secret",
-        "--s3-region", "cli-region");
+        "--startup-timeout", "45s");
 
     assertEquals(Paths.get("target/cli-local").toAbsolutePath().normalize(),
         config.getDataDir());
@@ -327,16 +342,13 @@ class TestOzoneLocal {
         config.getFormatMode());
     assertEquals(3, config.getDatanodes());
     assertEquals("cli-host", config.getHost());
-    assertEquals("127.0.0.1", config.getBindHost());
+    assertEquals("0.0.0.0", config.getBindHost());
     assertEquals(200, config.getScmPort());
     assertEquals(201, config.getOmPort());
     assertEquals(202, config.getS3gPort());
     assertFalse(config.isS3gEnabled());
     assertTrue(config.isEphemeral());
     assertEquals(Duration.ofSeconds(45), config.getStartupTimeout());
-    assertEquals("cli-access", config.getS3AccessKey());
-    assertEquals("cli-secret", config.getS3SecretKey());
-    assertEquals("cli-region", config.getS3Region());
   }
 
   @Test
@@ -508,14 +520,16 @@ class TestOzoneLocal {
     private final String displayHost;
     private final int scmPort;
     private final int omPort;
+    private final String s3Endpoint;
     private boolean failStart;
     private boolean started;
     private boolean closed;
 
-    private StubRuntime(String displayHost, int scmPort, int omPort) {
+    private StubRuntime(String displayHost, int scmPort, int omPort, String s3Endpoint) {
       this.displayHost = displayHost;
       this.scmPort = scmPort;
       this.omPort = omPort;
+      this.s3Endpoint = s3Endpoint;
     }
 
     @Override
@@ -548,7 +562,7 @@ class TestOzoneLocal {
 
     @Override
     public String getS3Endpoint() {
-      return "";
+      return s3Endpoint;
     }
 
     @Override
@@ -586,12 +600,6 @@ class TestOzoneLocal {
         return LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE;
       } else if ("--startup-timeout".equals(option)) {
         return LocalOzoneClusterConfig.DEFAULT_STARTUP_TIMEOUT_VALUE;
-      } else if ("--s3-access-key".equals(option)) {
-        return LocalOzoneClusterConfig.DEFAULT_S3_ACCESS_KEY;
-      } else if ("--s3-secret-key".equals(option)) {
-        return LocalOzoneClusterConfig.DEFAULT_S3_SECRET_KEY;
-      } else if ("--s3-region".equals(option)) {
-        return LocalOzoneClusterConfig.DEFAULT_S3_REGION;
       }
       return null;
     }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -123,6 +123,40 @@ class TestOzoneLocal {
   }
 
   @Test
+  void runCommandPrintsReconEndpointWhenEnabled() throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862,
+        "http://localhost:9878");
+    runtime.reconEndpoint = "http://localhost:9888";
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setOut(new PrintWriter(new OutputStreamWriter(out, UTF_8),
+        true));
+
+    int exitCode = commandLine.execute("--recon");
+
+    assertEquals(0, exitCode);
+    String text = out.toString(UTF_8.name());
+    assertTrue(text.contains("Recon endpoint: http://localhost:9888"), text);
+  }
+
+  @Test
+  void runCommandOmitsReconEndpointWhenDisabled() throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862,
+        "http://localhost:9878");
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setOut(new PrintWriter(new OutputStreamWriter(out, UTF_8),
+        true));
+
+    int exitCode = commandLine.execute();
+
+    assertEquals(0, exitCode);
+    assertFalse(out.toString(UTF_8.name()).contains("Recon endpoint:"));
+  }
+
+  @Test
   void runCommandOmitsS3SummaryWhenS3gDisabled() throws Exception {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
@@ -226,6 +260,10 @@ class TestOzoneLocal {
         LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED_VALUE);
     assertEnvDefault("s3gPort", OzoneLocal.ENV_S3G_PORT,
         LocalOzoneClusterConfig.DEFAULT_PORT_VALUE);
+    assertEnvDefault("reconEnabled", OzoneLocal.ENV_RECON_ENABLED,
+        LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED_VALUE);
+    assertEnvDefault("reconPort", OzoneLocal.ENV_RECON_PORT,
+        LocalOzoneClusterConfig.DEFAULT_PORT_VALUE);
     assertEnvDefault("ephemeral", OzoneLocal.ENV_EPHEMERAL,
         LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE);
     assertEnvDefault("startupTimeout", OzoneLocal.ENV_STARTUP_TIMEOUT,
@@ -253,6 +291,8 @@ class TestOzoneLocal {
     assertEquals(0, config.getOmPort());
     assertEquals(0, config.getS3gPort());
     assertTrue(config.isS3gEnabled());
+    assertEquals(0, config.getReconPort());
+    assertFalse(config.isReconEnabled());
     assertFalse(config.isEphemeral());
     assertEquals(Duration.ofMinutes(2), config.getStartupTimeout());
     assertEquals("admin", config.getS3AccessKey());
@@ -272,6 +312,8 @@ class TestOzoneLocal {
         "--om-port", "201",
         "--s3g-port", "202",
         "--no-s3g",
+        "--recon-port", "203",
+        "--recon",
         "--ephemeral",
         "--startup-timeout", "45s",
         "--s3-access-key", "cli-access",
@@ -289,6 +331,8 @@ class TestOzoneLocal {
     assertEquals(201, config.getOmPort());
     assertEquals(202, config.getS3gPort());
     assertFalse(config.isS3gEnabled());
+    assertEquals(203, config.getReconPort());
+    assertTrue(config.isReconEnabled());
     assertTrue(config.isEphemeral());
     assertEquals(Duration.ofSeconds(45), config.getStartupTimeout());
     assertEquals("cli-access", config.getS3AccessKey());
@@ -309,6 +353,18 @@ class TestOzoneLocal {
 
     assertTrue(config.isS3gEnabled());
     assertFalse(config.isEphemeral());
+  }
+
+  @Test
+  void resolveConfigAllowsReconToBeNegated() {
+    LocalOzoneClusterConfig config = resolve("--no-recon");
+
+    assertFalse(config.isReconEnabled());
+  }
+
+  @Test
+  void resolveConfigRejectsInvalidReconPort() {
+    assertConfigError("--recon-port", "65536", "--recon-port");
   }
 
   @Test
@@ -467,6 +523,7 @@ class TestOzoneLocal {
     private final int scmPort;
     private final int omPort;
     private final String s3Endpoint;
+    private String reconEndpoint = "";
     private boolean failStart;
     private boolean started;
     private List<String> discardedUserConfigKeys = emptyList();
@@ -513,6 +570,16 @@ class TestOzoneLocal {
     }
 
     @Override
+    public int getReconPort() {
+      return 0;
+    }
+
+    @Override
+    public String getReconEndpoint() {
+      return reconEndpoint;
+    }
+
+    @Override
     public List<String> getDiscardedUserConfigKeys() {
       return discardedUserConfigKeys;
     }
@@ -546,8 +613,12 @@ class TestOzoneLocal {
           || "--om-port".equals(option)
           || "--s3g-port".equals(option)) {
         return LocalOzoneClusterConfig.DEFAULT_PORT_VALUE;
+      } else if ("--recon-port".equals(option)) {
+        return LocalOzoneClusterConfig.DEFAULT_PORT_VALUE;
       } else if ("--s3g".equals(option)) {
         return LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED_VALUE;
+      } else if ("--recon".equals(option)) {
+        return LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED_VALUE;
       } else if ("--ephemeral".equals(option)) {
         return LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE;
       } else if ("--startup-timeout".equals(option)) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -130,6 +130,40 @@ class TestOzoneLocal {
   }
 
   @Test
+  void runCommandPrintsReconEndpointWhenEnabled() throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862,
+        "http://localhost:9878");
+    runtime.reconEndpoint = "http://localhost:9888";
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setOut(new PrintWriter(new OutputStreamWriter(out, UTF_8),
+        true));
+
+    int exitCode = commandLine.execute("--recon");
+
+    assertEquals(0, exitCode);
+    String text = out.toString(UTF_8.name());
+    assertTrue(text.contains("Recon endpoint: http://localhost:9888"), text);
+  }
+
+  @Test
+  void runCommandOmitsReconEndpointWhenDisabled() throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862,
+        "http://localhost:9878");
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setOut(new PrintWriter(new OutputStreamWriter(out, UTF_8),
+        true));
+
+    int exitCode = commandLine.execute();
+
+    assertEquals(0, exitCode);
+    assertFalse(out.toString(UTF_8.name()).contains("Recon endpoint:"));
+  }
+
+  @Test
   void runCommandOmitsS3SummaryWhenS3gDisabled() throws Exception {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     StubRuntime runtime = new StubRuntime("localhost", 9860, 9862, "");
@@ -296,6 +330,10 @@ class TestOzoneLocal {
         LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED_VALUE);
     assertEnvDefault("s3gPort", OzoneLocal.ENV_S3G_PORT,
         LocalOzoneClusterConfig.DEFAULT_PORT_VALUE);
+    assertEnvDefault("reconEnabled", OzoneLocal.ENV_RECON_ENABLED,
+        LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED_VALUE);
+    assertEnvDefault("reconPort", OzoneLocal.ENV_RECON_PORT,
+        LocalOzoneClusterConfig.DEFAULT_PORT_VALUE);
     assertEnvDefault("ephemeral", OzoneLocal.ENV_EPHEMERAL,
         LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE);
     assertEnvDefault("startupTimeout", OzoneLocal.ENV_STARTUP_TIMEOUT,
@@ -317,6 +355,8 @@ class TestOzoneLocal {
     assertEquals(0, config.getOmPort());
     assertEquals(0, config.getS3gPort());
     assertTrue(config.isS3gEnabled());
+    assertEquals(0, config.getReconPort());
+    assertFalse(config.isReconEnabled());
     assertFalse(config.isEphemeral());
     assertEquals(Duration.ofMinutes(2), config.getStartupTimeout());
   }
@@ -333,6 +373,8 @@ class TestOzoneLocal {
         "--om-port", "201",
         "--s3g-port", "202",
         "--no-s3g",
+        "--recon-port", "203",
+        "--recon",
         "--ephemeral",
         "--startup-timeout", "45s");
 
@@ -347,6 +389,8 @@ class TestOzoneLocal {
     assertEquals(201, config.getOmPort());
     assertEquals(202, config.getS3gPort());
     assertFalse(config.isS3gEnabled());
+    assertEquals(203, config.getReconPort());
+    assertTrue(config.isReconEnabled());
     assertTrue(config.isEphemeral());
     assertEquals(Duration.ofSeconds(45), config.getStartupTimeout());
   }
@@ -364,6 +408,18 @@ class TestOzoneLocal {
 
     assertTrue(config.isS3gEnabled());
     assertFalse(config.isEphemeral());
+  }
+
+  @Test
+  void resolveConfigAllowsReconToBeNegated() {
+    LocalOzoneClusterConfig config = resolve("--no-recon");
+
+    assertFalse(config.isReconEnabled());
+  }
+
+  @Test
+  void resolveConfigRejectsInvalidReconPort() {
+    assertConfigError("--recon-port", "65536", "--recon-port");
   }
 
   @Test
@@ -521,6 +577,7 @@ class TestOzoneLocal {
     private final int scmPort;
     private final int omPort;
     private final String s3Endpoint;
+    private String reconEndpoint = "";
     private boolean failStart;
     private boolean started;
     private boolean closed;
@@ -566,6 +623,16 @@ class TestOzoneLocal {
     }
 
     @Override
+    public int getReconPort() {
+      return 0;
+    }
+
+    @Override
+    public String getReconEndpoint() {
+      return reconEndpoint;
+    }
+
+    @Override
     public void close() {
       closed = true;
     }
@@ -594,8 +661,12 @@ class TestOzoneLocal {
           || "--om-port".equals(option)
           || "--s3g-port".equals(option)) {
         return LocalOzoneClusterConfig.DEFAULT_PORT_VALUE;
+      } else if ("--recon-port".equals(option)) {
+        return LocalOzoneClusterConfig.DEFAULT_PORT_VALUE;
       } else if ("--s3g".equals(option)) {
         return LocalOzoneClusterConfig.DEFAULT_S3G_ENABLED_VALUE;
+      } else if ("--recon".equals(option)) {
+        return LocalOzoneClusterConfig.DEFAULT_RECON_ENABLED_VALUE;
       } else if ("--ephemeral".equals(option)) {
         return LocalOzoneClusterConfig.DEFAULT_EPHEMERAL_VALUE;
       } else if ("--startup-timeout".equals(option)) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -18,18 +18,23 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.List;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
@@ -120,6 +125,60 @@ class TestOzoneLocal {
     int exitCode = new CommandLine(command).execute();
 
     assertEquals(1, exitCode);
+    assertTrue(runtime.closed);
+  }
+
+  @Test
+  void runCommandReportsDiscardedConfigToStdErr() throws Exception {
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    runtime.discardedUserConfigKeys = singletonList("ozone.replication");
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setErr(new PrintWriter(new OutputStreamWriter(err, UTF_8), true));
+
+    int exitCode = commandLine.execute();
+
+    assertEquals(0, exitCode);
+    // Service logging is off by default for this command, so the CLI has to say it itself.
+    assertTrue(err.toString(UTF_8.name()).contains("ozone.replication"),
+        err.toString(UTF_8.name()));
+  }
+
+  @Test
+  void runCommandReportsDiscardedConfigWhenStartupFails() throws Exception {
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    runtime.failStart = true;
+    runtime.discardedUserConfigKeys = singletonList("ozone.replication");
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setErr(new PrintWriter(new OutputStreamWriter(err, UTF_8), true));
+
+    int exitCode = commandLine.execute();
+
+    assertEquals(1, exitCode);
+    // A discarded override can be the very setting that made startup fail, so it is reported
+    // even on the failure path.
+    assertTrue(err.toString(UTF_8.name()).contains("ozone.replication"),
+        err.toString(UTF_8.name()));
+  }
+
+  @Test
+  void runCommandStartupFailureReportsCauseAndHowToGetDetail() {
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    runtime.failStart = true;
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    new CommandLine(command).parseArgs();
+
+    IOException error = assertThrows(IOException.class, command::call);
+
+    // GenericCli prints only the first line of the message, so it has to carry the cause itself.
+    String message = error.getMessage();
+    assertTrue(message.contains("startup failed"), message);
+    assertTrue(message.contains("--loglevel INFO"), message);
+    assertTrue(message.contains("--verbose"), message);
+    assertInstanceOf(IllegalStateException.class, error.getCause());
     assertTrue(runtime.closed);
   }
 
@@ -250,12 +309,33 @@ class TestOzoneLocal {
 
   @Test
   void resolveConfigRejectsInvalidDuration() {
-    assertParseError("--startup-timeout", "forever", "--startup-timeout");
+    // Pins the value echo: picocli's wrapper already names the option, so asserting on the
+    // option alone would pass even if the converter dropped the value from its message.
+    assertParseError("--startup-timeout", "forever", "Invalid duration 'forever'");
   }
 
   @Test
   void resolveConfigRejectsNonPositiveDuration() {
     assertConfigError("--startup-timeout", "0s", "--startup-timeout");
+  }
+
+  @Test
+  void resolveConfigRejectsDurationWithoutTimeUnit() {
+    // Without the unit check this parses as 120 milliseconds, so the run dies with an unrelated
+    // timeout instead of telling the user the value was misread. Asserts the quoted value: the
+    // bare digits also occur in the static "like 120s" hint, which would mask a dropped echo.
+    assertParseError("--startup-timeout", "120", "Missing time unit in '120'");
+  }
+
+  @Test
+  void resolveConfigAcceptsHadoopStyleMinutes() {
+    assertEquals(Duration.ofMinutes(2), resolve("--startup-timeout", "2m")
+        .getStartupTimeout());
+  }
+
+  @Test
+  void invalidFormatModeMessageNamesOffendingValue() {
+    assertParseError("--format", "sometimes", "sometimes");
   }
 
   @Test
@@ -364,6 +444,7 @@ class TestOzoneLocal {
     private final int omPort;
     private boolean failStart;
     private boolean started;
+    private List<String> discardedUserConfigKeys = emptyList();
     private boolean closed;
 
     private StubRuntime(String displayHost, int scmPort, int omPort) {
@@ -403,6 +484,11 @@ class TestOzoneLocal {
     @Override
     public String getS3Endpoint() {
       return "";
+    }
+
+    @Override
+    public List<String> getDiscardedUserConfigKeys() {
+      return discardedUserConfigKeys;
     }
 
     @Override

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -18,20 +18,28 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IDefaultValueProvider;
@@ -108,6 +116,7 @@ class TestOzoneLocal {
     assertTrue(text.contains("Local Ozone is running from"), text);
     assertTrue(text.contains("SCM RPC: localhost:9860"), text);
     assertTrue(text.contains("OM RPC: localhost:9862"), text);
+    assertFalse(text.contains("Datanodes:"), text);
     assertTrue(text.contains("Press Ctrl+C to stop."), text);
   }
 
@@ -121,6 +130,123 @@ class TestOzoneLocal {
 
     assertEquals(1, exitCode);
     assertTrue(runtime.closed);
+  }
+
+  /** The marker preserves the original cause for the root command's error handling. */
+  @Test
+  void runCommandPreservesStartupFailureAsTheCause() throws Exception {
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    runtime.failStart = true;
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setErr(new PrintWriter(new OutputStreamWriter(err, UTF_8), true));
+    commandLine.parseArgs();
+
+    Exception error = assertThrows(Exception.class, command::call);
+
+    assertTrue(error.getCause() instanceof IllegalStateException, error.toString());
+    assertEquals("startup failed", error.getCause().getMessage());
+    assertEquals("", err.toString(UTF_8.name()));
+    assertTrue(runtime.closed);
+  }
+
+  /**
+   * Drives the whole path a user hits: the cluster rejects the value and OzoneLocal prints the
+   * rejection before a hint on the next line.
+   * The timeout is preemptive because execute() otherwise blocks in awaitShutdown() until a JVM
+   * shutdown hook fires, so a check that stopped rejecting would hang the fork instead of failing.
+   */
+  @Test
+  void conflictingConfigReachesStderrThroughGenericCli(@TempDir Path dataDir) throws Exception {
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    OzoneLocal ozoneLocal = new OzoneLocal();
+    ozoneLocal.getCmd().setErr(new PrintWriter(new OutputStreamWriter(err, UTF_8), true));
+
+    int exitCode = assertTimeoutPreemptively(Duration.ofSeconds(30),
+        () -> ozoneLocal.execute(new String[] {"-D", OZONE_REPLICATION + "=THREE",
+            "run", "--data-dir", dataDir.toString()}));
+
+    assertEquals(GenericCli.EXECUTION_ERROR_EXIT_CODE, exitCode);
+    String[] lines = err.toString(UTF_8.name()).trim().split("\n");
+    assertEquals(2, lines.length, err.toString(UTF_8.name()));
+    assertTrue(lines[0].contains(OZONE_REPLICATION), lines[0]);
+    assertTrue(lines[0].contains("THREE"), lines[0]);
+    assertTrue(lines[1].contains("--verbose"), lines[1]);
+  }
+
+  @Test
+  void relativeDefaultNamedConfigFileCountsAsUserConfig(@TempDir Path tempDir) throws Exception {
+    Path customConfig = tempDir.resolve("ozone-default.xml").toAbsolutePath();
+    Files.write(customConfig, ("<configuration><property><name>" + OZONE_REPLICATION
+        + "</name><value>THREE</value></property></configuration>").getBytes(UTF_8));
+    Path relativeConfig = Paths.get("").toAbsolutePath().relativize(customConfig);
+    OzoneLocal ozoneLocal = new OzoneLocal();
+
+    ozoneLocal.getCmd().parseArgs("--conf", relativeConfig.toString(), "run");
+
+    OzoneConfiguration seed = ozoneLocal.getOzoneConf();
+    assertEquals("THREE", seed.get(OZONE_REPLICATION));
+    String[] sources = seed.getPropertySources(OZONE_REPLICATION);
+    String source = sources[sources.length - 1];
+    assertEquals(customConfig.normalize().toString(), source);
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    IOException error = assertThrows(IOException.class, () -> {
+      try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+        cluster.prepareConfiguration();
+      }
+    });
+
+    assertTrue(error.getMessage().contains(source), error.getMessage());
+  }
+
+  /**
+   * A --conf value carrying a scheme is a Hadoop fs.Path resource, not a local file name;
+   * absolutizing it through java.nio mangles it into a CWD-relative literal path that
+   * Configuration then skips silently, ignoring the user's file.
+   */
+  @Test
+  void fileUriConfigPathLoadsTheNamedFile(@TempDir Path tempDir) throws Exception {
+    Path customConfig = tempDir.resolve("my-ozone-site.xml").toAbsolutePath();
+    Files.write(customConfig, ("<configuration><property><name>" + OZONE_REPLICATION
+        + "</name><value>THREE</value></property></configuration>").getBytes(UTF_8));
+    OzoneLocal ozoneLocal = new OzoneLocal();
+
+    ozoneLocal.getCmd().parseArgs("--conf", customConfig.toUri().toString(), "run");
+
+    assertEquals("THREE", ozoneLocal.getOzoneConf().get(OZONE_REPLICATION));
+  }
+
+  /**
+   * An empty --conf (an unset shell variable, say) has to fail at option parse the way
+   * fs.Path rejects it, not resolve to the working directory and die later with an
+   * unrelated resource error.
+   */
+  @Test
+  void emptyConfigPathIsRejectedAtParse() {
+    OzoneLocal ozoneLocal = new OzoneLocal();
+
+    assertThrows(CommandLine.ParameterException.class,
+        () -> ozoneLocal.getCmd().parseArgs("--conf", "", "run"));
+  }
+
+  @Test
+  void startupFailureHintOnlySuggestsMissingDetail() {
+    String noDetail = OzoneLocal.startupFailureHint(false, false);
+    assertTrue(noDetail.contains("--loglevel INFO"), noDetail);
+    assertTrue(noDetail.contains("--verbose"), noDetail);
+
+    String logsEnabled = OzoneLocal.startupFailureHint(true, false);
+    assertFalse(logsEnabled.contains("--loglevel INFO"), logsEnabled);
+    assertTrue(logsEnabled.contains("--verbose"), logsEnabled);
+
+    String verboseEnabled = OzoneLocal.startupFailureHint(false, true);
+    assertTrue(verboseEnabled.contains("--loglevel INFO"), verboseEnabled);
+    assertFalse(verboseEnabled.contains("--verbose"), verboseEnabled);
+
+    assertNull(OzoneLocal.startupFailureHint(true, true));
   }
 
   @Test
@@ -230,7 +356,7 @@ class TestOzoneLocal {
 
   @Test
   void resolveConfigRejectsInvalidFormat() {
-    assertParseError("--format", "sometimes", "--format");
+    assertParseError("--format", "sometimes", "sometimes");
   }
 
   @Test
@@ -248,14 +374,34 @@ class TestOzoneLocal {
     assertConfigError("--datanodes", "0", "--datanodes");
   }
 
+  /**
+   * Pins the value echo: picocli's wrapper already names the option, so asserting on the
+   * option alone would pass even if the converter dropped the value from its message.
+   */
   @Test
   void resolveConfigRejectsInvalidDuration() {
-    assertParseError("--startup-timeout", "forever", "--startup-timeout");
+    assertParseError("--startup-timeout", "forever", "Invalid duration 'forever'");
   }
 
   @Test
   void resolveConfigRejectsNonPositiveDuration() {
     assertConfigError("--startup-timeout", "0s", "--startup-timeout");
+  }
+
+  /**
+   * Without the unit check this parses as 120 milliseconds, so the run dies with an unrelated
+   * timeout instead of telling the user the value was misread. Asserts the quoted value: the
+   * bare digits also occur in the static "like 120s" hint, which would mask a dropped echo.
+   */
+  @Test
+  void resolveConfigRejectsDurationWithoutTimeUnit() {
+    assertParseError("--startup-timeout", "120", "Missing time unit in '120'");
+  }
+
+  @Test
+  void resolveConfigAcceptsHadoopStyleMinutes() {
+    assertEquals(Duration.ofMinutes(2), resolve("--startup-timeout", "2m")
+        .getStartupTimeout());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

- OZONE_LOCAL_RECON_ENABLED=true and --with-recon or --without-recon
- OZONE_LOCAL_HTTPFS_ENABLED=true and --with-httpfs or --without-httpfs
- optional port envs/flags for each service
- data dirs under the local root, for example recon/ and httpfs/

Order:
- start SCM/OM/DN
- wait for local cluster readiness
- start S3G/Recon/HttpFS based on config
- wait for each optional service separately
- print all advertised endpoints

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14932

## How was this patch tested?

https://github.com/apache/ozone/actions/runs/29328163181
