### PR TITLE
HDDS-15764. [Recon] Show error card for unavailable datanode in Cluster Capacity

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -101,7 +101,7 @@ describe('Capacity Page', () => {
     expect(datanodeCard).toHaveTextContent(/FREE SPACE\s*3\s*KB/i);
   });
 
-  test('clamps pendingBlockSize to 0 when selected datanode reports -1 (offline/unreachable)', async () => {
+  test('shows error card instead of outdated data when default-selected datanode reports -1 (offline/unreachable)', async () => {
     capacityServer.use(
       rest.get('api/v1/pendingDeletion', (req, res, ctx) => {
         const component = req.url.searchParams.get('component');
@@ -136,13 +136,15 @@ describe('Capacity Page', () => {
     if (!datanodeCard) {
       return;
     }
-    // dn-1 is selected by default; its pendingBlockSize is -1 (offline sentinel).
-    // PENDING DELETION should show 0 B, not a negative value.
+    // dn-1 is selected by default; its pendingBlockSize is -1 (offline sentinel), so the
+    // datanode is unavailable and its capacity data may be outdated. Show an error card for
+    // USED SPACE and FREE SPACE instead of the stale storage-report values.
+    expect(await screen.findByTestId('dn-used-space-error')).toBeInTheDocument();
+    expect(await screen.findByTestId('dn-free-space-error')).toBeInTheDocument();
     await waitFor(() =>
-      expect(datanodeCard).toHaveTextContent(/PENDING DELETION\s*0\s*B/i)
+      expect(datanodeCard).toHaveTextContent(/USED SPACE\s*N\/A/i)
     );
-    // USED SPACE = used (4096) + clamped pendingBlockSize (0) = 4 KB
-    expect(datanodeCard).toHaveTextContent(/USED SPACE\s*4\s*KB/i);
+    expect(datanodeCard).toHaveTextContent(/FREE SPACE\s*N\/A/i);
   });
 
   test('shows scm-only error state when SCM pending deletion returns sentinel failure values', async () => {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/__tests__/capacity/Capacity.test.tsx
@@ -101,7 +101,7 @@ describe('Capacity Page', () => {
     expect(datanodeCard).toHaveTextContent(/FREE SPACE\s*3\s*KB/i);
   });
 
-  test('shows error card instead of outdated data when default-selected datanode reports -1 (offline/unreachable)', async () => {
+  test('defaults to the first available datanode when the first datanode reports -1 (offline/unreachable)', async () => {
     capacityServer.use(
       rest.get('api/v1/pendingDeletion', (req, res, ctx) => {
         const component = req.url.searchParams.get('component');
@@ -136,15 +136,70 @@ describe('Capacity Page', () => {
     if (!datanodeCard) {
       return;
     }
-    // dn-1 is selected by default; its pendingBlockSize is -1 (offline sentinel), so the
-    // datanode is unavailable and its capacity data may be outdated. Show an error card for
-    // USED SPACE and FREE SPACE instead of the stale storage-report values.
+    // dn-1 is unavailable (pendingBlockSize -1), but dn-2 is healthy, so the page should
+    // default to dn-2 and show its capacity instead of landing on the error card.
+    // USED SPACE = used (2048) + pendingBlockSize (2048) = 4 KB, FREE SPACE = remaining
+    // (2048) + committed (1024) = 3 KB.
+    await waitFor(() =>
+      expect(datanodeCard).toHaveTextContent(/USED SPACE\s*4\s*KB/i)
+    );
+    expect(datanodeCard).toHaveTextContent(/FREE SPACE\s*3\s*KB/i);
+    expect(screen.queryByTestId('dn-used-space-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dn-free-space-error')).not.toBeInTheDocument();
+    // The dropdown label must reflect the actually-selected DN (dn-2), not the first
+    // (unavailable) option.
+    const selectionItem = datanodeCard.querySelector('.ant-select-selection-item');
+    expect(selectionItem).toHaveTextContent('dn-2');
+    expect(selectionItem).not.toHaveTextContent('dn-1');
+  });
+
+  test('shows error card instead of outdated data when every datanode reports -1 (offline/unreachable)', async () => {
+    capacityServer.use(
+      rest.get('api/v1/pendingDeletion', (req, res, ctx) => {
+        const component = req.url.searchParams.get('component');
+        if (component === 'dn') {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              ...mockResponses.DnPendingDeletion,
+              pendingDeletionPerDataNode: [
+                { hostName: 'dn-1', datanodeUuid: 'uuid-1', pendingBlockSize: -1 },
+                { hostName: 'dn-2', datanodeUuid: 'uuid-2', pendingBlockSize: -1 }
+              ]
+            })
+          );
+        }
+        const map: Record<string, object> = {
+          scm: mockResponses.ScmPendingDeletion,
+          om: mockResponses.OmPendingDeletion
+        };
+        const body = component ? map[component] : undefined;
+        return body
+          ? res(ctx.status(200), ctx.json(body))
+          : res(ctx.status(400), ctx.json({ message: 'Unsupported pending deletion component.' }));
+      })
+    );
+
+    render(<Capacity />);
+
+    const downloadLink = await screen.findByText('Download Insights');
+    const datanodeCard = downloadLink.closest('.ant-card');
+    expect(datanodeCard).not.toBeNull();
+    if (!datanodeCard) {
+      return;
+    }
+    // No DN is available, so we fall back to dn-1; its pendingBlockSize is -1 (offline
+    // sentinel), so the datanode is unavailable and its capacity data may be outdated.
+    // Show an error card for USED SPACE and FREE SPACE instead of the stale
+    // storage-report values.
     expect(await screen.findByTestId('dn-used-space-error')).toBeInTheDocument();
     expect(await screen.findByTestId('dn-free-space-error')).toBeInTheDocument();
     await waitFor(() =>
       expect(datanodeCard).toHaveTextContent(/USED SPACE\s*N\/A/i)
     );
     expect(datanodeCard).toHaveTextContent(/FREE SPACE\s*N\/A/i);
+    // With every DN unavailable, the dropdown falls back to the first DN (dn-1).
+    expect(datanodeCard.querySelector('.ant-select-selection-item')).toHaveTextContent('dn-1');
   });
 
   test('shows scm-only error state when SCM pending deletion returns sentinel failure values', async () => {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -132,7 +132,10 @@ const Capacity: React.FC<object> = () => {
 
   const autoReload = useAutoReload(loadDataIfIdle);
 
-  const selectedDNDetails: DataNodeUsage & { pendingBlockSize: number } = React.useMemo(() => {
+  const selectedDNDetails: DataNodeUsage & {
+    pendingBlockSize: number;
+    unavailable: boolean;
+  } = React.useMemo(() => {
     const selected = storageDistribution.data.dataNodeUsage.find(datanode => datanode.hostName === selectedDatanode)
       ?? storageDistribution.data.dataNodeUsage[0];
     const dnPendingEntry = dnPendingDeletes.data.pendingDeletionPerDataNode?.find(
@@ -150,7 +153,10 @@ const Capacity: React.FC<object> = () => {
         reserved: 0
       }),
       ...dnPendingEntry,
-      pendingBlockSize: Math.max(0, dnPendingEntry.pendingBlockSize)
+      pendingBlockSize: Math.max(0, dnPendingEntry.pendingBlockSize),
+      // -1 is the sentinel for a DN whose pending deletion query failed (offline/unreachable).
+      // Its capacity data from the storage report may be outdated, so surface an error instead.
+      unavailable: dnPendingEntry.pendingBlockSize === -1
     }
   }, [selectedDatanode, storageDistribution.data.dataNodeUsage, dnPendingDeletes.data.pendingDeletionPerDataNode]);
 
@@ -510,6 +516,9 @@ const Capacity: React.FC<object> = () => {
             dataDetails={[{
               title: 'USED SPACE',
               size: (selectedDNDetails.used ?? 0) + (selectedDNDetails.pendingBlockSize ?? 0),
+              hasError: selectedDNDetails.unavailable,
+              errorMessage: 'Datanode is unavailable; capacity data may be outdated.',
+              errorTestId: 'dn-used-space-error',
               breakdown: [{
                 label: 'PENDING DELETION',
                 value: selectedDNDetails.pendingBlockSize ?? 0,
@@ -522,6 +531,9 @@ const Capacity: React.FC<object> = () => {
             }, {
               title: 'FREE SPACE',
               size: (selectedDNDetails.remaining ?? 0) + (selectedDNDetails.committed ?? 0),
+              hasError: selectedDNDetails.unavailable,
+              errorMessage: 'Datanode is unavailable; capacity data may be outdated.',
+              errorTestId: 'dn-free-space-error',
               breakdown: [{
                 label: unusedSpaceBreakdown,
                 value: selectedDNDetails.remaining ?? 0,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/capacity.tsx
@@ -100,11 +100,20 @@ const Capacity: React.FC<object> = () => {
     return storageDistribution.data.dataNodeUsage.filter(dn => pendingHostNames.has(dn.hostName));
   }, [storageDistribution.data.dataNodeUsage, dnPendingDeletes.data.pendingDeletionPerDataNode]);
 
-  // Seed selected datanode once data loads so dependent calculations work
+  // Seed selected datanode once data loads so dependent calculations work.
+  // Prefer the first available DN so the user does not land on the error card
+  // while a healthy DN exists; fall back to the first DN (surfacing the error
+  // card) only when every DN is unavailable.
   React.useEffect(() => {
     const hostNames = filteredDNs.map(dn => dn.hostName);
     if (!hostNames.includes(selectedDatanode)) {
-      setSelectedDatanode(hostNames[0] ?? "");
+      const unavailableHosts = new Set(
+        (dnPendingDeletes.data.pendingDeletionPerDataNode ?? [])
+          .filter(dn => dn.pendingBlockSize === -1)
+          .map(dn => dn.hostName)
+      );
+      const firstAvailable = hostNames.find(hostName => !unavailableHosts.has(hostName));
+      setSelectedDatanode(firstAvailable ?? hostNames[0] ?? "");
     }
   }, [filteredDNs]);
 
@@ -497,6 +506,7 @@ const Capacity: React.FC<object> = () => {
             downloadUrl={DN_CSV_DOWNLOAD_URL}
             onDownloadClick={() => downloadCsv(DN_CSV_DOWNLOAD_URL)}
             handleSelect={setSelectedDatanode}
+            selectedValue={selectedDatanode}
             dropdownItems={filteredDNs.map(datanode => ({
               label: (
                 <>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/components/CapacityDetail.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/capacity/components/CapacityDetail.tsx
@@ -50,6 +50,7 @@ type CapacityDetailProps = {
   disabledOpts?: string[];
   optsClass?: string;
   handleSelect?: React.Dispatch<React.SetStateAction<string>>
+  selectedValue?: string;
   loading: boolean;
   extra?: React.ReactNode;
 };
@@ -111,6 +112,7 @@ const CapacityDetail: React.FC<CapacityDetailProps> = (
     optsClass,
     dataDetails,
     handleSelect,
+    selectedValue,
     loading,
     extra
   }
@@ -149,7 +151,7 @@ const CapacityDetail: React.FC<CapacityDetailProps> = (
                 {selectorTitle}
                 <Select
                   showSearch
-                  defaultValue={options?.[0]?.value}
+                  value={selectedValue ?? options?.[0]?.value}
                   options={options}
                   onChange={handleSelect}
                   style={{ marginBottom: '16px' }}


### PR DESCRIPTION
## What changes were proposed in this pull request?
On the Recon **Cluster Capacity** page, the datanode detail card seeds its default selection to the first datanode in the filtered list, regardless of whether that DN is reachable. When the default-selected DN is unavailable — its pending-deletion query failed, signalled by the `pendingBlockSize === -1` sentinel — the card still rendered `used` / `remaining` / `committed` values from the storage report. For an offline or unreachable DN these values can be stale, so the UI silently displayed outdated capacity data. The node-selector dropdown already disables such DNs (`disabledOpts`), but the default seeding (`hostNames[0]`) can still land on one.

Now it will show error card when all DNs are down, otherwise if we selected DN which is not available it will auto switch to one of the available DN

Note : Code is generated using AI

## What is the link to the Apache JIRA

[HDDS-15764](https://issues.apache.org/jira/browse/HDDS-15764)

## How was this patch tested?

Tested manually and updated unit test case
<img width="3422" height="1794" alt="image" src="https://github.com/user-attachments/assets/ece37f5e-0351-4132-8d82-c293d038540f" />