### PR TITLE
HDDS-15392. Add OmKeyInfo and OmDirectoryInfo to snapshot diff codec registry.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -96,6 +96,8 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotDiffJob;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.lock.OMLockDetails;
@@ -426,6 +428,8 @@ public final class OmSnapshotManager implements AutoCloseable {
     registry.addCodec(SnapshotDiffReportOzone.DiffReportEntry.class,
         SnapshotDiffReportOzone.getDiffReportEntryCodec());
     registry.addCodec(SnapshotDiffJob.class, SnapshotDiffJob.codec());
+    registry.addCodec(OmKeyInfo.class, OmKeyInfo.getKeyTableCodec());
+    registry.addCodec(OmDirectoryInfo.class, OmDirectoryInfo.getCodec());
     return registry.build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -223,6 +223,8 @@ public class TestSnapshotDiffManager {
     codecRegistry = CodecRegistry.newBuilder()
         .addCodec(DiffReportEntry.class, getDiffReportEntryCodec())
         .addCodec(SnapshotDiffJob.class, SnapshotDiffJob.codec())
+        .addCodec(OmKeyInfo.class, OmKeyInfo.getKeyTableCodec())
+        .addCodec(OmDirectoryInfo.class, OmDirectoryInfo.getCodec())
         .build();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Developed with the help of Cursor AI.

This PR is intended as the foundation for a more efficient snapshot diff ([HDDS-9154](https://issues.apache.org/jira/browse/HDDS-9154)).

Added OmKeyInfo and OmDirectoryInfo to snapshot diff codec registry to prevent `IllegalStateException`s in the optimized snapshot diff paths. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15392

## How was this patch tested?

N/A