### PR TITLE
HDDS-13173. Clean up temporary checkpoint directories on snapshot defrag failure

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -741,7 +741,6 @@ public class SnapshotDefragService extends BackgroundService
           LOG.error("Failed to delete checkpoint directory {} for snapshot: {} (ID: {}). " +
               "Disk space may not be freed. Manual cleanup may be required.",
               checkpointLocation, snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(), cleanupException);
-          snapshotMetrics.incNumSnapshotDefragFails();
         }
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -617,9 +617,9 @@ public class SnapshotDefragService extends BackgroundService
   /**
    * Deletes checkpoint directories left behind under {@link #tmpDefragDir} for the given source
    * RocksDB name after {@link DBStore#getCheckpoint} failed to produce a checkpoint. The checkpoint
-   * directory name is only known to
-   * {@link org.apache.hadoop.hdds.utils.db.RDBCheckpointManager}, so any leftover is located by its
-   * {@code <dbName>_} + {@code RDB_CHECKPOINT_PREFIX} naming convention rather than by an exact path.
+   * directory name is only known to {@link org.apache.hadoop.hdds.utils.db.RDBCheckpointManager},
+   * so any leftover is located by its {@code <dbName>_} + {@code RDB_CHECKPOINT_DIR_PREFIX}
+   * naming convention rather than by an exact path.
    */
   private void deletePartialCheckpointDirs(String dbName) {
     String prefix = dbName + "_" + RDB_CHECKPOINT_DIR_PREFIX;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -645,6 +645,15 @@ public class SnapshotDefragService extends BackgroundService
     Pair<Boolean, Integer> needsDefragVersionPair = needsDefragmentation(snapshotInfo);
     if (!needsDefragVersionPair.getLeft()) {
       snapshotMetrics.incNumSnapshotDefragSnapshotSkipped();
+      int currentVersion = needsDefragVersionPair.getValue();
+      if (currentVersion > 0) {
+        try {
+          omSnapshotManager.deleteSnapshotCheckpointDirectories(snapshotId, currentVersion - 1);
+        } catch (IOException | IllegalArgumentException e) {
+          LOG.error("Failed to delete old checkpoint directories for snapshot: {} (ID: {})",
+              snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(), e);
+        }
+      }
       return false;
     }
     LOG.info("Defragmenting snapshot: {} (ID: {})", snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.snapshot.defrag;
 import static java.nio.file.Files.createDirectories;
 import static org.apache.commons.io.file.PathUtils.deleteDirectory;
 import static org.apache.hadoop.hdds.StringUtils.getLexicographicallyHigherString;
+import static org.apache.hadoop.hdds.utils.db.RDBCheckpointManager.RDB_CHECKPOINT_DIR_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_DEFRAG_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_DEFRAG_LIMIT_PER_TASK_DEFAULT;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.COLUMN_FAMILIES_TO_TRACK_IN_SNAPSHOT;
@@ -573,7 +574,13 @@ public class SnapshotDefragService extends BackgroundService
       Set<String> incrementalColumnFamilies) throws IOException {
     try (UncheckedAutoCloseableSupplier<OmSnapshot> snapshot = omSnapshotManager.getActiveSnapshot(
         snapshotInfo.getVolumeName(), snapshotInfo.getBucketName(), snapshotInfo.getName())) {
-      DBCheckpoint checkpoint = snapshot.get().getMetadataManager().getStore().getCheckpoint(tmpDefragDir, true);
+      DBStore snapshotStore = snapshot.get().getMetadataManager().getStore();
+      DBCheckpoint checkpoint = snapshotStore.getCheckpoint(tmpDefragDir, true);
+      if (checkpoint == null) {
+        deletePartialCheckpointDirs(snapshotStore.getDbLocation().getName());
+        throw new IOException("Failed to create checkpoint under " + tmpDefragDir + " for snapshot: "
+            + snapshotInfo.getTableKey() + " (ID: " + snapshotInfo.getSnapshotId() + ")");
+      }
       Path checkpointLocation = checkpoint.getCheckpointLocation();
       boolean checkpointSuccessful = false;
       try {
@@ -604,6 +611,36 @@ public class SnapshotDefragService extends BackgroundService
           }
         }
       }
+    }
+  }
+
+  /**
+   * Deletes checkpoint directories left behind under {@link #tmpDefragDir} for the given source
+   * RocksDB name after {@link DBStore#getCheckpoint} failed to produce a checkpoint. The checkpoint
+   * directory name is only known to
+   * {@link org.apache.hadoop.hdds.utils.db.RDBCheckpointManager}, so any leftover is located by its
+   * {@code <dbName>_} + {@code RDB_CHECKPOINT_PREFIX} naming convention rather than by an exact path.
+   */
+  private void deletePartialCheckpointDirs(String dbName) {
+    String prefix = dbName + "_" + RDB_CHECKPOINT_DIR_PREFIX;
+    try (Stream<Path> entries = Files.list(Paths.get(tmpDefragDir))) {
+      Iterator<Path> it = entries.iterator();
+      while (it.hasNext()) {
+        Path entry = it.next();
+        Path fileName = entry.getFileName();
+        if (fileName != null && fileName.toString().startsWith(prefix)) {
+          try {
+            deleteDirectory(entry);
+          } catch (IOException e) {
+            LOG.error("Failed to delete partial checkpoint directory {} under {}. " +
+                    "Disk space may not be freed. Manual cleanup may be required.",
+                entry, tmpDefragDir, e);
+          }
+        }
+      }
+    } catch (IOException e) {
+      LOG.error("Failed to list entries under {} to delete partial checkpoint directories. " +
+          "Disk space may not be freed. Manual cleanup may be required.", tmpDefragDir, e);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -732,7 +732,7 @@ public class SnapshotDefragService extends BackgroundService
               snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(), closeException);
         }
       }
-      if (defragSuccessful && checkpointLocation.toFile().exists()) {
+      if (!defragSuccessful && checkpointLocation.toFile().exists()) {
         try {
           deleteDirectory(checkpointLocation);
           LOG.info("Cleaned up failed checkpoint directory for snapshot: {} (ID: {})",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -604,7 +604,6 @@ public class SnapshotDefragService extends BackgroundService
           try {
             deleteDirectory(checkpointLocation);
           } catch (IOException cleanupException) {
-            snapshotMetrics.incNumSnapshotDefragFails();
             LOG.error("Failed to clean up checkpoint directory {} for snapshot: {} (ID: {}). " +
                 "Disk space may not be freed. Manual cleanup may be required.",
                 checkpointLocation, snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -656,6 +656,7 @@ public class SnapshotDefragService extends BackgroundService
     OmMetadataManagerImpl checkpointMetadataManager = createCheckpoint(checkpointSnapshotInfo,
         COLUMN_FAMILIES_TO_TRACK_IN_SNAPSHOT);
     Path checkpointLocation = checkpointMetadataManager.getStore().getDbLocation().toPath();
+    boolean defragSuccessful = false;
     try {
       DBStore checkpointDBStore = checkpointMetadataManager.getStore();
       if (LOG.isTraceEnabled()) {
@@ -704,7 +705,13 @@ public class SnapshotDefragService extends BackgroundService
         checkpointMetadataManager = null;
         // Switch the snapshot DB location to the new version.
         previousVersion  = atomicSwitchSnapshotDB(snapshotId, checkpointLocation);
-        omSnapshotManager.deleteSnapshotCheckpointDirectories(snapshotId, previousVersion);
+        try {
+          omSnapshotManager.deleteSnapshotCheckpointDirectories(snapshotId, previousVersion);
+        } catch (IOException deleteException) {
+          LOG.error("Failed to delete old checkpoint directories for snapshot: {} (ID: {})",
+              snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(), deleteException);
+        }
+        defragSuccessful = true;
       } finally {
         snapshotContentLocks.releaseLock();
       }
@@ -718,7 +725,24 @@ public class SnapshotDefragService extends BackgroundService
       }
     } finally {
       if (checkpointMetadataManager != null) {
-        checkpointMetadataManager.close();
+        try {
+          checkpointMetadataManager.close();
+        } catch (IOException closeException) {
+          LOG.error("Failed to close checkpoint metadata manager for snapshot: {} (ID: {})",
+              snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(), closeException);
+        }
+      }
+      if (defragSuccessful && checkpointLocation.toFile().exists()) {
+        try {
+          deleteDirectory(checkpointLocation);
+          LOG.info("Cleaned up failed checkpoint directory for snapshot: {} (ID: {})",
+              snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId());
+        } catch (IOException cleanupException) {
+          LOG.error("Failed to delete checkpoint directory {} for snapshot: {} (ID: {}). " +
+              "Disk space may not be freed. Manual cleanup may be required.",
+              checkpointLocation, snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(), cleanupException);
+          snapshotMetrics.incNumSnapshotDefragFails();
+        }
       }
     }
     return true;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -598,7 +598,7 @@ public class SnapshotDefragService extends BackgroundService
             deleteDirectory(checkpointLocation);
           } catch (IOException cleanupException) {
             LOG.error("Failed to clean up checkpoint directory {} for snapshot: {} (ID: {}). " +
-                "Disk spacde may not be freed. Manual cleanup may be required.",
+                "Disk space may not be freed. Manual cleanup may be required.",
                 checkpointLocation, snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(),
                 cleanupException);
           }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -574,19 +574,36 @@ public class SnapshotDefragService extends BackgroundService
     try (UncheckedAutoCloseableSupplier<OmSnapshot> snapshot = omSnapshotManager.getActiveSnapshot(
         snapshotInfo.getVolumeName(), snapshotInfo.getBucketName(), snapshotInfo.getName())) {
       DBCheckpoint checkpoint = snapshot.get().getMetadataManager().getStore().getCheckpoint(tmpDefragDir, true);
-      try (OmMetadataManagerImpl metadataManagerBeforeTruncate =
-               createDefragCheckpointMetadataManager(checkpoint, false)) {
-        DBStore dbStore = metadataManagerBeforeTruncate.getStore();
-        for (String table : metadataManagerBeforeTruncate.listTableNames()) {
-          if (!incrementalColumnFamilies.contains(table)) {
-            dbStore.dropTable(table);
+      Path checkpointLocation = checkpoint.getCheckpointLocation();
+      boolean checkpointSuccessful = false;
+      try {
+        try (OmMetadataManagerImpl metadataManagerBeforeTruncate =
+                 createDefragCheckpointMetadataManager(checkpoint, false)) {
+          DBStore dbStore = metadataManagerBeforeTruncate.getStore();
+          for (String table : metadataManagerBeforeTruncate.listTableNames()) {
+            if (!incrementalColumnFamilies.contains(table)) {
+              dbStore.dropTable(table);
+            }
+          }
+        } catch (Exception e) {
+          throw new IOException("Failed to close checkpoint of snapshot: " + snapshotInfo.getSnapshotId(), e);
+        }
+        // This will recreate the column families in the checkpoint.
+        OmMetadataManagerImpl result = createDefragCheckpointMetadataManager(checkpoint, false);
+        checkpointSuccessful = true;
+        return result;
+      } finally {
+        if (!checkpointSuccessful && Files.exists(checkpointLocation)) {
+          try {
+            deleteDirectory(checkpointLocation);
+          } catch (IOException cleanupException) {
+            LOG.error("Failed to clean up checkpoint directory {} for snapshot: {} (ID: {}). " +
+                "Disk spacde may not be freed. Manual cleanup may be required.",
+                checkpointLocation, snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(),
+                cleanupException);
           }
         }
-      } catch (Exception e) {
-        throw new IOException("Failed to close checkpoint of snapshot: " + snapshotInfo.getSnapshotId(), e);
       }
-      // This will recreate the column families in the checkpoint.
-      return createDefragCheckpointMetadataManager(checkpoint, false);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/defrag/SnapshotDefragService.java
@@ -593,7 +593,7 @@ public class SnapshotDefragService extends BackgroundService
             }
           }
         } catch (Exception e) {
-          throw new IOException("Failed to close checkpoint of snapshot: " + snapshotInfo.getSnapshotId(), e);
+          throw new IOException("Failed to prepare defrag checkpoint for snapshot: " + snapshotInfo.getSnapshotId(), e);
         }
         // This will recreate the column families in the checkpoint.
         OmMetadataManagerImpl result = createDefragCheckpointMetadataManager(checkpoint, false);
@@ -604,6 +604,7 @@ public class SnapshotDefragService extends BackgroundService
           try {
             deleteDirectory(checkpointLocation);
           } catch (IOException cleanupException) {
+            snapshotMetrics.incNumSnapshotDefragFails();
             LOG.error("Failed to clean up checkpoint directory {} for snapshot: {} (ID: {}). " +
                 "Disk space may not be freed. Manual cleanup may be required.",
                 checkpointLocation, snapshotInfo.getTableKey(), snapshotInfo.getSnapshotId(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
@@ -237,7 +237,7 @@ public class TestSnapshotDefragService {
   }
 
   private void putString(Table<String, CodecBuffer> table, String key,
-      String value) throws RocksDatabaseException, CodecException {
+                         String value) throws RocksDatabaseException, CodecException {
     table.put(key, StringCodec.get().toDirectCodecBuffer(value));
   }
 
@@ -251,7 +251,7 @@ public class TestSnapshotDefragService {
   }
 
   private Path createLiveSstDelta(DBStore sourceStore, String tableName,
-      String key, LiveSstType liveSstType) throws Exception {
+                                  String key, LiveSstType liveSstType) throws Exception {
     Table<String, CodecBuffer> sourceTable = sourceStore.getTable(
         tableName, StringCodec.get(), CodecBufferCodec.get(true));
     putString(sourceTable, key, "source-value");
@@ -292,7 +292,7 @@ public class TestSnapshotDefragService {
   }
 
   private void createMockSnapshot(SnapshotInfo snapshotInfo,
-      DBStore snapshotStore) throws IOException {
+                                  DBStore snapshotStore) throws IOException {
     OmSnapshot snapshot = mock(OmSnapshot.class);
     UncheckedAutoCloseableSupplier<OmSnapshot> snapshotSupplier =
         new UncheckedAutoCloseableSupplier<OmSnapshot>() {
@@ -703,7 +703,7 @@ public class TestSnapshotDefragService {
   }
 
   private void createMockSnapshot(SnapshotInfo snapshotInfo, Map<String, CodecBuffer> tableContents,
-      String... tables) throws IOException {
+                                  String... tables) throws IOException {
     OmSnapshot snapshot = mock(OmSnapshot.class);
     UncheckedAutoCloseableSupplier<OmSnapshot> snapshotSupplier = new UncheckedAutoCloseableSupplier<OmSnapshot>() {
 
@@ -744,7 +744,7 @@ public class TestSnapshotDefragService {
         ImmutableMap.of(tableName, "ab"));
 
     try (DBStore sourceStore = createDBStore(
-             "source-" + liveSstType + "-" + UUID.randomUUID(), tableName);
+        "source-" + liveSstType + "-" + UUID.randomUUID(), tableName);
          DBStore previousStore = createDBStore(
              "previous-" + liveSstType + "-" + UUID.randomUUID(), tableName);
          DBStore snapshotStore = createDBStore(
@@ -753,11 +753,11 @@ public class TestSnapshotDefragService {
              "checkpoint-" + liveSstType + "-" + UUID.randomUUID(),
              tableName)) {
       putString(previousStore.getTable(
-          tableName, StringCodec.get(), CodecBufferCodec.get(true)),
+              tableName, StringCodec.get(), CodecBufferCodec.get(true)),
           key, previousValue);
       previousStore.flushDB();
       putString(snapshotStore.getTable(
-          tableName, StringCodec.get(), CodecBufferCodec.get(true)),
+              tableName, StringCodec.get(), CodecBufferCodec.get(true)),
           key, currentValue);
       snapshotStore.flushDB();
       createMockSnapshot(previousSnapshotInfo, previousStore);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -1104,6 +1105,67 @@ public class TestSnapshotDefragService {
       verify(snapshotMetrics, Mockito.never()).incNumSnapshotFullDefrag();
       verify(snapshotMetrics, Mockito.never()).incNumSnapshotIncDefrag();
       // Verify checkpoint was closed in finally block
+      verify(checkpointMetadataManager).close();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testCheckpointCleanupOnDefragFailure(boolean previousSnapshotExists) throws IOException {
+    SnapshotInfo snapshotInfo = createMockSnapshotInfo(UUID.randomUUID(), "vol1", "bucket1", "snap2");
+    SnapshotInfo previousSnapshotInfo;
+    if (previousSnapshotExists) {
+      previousSnapshotInfo = createMockSnapshotInfo(UUID.randomUUID(), "vol1", "bucket1", "snap1");
+      snapshotInfo.setPathPreviousSnapshotId(previousSnapshotInfo.getSnapshotId());
+    } else {
+      previousSnapshotInfo = null;
+    }
+
+    SnapshotChainManager chainManager = mock(SnapshotChainManager.class);
+    try (MockedStatic<SnapshotUtils> mockedStatic = Mockito.mockStatic(SnapshotUtils.class)) {
+      mockedStatic.when(() -> SnapshotUtils.getSnapshotInfo(eq(ozoneManager), eq(chainManager),
+          eq(snapshotInfo.getSnapshotId()))).thenReturn(snapshotInfo);
+      if (previousSnapshotExists) {
+        mockedStatic.when(() -> SnapshotUtils.getSnapshotInfo(eq(ozoneManager), eq(chainManager),
+            eq(previousSnapshotInfo.getSnapshotId()))).thenReturn(previousSnapshotInfo);
+      }
+
+      SnapshotDefragService spyDefragService = Mockito.spy(defragService);
+      doReturn(Pair.of(true, 10)).when(spyDefragService).needsDefragmentation(eq(snapshotInfo));
+
+      @SuppressWarnings("resource") // Mock object, no actual resource management needed
+      OmMetadataManagerImpl checkpointMetadataManager = mock(OmMetadataManagerImpl.class);
+      File checkpointPath = tempDir.resolve("checkpoint_" + System.nanoTime()).toAbsolutePath().toFile();
+      // Create actual checkpoint directory to verify cleanup
+      assertTrue(checkpointPath.mkdirs(), "Failed to create checkpoint directory for test");
+      assertTrue(checkpointPath.exists(), "Checkpoint directory should exist before defragmentation");
+
+      DBStore checkpointDBStore = mock(DBStore.class);
+      when(checkpointMetadataManager.getStore()).thenReturn(checkpointDBStore);
+      when(checkpointDBStore.getDbLocation()).thenReturn(checkpointPath);
+      doNothing().when(checkpointMetadataManager).close();
+      doReturn(checkpointMetadataManager).when(spyDefragService).createCheckpoint(any(), any());
+
+      TablePrefixInfo prefixInfo = new TablePrefixInfo(Collections.emptyMap());
+      when(metadataManager.getTableBucketPrefix(anyString(), anyString())).thenReturn(prefixInfo);
+
+      // Make the defrag operation throw IOException to simulate failure
+      IOException defragException = new IOException("Defrag failed");
+      if (previousSnapshotExists) {
+        Mockito.doThrow(defragException).when(spyDefragService).performIncrementalDefragmentation(
+            any(), any(), anyInt(), any(), any(), any());
+      } else {
+        Mockito.doThrow(defragException).when(spyDefragService).performFullDefragmentation(
+            any(), any(), any());
+      }
+
+      // Attempt defragmentation and verify exception is thrown
+      IOException thrownException = org.junit.jupiter.api.Assertions.assertThrows(IOException.class,
+          () -> spyDefragService.checkAndDefragSnapshot(chainManager, snapshotInfo.getSnapshotId()));
+      assertEquals("Defrag failed", thrownException.getMessage());
+
+      // Verify that checkpointMetadataManager.close() was called in the finally block
+      // This confirms the finally block executed despite the exception
       verify(checkpointMetadataManager).close();
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -1153,7 +1152,7 @@ public class TestSnapshotDefragService {
       IOException defragException = new IOException("Defrag failed");
       if (previousSnapshotExists) {
         Mockito.doThrow(defragException).when(spyDefragService).performIncrementalDefragmentation(
-            any(), any(), anyInt(), any(), any(), any());
+            any(), any(), any(), any(), any());
       } else {
         Mockito.doThrow(defragException).when(spyDefragService).performFullDefragmentation(
             any(), any(), any());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/defrag/TestSnapshotDefragService.java
@@ -1167,6 +1167,8 @@ public class TestSnapshotDefragService {
       // Verify that checkpointMetadataManager.close() was called in the finally block
       // This confirms the finally block executed despite the exception
       verify(checkpointMetadataManager).close();
+      // Verify that the temporary checkpoint directory was deleted after failure
+      assertFalse(checkpointPath.exists(), "Checkpoint directory should be deleted after defragmentation failure");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Root Cause: When snapshot defragmentation fails due to transient errors, the temporary checkpoint directories are not cleaned up. Over 3+ days of continuous operations, these orphaned directories accumulate and exhaust disk space, causing OM startup failures.

Solution: Implement multi-layer exception handling with an explicit `defragSuccessful` flag.
1. Add success flag `defragSuccessful`: Initialize to false, set to true only after `atomicSwitchSnampshotDB()` succeeds.
2. Protect close(): Wrap in try-catch to prevent cleanup bypass
3. Protect old checkpoint deletion: Wrap in try-catch but continue with flag set
4. Add cleanup in finally block: Delete checkpoint directory if `!defragSuccessful`
5. Add metrics: Track cleanup failures via `incNumSnapshotDefragFails()`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13173

## How was this patch tested?
- Existing unit and integration tests validate the current change cause unexpected impacts
- Add new test case `testCheckpointCleanupOnDefragFailure` to validate the exception handling