### PR TITLE
HDDS-15867. [JDK25] Bump byte-buddy to 1.18.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <byte-buddy.version>1.18.11</byte-buddy.version>
     <cdi-api.version>2.0.SP1</cdi-api.version>
     <checkstyle.version>9.3</checkstyle.version>
     <classpath.skip>true</classpath.skip>
@@ -641,6 +642,16 @@
             <artifactId>log4j</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>${byte-buddy.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>${byte-buddy.version}</version>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
[INFO] org.apache.ozone:ozone-main:pom:2.3.0-SNAPSHOT
[INFO] +- org.assertj:assertj-core:jar:3.27.7:test
[INFO] |  \- net.bytebuddy:byte-buddy:jar:1.18.3:test
...
[INFO] +- org.mockito:mockito-core:jar:4.11.0:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.12.19:test
```

Goals of this change:

- Ensure consistent version of `byte-buddy` artifacts.
- Upgrade to latest version 1.18.11 for JDK25 support.

https://issues.apache.org/jira/browse/HDDS-15867

## How was this patch tested?

Dependency tree:

```
[INFO] org.apache.ozone:ozone-main:pom:2.3.0-SNAPSHOT
[INFO] +- org.assertj:assertj-core:jar:3.27.7:test
[INFO] |  \- net.bytebuddy:byte-buddy:jar:1.18.11:test
...
[INFO] +- org.mockito:mockito-core:jar:4.11.0:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.18.11:test
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/29427835830
