### PR TITLE
HDDS-15607. Return x-amz-meta-* user-defined object metadata on S3 GetObject

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -487,6 +487,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
       addLastModifiedDate(responseBuilder, keyDetails);
       addTagCountIfAny(responseBuilder, keyDetails);
+      addCustomMetadataHeaders(responseBuilder, keyDetails);
 
       long metadataLatencyNs = getMetrics().updateGetKeyMetadataStats(startNanos);
       perf.appendMetaLatencyNanos(metadataLatencyNs);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.get;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.put;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_KEY;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_HEADER_PREFIX;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_MATCH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_MODIFIED_SINCE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_NONE_MATCH_HEADER;
@@ -44,6 +45,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -194,6 +196,21 @@ public class TestObjectGet {
 
     Response response = get(rest, BUCKET_NAME, KEY_NAME);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void getKeyWithCustomMetadata() throws IOException, OS3Exception {
+    final String keyName = "key-with-meta";
+    final String metaValue = "mymeta";
+    MultivaluedMap<String, String> requestHeaders = new MultivaluedHashMap<>();
+    requestHeaders.putSingle(CUSTOM_METADATA_HEADER_PREFIX + "meta1", metaValue);
+    when(headers.getRequestHeaders()).thenReturn(requestHeaders);
+
+    assertSucceeds(() -> put(rest, BUCKET_NAME, keyName, CONTENT));
+
+    Response response = get(rest, BUCKET_NAME, keyName);
+    assertEquals(metaValue,
+        response.getHeaderString(CUSTOM_METADATA_HEADER_PREFIX + "meta1"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
s3-tests `test_object_set_get_metadata_*` fail with KeyError:'meta1'.
PutObject stores custom metadata via **getCustomMetadataFromHeaders()**, and HeadObject returns it via **addCustomMetadataHeaders()**, but GetObject does not."

- test_object_set_get_metadata_none_to_good
- test_object_set_get_metadata_none_to_empty
- test_object_set_get_metadata_overwrite_to_empty
- test_object_set_get_unicode_metadata

Fix:
Added**addCustomMetadataHeaders()** to the GET response builder.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15607

## How was this patch tested?

Added IT and UT.
**Before Fix:**
```
bash-5.1$ aws s3api put-object \
  --bucket metatest \
  --key foo \
  --body /tmp/bar \
  --metadata meta1=mymeta \
  --endpoint-url http://s3g:9878
{
    "ETag": "\"c157a79031e1c40f85931829bc5fc552\""
}
bash-5.1$ aws s3api get-object \
  --bucket metatest \
  --key foo \
  /tmp/out \
  --endpoint-url http://s3g:9878 \
  --query 'Metadata'
                <------------------------- Didn't return the metadata tag
  
bash-5.1$ aws s3api put-object \
  --bucket metatest \
  --key foo2 \
  --body /tmp/bar \
  --metadata meta1= \
  --endpoint-url http://s3g:9878
{
    "ETag": "\"c157a79031e1c40f85931829bc5fc552\""
}
bash-5.1$ aws s3api get-object \
  --bucket metatest \
  --key foo2 \
  /tmp/out2 \
  --endpoint-url http://s3g:9878 \
  --query 'Metadata'
                 <------------------------- Didn't return the metadata tag

```

**After Fix:**
```
bash-5.1$ aws s3api put-object \
  --bucket metatest \
  --key foo \
  --body /tmp/bar \
  --metadata meta1=mymeta \
  --endpoint-url http://s3g:9878/
{
    "ETag": "\"c157a79031e1c40f85931829bc5fc552\""
}
bash-5.1$ aws s3api get-object \
  --bucket metatest \
  --key foo \
  /tmp/out \
  --endpoint-url http://s3g:9878/ \
  --query 'Metadata'
{
    "meta1": "mymeta"
}
bash-5.1$ aws s3api put-object \
  --bucket metatest \
  --key foo2 \
  --body /tmp/bar \
  --metadata meta1= \
  --endpoint-url http://s3g:9878/
{
    "ETag": "\"c157a79031e1c40f85931829bc5fc552\""
}
bash-5.1$ aws s3api get-object \
  --bucket metatest \
  --key foo2 \
  /tmp/out2 \
  --endpoint-url http://s3g:9878/ \
  --query 'Metadata'
{
    "meta1": ""
}
```
