### PR TITLE
HDDS-15888. Stamp lastTransactionInfo on snapshot deletion to avoid premature GC

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.FILESYSTEM_SNAP
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OmUtils;
@@ -181,6 +182,13 @@ public class OMSnapshotDeleteRequest extends OMClientRequest {
       snapshotInfo.setSnapshotStatus(
           SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED);
       snapshotInfo.setDeletionTime(deletionTime);
+      // Stamp the deletion transaction so that areSnapshotChangesFlushedToDB() reports the deletion as
+      // unflushed until the double buffer persists it. SnapshotDeletingService relies on this
+      // (shouldIgnoreSnapshot) to defer moveTableKeys/purge; without the stamp the purge can be applied and
+      // empty the in-memory snapshot chain while the on-disk snapshotInfoTable still holds the snapshot as
+      // ACTIVE, letting KeyDeletingService reclaim blocks that the on-disk snapshot still references.
+      snapshotInfo.setLastTransactionInfo(
+          TransactionInfo.valueOf(context.getTermIndex()).toByteString());
 
       // Update table cache first
       omMetadataManager.getSnapshotInfoTable().addCacheEntry(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -282,13 +282,14 @@ public class TestOMSnapshotDeleteRequest extends SnapshotRequestAndResponseTests
   }
 
   /**
-   * Repro for the flush-lag reclamation window (companion to
-   * TestReclaimableKeyFilter#testKeyNotReclaimableWhenChainEmptyingPurgeIsUnflushed): snapshot deletion
-   * updates only status and deletionTime and never stamps lastTransactionInfo (unlike create, moveTableKeys,
-   * purge and key/dir purge), so areSnapshotChangesFlushedToDB() keys off the stale create-time stamp and
-   * reports an applied-but-unflushed deletion as flushed. SnapshotDeletingService#shouldIgnoreSnapshot relies
-   * on that method to defer processing until a snapshot's latest change is durable; the missing stamp lets
-   * the deletion be processed (moveTableKeys + purge submitted) before the double buffer has flushed it.
+   * Regression test for the flush-lag reclamation window. This is a companion to
+   * TestReclaimableKeyFilter#testKeyReclaimableWhenChainEmptyingPurgeUnflushedButDeleteFlushed.
+   *
+   * <p>Before OMSnapshotDeleteRequest stamped lastTransactionInfo, snapshot deletion updated only status and
+   * deletionTime. areSnapshotChangesFlushedToDB() therefore used the stale create-time stamp and reported an
+   * applied-but-unflushed deletion as flushed. SnapshotDeletingService#shouldIgnoreSnapshot relies on that method
+   * to defer processing until a snapshot's latest change is durable; the missing stamp allowed moveTableKeys and
+   * purge to be submitted before the double buffer flushed the deletion.
    */
   @Test
   public void testSnapshotDeleteIsNotReportedFlushedUntilFlushed() throws Exception {
@@ -319,12 +320,10 @@ public class TestOMSnapshotDeleteRequest extends SnapshotRequestAndResponseTests
     snapshotInfo = getOmMetadataManager().getSnapshotInfoTable().get(key);
     assertEquals(SNAPSHOT_DELETED, snapshotInfo.getSnapshotStatus());
 
-    // Correct behavior: the deletion (index 2) is not durable yet, so the snapshot's changes must not be
-    // reported as flushed. Current behavior: the deletion never stamps lastTransactionInfo, the check
-    // compares the stale create-time stamp against the flushed marker and returns true.
+    // The deletion (index 2) is not durable yet, so the snapshot's changes must not be reported as flushed.
+    // This verifies that lastTransactionInfo advanced from the create transaction to the delete transaction.
     assertFalse(OmSnapshotManager.areSnapshotChangesFlushedToDB(getOmMetadataManager(), key),
-        "snapshot deletion applied at index 2 is unflushed (marker at the create transaction) but is"
-            + " reported flushed because OMSnapshotDeleteRequest does not stamp lastTransactionInfo");
+        "snapshot deletion at index 2 must remain unflushed while the marker is at the create transaction");
   }
 
   private OMSnapshotDeleteRequest doPreExecute(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
+import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE;
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.createSnapshotRequest;
@@ -25,6 +26,7 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteSnapshot;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -34,8 +36,10 @@ import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -275,6 +279,52 @@ public class TestOMSnapshotDeleteRequest extends SnapshotRequestAndResponseTests
     assertEquals(SNAPSHOT_DELETED, snapshotInfo.getSnapshotStatus());
     assertEquals(0, getOmMetrics().getNumSnapshotActive());
     assertEquals(1, getOmMetrics().getNumSnapshotDeleteFails());
+  }
+
+  /**
+   * Repro for the flush-lag reclamation window (companion to
+   * TestReclaimableKeyFilter#testKeyNotReclaimableWhenChainEmptyingPurgeIsUnflushed): snapshot deletion
+   * updates only status and deletionTime and never stamps lastTransactionInfo (unlike create, moveTableKeys,
+   * purge and key/dir purge), so areSnapshotChangesFlushedToDB() keys off the stale create-time stamp and
+   * reports an applied-but-unflushed deletion as flushed. SnapshotDeletingService#shouldIgnoreSnapshot relies
+   * on that method to defer processing until a snapshot's latest change is durable; the missing stamp lets
+   * the deletion be processed (moveTableKeys + purge submitted) before the double buffer has flushed it.
+   */
+  @Test
+  public void testSnapshotDeleteIsNotReportedFlushedUntilFlushed() throws Exception {
+    when(getOzoneManager().isAdmin(any())).thenReturn(true);
+    String key = SnapshotInfo.getTableKey(getVolumeName(), getBucketName(), snapshotName);
+
+    // Create the snapshot at transaction index 1; validateAndUpdateCache stamps lastTransactionInfo.
+    OMRequest createRequest = createSnapshotRequest(getVolumeName(), getBucketName(), snapshotName);
+    OMSnapshotCreateRequest omSnapshotCreateRequest =
+        TestOMSnapshotCreateRequest.doPreExecute(createRequest, getOzoneManager());
+    omSnapshotCreateRequest.validateAndUpdateCache(getOzoneManager(), 1L);
+    SnapshotInfo snapshotInfo = getOmMetadataManager().getSnapshotInfoTable().get(key);
+    assertNotNull(snapshotInfo);
+    assertNotNull(snapshotInfo.getLastTransactionInfo(), "sanity: create stamps lastTransactionInfo");
+
+    // The double buffer flushes through the create transaction: persist the create's transaction info as
+    // the OM's flushed marker. Sanity: the snapshot's changes are now reported flushed.
+    getOmMetadataManager().getTransactionInfoTable().put(TRANSACTION_INFO_KEY,
+        TransactionInfo.fromByteString(snapshotInfo.getLastTransactionInfo()));
+    assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(getOmMetadataManager(), key),
+        "sanity: the create transaction is flushed");
+
+    // Delete the snapshot at transaction index 2. The change is applied to the table cache only; the
+    // double buffer has NOT flushed it (the flushed marker still points at the create transaction).
+    OMSnapshotDeleteRequest omSnapshotDeleteRequest =
+        doPreExecute(deleteSnapshotRequest(getVolumeName(), getBucketName(), snapshotName));
+    omSnapshotDeleteRequest.validateAndUpdateCache(getOzoneManager(), 2L);
+    snapshotInfo = getOmMetadataManager().getSnapshotInfoTable().get(key);
+    assertEquals(SNAPSHOT_DELETED, snapshotInfo.getSnapshotStatus());
+
+    // Correct behavior: the deletion (index 2) is not durable yet, so the snapshot's changes must not be
+    // reported as flushed. Current behavior: the deletion never stamps lastTransactionInfo, the check
+    // compares the stale create-time stamp against the flushed marker and returns true.
+    assertFalse(OmSnapshotManager.areSnapshotChangesFlushedToDB(getOmMetadataManager(), key),
+        "snapshot deletion applied at index 2 is unflushed (marker at the create transaction) but is"
+            + " reported flushed because OMSnapshotDeleteRequest does not stamp lastTransactionInfo");
   }
 
   private OMSnapshotDeleteRequest doPreExecute(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
@@ -341,8 +341,9 @@ public class TestReclaimableKeyFilter extends AbstractReclaimableFilterTest {
     // SnapshotPurge has been applied: the in-memory chain no longer has the snapshot...
     getSnapshotInfos().get(getKey(volume, bucket)).clear();
 
-    // ...but the purge is not flushed: the applied/cache view of snapshotInfoTable has no row while the
-    // on-disk (skip-cache) view still holds the row -- as DELETED, guaranteed by the SDS flush gate.
+    // ReclaimableKeyFilter determines that the chain is empty without consulting snapshotInfoTable. These stubs
+    // document the invariant guaranteed by the SnapshotDeletingService flush gate: after the applied purge removes
+    // the snapshot from the in-memory chain, the unflushed on-disk row can only be DELETED.
     Table<String, SnapshotInfo> snapshotInfoTable = mock(Table.class);
     OMMetadataManager metadataManager = getOzoneManager().getMetadataManager();
     when(metadataManager.getSnapshotInfoTable()).thenReturn(snapshotInfoTable);
@@ -371,6 +372,7 @@ public class TestReclaimableKeyFilter extends AbstractReclaimableFilterTest {
 
     getSnapshotInfos().get(getKey(volume, bucket)).clear();
 
+    // As above, these stubs document the durable-empty invariant but do not affect the filter result.
     Table<String, SnapshotInfo> snapshotInfoTable = mock(Table.class);
     OMMetadataManager metadataManager = getOzoneManager().getMetadataManager();
     when(metadataManager.getSnapshotInfoTable()).thenReturn(snapshotInfoTable);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.KeyManager;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -40,6 +41,7 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.lock.IOzoneManagerLock;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -314,5 +316,72 @@ public class TestReclaimableKeyFilter extends AbstractReclaimableFilterTest {
     }
     testReclaimableKeyFilter(volume, bucket, index, keyInfo, prevKeyInfo, prevPrevKeyInfo1,
         prevKeyInfo == null, size, replicatedSize);
+  }
+
+  /**
+   * Boundary of the flush-lag reclamation window: the purge of the last path snapshot has been APPLIED
+   * (the in-memory chain is empty) but is NOT yet flushed, so the on-disk snapshotInfoTable still holds the
+   * snapshot's row. Reclamation proceeding here is safe ONLY because the row can never be ACTIVE on disk:
+   * SnapshotDeletingService submits a purge only after the snapshot's deletion is flushed
+   * (shouldIgnoreSnapshot -> areSnapshotChangesFlushedToDB, which relies on OMSnapshotDeleteRequest stamping
+   * lastTransactionInfo). A DELETED-on-disk row is not user-readable, and re-processing it after a
+   * restore-from-backup re-runs moveTableKeys/purge idempotently. If a chain-removal path that bypasses that
+   * gate is ever added, this assumption breaks and reclamation here would resurrect an ACTIVE snapshot with
+   * physically deleted blocks.
+   */
+  @Test
+  public void testKeyReclaimableWhenChainEmptyingPurgeUnflushedButDeleteFlushed()
+      throws IOException, RocksDBException {
+    setup(2, 1, 1, 1, 1);
+    String volume = getVolumes().get(0);
+    String bucket = getBuckets().get(0);
+    SnapshotInfo purgedSnapshot = getSnapshotInfos().get(getKey(volume, bucket)).get(0);
+    purgedSnapshot.setSnapshotStatus(SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED);
+
+    // SnapshotPurge has been applied: the in-memory chain no longer has the snapshot...
+    getSnapshotInfos().get(getKey(volume, bucket)).clear();
+
+    // ...but the purge is not flushed: the applied/cache view of snapshotInfoTable has no row while the
+    // on-disk (skip-cache) view still holds the row -- as DELETED, guaranteed by the SDS flush gate.
+    Table<String, SnapshotInfo> snapshotInfoTable = mock(Table.class);
+    OMMetadataManager metadataManager = getOzoneManager().getMetadataManager();
+    when(metadataManager.getSnapshotInfoTable()).thenReturn(snapshotInfoTable);
+    when(snapshotInfoTable.get(eq(purgedSnapshot.getTableKey()))).thenReturn(null);
+    when(snapshotInfoTable.getSkipCache(eq(purgedSnapshot.getTableKey()))).thenReturn(purgedSnapshot);
+
+    OmKeyInfo keyInfo = getMockedOmKeyInfo(1);
+    when(keyInfo.getVolumeName()).thenReturn(volume);
+    when(keyInfo.getBucketName()).thenReturn(bucket);
+
+    assertTrue(getReclaimableFilter().apply(Table.newKeyValue("deletedKey", keyInfo)),
+        "with the chain empty and the unflushed purge's on-disk row at worst DELETED, the AOS deleted key "
+            + "is reclaimable");
+  }
+
+  /**
+   * Control for the flush-lag repro above: when the chain is empty AND durably so (the on-disk
+   * snapshotInfoTable has no row either), reclamation must proceed.
+   */
+  @Test
+  public void testKeyReclaimableWhenChainDurablyEmpty() throws IOException, RocksDBException {
+    setup(2, 1, 1, 1, 1);
+    String volume = getVolumes().get(0);
+    String bucket = getBuckets().get(0);
+    SnapshotInfo purgedSnapshot = getSnapshotInfos().get(getKey(volume, bucket)).get(0);
+
+    getSnapshotInfos().get(getKey(volume, bucket)).clear();
+
+    Table<String, SnapshotInfo> snapshotInfoTable = mock(Table.class);
+    OMMetadataManager metadataManager = getOzoneManager().getMetadataManager();
+    when(metadataManager.getSnapshotInfoTable()).thenReturn(snapshotInfoTable);
+    when(snapshotInfoTable.get(eq(purgedSnapshot.getTableKey()))).thenReturn(null);
+    when(snapshotInfoTable.getSkipCache(eq(purgedSnapshot.getTableKey()))).thenReturn(null);
+
+    OmKeyInfo keyInfo = getMockedOmKeyInfo(1);
+    when(keyInfo.getVolumeName()).thenReturn(volume);
+    when(keyInfo.getBucketName()).thenReturn(bucket);
+
+    assertTrue(getReclaimableFilter().apply(Table.newKeyValue("deletedKey", keyInfo)),
+        "with no snapshot in the chain and none on disk, the AOS deleted key is reclaimable");
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unlike create/moveTableKeys/purge, `OMSnapshotDeleteRequest` never stamps `lastTransactionInfo`. `areSnapshotChangesFlushedToDB()` therefore reads the stale create-time stamp and reports an unflushed deletion as flushed, so `SnapshotDeletingService` does not defer it and can purge the snapshot while the delete and purge exist only in the double buffer. The purge empties the in-memory chain, `ReclaimableFilter` finds no previous snapshot (`areSnapshotChangesFlushedToDB(null)` is vacuously true), and `KeyDeletingService` hands blocks to SCM irreversibly while the on-disk `snapshotInfoTable` still shows the snapshot `ACTIVE` and referencing them.

```
Ratis log                 applied (cache + chain)          RocksDB (flushed marker)
idx 1: CreateSnapshot s1  s1 ACTIVE, lastTxnInfo = idx 1
idx 2: DeleteKey k        tombstone k in AOS deletedTable  <flushed through idx 2>
idx 3: DeleteSnapshot s1  s1 DELETED, lastTxnInfo NOT stamped (still idx 1)
   SDS gate: lastTxnInfo idx 1 <= flushed idx 2 => "flushed" (WRONG, delete is not durable);
   with the stamp: idx 3 > idx 2 => defer. Instead:
idx 4-5: moveTableKeys + purge s1   in-memory chain now empty  (idx 3-5 unflushed)
   KDS: no previous snapshot => k reclaimable => blocks deleted via SCM (irreversible)
   On-disk state: s1 ACTIVE, k captured in s1, k's blocks gone.
```

### Severity

Low. The deletion was user-requested and Ratis-acked, DELETED snapshots cannot be unmarked, and crash recovery replays idx 3-5, so no supported flow reads the lost blocks. The inconsistency surfaces only via recovery that drops acked transactions (RocksDB restored without the matching Ratis log). Still worth fixing because both existing flush gates exist precisely to keep irreversible block deletion behind locally durable state, and the missing stamp silently defeats them. Found by model-checking the snapshot chain with [TLA+](https://en.wikipedia.org/wiki/TLA%2B), then reproduced in unit tests.

### Fix

Stamp `lastTransactionInfo` in `OMSnapshotDeleteRequest.validateAndUpdateCache`, matching the other snapshot requests. The existing SDS gate then defers move/purge until the deletion is durable, so a chain-removed snapshot is at worst DELETED on disk, never ACTIVE.

Cost: snapshot GC waits at most one double-buffer flush cycle.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15888

## How was this patch tested?

- New `TestOMSnapshotDeleteRequest#testSnapshotDeleteIsNotReportedFlushedUntilFlushed`: fails without the fix, passes with it.
- New `TestReclaimableKeyFilter` boundary tests: empty-chain reclamation is only legal with the on-disk row absent or DELETED; javadoc records the invariant.
- Tests are `Generated-by: Claude Code (Fable 5)`