### PR TITLE
HDDS-9411. Restrict FileInputStream/FileOutputStream import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2152,6 +2152,14 @@
                       <bannedImport>io.netty.util.internal.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
+                    <reason>Classes (e.g. FileInputStream, FileOutputStream) overriding the Object.finalize() method will cause gc to run a much longer time</reason>
+                    <bannedImports>
+                      <bannedImport>java.io.FileInputStream</bannedImport>
+                      <bannedImport>java.io.FileOutputStream</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

 - `java.io.FileInputStream` and `java.io.FileOutputStream` override `finalize()`, which can increase GC time.
 -  This PR adds enforcer rule in the root `pom.xml` under the existing `ban-imports` execution to block imports of these classes.
 - This change is similar to [RATIS-1900](https://issues.apache.org/jira/browse/RATIS-1900)
 -  Referred : https://github.com/apache/ratis/blob/f4c3781468e756220836e88d953fd5598177afdf/pom.xml#L512-L519 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9411

## How was this patch tested?

- Manual testing :  
temporarily added these imports in a file , e.g. : `hadoop-hdds/common/…/hdds/utils/IOUtils.java`:
```
import java.io.FileInputStream;
import java.io.FileOutputStream;
```
build fails with below trace as expected:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.3:enforce (ban-imports) on project hdds-common: 
[ERROR] Rule 12: org.apache.maven.plugins.enforcer.RestrictImports failed with message:
[ERROR] 
[ERROR] Banned imports detected:
[ERROR] 
[ERROR] Reason: Classes (e.g. FileInputStream, FileOutputStream) overriding the Object.finalize() method will cause gc to run a much longer time
[ERROR]         in file:///Users/psapate/Desktop/open-source/ozone/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
[ERROR]                 java.io.FileInputStream         (Line: 34, Matched by: java.io.FileInputStream)
[ERROR]                 java.io.FileOutputStream        (Line: 35, Matched by: java.io.FileOutputStream)
```

 - CI : https://github.com/prathmesh12-coder/ozone/actions/runs/29557363006 
