### PR TITLE
HDDS-15892. Massive local build time degradation when using agent worktrees

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -129,7 +129,7 @@ run cp -p -r "${ROOT}/hadoop-ozone/dist/target/k8s" kubernetes
 
 run mkdir compose/_keytabs
 
-for file in $(find "${ROOT}" -path '*/target/classes/*.classpath' | sort); do
+for file in $(find "${ROOT}" -path "${ROOT}/.*" -prune -o -path '*/target/classes/*.classpath' -print | sort); do
   # We need to add the artifact manually as it's not part the generated classpath desciptor
   module=$(basename "${file%.classpath}")
   sed -i -e "s;$;:\$HDDS_LIB_JARS_DIR/${module}-${HDDS_VERSION}.jar;" "$file"
@@ -137,7 +137,7 @@ for file in $(find "${ROOT}" -path '*/target/classes/*.classpath' | sort); do
   run cp -p "$file" share/ozone/classpath/
 done
 
-for file in $(find "${ROOT}" -path '*/share/ozone/lib/*jar' | sort); do
+for file in $(find "${ROOT}" -path "${ROOT}/.*" -prune -o -path '*/share/ozone/lib/*jar' -print | sort); do
   # copy without printing to output due to large number of files
   cp -p "$file" share/ozone/lib/
 done


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix identified and implemented by Claude Code Opus 4.8

### Issue

Agents like Claude and Cursor add worktrees to hidden directories within the repo by default, like `.claude/worktrees/`. I have not been super proactive about cleaning worktrees when I'm done with them, and have accumulated ~20 so far.

My local build command is:
```
mvn -DskipTests=true -Dmaven.javadoc.skip=true -DskipRecon --threads 2.0C -DskipShade -Dskip.npx clean package
```

This finishes in ~2 minutes in worktrees, but has crept up to 4+ minutes when run from the repo root. All the extra time seems to come from the distribution step.

From repo root:
```
[INFO] Apache Ozone Distribution .......................... SUCCESS [02:55 min]
```
From worktree:
```
[INFO] Apache Ozone Distribution .......................... SUCCESS [ 37.590 s]
```

### Cause

The culprit looks to be the `find` commands in [dist-layout-stitching](https://github.com/apache/ozone/blob/93e7b364e404c59161386e0a4b21129a32ba4112/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching) which are traversing all subdirectories to find classpath and jar files, even hidden ones, which means they are incorrectly operating on every worktree's build results as well.

### Fix

The solution proposed here ignores all hidden directories that are immediate children of the repo root. This is a generic fix which will ignore directories like `.claude` and `.cursor`, and also save some time traversing other potentially large hidden directories.

## What is the link to the Apache JIRA

HDDS-15892

## How was this patch tested?

Built locally from the master branch from repo root (not a worktree) with this patch applied:
```
$ mvn -DskipTests=true -Dmaven.javadoc.skip=true -DskipRecon --threads 2.0C -DskipShade -Dskip.npx clean package
...
[INFO] Apache Ozone Distribution .......................... SUCCESS [ 29.942 s]
[INFO] Apache Ozone Fault Injection Tests ................. SUCCESS [  0.353 s]
[INFO] Apache Ozone Network Tests ......................... SUCCESS [  0.293 s]
[INFO] Apache Ozone Mini Cluster .......................... SUCCESS [  1.089 s]
[INFO] Apache Ozone Integration Tests ..................... SUCCESS [  4.847 s]
[INFO] Apache Ozone Recon Integration Tests ............... SUCCESS [  0.712 s]
[INFO] Apache Ozone S3 Integration Tests .................. SUCCESS [  0.952 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:43 min (Wall Clock)
[INFO] Finished at: 2026-07-17T13:57:22-04:00
[INFO] ------------------------------------------------------------------------
[INFO] 936 goals, 936 executed
```