### PR TITLE
HDDS-15925. Avoid redundant getBucketInfo RPC on OFS getFileStatus

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
@@ -51,10 +51,10 @@ Verify ls fails on OBS bucket
 Create key in OBS bucket
     Execute             ozone sh key put /${volume}/${bucket}/testfile NOTICE.txt
 
-Verify ls fails on OBS bucket key
+Verify ls succeeds on OBS bucket key
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
-    ${result} =         Execute and checkrc   ozone fs -ls ${url}     255
-    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
+    ${result} =         Execute and checkrc   ozone fs -ls ${url}     0
+    Should contain      ${result}             testfile
 
 Verify rm fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs-obs.robot
@@ -51,10 +51,10 @@ Verify ls fails on OBS bucket
 Create key in OBS bucket
     Execute             ozone sh key put /${volume}/${bucket}/testfile NOTICE.txt
 
-Verify ls succeeds on OBS bucket key
+Verify ls fails on OBS bucket key
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile
-    ${result} =         Execute and checkrc   ozone fs -ls ${url}     0
-    Should contain      ${result}             testfile
+    ${result} =         Execute and checkrc   ozone fs -ls ${url}     255
+    Should contain      ${result}             Bucket: ${bucket} has layout: OBJECT_STORE, which does not support file system semantics. Bucket Layout must be FILE_SYSTEM_OPTIMIZED or LEGACY.
 
 Verify rm fails on OBS bucket
     ${url} =            Format FS URL         ${SCHEME}    ${volume}    ${bucket}    testfile

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1835,6 +1835,33 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
     assertEquals(ReplicationType.EC.name(), key.getReplicationConfig().getReplicationType().name());
   }
 
+  /**
+   * HDDS-15925: rooted OFS getFileStatus on a key path must not issue InfoBucket
+   * before GetFileStatus.
+   */
+  @Test
+  void testGetFileStatusUsesSingleOmRpc() throws Exception {
+    String keyName = "single-rpc-" + RandomStringUtils.secure().nextAlphabetic(5);
+    Path filePath = new Path(bucketPath, keyName);
+    ContractTestUtils.touch(fs, filePath);
+
+    OMMetrics metrics = getOMMetrics();
+    long bucketInfosBefore = metrics.getNumBucketInfos();
+    long getFileStatusBefore = metrics.getNumGetFileStatus();
+
+    FileStatus status = fs.getFileStatus(filePath);
+    assertTrue(status.isFile());
+
+    assertEquals(bucketInfosBefore, metrics.getNumBucketInfos(),
+        "getFileStatus must not trigger InfoBucket");
+    assertEquals(getFileStatusBefore + 1, metrics.getNumGetFileStatus());
+
+    long getFileStatusAfterFirst = metrics.getNumGetFileStatus();
+    fs.getFileStatus(filePath);
+    assertEquals(bucketInfosBefore, metrics.getNumBucketInfos());
+    assertEquals(getFileStatusAfterFirst + 1, metrics.getNumGetFileStatus());
+  }
+
   @Test
   void testGetFileStatus() throws Exception {
     String volumeNameLocal = getRandomNonExistVolumeName();
@@ -1845,49 +1872,6 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
         () -> fs.getFileStatus(new Path(volume, bucketNameLocal)));
     // Cleanup
     fs.delete(volume, false);
-  }
-
-  @Test
-  void testGetFileStatusUsesSingleOmRpcAfterCacheWarm() throws Exception {
-    Path path = new Path(bucketPath, "single-rpc-stat-test");
-    fs.mkdirs(path);
-    // Warm the bucket layout cache; ignore metrics from the first stat.
-    fs.getFileStatus(path);
-
-    long getFileStatusBefore = getOMMetrics().getNumGetFileStatus();
-    long bucketInfoBefore = getOMMetrics().getNumBucketInfos();
-
-    FileStatus status = fs.getFileStatus(path);
-    assertTrue(status.isDirectory());
-
-    assertEquals(getFileStatusBefore + 1, getOMMetrics().getNumGetFileStatus());
-    assertEquals(bucketInfoBefore, getOMMetrics().getNumBucketInfos());
-  }
-
-  @Test
-  void testGetFileStatusOnBucketRoot() throws Exception {
-    FileStatus status = fs.getFileStatus(bucketPath);
-    assertTrue(status.isDirectory());
-  }
-
-  @Test
-  void testGetFileStatusOnObjectStoreBucketRejectsInvalidLayout()
-      throws Exception {
-    OzoneBucket obsBucket =
-        TestDataUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
-    Path obsBucketPath = new Path(
-        new Path(OZONE_URI_DELIMITER + obsBucket.getVolumeName()),
-        obsBucket.getName());
-    try {
-      IllegalArgumentException exception = assertThrows(
-          IllegalArgumentException.class, () -> fs.getFileStatus(obsBucketPath));
-      assertThat(exception.getMessage())
-          .contains(BucketLayout.OBJECT_STORE.name());
-    } finally {
-      objectStore.getVolume(obsBucket.getVolumeName())
-          .deleteBucket(obsBucket.getName());
-      objectStore.deleteVolume(obsBucket.getVolumeName());
-    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1868,10 +1868,13 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
     String bucketNameLocal = RandomStringUtils.secure().nextNumeric(5);
     Path volume = new Path("/" + volumeNameLocal);
     fs.mkdirs(volume);
-    assertThrows(OMException.class,
-        () -> fs.getFileStatus(new Path(volume, bucketNameLocal)));
-    // Cleanup
-    fs.delete(volume, false);
+    try {
+      FileNotFoundException exception = assertThrows(FileNotFoundException.class,
+          () -> fs.getFileStatus(new Path(volume, bucketNameLocal)));
+      assertThat(exception.getMessage()).contains("Bucket doesn't exist");
+    } finally {
+      fs.delete(volume, false);
+    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1848,6 +1848,56 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
   }
 
   @Test
+  void testGetFileStatusUsesSingleOmRpcAfterCacheWarm() throws Exception {
+    Path path = new Path(bucketPath, "single-rpc-stat-test");
+    fs.mkdirs(path);
+    // Warm the bucket layout cache; ignore metrics from the first stat.
+    fs.getFileStatus(path);
+
+    long getFileStatusBefore = getOMMetrics().getNumGetFileStatus();
+    long bucketInfoBefore = getOMMetrics().getNumBucketInfos();
+
+    FileStatus status = fs.getFileStatus(path);
+    assertTrue(status.isDirectory());
+
+    assertEquals(getFileStatusBefore + 1, getOMMetrics().getNumGetFileStatus());
+    assertEquals(bucketInfoBefore, getOMMetrics().getNumBucketInfos());
+  }
+
+  @Test
+  void testGetFileStatusOnBucketRoot() throws Exception {
+    FileStatus status = fs.getFileStatus(bucketPath);
+    assertTrue(status.isDirectory());
+  }
+
+  @Test
+  void testGetFileStatusOnObjectStoreBucketRejectsInvalidLayout()
+      throws Exception {
+    OzoneBucket obsBucket =
+        TestDataUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
+    Path obsBucketPath = new Path(
+        new Path(OZONE_URI_DELIMITER + obsBucket.getVolumeName()),
+        obsBucket.getName());
+    try {
+      IllegalArgumentException exception = assertThrows(
+          IllegalArgumentException.class, () -> fs.getFileStatus(obsBucketPath));
+      assertThat(exception.getMessage())
+          .contains(BucketLayout.OBJECT_STORE.name());
+    } finally {
+      objectStore.deleteVolume(obsBucket.getVolumeName());
+    }
+  }
+
+  @Test
+  void testGetFileStatusMissingFile() throws Exception {
+    Path missingFile = new Path(bucketPath, "missing-file-" +
+        RandomStringUtils.secure().nextAlphanumeric(5));
+    FileNotFoundException exception = assertThrows(FileNotFoundException.class,
+        () -> fs.getFileStatus(missingFile));
+    assertThat(exception.getMessage()).contains("No such file or directory");
+  }
+
+  @Test
   void testUnbuffer() throws IOException {
     String testKeyName = "testKey2";
     Path path = new Path(bucketPath, testKeyName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1884,6 +1884,8 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
       assertThat(exception.getMessage())
           .contains(BucketLayout.OBJECT_STORE.name());
     } finally {
+      objectStore.getVolume(obsBucket.getVolumeName())
+          .deleteBucket(obsBucket.getName());
       objectStore.deleteVolume(obsBucket.getVolumeName());
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1835,10 +1835,6 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
     assertEquals(ReplicationType.EC.name(), key.getReplicationConfig().getReplicationType().name());
   }
 
-  /**
-   * HDDS-15925: rooted OFS getFileStatus on a key path must not issue InfoBucket
-   * before GetFileStatus.
-   */
   @Test
   void testGetFileStatusUsesSingleOmRpc() throws Exception {
     String keyName = "single-rpc-" + RandomStringUtils.secure().nextAlphabetic(5);
@@ -1860,6 +1856,29 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
     fs.getFileStatus(filePath);
     assertEquals(bucketInfosBefore, metrics.getNumBucketInfos());
     assertEquals(getFileStatusAfterFirst + 1, metrics.getNumGetFileStatus());
+  }
+
+  @Test
+  void testGetFileStatusRejectsObsBucket() throws Exception {
+    OzoneBucket obsBucket =
+        TestDataUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
+    Path obsBucketPath = new Path(
+        new Path(OZONE_URI_DELIMITER, obsBucket.getVolumeName()),
+        obsBucket.getName());
+    String keyName = "obs-key-" + RandomStringUtils.secure().nextAlphabetic(5);
+    TestDataUtil.createKey(obsBucket, keyName,
+        "data".getBytes(StandardCharsets.UTF_8));
+    Path keyPath = new Path(obsBucketPath, keyName);
+
+    OMMetrics metrics = getOMMetrics();
+    long bucketInfosBefore = metrics.getNumBucketInfos();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> fs.getFileStatus(keyPath));
+    assertThat(exception.getMessage()).contains(obsBucket.getName());
+    assertThat(exception.getMessage()).contains("OBJECT_STORE");
+    assertEquals(bucketInfosBefore, metrics.getNumBucketInfos(),
+        "getFileStatus must not trigger InfoBucket");
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.IOzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -193,7 +194,8 @@ public class TestOmAcls {
 
   @Test
   public void testGetFileStatusPermissionDenied() throws Exception {
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
     TestDataUtil.createKey(bucket, "testKey", "testcontent".getBytes(StandardCharsets.UTF_8));
 
     authorizer.keyAclAllow = false;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotTests.java
@@ -65,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.google.common.collect.Lists;
@@ -525,6 +526,7 @@ public abstract class OmSnapshotTests {
     KeyInfoWithVolumeContext fileInfo = writeClient.getKeyInfo(keyArgs, false);
     assertEquals(fileInfo.getKeyInfo().getKeyName(), snapshotKeyPrefix + key1);
 
+    assumeFalse(bucketLayout.equals(BucketLayout.OBJECT_STORE));
     OzoneFileStatus ozoneFileStatus = writeClient.getFileStatus(keyArgs);
     assertEquals(ozoneFileStatus.getKeyInfo().getKeyName(),
         snapshotKeyPrefix + key1);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatusLight;
 import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
@@ -277,6 +278,10 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
     args = bucket.update(args);
 
     try {
+      if (bucket.bucketLayout() != null) {
+        OzoneFSUtils.validateBucketLayout(bucket.requestedBucket(),
+            bucket.bucketLayout());
+      }
       if (isAclEnabled) {
         checkAcls(getResourceType(args), StoreType.OZONE, ACLType.READ,
             bucket, args.getKeyName());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMetadataReader.java
@@ -18,12 +18,22 @@
 package org.apache.hadoop.ozone.om;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Context;
 import org.apache.hadoop.ipc_.Server;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -69,4 +79,62 @@ public class TestOMMetadataReader {
     }
   }
 
+  @Test
+  public void getFileStatusRejectsObjectStoreLayout() throws Exception {
+    OzoneManager ozoneManager = mock(OzoneManager.class);
+    KeyManager keyManager = mock(KeyManager.class);
+    when(ozoneManager.getAclsEnabled()).thenReturn(false);
+    when(ozoneManager.getBucketManager()).thenReturn(mock(BucketManager.class));
+    when(ozoneManager.getVolumeManager()).thenReturn(mock(VolumeManager.class));
+    when(ozoneManager.getPerfMetrics()).thenReturn(mock(OMPerformanceMetrics.class));
+    when(ozoneManager.resolveBucketLink(any(OmKeyArgs.class)))
+        .thenReturn(new ResolvedBucket("vol", "obs-bucket", "vol", "obs-bucket",
+            "owner", BucketLayout.OBJECT_STORE));
+
+    OmMetadataReader reader = new OmMetadataReader(keyManager,
+        mock(PrefixManager.class), ozoneManager, mock(org.slf4j.Logger.class),
+        mock(AuditLogger.class), mock(OmMetadataReaderMetrics.class), null);
+
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName("vol")
+        .setBucketName("obs-bucket")
+        .setKeyName("key1")
+        .build();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> reader.getFileStatus(keyArgs));
+    assertTrue(exception.getMessage().contains("obs-bucket"));
+    assertTrue(exception.getMessage().contains("OBJECT_STORE"));
+    verify(keyManager, never()).getFileStatus(any(), anyString());
+  }
+
+  @Test
+  public void getFileStatusAllowsLegacyLayout() throws Exception {
+    OzoneManager ozoneManager = mock(OzoneManager.class);
+    KeyManager keyManager = mock(KeyManager.class);
+    when(ozoneManager.getAclsEnabled()).thenReturn(false);
+    when(ozoneManager.getBucketManager()).thenReturn(mock(BucketManager.class));
+    when(ozoneManager.getVolumeManager()).thenReturn(mock(VolumeManager.class));
+    when(ozoneManager.getPerfMetrics()).thenReturn(mock(OMPerformanceMetrics.class));
+    when(ozoneManager.resolveBucketLink(any(OmKeyArgs.class)))
+        .thenReturn(new ResolvedBucket("vol", "legacy-bucket", "vol",
+            "legacy-bucket", "owner", BucketLayout.LEGACY));
+    OzoneFileStatus expectedStatus = new OzoneFileStatus();
+    when(keyManager.getFileStatus(any(OmKeyArgs.class), anyString()))
+        .thenReturn(expectedStatus);
+
+    OmMetadataReader reader = new OmMetadataReader(keyManager,
+        mock(PrefixManager.class), ozoneManager, mock(org.slf4j.Logger.class),
+        mock(AuditLogger.class), mock(OmMetadataReaderMetrics.class), null);
+
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName("vol")
+        .setBucketName("legacy-bucket")
+        .setKeyName("key1")
+        .build();
+
+    OzoneFileStatus status = reader.getFileStatus(keyArgs);
+    assertEquals(expectedStatus, status);
+    verify(keyManager).getFileStatus(any(OmKeyArgs.class), anyString());
+  }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -133,11 +132,6 @@ public class BasicRootedOzoneClientAdapterImpl
   private BucketLayout defaultOFSBucketLayout;
   private final OzoneConfiguration config;
   private final OzoneClientConfig clientConfig;
-  /**
-   * Cache of successfully validated bucket layouts for read paths.
-   */
-  private final ConcurrentHashMap<String, BucketLayout> validatedBucketLayouts =
-      new ConcurrentHashMap<>();
 
   /**
    * Create new OzoneClientAdapter implementation.
@@ -280,47 +274,6 @@ public class BasicRootedOzoneClientAdapterImpl
         createIfNotExist);
   }
 
-  private static String bucketLayoutCacheKey(String volumeStr, String bucketStr) {
-    return volumeStr + OZONE_URI_DELIMITER + bucketStr;
-  }
-
-  private BucketLayout validateBucketLayoutForBucket(OzoneBucket bucket)
-      throws IOException {
-    BucketLayout resolvedBucketLayout =
-        OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
-            new HashSet<>());
-    OzoneFSUtils.validateBucketLayout(bucket.getName(), resolvedBucketLayout);
-    return resolvedBucketLayout;
-  }
-
-  private void cacheValidatedBucketLayout(String volumeStr, String bucketStr,
-      BucketLayout layout) {
-    validatedBucketLayouts.putIfAbsent(
-        bucketLayoutCacheKey(volumeStr, bucketStr), layout);
-  }
-
-  private void validateAndCacheBucketLayout(String volumeStr, String bucketStr,
-      OzoneBucket bucket) throws IOException {
-    BucketLayout layout = validateBucketLayoutForBucket(bucket);
-    cacheValidatedBucketLayout(volumeStr, bucketStr, layout);
-  }
-
-  private void resolveAndValidateBucketLayout(String volumeStr, String bucketStr)
-      throws IOException {
-    OzoneBucket bucket = proxy.getBucketDetails(volumeStr, bucketStr);
-    validateAndCacheBucketLayout(volumeStr, bucketStr, bucket);
-  }
-
-  private void ensureBucketLayoutValid(OFSPath ofsPath) throws IOException {
-    String volumeStr = ofsPath.getVolumeName();
-    String bucketStr = ofsPath.getBucketName();
-    if (validatedBucketLayouts.containsKey(
-        bucketLayoutCacheKey(volumeStr, bucketStr))) {
-      return;
-    }
-    resolveAndValidateBucketLayout(volumeStr, bucketStr);
-  }
-
   /**
    * Get OzoneBucket object to operate in.
    * Optionally create volume and bucket if not found.
@@ -344,7 +297,13 @@ public class BasicRootedOzoneClientAdapterImpl
     OzoneBucket bucket;
     try {
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
-      validateAndCacheBucketLayout(volumeStr, bucketStr, bucket);
+
+      // resolve the bucket layout in case of Link Bucket
+      BucketLayout resolvedBucketLayout =
+          OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
+              new HashSet<>());
+
+      OzoneFSUtils.validateBucketLayout(bucket.getName(), resolvedBucketLayout);
     } catch (OMException ex) {
       if (createIfNotExist) {
         // getBucketDetails can throw VOLUME_NOT_FOUND when the parent volume
@@ -386,7 +345,12 @@ public class BasicRootedOzoneClientAdapterImpl
         }
         // Try get bucket again
         bucket = proxy.getBucketDetails(volumeStr, bucketStr);
-        validateAndCacheBucketLayout(volumeStr, bucketStr, bucket);
+
+        BucketLayout resolvedBucketLayout =
+            OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
+                new HashSet<>());
+
+        OzoneFSUtils.validateBucketLayout(bucket.getName(), resolvedBucketLayout);
       } else {
         throw ex;
       }
@@ -732,6 +696,10 @@ public class BasicRootedOzoneClientAdapterImpl
    * Return FileStatusAdapter based on OFSPath being a
    * valid bucket path or valid snapshot path.
    * Throws exception in case of failure.
+   *
+   * <p>Non-snapshot paths call OM GetFileStatus directly (HDDS-15925) without a
+   * prior InfoBucket RPC. OBJECT_STORE buckets are not rejected on this path;
+   * mutating OFS operations still validate layout via {@link #getBucket(OFSPath, boolean)}.
    */
   private FileStatusAdapter getFileStatusForKeyOrSnapshot(
       OFSPath ofsPath, URI uri, Path qualifiedPath, String userName,
@@ -743,12 +711,12 @@ public class BasicRootedOzoneClientAdapterImpl
         OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
         return getFileStatusAdapterWithSnapshotIndicator(
             volume, bucket, uri);
+      } else {
+        OzoneFileStatus status = proxy.getOzoneFileStatus(ofsPath.getVolumeName(),
+            ofsPath.getBucketName(), key, headOp);
+        return toFileStatusAdapter(status, userName, uri, qualifiedPath,
+            ofsPath.getNonKeyPath());
       }
-      ensureBucketLayoutValid(ofsPath);
-      OzoneFileStatus status = proxy.getOzoneFileStatus(
-          ofsPath.getVolumeName(), ofsPath.getBucketName(), key, headOp);
-      return toFileStatusAdapter(status, userName, uri, qualifiedPath,
-          ofsPath.getNonKeyPath());
     } catch (OMException e) {
       if (e.getResult() == OMException.ResultCodes.FILE_NOT_FOUND) {
         throw new FileNotFoundException(key + ": No such file or directory!");

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -132,6 +133,11 @@ public class BasicRootedOzoneClientAdapterImpl
   private BucketLayout defaultOFSBucketLayout;
   private final OzoneConfiguration config;
   private final OzoneClientConfig clientConfig;
+  /**
+   * Cache of successfully validated bucket layouts for read paths.
+   */
+  private final ConcurrentHashMap<String, BucketLayout> validatedBucketLayouts =
+      new ConcurrentHashMap<>();
 
   /**
    * Create new OzoneClientAdapter implementation.
@@ -274,6 +280,47 @@ public class BasicRootedOzoneClientAdapterImpl
         createIfNotExist);
   }
 
+  private static String bucketLayoutCacheKey(String volumeStr, String bucketStr) {
+    return volumeStr + OZONE_URI_DELIMITER + bucketStr;
+  }
+
+  private BucketLayout validateBucketLayoutForBucket(OzoneBucket bucket)
+      throws IOException {
+    BucketLayout resolvedBucketLayout =
+        OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
+            new HashSet<>());
+    OzoneFSUtils.validateBucketLayout(bucket.getName(), resolvedBucketLayout);
+    return resolvedBucketLayout;
+  }
+
+  private void cacheValidatedBucketLayout(String volumeStr, String bucketStr,
+      BucketLayout layout) {
+    validatedBucketLayouts.putIfAbsent(
+        bucketLayoutCacheKey(volumeStr, bucketStr), layout);
+  }
+
+  private void validateAndCacheBucketLayout(String volumeStr, String bucketStr,
+      OzoneBucket bucket) throws IOException {
+    BucketLayout layout = validateBucketLayoutForBucket(bucket);
+    cacheValidatedBucketLayout(volumeStr, bucketStr, layout);
+  }
+
+  private void resolveAndValidateBucketLayout(String volumeStr, String bucketStr)
+      throws IOException {
+    OzoneBucket bucket = proxy.getBucketDetails(volumeStr, bucketStr);
+    validateAndCacheBucketLayout(volumeStr, bucketStr, bucket);
+  }
+
+  private void ensureBucketLayoutValid(OFSPath ofsPath) throws IOException {
+    String volumeStr = ofsPath.getVolumeName();
+    String bucketStr = ofsPath.getBucketName();
+    if (validatedBucketLayouts.containsKey(
+        bucketLayoutCacheKey(volumeStr, bucketStr))) {
+      return;
+    }
+    resolveAndValidateBucketLayout(volumeStr, bucketStr);
+  }
+
   /**
    * Get OzoneBucket object to operate in.
    * Optionally create volume and bucket if not found.
@@ -297,13 +344,7 @@ public class BasicRootedOzoneClientAdapterImpl
     OzoneBucket bucket;
     try {
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
-
-      // resolve the bucket layout in case of Link Bucket
-      BucketLayout resolvedBucketLayout =
-          OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
-              new HashSet<>());
-
-      OzoneFSUtils.validateBucketLayout(bucket.getName(), resolvedBucketLayout);
+      validateAndCacheBucketLayout(volumeStr, bucketStr, bucket);
     } catch (OMException ex) {
       if (createIfNotExist) {
         // getBucketDetails can throw VOLUME_NOT_FOUND when the parent volume
@@ -345,6 +386,7 @@ public class BasicRootedOzoneClientAdapterImpl
         }
         // Try get bucket again
         bucket = proxy.getBucketDetails(volumeStr, bucketStr);
+        validateAndCacheBucketLayout(volumeStr, bucketStr, bucket);
       } else {
         throw ex;
       }
@@ -696,16 +738,17 @@ public class BasicRootedOzoneClientAdapterImpl
       boolean headOp) throws IOException {
     String key = ofsPath.getKeyName();
     try {
-      OzoneBucket bucket = getBucket(ofsPath, false);
       if (ofsPath.isSnapshotPath()) {
+        OzoneBucket bucket = getBucket(ofsPath, false);
         OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
         return getFileStatusAdapterWithSnapshotIndicator(
             volume, bucket, uri);
-      } else {
-        OzoneFileStatus status = bucket.getFileStatus(key, headOp);
-        return toFileStatusAdapter(status, userName, uri, qualifiedPath,
-            ofsPath.getNonKeyPath());
       }
+      ensureBucketLayoutValid(ofsPath);
+      OzoneFileStatus status = proxy.getOzoneFileStatus(
+          ofsPath.getVolumeName(), ofsPath.getBucketName(), key, headOp);
+      return toFileStatusAdapter(status, userName, uri, qualifiedPath,
+          ofsPath.getNonKeyPath());
     } catch (OMException e) {
       if (e.getResult() == OMException.ResultCodes.FILE_NOT_FOUND) {
         throw new FileNotFoundException(key + ": No such file or directory!");

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -698,8 +698,8 @@ public class BasicRootedOzoneClientAdapterImpl
    * Throws exception in case of failure.
    *
    * <p>Non-snapshot paths call OM GetFileStatus directly (HDDS-15925) without a
-   * prior InfoBucket RPC. OBJECT_STORE buckets are not rejected on this path;
-   * mutating OFS operations still validate layout via {@link #getBucket(OFSPath, boolean)}.
+   * prior InfoBucket RPC. OBJECT_STORE buckets are rejected by OM GetFileStatus.
+   * Mutating OFS operations still validate layout via {@link #getBucket(OFSPath, boolean)}.
    */
   private FileStatusAdapter getFileStatusForKeyOrSnapshot(
       OFSPath ofsPath, URI uri, Path qualifiedPath, String userName,
@@ -722,6 +722,10 @@ public class BasicRootedOzoneClientAdapterImpl
         throw new FileNotFoundException(key + ": No such file or directory!");
       } else if (e.getResult() == OMException.ResultCodes.BUCKET_NOT_FOUND) {
         throw new FileNotFoundException(key + ": Bucket doesn't exist!");
+      }
+      String message = e.getMessage();
+      if (message != null && message.contains("does not support file system semantics")) {
+        throw new IllegalArgumentException(message);
       }
       throw e;
     }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -43,7 +44,9 @@ import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,11 +65,13 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   private BasicRootedOzoneClientAdapterImpl adapter;
   private OzoneBucket bucket;
+  private ClientProtocol proxy;
 
   @BeforeEach
   public void setUp() throws Exception {
     adapter = mock(BasicRootedOzoneClientAdapterImpl.class, CALLS_REAL_METHODS);
     bucket = mock(OzoneBucket.class);
+    proxy = mock(ClientProtocol.class);
     doReturn(bucket).when(adapter).getBucket(any(OFSPath.class), eq(false));
 
     // Inject a mock object store so the volume/snapshot dispatch branches can
@@ -77,10 +82,29 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
     when(volume.getCreationTime()).thenReturn(Instant.EPOCH);
     ObjectStore objectStore = mock(ObjectStore.class);
     when(objectStore.getVolume(anyString())).thenReturn(volume);
-    Field field =
-        BasicRootedOzoneClientAdapterImpl.class.getDeclaredField("objectStore");
+    setField(adapter, "objectStore", objectStore);
+    setField(adapter, "proxy", proxy);
+    warmLayoutCache("vol", "bucket");
+  }
+
+  private static void setField(Object target, String name, Object value)
+      throws Exception {
+    Field field = BasicRootedOzoneClientAdapterImpl.class.getDeclaredField(name);
     field.setAccessible(true);
-    field.set(adapter, objectStore);
+    field.set(target, value);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void warmLayoutCache(String volumeName, String bucketName)
+      throws Exception {
+    Field cacheField =
+        BasicRootedOzoneClientAdapterImpl.class.getDeclaredField(
+            "validatedBucketLayouts");
+    cacheField.setAccessible(true);
+    ConcurrentHashMap<String, BucketLayout> cache =
+        new ConcurrentHashMap<>();
+    cache.put(volumeName + "/" + bucketName, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    cacheField.set(adapter, cache);
   }
 
   private static OzoneFileStatus fileStatus(boolean isDir) {
@@ -101,25 +125,27 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void keyPathThreadsHeadOp() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenReturn(fileStatus(false));
+    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
+        anyBoolean())).thenReturn(fileStatus(false));
 
     assertFalse(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user", true).isDir());
 
     ArgumentCaptor<Boolean> headOp = ArgumentCaptor.forClass(Boolean.class);
-    verify(bucket).getFileStatus(anyString(), headOp.capture());
+    verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
+        headOp.capture());
     assertTrue(headOp.getValue());
   }
 
   @Test
   public void fourArgOverloadDoesNotUseHeadOp() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenReturn(fileStatus(true));
+    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
+        anyBoolean())).thenReturn(fileStatus(true));
 
     assertTrue(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user").isDir());
-    verify(bucket).getFileStatus(anyString(), eq(false));
+    verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
+        eq(false));
   }
 
   @Test
@@ -130,8 +156,8 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void fileNotFoundMappedToFileNotFoundException() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenThrow(new OMException("missing",
+    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
+        anyBoolean())).thenThrow(new OMException("missing",
             OMException.ResultCodes.FILE_NOT_FOUND));
     assertThrows(FileNotFoundException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
@@ -140,8 +166,8 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void otherOMExceptionPropagates() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenThrow(new OMException("boom",
+    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
+        anyBoolean())).thenThrow(new OMException("boom",
             OMException.ResultCodes.INTERNAL_ERROR));
     assertThrows(OMException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
@@ -150,8 +176,8 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void bucketNotFoundMappedToFileNotFoundException() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenThrow(new OMException("no bucket",
+    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
+        anyBoolean())).thenThrow(new OMException("no bucket",
             OMException.ResultCodes.BUCKET_NOT_FOUND));
     assertThrows(FileNotFoundException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
@@ -36,7 +36,6 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -46,7 +45,6 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,37 +72,21 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
     proxy = mock(ClientProtocol.class);
     doReturn(bucket).when(adapter).getBucket(any(OFSPath.class), eq(false));
 
-    // Inject a mock object store so the volume/snapshot dispatch branches can
-    // run without a live OM connection.
+    Field proxyField =
+        BasicRootedOzoneClientAdapterImpl.class.getDeclaredField("proxy");
+    proxyField.setAccessible(true);
+    proxyField.set(adapter, proxy);
+
     OzoneVolume volume = mock(OzoneVolume.class);
     when(volume.getName()).thenReturn("vol");
     when(volume.getOwner()).thenReturn("user");
     when(volume.getCreationTime()).thenReturn(Instant.EPOCH);
     ObjectStore objectStore = mock(ObjectStore.class);
     when(objectStore.getVolume(anyString())).thenReturn(volume);
-    setField(adapter, "objectStore", objectStore);
-    setField(adapter, "proxy", proxy);
-    warmLayoutCache("vol", "bucket");
-  }
-
-  private static void setField(Object target, String name, Object value)
-      throws Exception {
-    Field field = BasicRootedOzoneClientAdapterImpl.class.getDeclaredField(name);
+    Field field =
+        BasicRootedOzoneClientAdapterImpl.class.getDeclaredField("objectStore");
     field.setAccessible(true);
-    field.set(target, value);
-  }
-
-  @SuppressWarnings("unchecked")
-  private void warmLayoutCache(String volumeName, String bucketName)
-      throws Exception {
-    Field cacheField =
-        BasicRootedOzoneClientAdapterImpl.class.getDeclaredField(
-            "validatedBucketLayouts");
-    cacheField.setAccessible(true);
-    ConcurrentHashMap<String, BucketLayout> cache =
-        new ConcurrentHashMap<>();
-    cache.put(volumeName + "/" + bucketName, BucketLayout.FILE_SYSTEM_OPTIMIZED);
-    cacheField.set(adapter, cache);
+    field.set(adapter, objectStore);
   }
 
   private static OzoneFileStatus fileStatus(boolean isDir) {
@@ -125,27 +107,26 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void keyPathThreadsHeadOp() throws IOException {
-    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
-        anyBoolean())).thenReturn(fileStatus(false));
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(fileStatus(false));
 
     assertFalse(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user", true).isDir());
 
     ArgumentCaptor<Boolean> headOp = ArgumentCaptor.forClass(Boolean.class);
-    verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
+    verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), eq("key"),
         headOp.capture());
     assertTrue(headOp.getValue());
   }
 
   @Test
   public void fourArgOverloadDoesNotUseHeadOp() throws IOException {
-    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
-        anyBoolean())).thenReturn(fileStatus(true));
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(fileStatus(true));
 
     assertTrue(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user").isDir());
-    verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
-        eq(false));
+    verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), eq("key"), eq(false));
   }
 
   @Test
@@ -156,8 +137,8 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void fileNotFoundMappedToFileNotFoundException() throws IOException {
-    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
-        anyBoolean())).thenThrow(new OMException("missing",
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
+        .thenThrow(new OMException("missing",
             OMException.ResultCodes.FILE_NOT_FOUND));
     assertThrows(FileNotFoundException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
@@ -166,8 +147,8 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void otherOMExceptionPropagates() throws IOException {
-    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
-        anyBoolean())).thenThrow(new OMException("boom",
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
+        .thenThrow(new OMException("boom",
             OMException.ResultCodes.INTERNAL_ERROR));
     assertThrows(OMException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
@@ -176,8 +157,8 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void bucketNotFoundMappedToFileNotFoundException() throws IOException {
-    when(proxy.getOzoneFileStatus(eq("vol"), eq("bucket"), anyString(),
-        anyBoolean())).thenThrow(new OMException("no bucket",
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
+        .thenThrow(new OMException("no bucket",
             OMException.ResultCodes.BUCKET_NOT_FOUND));
     assertThrows(FileNotFoundException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
@@ -195,7 +176,6 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
     when(bucket.getVolumeName()).thenReturn("vol");
     when(bucket.getName()).thenReturn("bucket");
     when(bucket.getCreationTime()).thenReturn(Instant.EPOCH);
-    // keyName == ".snapshot" is the snapshot indicator path.
     assertTrue(adapter.getFileStatus("/vol/bucket/.snapshot", URI_OFS,
         WORKING_DIR, "user", true).isDir());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rooted OFS `getFileStatus()` on normal bucket/key paths (non-snapshot) previously called `getBucket()` → InfoBucket, then `bucket.getFileStatus()`, which is already `proxy.getOzoneFileStatus()`. This PR skips the redundant **InfoBucket** RPC and calls **`GetFileStatus` only** via `proxy.getOzoneFileStatus(..., headOp)`.

Snapshot indicator paths are unchanged: they still use `getBucket()` and synthetic status (no `GetFileStatus`).

**Behavior change (accepted):** Client-side `validateBucketLayout()` no longer runs on the stat path. OM accepts `GetFileStatus` for **OBJECT_STORE** buckets, so rooted `getFileStatus` may succeed or return `FILE_NOT_FOUND` instead of throwing `IllegalArgumentException`. Mutating OFS operations (`mkdir`, `create`, `delete`, etc.) still call `getBucket()` and reject OBJECT_STORE as before.

This is a **client-side** optimization for [HDDS-15925](https://issues.apache.org/jira/browse/HDDS-15925). It is **not** the [HDDS-11232](https://issues.apache.org/jira/browse/HDDS-11232) approach (no combined OM response / server-side merge of bucket info with file status). HDDS-15925 references HDDS-11232 for the same RPC-reduction theme.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15925

## How was this patch tested?

- [x] Unit: `TestBasicRootedOzoneClientAdapterHeadOp` (direct `getOzoneFileStatus` / `headOp`)
- [x] Integration: `TestOFS#testGetFileStatusUsesSingleOmRpc` (OM metrics: no InfoBucket increment, `GetFileStatus` +1 per stat)
- [x] Integration: missing-bucket stat expects `FileNotFoundException` (client mapping)
- [x] Smoketest: `ozonefs-obs.robot` updated for OBS stat vs mutating ops
- [x] CI on https://github.com/apache/ozone/pull/10792

Generated-by: Cursor (Composer)