### PR TITLE
HDDS-15772. Stop forcing java.net.preferIPv4Stack=true

### DIFF
--- a/hadoop-hdds/common/src/main/conf/ozone-env.sh
+++ b/hadoop-hdds/common/src/main/conf/ozone-env.sh
@@ -86,11 +86,11 @@ fi
 # memory size.
 # export OZONE_HEAPSIZE_MIN=
 
-# Extra Java runtime options for all Ozone commands. We don't support
-# IPv6 yet/still, so by default the preference is set to IPv4.
+# Extra Java runtime options for all Ozone commands. Ozone does not override
+# the JVM's IP stack preference. To force IPv4-only networking:
 # export OZONE_OPTS="-Djava.net.preferIPv4Stack=true"
-# For Kerberos debugging, an extended option set logs more information
-# export OZONE_OPTS="-Djava.net.preferIPv4Stack=true -Dsun.security.krb5.debug=true -Dsun.security.spnego.debug"
+# For Kerberos debugging, an extended option set logs more information:
+# export OZONE_OPTS="-Dsun.security.krb5.debug=true -Dsun.security.spnego.debug"
 
 # Some parts of the shell code may do special things dependent upon
 # the operating system.  We have to set this here. See the next

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -636,7 +636,7 @@ function ozone_bootstrap
   export HDDS_LIB_JARS_DIR="${OZONE_HOME}/share/ozone/lib"
 
   export OZONE_OS_TYPE=${OZONE_OS_TYPE:-$(uname -s)}
-  export OZONE_OPTS=${OZONE_OPTS:-"-Djava.net.preferIPv4Stack=true"}
+  export OZONE_OPTS=${OZONE_OPTS:-}
   ozone_using_envvar OZONE_OPTS
   JSVC_HOME=${JSVC_HOME:-"/usr/bin"}
 
@@ -1334,8 +1334,6 @@ function ozone_add_to_classpath_userpath
 ## @return       may exit on failure conditions
 function ozone_os_tricks
 {
-  local bindv6only
-
   OZONE_IS_CYGWIN=false
   case ${OZONE_OS_TYPE} in
     Darwin)
@@ -1356,25 +1354,6 @@ function ozone_os_tricks
       # with the many threads that we use in Hadoop. Tune the variable
       # down to prevent vmem explosion.
       export MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-4}
-      # we put this in QA test mode off so that non-Linux can test
-      if [[ "${QATESTMODE}" = true ]]; then
-        return
-      fi
-
-      # NOTE! OZONE_ALLOW_IPV6 is a developer hook.  We leave it
-      # undocumented in ozone-env.sh because we don't want users to
-      # shoot themselves in the foot while devs make IPv6 work.
-
-      bindv6only=$(/sbin/sysctl -n net.ipv6.bindv6only 2> /dev/null)
-
-      if [[ -n "${bindv6only}" ]] &&
-         [[ "${bindv6only}" -eq "1" ]] &&
-         [[ "${OZONE_ALLOW_IPV6}" != "yes" ]]; then
-        ozone_error "ERROR: \"net.ipv6.bindv6only\" is set to 1 "
-        ozone_error "ERROR: Hadoop networking could be broken. Aborting."
-        ozone_error "ERROR: For more info: http://wiki.apache.org/hadoop/HadoopIPv6"
-        exit 1
-      fi
     ;;
     CYGWIN*)
       # Flag that we're running on Cygwin to trigger path translation later.

--- a/hadoop-ozone/dist/src/test/shell/ozone_bootstrap.bats
+++ b/hadoop-ozone/dist/src/test/shell/ozone_bootstrap.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load ozone-functions_test_helper
+
+bootstrap_ozone() {
+  export OZONE_LIBEXEC_DIR="${BATS_TEST_DIRNAME}/../../shell/ozone"
+  unset OZONE_BOOTSTRAPPED OZONE_HOME
+  ozone_bootstrap
+}
+
+@test "ozone_bootstrap does not force the IPv4 stack by default" {
+  unset OZONE_OPTS
+
+  bootstrap_ozone
+
+  [[ -z "${OZONE_OPTS}" ]]
+}
+
+@test "ozone_bootstrap preserves an explicit IPv4 stack preference" {
+  export OZONE_OPTS="-Djava.net.preferIPv4Stack=true"
+
+  bootstrap_ozone
+
+  [[ "${OZONE_OPTS}" == "-Djava.net.preferIPv4Stack=true" ]]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2376,7 +2376,6 @@
           <systemPropertyVariables>
             <hadoop.log.dir>${project.build.directory}/log</hadoop.log.dir>
             <hadoop.tmp.dir>${project.build.directory}/tmp</hadoop.tmp.dir>
-            <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
             <java.security.egd>${java.security.egd}</java.security.egd>
             <java.security.krb5.conf>${project.build.directory}/test-classes/krb5.conf</java.security.krb5.conf>
             <require.test.libhadoop>${require.test.libhadoop}</require.test.libhadoop>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone currently forces `java.net.preferIPv4Stack=true` for daemon processes and Maven test executions. 
This prevents the JVM from using its default networking behavior and blocks IPv6-capable or dual-stack environments unnecessarily.
- Removes the default `java.net.preferIPv4Stack=true` setting from Ozone shell bootstrap.
- Removes the corresponding global Surefire system property.
- Removes the legacy Linux `net.ipv6.bindv6only` check and the undocumented `OZONE_ALLOW_IPV6` developer override.
- Updates `ozone-env.sh` to document that Ozone follows the JVM's default IP stack preference while retaining instructions for operators who need to force IPv4.
- Adds Bats coverage verifying that shell bootstrap does not force IPv4 by default and preserves an explicitly configured IPv4 preference.

Operators can continue to force IPv4 when required by setting:
```shell
export OZONE_OPTS="-Djava.net.preferIPv4Stack=true"
```

Generated-by: Codex (GPT-5)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15772

## How was this patch tested?

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/29590987895
<img width="600" height="178" alt="截圖 2026-07-18 下午1 18 02" src="https://github.com/user-attachments/assets/685bf808-d380-41ef-8406-0349723c317d" />
