### PR TITLE
HDDS-15773. Make HddsUtils host:port helpers IPv6-safe

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/client/TestHddsClientUtils.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/client/TestHddsClientUtils.java
@@ -176,6 +176,50 @@ public class TestHddsClientUtils {
   }
 
   @Test
+  public void testClientAddressIPv6() {
+    // Bare IPv6 literal without port: port falls back to the default and the
+    // host must be re-bracketed before the address string is parsed.
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, "2001:db8::1");
+    InetSocketAddress addr =
+        HddsUtils.getScmAddressForClients(conf).iterator().next();
+    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
+    assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+
+    // Bracketed IPv6 literal with explicit port.
+    conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, "[2001:db8::1]:9876");
+    addr = HddsUtils.getScmAddressForClients(conf).iterator().next();
+    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
+    assertEquals(9876, addr.getPort());
+
+    // Bracketed IPv6 literal without port (host:port documents port as
+    // optional).
+    conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, "[2001:db8::1]");
+    addr = HddsUtils.getScmAddressForClients(conf).iterator().next();
+    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
+    assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+  }
+
+  @Test
+  public void testClientFallbackToScmNamesIPv6() {
+    // Bare IPv6 literal in ozone.scm.names.
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_SCM_NAMES, "2001:db8::1");
+    InetSocketAddress addr =
+        HddsUtils.getScmAddressForClients(conf).iterator().next();
+    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
+    assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+
+    // On the ozone.scm.names fallback path an inline port is ignored and the
+    // default client port is used instead (same semantics as
+    // testClientFallbackToScmNamesWithPort).
+    conf.set(OZONE_SCM_NAMES, "[2001:db8::1]:300");
+    addr = HddsUtils.getScmAddressForClients(conf).iterator().next();
+    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
+    assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+  }
+
+  @Test
   @SuppressWarnings("StringSplitter")
   public void testBlockClientFallbackToClientWithPort() {
     // When OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY is undefined it should

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/client/TestHddsClientUtils.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/client/TestHddsClientUtils.java
@@ -127,6 +127,13 @@ public class TestHddsClientUtils {
     assertEquals(port, scmAddr.getPort());
   }
 
+  private void checkScmClientAddr(String confKey, String value,
+      String expectedHost, int expectedPort) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(confKey, value);
+    checkAddr(conf, expectedHost, expectedPort);
+  }
+
   @Test
   public void testBlockClientFallbackToClientNoPort() {
     // When OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY is undefined it should
@@ -179,44 +186,30 @@ public class TestHddsClientUtils {
   public void testClientAddressIPv6() {
     // Bare IPv6 literal without port: port falls back to the default and the
     // host must be re-bracketed before the address string is parsed.
-    final OzoneConfiguration conf = new OzoneConfiguration();
-    conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, "2001:db8::1");
-    InetSocketAddress addr =
-        HddsUtils.getScmAddressForClients(conf).iterator().next();
-    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
-    assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+    checkScmClientAddr(OZONE_SCM_CLIENT_ADDRESS_KEY, "2001:db8::1",
+        "2001:db8:0:0:0:0:0:1", OZONE_SCM_CLIENT_PORT_DEFAULT);
 
     // Bracketed IPv6 literal with explicit port.
-    conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, "[2001:db8::1]:9876");
-    addr = HddsUtils.getScmAddressForClients(conf).iterator().next();
-    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
-    assertEquals(9876, addr.getPort());
+    checkScmClientAddr(OZONE_SCM_CLIENT_ADDRESS_KEY, "[2001:db8::1]:9876",
+        "2001:db8:0:0:0:0:0:1", 9876);
 
     // Bracketed IPv6 literal without port (host:port documents port as
     // optional).
-    conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, "[2001:db8::1]");
-    addr = HddsUtils.getScmAddressForClients(conf).iterator().next();
-    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
-    assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+    checkScmClientAddr(OZONE_SCM_CLIENT_ADDRESS_KEY, "[2001:db8::1]",
+        "2001:db8:0:0:0:0:0:1", OZONE_SCM_CLIENT_PORT_DEFAULT);
   }
 
   @Test
   public void testClientFallbackToScmNamesIPv6() {
     // Bare IPv6 literal in ozone.scm.names.
-    final OzoneConfiguration conf = new OzoneConfiguration();
-    conf.set(OZONE_SCM_NAMES, "2001:db8::1");
-    InetSocketAddress addr =
-        HddsUtils.getScmAddressForClients(conf).iterator().next();
-    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
-    assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+    checkScmClientAddr(OZONE_SCM_NAMES, "2001:db8::1",
+        "2001:db8:0:0:0:0:0:1", OZONE_SCM_CLIENT_PORT_DEFAULT);
 
     // On the ozone.scm.names fallback path an inline port is ignored and the
     // default client port is used instead (same semantics as
     // testClientFallbackToScmNamesWithPort).
-    conf.set(OZONE_SCM_NAMES, "[2001:db8::1]:300");
-    addr = HddsUtils.getScmAddressForClients(conf).iterator().next();
-    assertEquals("2001:db8:0:0:0:0:0:1", addr.getHostString());
-    assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+    checkScmClientAddr(OZONE_SCM_NAMES, "[2001:db8::1]:300",
+        "2001:db8:0:0:0:0:0:1", OZONE_SCM_CLIENT_PORT_DEFAULT);
   }
 
   @Test

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -203,7 +203,7 @@ public final class HddsUtils {
     if ((value == null) || value.isEmpty()) {
       return Optional.empty();
     }
-    String hostname = value.replaceAll("\\:[0-9]+$", "");
+    String hostname = HostAndPort.fromString(value).getHost();
     if (hostname.isEmpty()) {
       return Optional.empty();
     } else {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -165,7 +165,7 @@ public final class HddsUtils {
       }
 
       return Collections.singletonList(
-          NetUtils.createSocketAddr(getHostName(address).get() + ":" + port));
+          NetUtils.createSocketAddr(getHostPortString(getHostName(address).get(), port)));
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -586,23 +586,6 @@ public final class HddsUtils {
   }
 
   /**
-   * Utility string formatter method to display SCM roles.
-   *
-   * @param nodes
-   * @return String
-   */
-  public static String format(List<String> nodes) {
-    StringBuilder sb = new StringBuilder();
-    for (String node : nodes) {
-      String[] x = node.split(":");
-      sb.append(String
-          .format("{ HostName : %s, Ratis Port : %s, Role : %s } ", x[0], x[1],
-              x[2]));
-    }
-    return sb.toString();
-  }
-
-  /**
    * Return Ozone service shutdown time out.
    * @param conf
    */

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -57,6 +57,25 @@ public class TestHddsUtils {
 
     assertEquals(Optional.empty(),
         HddsUtils.getHostName(":1234"));
+
+    assertEquals(Optional.of("::1"),
+        HddsUtils.getHostName("[::1]:9862"));
+
+    assertEquals(Optional.of("::1"),
+        HddsUtils.getHostName("::1"));
+
+    assertEquals(Optional.of("2001:db8::1"),
+        HddsUtils.getHostName("2001:db8::1"));
+
+    assertEquals(Optional.of("2001:db8::1"),
+        HddsUtils.getHostName("[2001:db8::1]:9862"));
+
+    assertEquals(Optional.of("2001:db8::1"),
+        HddsUtils.getHostName("[2001:db8::1]"));
+
+    // Malformed host:port input is rejected, matching getHostPort().
+    assertThrows(IllegalArgumentException.class,
+        () -> HddsUtils.getHostName("a:b"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change makes `HddsUtils` host:port handling IPv6-safe.

`getHostName()` previously removed a trailing `:port` with a regex. This left brackets in `[::1]:9862` and corrupted bare IPv6 literals such as `::1` or `2001:db8::1`. `getScmAddressForClients()` then rebuilt addresses using `host + ":" + port`, which creates an ambiguous address for IPv6 hosts.

This patch:

- Uses Guava `HostAndPort` in `getHostName()`, matching the adjacent `getHostPort()` helper and returning unbracketed IPv6 hosts.
- Uses `getHostPortString()` to rebuild SCM client addresses, producing valid bracketed IPv6 addresses such as `[2001:db8::1]:9860`.
- Removes the unused `HddsUtils.format(List<String>)` method. It has no repository callers and parses role strings with IPv6-unsafe fixed-colon splitting.

Malformed host:port inputs, including `a:b`, `host:99999`, and unbracketed IPv6-with-port values, now throw `IllegalArgumentException`. This matches `getHostPort()` and the documented contract of `getHostNameFromConfigKeys()`.

The fixed-index role parsing in `StorageContainerManager#getScmRatisRoles()` (HDDS-15774) and the `ServerNotLeaderException` suggested-leader flow (HDDS-15895) remain out of scope and require separate follow-up changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15773

## How was this patch tested?

- Added `TestHddsUtils#testGetHostName` coverage for bracketed and bare IPv6 literals, IPv6 without a port, and malformed input.
- Added `TestHddsClientUtils` coverage for IPv6 SCM client addresses and the `ozone.scm.names` fallback path.
- Full `TestHddsUtils` and T`estHddsClientUtils` runs pass; hdds-common module unit tests pass (404 tests, 0 failures).
- `checkstyle.sh, rat.sh, and author.sh` pass locally; full `mvn clean install -DskipTests` succeeds.

Generated-by: Claude Code (Opus 4.8)
