### PR TITLE
HDDS-15906. Add gateway LLM provider for Recon chatbot (OpenAI-compatible gateways).

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
@@ -56,3 +56,29 @@ OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop
 
 no_proxy=om1,om2,om3,scm,s3g,recon,kdc,localhost,127.0.0.1
+
+# Recon AI Chatbot — DISABLED by default.
+#
+# WARNING: The plaintext API key approach shown below is for LOCAL DOCKER
+# TESTING ONLY. It must NOT be used on production clusters because plaintext
+# keys are exposed via 'hadoop conf | grep api.key' and via Recon's /conf HTTP
+# endpoint. For production clusters, store the key in a Hadoop JCEKS credential
+# store instead (see ozone-site.xml.template for full setup instructions).
+#
+# To enable the chatbot locally for testing:
+#   1. Uncomment ONE block below (direct provider or gateway).
+#   2. Replace the placeholder key with a real key.
+#   3. Never commit a real key to git — rotate it immediately if you do.
+#
+# --- Direct provider (Gemini example; OpenAI and Anthropic are also supported) ---
+# OZONE-SITE.XML_ozone.recon.chatbot.enabled=true
+# OZONE-SITE.XML_ozone.recon.chatbot.provider=gemini
+# OZONE-SITE.XML_ozone.recon.chatbot.gemini.api.key=YOUR_GEMINI_API_KEY_HERE
+#
+# --- OpenAI-compatible gateway (LiteLLM etc.) — one door for all models ---
+# OZONE-SITE.XML_ozone.recon.chatbot.enabled=true
+# OZONE-SITE.XML_ozone.recon.chatbot.provider=gateway
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.base.url=https://your-gateway/v1
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.api.key=YOUR_GATEWAY_KEY_HERE
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.models=gpt-4.1,claude-sonnet,gemini-2.5-flash
+# OZONE-SITE.XML_ozone.recon.chatbot.default.model=claude-sonnet

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -89,9 +89,19 @@ OZONE-SITE.XML_ozone.snapshot.defrag.service.interval=30s
 # store instead (see ozone-site.xml.template for full setup instructions).
 #
 # To enable the chatbot locally for testing:
-#   1. Uncomment the lines below.
-#   2. Replace YOUR_GEMINI_API_KEY_HERE with a real key.
+#   1. Uncomment ONE block below (direct provider or gateway).
+#   2. Replace the placeholder key with a real key.
 #   3. Never commit a real key to git — rotate it immediately if you do.
+#
+# --- Direct provider (Gemini example; OpenAI and Anthropic are also supported) ---
 # OZONE-SITE.XML_ozone.recon.chatbot.enabled=true
 # OZONE-SITE.XML_ozone.recon.chatbot.provider=gemini
 # OZONE-SITE.XML_ozone.recon.chatbot.gemini.api.key=YOUR_GEMINI_API_KEY_HERE
+#
+# --- OpenAI-compatible gateway (LiteLLM etc.) — one door for all models ---
+# OZONE-SITE.XML_ozone.recon.chatbot.enabled=true
+# OZONE-SITE.XML_ozone.recon.chatbot.provider=gateway
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.base.url=https://your-gateway/v1
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.api.key=YOUR_GATEWAY_KEY_HERE
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.models=gpt-4.1,claude-sonnet,gemini-2.5-flash
+# OZONE-SITE.XML_ozone.recon.chatbot.default.model=claude-sonnet

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -180,3 +180,29 @@ OZONE-SITE.XML_ozone.om.tenant.dev.skip.ranger=true
 
 # Explicitly enable filesystem snapshot feature for this Docker compose cluster
 OZONE-SITE.XML_ozone.filesystem.snapshot.enabled=true
+
+# Recon AI Chatbot — DISABLED by default.
+#
+# WARNING: The plaintext API key approach shown below is for LOCAL DOCKER
+# TESTING ONLY. It must NOT be used on production clusters because plaintext
+# keys are exposed via 'hadoop conf | grep api.key' and via Recon's /conf HTTP
+# endpoint. For production clusters, store the key in a Hadoop JCEKS credential
+# store instead (see ozone-site.xml.template for full setup instructions).
+#
+# To enable the chatbot locally for testing:
+#   1. Uncomment ONE block below (direct provider or gateway).
+#   2. Replace the placeholder key with a real key.
+#   3. Never commit a real key to git — rotate it immediately if you do.
+#
+# --- Direct provider (Gemini example; OpenAI and Anthropic are also supported) ---
+# OZONE-SITE.XML_ozone.recon.chatbot.enabled=true
+# OZONE-SITE.XML_ozone.recon.chatbot.provider=gemini
+# OZONE-SITE.XML_ozone.recon.chatbot.gemini.api.key=YOUR_GEMINI_API_KEY_HERE
+#
+# --- OpenAI-compatible gateway (LiteLLM etc.) — one door for all models ---
+# OZONE-SITE.XML_ozone.recon.chatbot.enabled=true
+# OZONE-SITE.XML_ozone.recon.chatbot.provider=gateway
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.base.url=https://your-gateway/v1
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.api.key=YOUR_GATEWAY_KEY_HERE
+# OZONE-SITE.XML_ozone.recon.chatbot.gateway.models=gpt-4.1,claude-sonnet,gemini-2.5-flash
+# OZONE-SITE.XML_ozone.recon.chatbot.default.model=claude-sonnet

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/chatbot/ChatbotConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/chatbot/ChatbotConfigKeys.java
@@ -55,12 +55,24 @@ public final class ChatbotConfigKeys {
   public static final String OZONE_RECON_CHATBOT_ANTHROPIC_API_KEY = OZONE_RECON_CHATBOT_PREFIX
       + "anthropic.api.key";
 
+  /**
+   * Gateway API key. Used when provider is set to "gateway" to route all requests
+   * (regardless of underlying model) through an OpenAI-compatible gateway (e.g. LiteLLM).
+   */
+  public static final String OZONE_RECON_CHATBOT_GATEWAY_API_KEY = OZONE_RECON_CHATBOT_PREFIX + "gateway.api.key";
+
   // ── Per-provider base URL overrides (optional) ──────────────
   public static final String OZONE_RECON_CHATBOT_OPENAI_BASE_URL = OZONE_RECON_CHATBOT_PREFIX + "openai.base.url";
   public static final String OZONE_RECON_CHATBOT_OPENAI_BASE_URL_DEFAULT = "https://api.openai.com";
   
   public static final String OZONE_RECON_CHATBOT_GEMINI_BASE_URL = OZONE_RECON_CHATBOT_PREFIX + "gemini.base.url";
   public static final String OZONE_RECON_CHATBOT_GEMINI_BASE_URL_DEFAULT = "https://generativelanguage.googleapis.com/v1beta/openai/";
+
+  /**
+   * Required base URL when using the "gateway" provider. Points to your internal
+   * OpenAI-compatible endpoint. No default is provided.
+   */
+  public static final String OZONE_RECON_CHATBOT_GATEWAY_BASE_URL = OZONE_RECON_CHATBOT_PREFIX + "gateway.base.url";
 
   // ── Execution policy ────────────────────────────────────────
 
@@ -140,6 +152,14 @@ public final class ChatbotConfigKeys {
       OZONE_RECON_CHATBOT_PREFIX + "anthropic.models";
   public static final String OZONE_RECON_CHATBOT_ANTHROPIC_MODELS_DEFAULT =
       "claude-opus-4-6,claude-sonnet-4-6";
+
+  /**
+   * Comma-separated list of model aliases exposed by your OpenAI-compatible gateway.
+   * Required when using the "gateway" provider. Include all models (Claude, Gemini, GPT)
+   * that your gateway supports. No default is provided.
+   */
+  public static final String OZONE_RECON_CHATBOT_GATEWAY_MODELS =
+      OZONE_RECON_CHATBOT_PREFIX + "gateway.models";
 
   // ── Anthropic-specific headers ───────────────────────────────
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/chatbot/llm/LangChain4jDispatcher.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/chatbot/llm/LangChain4jDispatcher.java
@@ -79,6 +79,7 @@ public class LangChain4jDispatcher implements LLMClient {
   private static final String PROVIDER_OPENAI = "openai";
   private static final String PROVIDER_GEMINI = "gemini";
   private static final String PROVIDER_ANTHROPIC = "anthropic";
+  private static final String PROVIDER_GATEWAY = "gateway";
 
   private final OzoneConfiguration configuration;
   private final CredentialHelper credentialHelper;
@@ -146,6 +147,12 @@ public class LangChain4jDispatcher implements LLMClient {
       supportedModels.put("anthropic", parseModelList(configuration,
           ChatbotConfigKeys.OZONE_RECON_CHATBOT_ANTHROPIC_MODELS,
           ChatbotConfigKeys.OZONE_RECON_CHATBOT_ANTHROPIC_MODELS_DEFAULT));
+    }
+    if (!credentialHelper.getSecret(
+        ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_API_KEY).isEmpty()) {
+      supportedModels.put("gateway", parseModelList(configuration,
+          ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_MODELS,
+          ""));
     }
 
     this.routing = new LlmRouting(defaultProvider, defaultModel, supportedModels);
@@ -363,9 +370,29 @@ public class LangChain4jDispatcher implements LLMClient {
       return buildGeminiModel(model, temperature, maxTokens);
     case PROVIDER_ANTHROPIC:
       return buildAnthropicModel(model, temperature, maxTokens);
+    case PROVIDER_GATEWAY:
+      return buildGatewayModel(model, temperature, maxTokens);
     default:
       throw new LLMException("Unknown or unconfigured provider: '" + provider + "'");
     }
+  }
+
+  private ChatLanguageModel buildGatewayModel(String model, double temperature, int maxTokens)
+      throws LLMException {
+    String key = resolveKey(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_API_KEY, "gateway");
+    String baseUrl = configuration.get(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_BASE_URL);
+    if (StringUtils.isBlank(baseUrl)) {
+      throw new LLMException(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_BASE_URL
+          + " must be set when using the gateway provider.");
+    }
+
+    OpenAiChatModel.OpenAiChatModelBuilder builder = OpenAiChatModel.builder()
+        .apiKey(key)
+        .modelName(model)
+        .baseUrl(baseUrl)
+        .timeout(timeout);
+    applyGenerationParams(builder, temperature, maxTokens);
+    return builder.build();
   }
 
   private ChatLanguageModel buildOpenAiModel(String model, double temperature, int maxTokens)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/chatbot/llm/TestLangChain4jDispatcher.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/chatbot/llm/TestLangChain4jDispatcher.java
@@ -76,6 +76,13 @@ public class TestLangChain4jDispatcher {
   }
 
   @Test
+  public void testIsAvailableWithGatewayKey() {
+    conf.set(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_API_KEY, "fake-gateway-key");
+    dispatcher = new LangChain4jDispatcher(conf, new CredentialHelper(conf));
+    assertTrue(dispatcher.isAvailable());
+  }
+
+  @Test
   public void testGetSupportedModelsEmptyWithoutKeys() {
     List<String> models = dispatcher.getSupportedModels();
     assertNotNull(models);
@@ -89,6 +96,17 @@ public class TestLangChain4jDispatcher {
     List<String> models = dispatcher.getSupportedModels();
     assertFalse(models.isEmpty());
     assertTrue(models.stream().anyMatch(m -> m.startsWith("gemini")));
+  }
+
+  @Test
+  public void testGetSupportedModelsWithGatewayKey() {
+    conf.set(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_API_KEY, "fake-gateway-key");
+    conf.set(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_MODELS, "claude-sonnet,gpt-4.1");
+    dispatcher = new LangChain4jDispatcher(conf, new CredentialHelper(conf));
+    List<String> models = dispatcher.getSupportedModels();
+    assertFalse(models.isEmpty());
+    assertTrue(models.contains("claude-sonnet"));
+    assertTrue(models.contains("gpt-4.1"));
   }
 
   @Test
@@ -165,5 +183,42 @@ public class TestLangChain4jDispatcher {
 
     assertTrue(ex.getMessage().toLowerCase().contains("gemini"),
         "Mismatched pair should fall back to default gemini provider");
+  }
+
+  @Test
+  public void testGatewayProviderRoutesCorrectly() {
+    conf.set(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_API_KEY, "fake-gateway-key");
+    conf.set(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_BASE_URL, "https://gateway.example.com");
+    conf.set(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_MODELS, "claude-sonnet");
+    dispatcher = new LangChain4jDispatcher(conf, new CredentialHelper(conf));
+
+    List<LLMClient.ChatMessage> messages = new ArrayList<>();
+    messages.add(new LLMClient.ChatMessage("user", "hello"));
+
+    // Expected to throw because fake URL is not reachable, but it should reach the builder
+    Exception ex = assertThrows(Exception.class, () ->
+        dispatcher.chatCompletion(messages, "claude-sonnet", "gateway",
+            new GenParams(0.1, 1000), null));
+        
+    // Verification that it tried to route to gateway is implicit if it doesn't throw
+    // the "No API key" or base URL errors.
+  }
+
+  @Test
+  public void testGatewayProviderThrowsWhenBaseUrlBlank() {
+    conf.set(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_API_KEY, "fake-gateway-key");
+    conf.set(ChatbotConfigKeys.OZONE_RECON_CHATBOT_GATEWAY_MODELS, "claude-sonnet");
+    // Leave base URL blank
+    dispatcher = new LangChain4jDispatcher(conf, new CredentialHelper(conf));
+
+    List<LLMClient.ChatMessage> messages = new ArrayList<>();
+    messages.add(new LLMClient.ChatMessage("user", "hello"));
+
+    LLMClient.LLMException ex = assertThrows(LLMClient.LLMException.class, () ->
+        dispatcher.chatCompletion(messages, "claude-sonnet", "gateway",
+            new GenParams(0.1, 1000), null));
+
+    assertTrue(ex.getMessage().contains("must be set when using the gateway provider"),
+        "Should throw if gateway.base.url is missing");
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/chatbot/llm/TestLangChain4jDispatcher.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/chatbot/llm/TestLangChain4jDispatcher.java
@@ -195,13 +195,15 @@ public class TestLangChain4jDispatcher {
     List<LLMClient.ChatMessage> messages = new ArrayList<>();
     messages.add(new LLMClient.ChatMessage("user", "hello"));
 
-    // Expected to throw because fake URL is not reachable, but it should reach the builder
+    // Fake URL is not reachable; routing past key/base-url validation means we attempted gateway.
     Exception ex = assertThrows(Exception.class, () ->
         dispatcher.chatCompletion(messages, "claude-sonnet", "gateway",
             new GenParams(0.1, 1000), null));
-        
-    // Verification that it tried to route to gateway is implicit if it doesn't throw
-    // the "No API key" or base URL errors.
+    String msg = ex.getMessage() != null ? ex.getMessage() : "";
+    assertFalse(msg.contains("must be set when using the gateway provider"),
+        "Should not fail on missing gateway.base.url");
+    assertFalse(msg.contains("No API key configured"),
+        "Should not fail on missing gateway API key");
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/chatbot/llm/TestLlmRouting.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/chatbot/llm/TestLlmRouting.java
@@ -39,6 +39,7 @@ public class TestLlmRouting {
     Map<String, List<String>> supportedModels = new HashMap<>();
     supportedModels.put("gemini", Arrays.asList("gemini-2.5-flash", "gemini-2.5-pro"));
     supportedModels.put("openai", Arrays.asList("gpt-4.1", "gpt-4.1-mini"));
+    supportedModels.put("gateway", Arrays.asList("claude-sonnet", "gpt-4.1-gateway"));
     routing = new LlmRouting(DEFAULT_PROVIDER, DEFAULT_MODEL, supportedModels);
   }
 
@@ -47,6 +48,13 @@ public class TestLlmRouting {
     LlmRouting.Resolved resolved = routing.resolve("openai", "gpt-4.1");
     assertEquals("openai", resolved.getProvider());
     assertEquals("gpt-4.1", resolved.getModel());
+  }
+
+  @Test
+  public void testValidGatewayProviderAndModel() {
+    LlmRouting.Resolved resolved = routing.resolve("gateway", "claude-sonnet");
+    assertEquals("gateway", resolved.getProvider());
+    assertEquals("claude-sonnet", resolved.getModel());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds a dedicated `gateway` LLM provider to the Recon chatbot so operators can route all chatbot traffic through a single OpenAI-compatible gateway (for example LiteLLM), instead of misconfiguring direct provider keys.

**Problem**

When customers front multiple LLM vendors (OpenAI, Gemini, Anthropic) with one OpenAI-compatible gateway, the existing chatbot configuration is awkward: they must set `provider=openai` and list non-OpenAI model aliases under `openai.models`. That is confusing, easy to misconfigure, and does not reflect how the gateway is actually used.

**Solution**

This PR introduces a new `gateway` provider that uses the same OpenAI-compatible LangChain4j client under the hood, with explicit configuration keys:

- `ozone.recon.chatbot.provider=gateway`
- `ozone.recon.chatbot.gateway.api.key`
- `ozone.recon.chatbot.gateway.base.url` (required; no default)
- `ozone.recon.chatbot.gateway.models` (comma-separated model aliases)

When `gateway.api.key` is set, Recon registers the gateway provider and exposes the configured model list via the existing chatbot models API. If `gateway.base.url` is missing, Recon fails fast with a clear error rather than silently falling back to the public OpenAI endpoint.

Existing `openai`, `gemini`, and `anthropic` providers are unchanged.

**Implementation notes**

- New config constants in `ChatbotConfigKeys.java`
- `LangChain4jDispatcher` registers `gateway` at startup and routes requests through `buildGatewayModel()`
- Unit tests cover availability, model listing, routing, and the missing-base-URL validation path
- A commented gateway example block is added to the compose `docker-config` for local testing

Model names must match the gateway’s configured aliases exactly. There is no auto-discovery from `/v1/models`; operators maintain the list in `gateway.models`.

### Administrator guide updates for the gateway provider are planned separately.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15906

## How was this patch tested?
- Unit tests:
    - `mvn -pl :ozone-recon test -Dtest=TestLangChain4jDispatcher,TestLlmRouting -DskipShade -DskipRecon -DskipDocs`
- Manual smoke test on a local Docker compose cluster:
    - Enabled the chatbot with `provider=gateway`
    - Pointed `gateway.base.url` at a LiteLLM OpenAI-compatible endpoint
    - Configured `gateway.models` with aliases for OpenAI, Gemini, and Anthropic models exposed by the gateway
    - Verified chatbot requests succeed end-to-end through the gateway for multiple model aliases
    
<img width="592" height="296" alt="Screenshot 2026-07-18 at 9 26 10 PM" src="https://github.com/user-attachments/assets/828dda67-fb02-4155-93a8-4d88425a36b6" />
