### PR TITLE
HDDS-15912. HttpFS Gateway launcher should use runtime-managed log/temp dirs instead of OZONE_HOME paths.

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -182,7 +182,7 @@ function ozonecmd_case
     ;;
     httpfs)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
-      OZONE_HTTPFS_OPTS="${OZONE_HTTPFS_OPTS} -Dhttpfs.home.dir=${OZONE_HOME} -Dhttpfs.config.dir=${OZONE_CONF_DIR} -Dhttpfs.log.dir=${OZONE_HOME}/log -Dhttpfs.temp.dir=${OZONE_HOME}/temp -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties"
+      OZONE_HTTPFS_OPTS="${OZONE_HTTPFS_OPTS} -Dhttpfs.home.dir=${OZONE_HOME} -Dhttpfs.config.dir=${OZONE_CONF_DIR} -Dhttpfs.log.dir=${OZONE_LOG_DIR} -Dhttpfs.temp.dir=${OZONE_PID_DIR} -Dlog4j.configuration=file:${OZONE_CONF_DIR}/log4j.properties"
       OZONE_CLASSNAME='org.apache.ozone.fs.http.server.HttpFSServerWebServer'
       OZONE_RUN_ARTIFACT_NAME="ozone-httpfsgateway"
     ;;


### PR DESCRIPTION
## What changes were proposed in this pull request?

HttpFS launcher currently sets httpfs.log.dir and httpfs.temp.dir under `OZONE_HOME (${OZONE_HOME}/log`, `${OZONE_HOME}/temp)`.
HttpFSServerWebApp initializes through ServerWebApp, and Server.init() validates these directories at startup. If `${OZONE_HOME}/temp` is missing, startup fails with `S01: Dir .../temp` does not exist, and Jetty stops the connector.

Fix: switch launcher defaults to runtime-managed directories:

```
httpfs.log.dir=${OZONE_LOG_DIR}
httpfs.temp.dir=${OZONE_PID_DIR}
```
This removes dependency on install-tree temp/log paths and makes HttpFS startup more robust across deployment layouts.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15912

## How was this patch tested?

Tested Manually.