### PR TITLE
HDDS-15608. Return BucketAlreadyOwnedByYou when the same S3 owner recreates an existing bucket

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -35,7 +35,7 @@ Create new bucket
 Create bucket which already exists
     ${bucket} =         Create bucket
     ${result} =         Execute AWSS3APICli and checkrc         create-bucket --bucket ${bucket}   255
-                        Should contain          ${result}           BucketAlreadyExists
+                        Should contain          ${result}           BucketAlreadyOwnedByYou
 
 Create bucket with invalid bucket name
     ${randStr} =        Generate Ozone String

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -124,6 +124,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -242,6 +243,35 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     assertTrue(s3Client.doesBucketExist(bucketName));
     assertTrue(s3Client.doesBucketExistV2(bucketName));
     assertTrue(isBucketEmpty(b));
+  }
+
+  /**
+   * s3-tests: test_bucket_create_exists.
+   */
+  @Test
+  public void testCreateBucketAlreadyOwnedByYou() {
+    final String bucketName = getBucketName("owned-by-you");
+    s3Client.createBucket(bucketName);
+
+    AmazonServiceException ase = assertThrows(AmazonServiceException.class,
+        () -> s3Client.createBucket(bucketName));
+    assertEquals(409, ase.getStatusCode());
+    assertEquals(S3ErrorTable.BUCKET_ALREADY_OWNED_BY_YOU.getCode(), ase.getErrorCode());
+  }
+
+  @Test
+  public void testCreateBucketAlreadyExistsDifferentOwner() throws IOException {
+    final String bucketName = getBucketName("other-owner");
+    final String otherOwner = "other-s3-owner";
+    try (OzoneClient ozoneClient = cluster.newClient()) {
+      ozoneClient.getObjectStore().getS3Volume().createBucket(bucketName,
+          BucketArgs.newBuilder().setOwner(otherOwner).build());
+    }
+
+    AmazonServiceException ase = assertThrows(AmazonServiceException.class,
+        () -> s3Client.createBucket(bucketName));
+    assertEquals(409, ase.getStatusCode());
+    assertEquals(S3ErrorTable.BUCKET_ALREADY_EXISTS.getCode(), ase.getErrorCode());
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -219,6 +219,37 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     }
   }
 
+  /**
+   * s3-tests: test_bucket_create_exists.
+   */
+  @Test
+  public void testCreateBucketAlreadyOwnedByYou() {
+    final String bucketName = getBucketName("owned-by-you");
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    S3Exception exception = assertThrows(S3Exception.class,
+        () -> s3Client.createBucket(b -> b.bucket(bucketName)));
+    assertEquals(409, exception.statusCode());
+    assertEquals(S3ErrorTable.BUCKET_ALREADY_OWNED_BY_YOU.getCode(),
+        exception.awsErrorDetails().errorCode());
+  }
+
+  @Test
+  public void testCreateBucketAlreadyExistsDifferentOwner() throws IOException {
+    final String bucketName = getBucketName("other-owner");
+    final String otherOwner = "other-s3-owner";
+    try (OzoneClient ozoneClient = cluster.newClient()) {
+      ozoneClient.getObjectStore().getS3Volume().createBucket(bucketName,
+          BucketArgs.newBuilder().setOwner(otherOwner).build());
+    }
+
+    S3Exception exception = assertThrows(S3Exception.class,
+        () -> s3Client.createBucket(b -> b.bucket(bucketName)));
+    assertEquals(409, exception.statusCode());
+    assertEquals(S3ErrorTable.BUCKET_ALREADY_EXISTS.getCode(),
+        exception.awsErrorDetails().errorCode());
+  }
+
   @Test
   public void testPutObject() {
     final String bucketName = getBucketName();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -272,6 +272,9 @@ public class BucketEndpoint extends BucketOperationHandler {
     try {
       return handler.handlePutRequest(context, bucketName, body);
     } catch (OMException ex) {
+      if (ex.getResult() == ResultCodes.BUCKET_ALREADY_EXISTS) {
+        throw newDuplicateBucketError(bucketName, ex);
+      }
       throw newError(bucketName, ex);
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -28,6 +28,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
 import static org.apache.hadoop.ozone.OzoneConsts.KB;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_CLIENT_BUFFER_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_CLIENT_BUFFER_SIZE_KEY;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_EXISTS;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_OWNED_BY_YOU;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_TAG;
@@ -62,6 +64,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -107,6 +110,7 @@ import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
 import org.apache.hadoop.ozone.s3.signature.SignatureInfo;
 import org.apache.hadoop.ozone.s3.util.AuditUtils;
 import org.apache.hadoop.ozone.s3.util.S3Utils;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.ratis.util.function.CheckedRunnable;
@@ -241,6 +245,34 @@ public abstract class EndpointBase {
 
   protected OzoneVolume getVolume() throws IOException {
     return client.getObjectStore().getS3Volume();
+  }
+
+  /**
+   * Maps a duplicate bucket create to the S3 error expected by AWS when the
+   * requester already owns the bucket name.
+   */
+  protected OS3Exception newDuplicateBucketError(String bucketName, OMException cause) {
+    try {
+      OzoneBucket existingBucket = getVolume().getBucket(bucketName);
+      if (isSameBucketOwner(existingBucket.getOwner())) {
+        return newError(BUCKET_ALREADY_OWNED_BY_YOU, bucketName, cause);
+      }
+    } catch (IOException ex) {
+      LOG.debug("Could not resolve duplicate bucket owner for {}", bucketName, ex);
+    }
+    return newError(BUCKET_ALREADY_EXISTS, bucketName, cause);
+  }
+
+  private boolean isSameBucketOwner(String bucketOwner) {
+    return Objects.equals(getRequestOwner(), bucketOwner);
+  }
+
+  private String getRequestOwner() {
+    if (s3Auth == null || s3Auth.getUserPrincipal() == null) {
+      return null;
+    }
+    return UserGroupInformation.createRemoteUser(s3Auth.getUserPrincipal())
+        .getShortUserName();
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -64,7 +64,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -264,7 +264,8 @@ public abstract class EndpointBase {
   }
 
   private boolean isSameBucketOwner(String bucketOwner) {
-    return Objects.equals(getRequestOwner(), bucketOwner);
+    String requestOwner = getRequestOwner();
+    return requestOwner != null && requestOwner.equals(bucketOwner);
   }
 
   private String getRequestOwner() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -134,6 +134,10 @@ public enum S3ErrorTable {
       "BucketAlreadyExists", "The requested bucket name is not available" +
       " as it already exists.", HTTP_CONFLICT),
 
+  BUCKET_ALREADY_OWNED_BY_YOU(
+      "BucketAlreadyOwnedByYou", "Your previous request to create the named" +
+      " bucket succeeded and you already own it.", HTTP_CONFLICT),
+
   INVALID_TAG(
       "InvalidTag", "Your request contains tag input that is not valid.", HTTP_BAD_REQUEST),
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
@@ -124,6 +124,7 @@ public final class OzoneVolumeStub extends OzoneVolume {
     buckets.put(bucketName, OzoneBucketStub.newBuilder()
         .setVolumeName(getName())
         .setName(bucketName)
+        .setOwner(bucketArgs.getOwner())
         .setDefaultReplicationConfig(new DefaultReplicationConfig(
             RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.THREE)))

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -21,10 +21,10 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_OWNED_BY_YOU;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import javax.ws.rs.core.Response;
 import org.apache.hadoop.ozone.OzoneConfigKeys;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -20,11 +20,14 @@ package org.apache.hadoop.ozone.s3.endpoint;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_EXISTS;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_OWNED_BY_YOU;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import javax.ws.rs.core.Response;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,12 +38,15 @@ import org.junit.jupiter.api.Test;
  */
 public class TestBucketPut {
 
+  private static final String OTHER_BUCKET_OWNER = "other-s3-owner";
+
   private String bucketName = OzoneConsts.BUCKET;
   private BucketEndpoint bucketEndpoint;
+  private OzoneClient clientStub;
 
   @BeforeEach
   public void setup() throws Exception {
-    OzoneClient clientStub = new OzoneClientStub();
+    clientStub = new OzoneClientStub();
 
     bucketEndpoint = EndpointBuilder.newBucketEndpointBuilder()
         .setClient(clientStub)
@@ -48,12 +54,21 @@ public class TestBucketPut {
   }
 
   @Test
-  public void testCreateBucketAndFailOnDuplicate() throws Exception {
+  public void testCreateBucketAndFailOnDuplicateWithSameOWNER() throws Exception {
     Response response = bucketEndpoint.put(bucketName, null);
     assertEquals(HTTP_OK, response.getStatus());
     assertNotNull(response.getLocation());
 
-    // Create-bucket on an existing bucket fails
+    assertErrorResponse(BUCKET_ALREADY_OWNED_BY_YOU,
+        () -> bucketEndpoint.put(bucketName, null));
+  }
+
+  @Test
+  public void testCreateBucketAndFailOnDuplicateWithDifferentOwner() throws Exception {
+    clientStub.getObjectStore().createVolume(OzoneConfigKeys.OZONE_S3_VOLUME_NAME_DEFAULT);
+    clientStub.getObjectStore().getS3Volume().createBucket(bucketName,
+        BucketArgs.newBuilder().setOwner(OTHER_BUCKET_OWNER).build());
+
     assertErrorResponse(BUCKET_ALREADY_EXISTS,
         () -> bucketEndpoint.put(bucketName, null));
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -21,6 +21,8 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_OWNED_BY_YOU;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -30,6 +32,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.signature.SignatureInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +41,7 @@ import org.junit.jupiter.api.Test;
  */
 public class TestBucketPut {
 
+  private static final String BUCKET_OWNER = "my-s3-owner";
   private static final String OTHER_BUCKET_OWNER = "other-s3-owner";
 
   private String bucketName = OzoneConsts.BUCKET;
@@ -54,22 +58,53 @@ public class TestBucketPut {
   }
 
   @Test
-  public void testCreateBucketAndFailOnDuplicateWithSameOWNER() throws Exception {
-    Response response = bucketEndpoint.put(bucketName, null);
-    assertEquals(HTTP_OK, response.getStatus());
-    assertNotNull(response.getLocation());
+  public void testCreateBucketAndFailOnDuplicateWithSameOwner() throws Exception {
+    BucketEndpoint endpoint = newBucketEndpointWithRequestOwner(BUCKET_OWNER);
+    clientStub.getObjectStore().createVolume(OzoneConfigKeys.OZONE_S3_VOLUME_NAME_DEFAULT);
+    clientStub.getObjectStore().getS3Volume().createBucket(bucketName,
+        BucketArgs.newBuilder().setOwner(BUCKET_OWNER).build());
 
     assertErrorResponse(BUCKET_ALREADY_OWNED_BY_YOU,
+        () -> endpoint.put(bucketName, null));
+  }
+
+  @Test
+  public void testCreateBucketAndFailOnDuplicateWithUnknownRequestOwner() throws Exception {
+    clientStub.getObjectStore().createVolume(OzoneConfigKeys.OZONE_S3_VOLUME_NAME_DEFAULT);
+    clientStub.getObjectStore().getS3Volume().createBucket(bucketName);
+
+    assertErrorResponse(BUCKET_ALREADY_EXISTS,
         () -> bucketEndpoint.put(bucketName, null));
   }
 
   @Test
   public void testCreateBucketAndFailOnDuplicateWithDifferentOwner() throws Exception {
+    BucketEndpoint endpoint = newBucketEndpointWithRequestOwner(BUCKET_OWNER);
     clientStub.getObjectStore().createVolume(OzoneConfigKeys.OZONE_S3_VOLUME_NAME_DEFAULT);
     clientStub.getObjectStore().getS3Volume().createBucket(bucketName,
         BucketArgs.newBuilder().setOwner(OTHER_BUCKET_OWNER).build());
 
     assertErrorResponse(BUCKET_ALREADY_EXISTS,
-        () -> bucketEndpoint.put(bucketName, null));
+        () -> endpoint.put(bucketName, null));
+  }
+
+  @Test
+  public void testCreateBucketSuccess() throws Exception {
+    Response response = bucketEndpoint.put(bucketName, null);
+    assertEquals(HTTP_OK, response.getStatus());
+    assertNotNull(response.getLocation());
+  }
+
+  private BucketEndpoint newBucketEndpointWithRequestOwner(String requestOwner) {
+    SignatureInfo signatureInfo = mock(SignatureInfo.class);
+    when(signatureInfo.isSignPayload()).thenReturn(true);
+    when(signatureInfo.getAwsAccessId()).thenReturn(requestOwner);
+    when(signatureInfo.getStringToSign()).thenReturn("");
+    when(signatureInfo.getSignature()).thenReturn("");
+
+    return EndpointBuilder.newBucketEndpointBuilder()
+        .setClient(clientStub)
+        .setSignatureInfo(signatureInfo)
+        .build();
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -36,7 +36,7 @@ import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.put;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.putBucketTagging;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.putTagging;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.uploadPart;
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_OWNED_BY_YOU;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.X_AMZ_CONTENT_SHA256;
@@ -188,7 +188,7 @@ public class TestS3GatewayMetrics {
     OS3Exception e = assertThrows(OS3Exception.class, () -> bucketEndpoint.put(
         bucketName, null));
     assertEquals(HTTP_CONFLICT, e.getHttpCode());
-    assertEquals(BUCKET_ALREADY_OWNED_BY_YOU.getCode(), e.getCode());
+    assertEquals(BUCKET_ALREADY_EXISTS.getCode(), e.getCode());
 
     long curMetric = metrics.getCreateBucketFailure();
     assertEquals(1L, curMetric - oriMetric);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -36,7 +36,7 @@ import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.put;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.putBucketTagging;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.putTagging;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.uploadPart;
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_EXISTS;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_OWNED_BY_YOU;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.X_AMZ_CONTENT_SHA256;
@@ -188,7 +188,7 @@ public class TestS3GatewayMetrics {
     OS3Exception e = assertThrows(OS3Exception.class, () -> bucketEndpoint.put(
         bucketName, null));
     assertEquals(HTTP_CONFLICT, e.getHttpCode());
-    assertEquals(BUCKET_ALREADY_EXISTS.getCode(), e.getCode());
+    assertEquals(BUCKET_ALREADY_OWNED_BY_YOU.getCode(), e.getCode());
 
     long curMetric = metrics.getCreateBucketFailure();
     assertEquals(1L, curMetric - oriMetric);


### PR DESCRIPTION
## What changes were proposed in this pull request?
s3-tests `test_bucket_create_exists` fails when the same S3 client creates a bucket twice. Ozone S3 Gateway always returns 409 with error code BucketAlreadyExists.

AWS S3 expects:

```
Scenario                                                         |      HTTP      | Error code
--                                                               |        --      | --
Same S3 owner creates a bucket that already exists               |     409        | BucketAlreadyOwnedByYou
Different S3 owner creates a bucket with an existing global name |    409         | BucketAlreadyExists
```

Add **BUCKET_ALREADY_OWNED_BY_YOU** to `S3ErrorTable `(BucketAlreadyOwnedByYou, HTTP 409) and return when same S3 owner creates a bucket that already exists

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15608

## How was this patch tested?

Added IT and UT.
Manual Testing:
**Before Fix:**
```
// wrong behaviour: same owner creating a bucket already existing --> throws BucketAlreadyExists error

 BUCKET="duplicate-test-$$"
bash-5.1$ aws s3api create-bucket \
  --bucket "$BUCKET" \
  --endpoint-url http://s3g:9878/
{
    "Location": "http://s3g:9878/duplicate-test-117"
}
bash-5.1$ aws s3api create-bucket \
  --bucket "$BUCKET" \
  --endpoint-url http://s3g:9878/

// Different owner of bucket getting BucketAlreadyExists error is okay
An error occurred (BucketAlreadyExists) when calling the CreateBucket operation: The requested bucket name is not available as it already exists.

bash-5.1$ BUCKET="duplicate-other-owner-$$"
bash-5.1$ ozone sh bucket create "/s3v/${BUCKET}" --user other-s3-owner
bash-5.1$ aws s3api create-bucket \
  --bucket "$BUCKET" \
  --endpoint-url http://s3g:9878/

An error occurred (BucketAlreadyExists) when calling the CreateBucket operation: The requested bucket name is not available as it already exists.

```
**After Fix:**
```
// Same owner creating already existing bucket ---> Throw BUCKET_ALREADY_OWNED_BY_YOU

BUCKET="duplicate-test-$$"
bash-5.1$ aws s3api create-bucket \
  --bucket "$BUCKET" \
  --endpoint-url http://s3g:9878/
{
    "Location": "http://s3g:9878/duplicate-test-119"
}
bash-5.1$ aws s3api create-bucket \
  --bucket "$BUCKET" \
  --endpoint-url http://s3g:9878/

An error occurred (BucketAlreadyOwnedByYou) when calling the CreateBucket operation: Your previous request to create the named bucket succeeded and you already own it.

// Bucket owned by other user ---> Throws BUCKET_ALREADY_EXISTS

bash-5.1$ BUCKET="duplicate-other-owner-$$"
bash-5.1$ ozone sh bucket create "/s3v/${BUCKET}" --user other-s3-owner
bash-5.1$ aws s3api create-bucket \
  --bucket "$BUCKET" \
  --endpoint-url http://s3g:9878/

An error occurred (BucketAlreadyExists) when calling the CreateBucket operation: The requested bucket name is not available as it already exists.
```