### PR TITLE
HDDS-15249. SCM Pipeline Support Create And Get With StorageTier

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.ratis.util.TimeDuration;
@@ -711,6 +712,11 @@ public final class OzoneConfigKeys {
   public static final String OZONE_CLIENT_ELASTIC_BYTE_BUFFER_POOL_MAX_SIZE =
       "ozone.client.elastic.byte.buffer.pool.max.size";
   public static final String OZONE_CLIENT_ELASTIC_BYTE_BUFFER_POOL_MAX_SIZE_DEFAULT = "16GB";
+
+  public static final String OZONE_DEFAULT_STORAGE_TIER_KEY =
+      "ozone.default.storageTier";
+  public static final String OZONE_DEFAULT_STORAGE_TIER_DEFAULT =
+      StorageTier.DISK.toString();
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4287,6 +4287,20 @@
   </property>
 
   <property>
+    <name>ozone.default.storageTier</name>
+    <value>DISK</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      Default StorageTier used for pipeline creation and block allocation
+      when a client does not specify a StorageTier (StoragePolicy).
+      For old-version clients that do not carry a StoragePolicy the
+      StorageTier is null; this value is used as the fallback so their
+      write path is unchanged. Supported values are DISK, SSD, ARCHIVE,
+      RAM_DISK.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.client.ec.grpc.retries.enabled</name>
     <value>true</value>
     <tag>CLIENT</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -30,6 +30,7 @@ import javax.management.ObjectName;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.scm.ScmConfig;
@@ -160,8 +161,19 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
           INVALID_BLOCK_SIZE);
     }
 
+    // TODO: Implement pass storageTier(StoragePolicy) from API.
+    // For the old version client, it will not have a "default StoragePolicy",
+    // so its StorageTier will be null, we use the "default StorageTier" to
+    // write data for them. The value of the "default StorageTier" can be set
+    // via configuration, and the default is StorageTier.DISK.
+    //
+    // By default, if the Datanode Volume StorageType is not explicitly
+    // configured, it will be of type StorageType.DISK and therefore belong
+    // to a StorageTier.DISK tier, so for old clients the write process is
+    // unchanged if the Datanode Volume configuration is not changed.
+    StorageTier storageTier = StorageTier.getDefaultTier();
     ContainerInfo containerInfo = writableContainerFactory.getContainer(
-        size, replicationConfig, owner, excludeList);
+        size, replicationConfig, owner, excludeList, storageTier);
 
     if (containerInfo != null) {
       return newBlock(containerInfo);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -33,6 +33,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
@@ -194,7 +195,8 @@ public class ContainerManagerImpl implements ContainerManager {
 
     if (pipelines.isEmpty()) {
       try {
-        pipeline = pipelineManager.createPipeline(replicationConfig);
+        pipeline = pipelineManager.createPipeline(replicationConfig,
+            StorageTier.getDefaultTier());
         if (replicationConfig.getReplicationType() == HddsProtos.ReplicationType.EC) {
           pipelineManager.openPipeline(pipeline.getId());
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/PipelineStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/PipelineStateManagerInvoker.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.NavigableSet;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
@@ -136,9 +137,19 @@ public class PipelineStateManagerInvoker extends ScmInvoker<PipelineStateManager
       }
 
       @Override
+      public List<Pipeline> getPipelines(ReplicationConfig arg0, StorageTier arg1) {
+        return invoker.getImpl().getPipelines(arg0, arg1);
+      }
+
+      @Override
+      public List<Pipeline> getPipelines(ReplicationConfig arg0, Pipeline.PipelineState arg1, StorageTier arg2) {
+        return invoker.getImpl().getPipelines(arg0, arg1, arg2);
+      }
+
+      @Override
       public List<Pipeline> getPipelines(ReplicationConfig arg0, Pipeline.PipelineState arg1, Collection arg2,
-          Collection arg3) {
-        return invoker.getImpl().getPipelines(arg0, arg1, arg2, arg3);
+          Collection arg3, StorageTier arg4) {
+        return invoker.getImpl().getPipelines(arg0, arg1, arg2, arg3, arg4);
       }
 
       @Override
@@ -238,39 +249,57 @@ public class PipelineStateManagerInvoker extends ScmInvoker<PipelineStateManager
         returnValue = getImpl().getPipelines(arg11, arg12);
         break;
       }
-      if (p.length == 4 && (p[0] == null || ReplicationConfig.class.isInstance(p[0])) && (p[1] == null ||
-          Pipeline.PipelineState.class.isInstance(p[1])) && (p[2] == null || Collection.class.isInstance(p[2])) && (p[3]
-          == null || Collection.class.isInstance(p[3]))) {
+      if (p.length == 2 && (p[0] == null || ReplicationConfig.class.isInstance(p[0])) && (p[1] == null ||
+          StorageTier.class.isInstance(p[1]))) {
         final ReplicationConfig arg13 = (ReplicationConfig) p[0];
-        final Pipeline.PipelineState arg14 = (Pipeline.PipelineState) p[1];
-        final Collection arg15 = (Collection) p[2];
-        final Collection arg16 = (Collection) p[3];
+        final StorageTier arg14 = (StorageTier) p[1];
         returnType = List.class;
-        returnValue = getImpl().getPipelines(arg13, arg14, arg15, arg16);
+        returnValue = getImpl().getPipelines(arg13, arg14);
+        break;
+      }
+      if (p.length == 3 && (p[0] == null || ReplicationConfig.class.isInstance(p[0])) && (p[1] == null ||
+          Pipeline.PipelineState.class.isInstance(p[1])) && (p[2] == null || StorageTier.class.isInstance(p[2]))) {
+        final ReplicationConfig arg15 = (ReplicationConfig) p[0];
+        final Pipeline.PipelineState arg16 = (Pipeline.PipelineState) p[1];
+        final StorageTier arg17 = (StorageTier) p[2];
+        returnType = List.class;
+        returnValue = getImpl().getPipelines(arg15, arg16, arg17);
+        break;
+      }
+      if (p.length == 5 && (p[0] == null || ReplicationConfig.class.isInstance(p[0])) && (p[1] == null ||
+          Pipeline.PipelineState.class.isInstance(p[1])) && (p[2] == null || Collection.class.isInstance(p[2])) && (p[3]
+          == null || Collection.class.isInstance(p[3])) && (p[4] == null || StorageTier.class.isInstance(p[4]))) {
+        final ReplicationConfig arg18 = (ReplicationConfig) p[0];
+        final Pipeline.PipelineState arg19 = (Pipeline.PipelineState) p[1];
+        final Collection arg20 = (Collection) p[2];
+        final Collection arg21 = (Collection) p[3];
+        final StorageTier arg22 = (StorageTier) p[4];
+        returnType = List.class;
+        returnValue = getImpl().getPipelines(arg18, arg19, arg20, arg21, arg22);
         break;
       }
       throw new IllegalArgumentException("Method not found: " + methodName + " in PipelineStateManager");
 
     case "reinitialize":
-      final Table arg17 = p.length > 0 ? (Table) p[0] : null;
-      getImpl().reinitialize(arg17);
+      final Table arg23 = p.length > 0 ? (Table) p[0] : null;
+      getImpl().reinitialize(arg23);
       return Message.EMPTY;
 
     case "removeContainerFromPipeline":
-      final PipelineID arg18 = p.length > 0 ? (PipelineID) p[0] : null;
-      final ContainerID arg19 = p.length > 1 ? (ContainerID) p[1] : null;
-      getImpl().removeContainerFromPipeline(arg18, arg19);
+      final PipelineID arg24 = p.length > 0 ? (PipelineID) p[0] : null;
+      final ContainerID arg25 = p.length > 1 ? (ContainerID) p[1] : null;
+      getImpl().removeContainerFromPipeline(arg24, arg25);
       return Message.EMPTY;
 
     case "removePipeline":
-      final HddsProtos.PipelineID arg20 = p.length > 0 ? (HddsProtos.PipelineID) p[0] : null;
-      getImpl().removePipeline(arg20);
+      final HddsProtos.PipelineID arg26 = p.length > 0 ? (HddsProtos.PipelineID) p[0] : null;
+      getImpl().removePipeline(arg26);
       return Message.EMPTY;
 
     case "updatePipelineState":
-      final HddsProtos.PipelineID arg21 = p.length > 0 ? (HddsProtos.PipelineID) p[0] : null;
-      final HddsProtos.PipelineState arg22 = p.length > 1 ? (HddsProtos.PipelineState) p[1] : null;
-      getImpl().updatePipelineState(arg21, arg22);
+      final HddsProtos.PipelineID arg27 = p.length > 0 ? (HddsProtos.PipelineID) p[0] : null;
+      final HddsProtos.PipelineState arg28 = p.length > 1 ? (HddsProtos.PipelineState) p[1] : null;
+      getImpl().updatePipelineState(arg27, arg28);
       return Message.EMPTY;
 
     default:

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -242,7 +243,9 @@ public class BackgroundPipelineCreator implements SCMService {
           (ReplicationConfig) it.next();
 
       try {
-        Pipeline pipeline = pipelineManager.createPipeline(replicationConfig);
+        // Only create default StorageTier Pipeline
+        Pipeline pipeline = pipelineManager.createPipeline(replicationConfig,
+            StorageTier.getDefaultTier());
         LOG.info("Created new pipeline {}", pipeline);
       } catch (IOException ioe) {
         it.remove();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineFactory.java
@@ -81,11 +81,10 @@ public class PipelineFactory {
 
   public Pipeline create(
       ReplicationConfig replicationConfig, List<DatanodeDetails> excludedNodes,
-      List<DatanodeDetails> favoredNodes)
+      List<DatanodeDetails> favoredNodes, StorageTier storageTier)
       throws IOException {
-    // TODO StoragePolicy replace this StorageTier with the passed StorageTier
     Pipeline pipeline = providers.get(replicationConfig.getReplicationType())
-        .create(replicationConfig, excludedNodes, favoredNodes, StorageTier.getDefaultTier());
+        .create(replicationConfig, excludedNodes, favoredNodes, storageTier);
     checkPipeline(pipeline);
     return pipeline;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -37,12 +37,14 @@ import org.apache.hadoop.hdds.utils.db.Table;
  */
 public interface PipelineManager extends Closeable, PipelineManagerMXBean {
 
-  Pipeline createPipeline(ReplicationConfig replicationConfig)
+  Pipeline createPipeline(ReplicationConfig replicationConfig,
+                          StorageTier storageTier)
       throws IOException;
 
   Pipeline createPipeline(ReplicationConfig replicationConfig,
                           List<DatanodeDetails> excludedNodes,
-                          List<DatanodeDetails> favoredNodes)
+                          List<DatanodeDetails> favoredNodes,
+                          StorageTier storageTier)
       throws IOException;
 
   Pipeline buildECPipeline(ReplicationConfig replicationConfig,
@@ -78,8 +80,15 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
   List<Pipeline> getPipelines(
       ReplicationConfig replicationConfig,
       Pipeline.PipelineState state,
+      StorageTier storageTier
+  );
+
+  List<Pipeline> getPipelines(
+      ReplicationConfig replicationConfig,
+      Pipeline.PipelineState state,
       Collection<DatanodeDetails> excludeDns,
-      Collection<PipelineID> excludePipelines
+      Collection<PipelineID> excludePipelines,
+      StorageTier storageTier
   );
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -214,9 +214,10 @@ public class PipelineManagerImpl implements PipelineManager {
     if (replicationConfig.getReplicationType() != ReplicationType.EC) {
       throw new IllegalArgumentException("Replication type must be EC");
     }
+    // TODO StoragePolicy Support EC
     checkIfPipelineCreationIsAllowed(replicationConfig);
     return pipelineFactory.create(replicationConfig, excludedNodes,
-        favoredNodes);
+        favoredNodes, StorageTier.getDefaultTier());
   }
 
   /**
@@ -238,15 +239,17 @@ public class PipelineManagerImpl implements PipelineManager {
   }
 
   @Override
-  public Pipeline createPipeline(ReplicationConfig replicationConfig)
+  public Pipeline createPipeline(ReplicationConfig replicationConfig,
+      StorageTier storageTier)
       throws IOException {
     return createPipeline(replicationConfig, Collections.emptyList(),
-        Collections.emptyList());
+        Collections.emptyList(), storageTier);
   }
 
   @Override
   public Pipeline createPipeline(ReplicationConfig replicationConfig,
-      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
+      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
+      StorageTier storageTier)
       throws IOException {
     checkIfPipelineCreationIsAllowed(replicationConfig);
 
@@ -255,8 +258,10 @@ public class PipelineManagerImpl implements PipelineManager {
     try {
       try {
         pipeline = pipelineFactory.create(replicationConfig,
-            excludedNodes, favoredNodes);
+            excludedNodes, favoredNodes, storageTier);
       } catch (IOException e) {
+        LOG.debug("Failed to create pipeline with replicationConfig {} " +
+            "storageTier {}.", replicationConfig, storageTier, e);
         metrics.incNumPipelineCreationFailed();
         throw e;
       }
@@ -365,12 +370,19 @@ public class PipelineManagerImpl implements PipelineManager {
   }
 
   @Override
+  public List<Pipeline> getPipelines(ReplicationConfig config,
+      Pipeline.PipelineState state, StorageTier storageTier) {
+    return stateManager.getPipelines(config, state, storageTier);
+  }
+
+  @Override
   public List<Pipeline> getPipelines(
       ReplicationConfig replicationConfig,
       Pipeline.PipelineState state, Collection<DatanodeDetails> excludeDns,
-      Collection<PipelineID> excludePipelines) {
+      Collection<PipelineID> excludePipelines, StorageTier storageTier) {
     return stateManager
-        .getPipelines(replicationConfig, state, excludeDns, excludePipelines);
+        .getPipelines(replicationConfig, state, excludeDns, excludePipelines,
+            storageTier);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.NavigableSet;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
@@ -90,9 +91,21 @@ public interface PipelineStateManager extends SCMHandler {
 
   List<Pipeline> getPipelines(
       ReplicationConfig replicationConfig,
+      StorageTier storageTier
+  );
+
+  List<Pipeline> getPipelines(
+      ReplicationConfig replicationConfig,
+      Pipeline.PipelineState state,
+      StorageTier storageTier
+  );
+
+  List<Pipeline> getPipelines(
+      ReplicationConfig replicationConfig,
       Pipeline.PipelineState state,
       Collection<DatanodeDetails> excludeDns,
-      Collection<PipelineID> excludePipelines
+      Collection<PipelineID> excludePipelines,
+      StorageTier storageTier
   );
 
   int getPipelineCount(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -169,13 +170,37 @@ public final class PipelineStateManagerImpl implements PipelineStateManager {
 
   @Override
   public List<Pipeline> getPipelines(
+      ReplicationConfig replicationConfig, StorageTier storageTier) {
+    lock.readLock().lock();
+    try {
+      return pipelineStateMap.getPipelines(replicationConfig, storageTier);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public List<Pipeline> getPipelines(
+      ReplicationConfig replicationConfig,
+      Pipeline.PipelineState state, StorageTier storageTier) {
+    lock.readLock().lock();
+    try {
+      return pipelineStateMap.getPipelines(replicationConfig, state, storageTier);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public List<Pipeline> getPipelines(
       ReplicationConfig replicationConfig,
       Pipeline.PipelineState state, Collection<DatanodeDetails> excludeDns,
-      Collection<PipelineID> excludePipelines) {
+      Collection<PipelineID> excludePipelines, StorageTier storageTier) {
     lock.readLock().lock();
     try {
       return pipelineStateMap
-          .getPipelines(replicationConfig, state, excludeDns, excludePipelines);
+          .getPipelines(replicationConfig, state, excludeDns, excludePipelines,
+              storageTier);
     } finally {
       lock.readLock().unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -32,7 +32,9 @@ import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState;
@@ -211,6 +213,45 @@ class PipelineStateMap {
   }
 
   /**
+   * Get list of pipelines corresponding to specified replication type
+   * and storageTier.
+   *
+   * @param replicationConfig - ReplicationConfig
+   * @param storageTier       - Required storageTier
+   * @return List of pipelines with specified replication type and storageTier
+   */
+  List<Pipeline> getPipelines(ReplicationConfig replicationConfig,
+      StorageTier storageTier) {
+    Objects.requireNonNull(replicationConfig, "ReplicationConfig cannot be null");
+    Objects.requireNonNull(storageTier, "Pipeline storageTier cannot be null");
+    return getPipelines(replicationConfig).stream()
+        .filter(pipeline -> Objects.equals(
+            pipeline.getSupportedStorageTier(), storageTier))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Get list of pipeline corresponding to specified replication type,
+   * replication factor, pipeline state and storageTier.
+   *
+   * @param replicationConfig - ReplicationConfig
+   * @param state             - Required PipelineState
+   * @param storageTier       - Required storageTier
+   * @return List of pipelines with specified replication type,
+   * replication factor, pipeline state and storageTier
+   */
+  List<Pipeline> getPipelines(ReplicationConfig replicationConfig,
+      PipelineState state, StorageTier storageTier) {
+    Objects.requireNonNull(replicationConfig, "ReplicationConfig cannot be null");
+    Objects.requireNonNull(state, "Pipeline state cannot be null");
+    Objects.requireNonNull(storageTier, "Pipeline storageTier cannot be null");
+    return getPipelines(replicationConfig, state).stream()
+        .filter(pipeline -> Objects.equals(
+            pipeline.getSupportedStorageTier(), storageTier))
+        .collect(Collectors.toList());
+  }
+
+  /**
    * Get a count of pipelines with the given replicationConfig and state.
    * This method is most efficient when getting a count for OPEN pipeline
    * as the result can be obtained directly from the cached open list.
@@ -247,23 +288,28 @@ class PipelineStateMap {
    * @param state             - Required PipelineState
    * @param excludeDns        dns to exclude
    * @param excludePipelines  pipelines to exclude
+   * @param storageTier       - Required storageTier
    * @return List of pipelines with specified replication type,
    * replication factor and pipeline state
    */
   List<Pipeline> getPipelines(ReplicationConfig replicationConfig,
       PipelineState state, Collection<DatanodeDetails> excludeDns,
-      Collection<PipelineID> excludePipelines) {
+      Collection<PipelineID> excludePipelines, StorageTier storageTier) {
     Objects.requireNonNull(replicationConfig, "ReplicationConfig cannot be null");
     Objects.requireNonNull(state, "Pipeline state cannot be null");
     Objects.requireNonNull(excludeDns, "Datanode exclude list cannot be null");
     Objects.requireNonNull(excludePipelines, "Pipeline exclude list cannot be null");
+    Objects.requireNonNull(storageTier, "Pipeline storageTier cannot be null");
 
     List<Pipeline> pipelines = null;
     if (state == PipelineState.OPEN) {
       pipelines = new ArrayList<>(query2OpenPipelines.getOrDefault(
           replicationConfig, Collections.emptyList()));
       if (excludeDns.isEmpty() && excludePipelines.isEmpty()) {
-        return pipelines;
+        return pipelines.stream()
+            .filter(pipeline -> Objects.equals(
+                pipeline.getSupportedStorageTier(), storageTier))
+            .collect(Collectors.toList());
       }
     } else {
       pipelines = new ArrayList<>(pipelineMap.values());
@@ -272,6 +318,10 @@ class PipelineStateMap {
     Iterator<Pipeline> iter = pipelines.iterator();
     while (iter.hasNext()) {
       Pipeline pipeline = iter.next();
+      if (!Objects.equals(pipeline.getSupportedStorageTier(), storageTier)) {
+        iter.remove();
+        continue;
+      }
       if (!pipeline.getReplicationConfig().equals(replicationConfig) ||
           pipeline.getPipelineState() != state ||
           excludePipelines.contains(pipeline.getId())) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -225,8 +225,7 @@ class PipelineStateMap {
     Objects.requireNonNull(replicationConfig, "ReplicationConfig cannot be null");
     Objects.requireNonNull(storageTier, "Pipeline storageTier cannot be null");
     return getPipelines(replicationConfig).stream()
-        .filter(pipeline -> Objects.equals(
-            pipeline.getSupportedStorageTier(), storageTier))
+        .filter(pipeline -> matchesStorageTier(pipeline, storageTier))
         .collect(Collectors.toList());
   }
 
@@ -246,9 +245,20 @@ class PipelineStateMap {
     Objects.requireNonNull(state, "Pipeline state cannot be null");
     Objects.requireNonNull(storageTier, "Pipeline storageTier cannot be null");
     return getPipelines(replicationConfig, state).stream()
-        .filter(pipeline -> Objects.equals(
-            pipeline.getSupportedStorageTier(), storageTier))
+        .filter(pipeline -> matchesStorageTier(pipeline, storageTier))
         .collect(Collectors.toList());
+  }
+
+  /**
+   * A pipeline with no supportedStorageTier (e.g. one created by an older
+   * SCM before this field was introduced, or restored from a legacy DB
+   * snapshot) is treated as matching any tier. This preserves backward
+   * compatibility during rolling upgrade: legacy pipelines remain usable
+   * until they are scrubbed and replaced by tier-tagged ones.
+   */
+  static boolean matchesStorageTier(Pipeline pipeline, StorageTier storageTier) {
+    final StorageTier pipelineTier = pipeline.getSupportedStorageTier();
+    return pipelineTier == null || Objects.equals(pipelineTier, storageTier);
   }
 
   /**
@@ -307,8 +317,7 @@ class PipelineStateMap {
           replicationConfig, Collections.emptyList()));
       if (excludeDns.isEmpty() && excludePipelines.isEmpty()) {
         return pipelines.stream()
-            .filter(pipeline -> Objects.equals(
-                pipeline.getSupportedStorageTier(), storageTier))
+            .filter(pipeline -> matchesStorageTier(pipeline, storageTier))
             .collect(Collectors.toList());
       }
     } else {
@@ -318,7 +327,7 @@ class PipelineStateMap {
     Iterator<Pipeline> iter = pipelines.iterator();
     while (iter.hasNext()) {
       Pipeline pipeline = iter.next();
-      if (!Objects.equals(pipeline.getSupportedStorageTier(), storageTier)) {
+      if (!matchesStorageTier(pipeline, storageTier)) {
         iter.remove();
         continue;
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -104,15 +104,19 @@ public class RatisPipelineProvider
     }
   }
 
-  private boolean exceedPipelineNumberLimit(RatisReplicationConfig replicationConfig) {
+  private boolean exceedPipelineNumberLimit(
+      RatisReplicationConfig replicationConfig, StorageTier storageTier) {
     // Apply limits only for replication factor THREE
     if (replicationConfig.getReplicationFactor() != ReplicationFactor.THREE) {
       return false;
     }
 
+    // TODO Adjusting Pipeline Limits To Each StorageTier
     PipelineStateManager pipelineStateManager = getPipelineStateManager();
-    int totalActivePipelines = pipelineStateManager.getPipelines(replicationConfig).size();
-    int closedPipelines = pipelineStateManager.getPipelines(replicationConfig, PipelineState.CLOSED).size();
+    int totalActivePipelines = pipelineStateManager
+        .getPipelines(replicationConfig, storageTier).size();
+    int closedPipelines = pipelineStateManager
+        .getPipelines(replicationConfig, PipelineState.CLOSED, storageTier).size();
     int openPipelines = totalActivePipelines - closedPipelines;
     // Check per-datanode pipeline limit
     if (datanodePipelineLimit > 0) {
@@ -150,7 +154,7 @@ public class RatisPipelineProvider
   public synchronized Pipeline create(RatisReplicationConfig replicationConfig,
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes, StorageTier storageTier)
       throws IOException {
-    if (exceedPipelineNumberLimit(replicationConfig)) {
+    if (exceedPipelineNumberLimit(replicationConfig, storageTier)) {
       String limitInfo = (datanodePipelineLimit > 0)
           ? String.format("per datanode: %d", datanodePipelineLimit)
           : String.format(": %d", pipelineNumberLimit);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -111,27 +111,31 @@ public class RatisPipelineProvider
       return false;
     }
 
-    // TODO Adjusting Pipeline Limits To Each StorageTier
     PipelineStateManager pipelineStateManager = getPipelineStateManager();
-    int totalActivePipelines = pipelineStateManager
-        .getPipelines(replicationConfig, storageTier).size();
-    int closedPipelines = pipelineStateManager
-        .getPipelines(replicationConfig, PipelineState.CLOSED, storageTier).size();
-    int openPipelines = totalActivePipelines - closedPipelines;
-    // Check per-datanode pipeline limit
+    // Check per-datanode pipeline limit (StorageTier-aware).
     if (datanodePipelineLimit > 0) {
+      int totalActive = pipelineStateManager
+          .getPipelines(replicationConfig, storageTier).size();
+      int closed = pipelineStateManager
+          .getPipelines(replicationConfig, PipelineState.CLOSED, storageTier).size();
+      int openTierAware = totalActive - closed;
       int healthyNodeCount = getNodeManager()
           .getNodeCount(NodeStatus.inServiceHealthy());
       int allowedOpenPipelines = (datanodePipelineLimit * healthyNodeCount)
           / replicationConfig.getRequiredNodes();
-      return openPipelines >= allowedOpenPipelines;
+      return openTierAware >= allowedOpenPipelines;
     }
-    // Check global pipeline limit
+    // Check global pipeline limit (StorageTier-agnostic).
     if (pipelineNumberLimit > 0) {
+      int totalActiveAllTiers = pipelineStateManager
+          .getPipelines(replicationConfig).size();
+      int closedAllTiers = pipelineStateManager
+          .getPipelines(replicationConfig, PipelineState.CLOSED).size();
+      int openAllTiers = totalActiveAllTiers - closedAllTiers;
       int factorOnePipelineCount = pipelineStateManager
           .getPipelines(RatisReplicationConfig.getInstance(ReplicationFactor.ONE)).size();
       int allowedOpenPipelines = pipelineNumberLimit - factorOnePipelineCount;
-      return openPipelines >= allowedOpenPipelines;
+      return openAllTiers >= allowedOpenPipelines;
     }
     // No limits are set
     return false;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -112,30 +112,26 @@ public class RatisPipelineProvider
     }
 
     PipelineStateManager pipelineStateManager = getPipelineStateManager();
-    // Check per-datanode pipeline limit (StorageTier-aware).
+    int totalActivePipelines = pipelineStateManager
+        .getPipelines(replicationConfig, storageTier).size();
+    int closedPipelines = pipelineStateManager
+        .getPipelines(replicationConfig, PipelineState.CLOSED, storageTier).size();
+    int openPipelines = totalActivePipelines - closedPipelines;
+    // Check per-datanode pipeline limit
     if (datanodePipelineLimit > 0) {
-      int totalActive = pipelineStateManager
-          .getPipelines(replicationConfig, storageTier).size();
-      int closed = pipelineStateManager
-          .getPipelines(replicationConfig, PipelineState.CLOSED, storageTier).size();
-      int openTierAware = totalActive - closed;
       int healthyNodeCount = getNodeManager()
           .getNodeCount(NodeStatus.inServiceHealthy());
       int allowedOpenPipelines = (datanodePipelineLimit * healthyNodeCount)
           / replicationConfig.getRequiredNodes();
-      return openTierAware >= allowedOpenPipelines;
+      return openPipelines >= allowedOpenPipelines;
     }
-    // Check global pipeline limit (StorageTier-agnostic).
+    // Check global pipeline limit
     if (pipelineNumberLimit > 0) {
-      int totalActiveAllTiers = pipelineStateManager
-          .getPipelines(replicationConfig).size();
-      int closedAllTiers = pipelineStateManager
-          .getPipelines(replicationConfig, PipelineState.CLOSED).size();
-      int openAllTiers = totalActiveAllTiers - closedAllTiers;
       int factorOnePipelineCount = pipelineStateManager
-          .getPipelines(RatisReplicationConfig.getInstance(ReplicationFactor.ONE)).size();
+          .getPipelines(RatisReplicationConfig.getInstance(ReplicationFactor.ONE),
+              storageTier).size();
       int allowedOpenPipelines = pipelineNumberLimit - factorOnePipelineCount;
-      return openAllTiers >= allowedOpenPipelines;
+      return openPipelines >= allowedOpenPipelines;
     }
     // No limits are set
     return false;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerFactory.java
@@ -21,9 +21,11 @@ import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT;
 
+import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
@@ -62,17 +64,19 @@ public class WritableContainerFactory {
   }
 
   public ContainerInfo getContainer(final long size,
-      ReplicationConfig repConfig, String owner, ExcludeList excludeList)
+      ReplicationConfig repConfig, String owner, ExcludeList excludeList,
+      @Nonnull StorageTier storageTier)
       throws IOException {
     switch (repConfig.getReplicationType()) {
     case STAND_ALONE:
       return standaloneProvider
-          .getContainer(size, repConfig, owner, excludeList);
+          .getContainer(size, repConfig, owner, excludeList, storageTier);
     case RATIS:
-      return ratisProvider.getContainer(size, repConfig, owner, excludeList);
+      return ratisProvider.getContainer(size, repConfig, owner, excludeList,
+          storageTier);
     case EC:
-      return ecProvider.getContainer(size, (ECReplicationConfig)repConfig,
-          owner, excludeList);
+      return ecProvider.getContainer(size, (ECReplicationConfig) repConfig,
+          owner, excludeList, storageTier);
     default:
       throw new IOException(repConfig.getReplicationType()
           + " is an invalid replication type");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerProvider.java
@@ -17,8 +17,10 @@
 
 package org.apache.hadoop.hdds.scm.pipeline;
 
+import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 
@@ -45,12 +47,14 @@ public interface WritableContainerProvider<T extends ReplicationConfig> {
    * @param owner The owner of the container
    * @param excludeList A set of datanodes, container and pipelines which should
    *                    not be considered.
+   * @param storageTier The storageTier of the container
    * @return A ContainerInfo which is open and has the capacity to store the
    *         desired block size.
    * @throws IOException
    */
   ContainerInfo getContainer(long size, T repConfig,
-      String owner, ExcludeList excludeList)
+      String owner, ExcludeList excludeList,
+      @Nonnull StorageTier storageTier)
       throws IOException;
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.pipeline;
 import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
 import static org.apache.hadoop.hdds.scm.node.NodeStatus.inServiceHealthy;
 
+import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.NavigableSet;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
@@ -91,8 +93,10 @@ public class WritableECContainerProvider
    */
   @Override
   public ContainerInfo getContainer(final long size,
-      ECReplicationConfig repConfig, String owner, ExcludeList excludeList)
+      ECReplicationConfig repConfig, String owner, ExcludeList excludeList,
+      @Nonnull StorageTier storageTier)
       throws IOException {
+    // TODO StoragePolicy Support EC
     int maximumPipelines = getMaximumPipelines(repConfig);
     int openPipelineCount;
     synchronized (this) {
@@ -201,8 +205,9 @@ public class WritableECContainerProvider
       excludedNodes = new ArrayList<>(excludeList.getDatanodes());
     }
 
+    // TODO StoragePolicy Support EC
     Pipeline newPipeline = pipelineManager.createPipeline(repConfig,
-        excludedNodes, Collections.emptyList());
+        excludedNodes, Collections.emptyList(), StorageTier.getDefaultTier());
     // the returned ContainerInfo should not be null (due to not enough space in the Datanodes specifically) because
     // this is a new pipeline and pipeline creation checks for sufficient space in the Datanodes
     ContainerInfo container =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
@@ -17,11 +17,13 @@
 
 package org.apache.hadoop.hdds.scm.pipeline;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.PipelineRequestInformation;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -55,7 +57,8 @@ public class WritableRatisContainerProvider
 
   @Override
   public ContainerInfo getContainer(final long size,
-      ReplicationConfig repConfig, String owner, ExcludeList excludeList)
+      ReplicationConfig repConfig, String owner, ExcludeList excludeList,
+      @Nonnull StorageTier storageTier)
       throws IOException {
     /*
       Here is the high level logic.
@@ -80,7 +83,7 @@ public class WritableRatisContainerProvider
         PipelineRequestInformation.Builder.getBuilder().setSize(size).build();
 
     ContainerInfo containerInfo =
-        getContainer(repConfig, owner, excludeList, req);
+        getContainer(repConfig, owner, excludeList, req, storageTier);
     if (containerInfo != null) {
       return containerInfo;
     }
@@ -88,19 +91,19 @@ public class WritableRatisContainerProvider
     try {
       // TODO: #CLUTIL Remove creation logic when all replication types
       //  and factors are handled by pipeline creator
-      Pipeline pipeline = pipelineManager.createPipeline(repConfig);
+      Pipeline pipeline = pipelineManager.createPipeline(repConfig, storageTier);
 
       // wait until pipeline is ready
       pipelineManager.waitPipelineReady(pipeline.getId(), 0);
 
     } catch (SCMException se) {
-      LOG.warn("Pipeline creation failed for repConfig {} " +
+      LOG.warn("Pipeline creation failed for repConfig: {} storageTier: {} " +
           "Datanodes may be used up. Try to see if any pipeline is in " +
               "ALLOCATED state, and then will wait for it to be OPEN",
-              repConfig, se);
+              repConfig, storageTier, se);
       List<Pipeline> allocatedPipelines = findPipelinesByState(repConfig,
               excludeList,
-              Pipeline.PipelineState.ALLOCATED);
+              Pipeline.PipelineState.ALLOCATED, storageTier);
       if (!allocatedPipelines.isEmpty()) {
         List<PipelineID> allocatedPipelineIDs =
                 allocatedPipelines.stream()
@@ -119,14 +122,14 @@ public class WritableRatisContainerProvider
         failureReason = se.getMessage();
       }
     } catch (IOException e) {
-      LOG.warn("Pipeline creation failed for repConfig: {}. "
-          + "Retrying get pipelines call once.", repConfig, e);
+      LOG.warn("Pipeline creation failed for repConfig: {} storageTier: {}. "
+          + "Retrying get pipelines call once.", repConfig, storageTier, e);
       failureReason = e.getMessage();
     }
 
     // If Exception occurred or successful creation of pipeline do one
     // final try to fetch pipelines.
-    containerInfo = getContainer(repConfig, owner, excludeList, req);
+    containerInfo = getContainer(repConfig, owner, excludeList, req, storageTier);
     if (containerInfo != null) {
       return containerInfo;
     }
@@ -134,24 +137,27 @@ public class WritableRatisContainerProvider
     // we have tried all strategies we know but somehow we are not able
     // to get a container for this block. Log that info and throw an exception.
     LOG.error(
-        "Unable to allocate a block for the size: {}, repConfig: {}",
-        size, repConfig);
+        "Unable to allocate a block for the size: {}, repConfig: {}, storageTier: {}.",
+        size, repConfig, storageTier);
     throw new IOException(
         "Unable to allocate a container to the block of size: " + size
-            + ", replicationConfig: " + repConfig + ". " + failureReason);
+            + ", replicationConfig: " + repConfig
+            + " for storageTier: " + storageTier + ". " + failureReason);
   }
 
   @Nullable
   private ContainerInfo getContainer(ReplicationConfig repConfig, String owner,
-      ExcludeList excludeList, PipelineRequestInformation req) {
+      ExcludeList excludeList, PipelineRequestInformation req,
+      @Nonnull StorageTier storageTier) {
     // Acquire pipeline manager lock, to avoid any updates to pipeline
     // while allocate container happens. This is to avoid scenario like
     // mentioned in HDDS-5655.
     pipelineManager.acquireReadLock();
     try {
       List<Pipeline> availablePipelines = findPipelinesByState(repConfig,
-          excludeList, Pipeline.PipelineState.OPEN);
-      return selectContainer(availablePipelines, req, owner, excludeList);
+          excludeList, Pipeline.PipelineState.OPEN, storageTier);
+      return selectContainer(availablePipelines, req, owner, excludeList,
+          storageTier);
     } finally {
       pipelineManager.releaseReadLock();
     }
@@ -160,27 +166,31 @@ public class WritableRatisContainerProvider
   private List<Pipeline> findPipelinesByState(
           final ReplicationConfig repConfig,
           final ExcludeList excludeList,
-          final Pipeline.PipelineState pipelineState) {
+          final Pipeline.PipelineState pipelineState,
+          @Nonnull StorageTier storageTier) {
     List<Pipeline> pipelines = pipelineManager.getPipelines(repConfig,
             pipelineState, excludeList.getDatanodes(),
-            excludeList.getPipelineIds());
+            excludeList.getPipelineIds(), storageTier);
     if (pipelines.isEmpty() && !excludeList.isEmpty()) {
       // if no pipelines can be found, try finding pipeline without
       // exclusion
-      pipelines = pipelineManager.getPipelines(repConfig, pipelineState);
+      pipelines = pipelineManager.getPipelines(repConfig, pipelineState,
+          storageTier);
     }
     return pipelines;
   }
 
   private @Nullable ContainerInfo selectContainer(
       List<Pipeline> availablePipelines, PipelineRequestInformation req,
-      String owner, ExcludeList excludeList) {
+      String owner, ExcludeList excludeList,
+      @Nonnull StorageTier storageTier) {
 
     while (!availablePipelines.isEmpty()) {
       Pipeline pipeline = pipelineChoosePolicy.choosePipeline(
           availablePipelines, req);
 
       // look for OPEN containers that match the criteria.
+      // TODO StoragePolicy replace this StorageType with container actual StorageType
       final ContainerInfo containerInfo = containerManager.getMatchingContainer(
           req.getSize(), owner, pipeline, excludeList.getContainerIds());
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -860,8 +861,10 @@ public class SCMClientProtocolServer implements
     }
     try {
       getScm().checkAdminAccess(getRemoteUser(), false);
+      // TODO: Support Allocate Pipeline Command with StorageTier
       Pipeline result = scm.getPipelineManager().createPipeline(
-          ReplicationConfig.fromProtoTypeAndFactor(type, factor));
+          ReplicationConfig.fromProtoTypeAndFactor(type, factor),
+          StorageTier.getDefaultTier());
       AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
           SCMAction.CREATE_PIPELINE, auditMap));
       return result;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -194,7 +195,7 @@ public class TestBlockManager {
 
   @Test
   public void testAllocateBlock() throws Exception {
-    pipelineManager.createPipeline(replicationConfig);
+    pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
     AllocatedBlock block = blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,
         replicationConfig, OzoneConsts.OZONE, new ExcludeList());
@@ -205,7 +206,7 @@ public class TestBlockManager {
   public void testAllocateBlockWithExclusion() throws Exception {
     try {
       while (true) {
-        pipelineManager.createPipeline(replicationConfig);
+        pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
       }
     } catch (IOException e) {
     }
@@ -272,7 +273,7 @@ public class TestBlockManager {
     for (int i = 0; i < threadCount; i++) {
       executors.add(Executors.newSingleThreadExecutor());
     }
-    pipelineManager.createPipeline(replicationConfig);
+    pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
     Map<Long, List<AllocatedBlock>> allocatedBlockMap =
             new ConcurrentHashMap<>();
@@ -328,7 +329,7 @@ public class TestBlockManager {
     for (int i = 0; i < threadCount; i++) {
       executors.add(Executors.newSingleThreadExecutor());
     }
-    pipelineManager.createPipeline(replicationConfig);
+    pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
     Map<Long, List<AllocatedBlock>> allocatedBlockMap =
             new ConcurrentHashMap<>();
@@ -388,7 +389,7 @@ public class TestBlockManager {
     for (int i = 0; i < threadCount; i++) {
       executors.add(Executors.newSingleThreadExecutor());
     }
-    pipelineManager.createPipeline(replicationConfig);
+    pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
     Map<Long, List<AllocatedBlock>> allocatedBlockMap =
         new ConcurrentHashMap<>();
@@ -466,8 +467,8 @@ public class TestBlockManager {
   public void testMultipleBlockAllocation()
       throws IOException, TimeoutException, InterruptedException {
 
-    pipelineManager.createPipeline(replicationConfig);
-    pipelineManager.createPipeline(replicationConfig);
+    pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
+    pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
 
     AllocatedBlock allocatedBlock = blockManager
@@ -513,7 +514,7 @@ public class TestBlockManager {
     for (int i = 0;
          i < nodeManager.getNodes(NodeStatus.inServiceHealthy()).size()
              / replicationConfig.getRequiredNodes(); i++) {
-      pipelineManager.createPipeline(replicationConfig);
+      pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
     }
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -105,7 +106,7 @@ public class TestContainerManagerImpl {
     doReturn(true).when(pipelineManager).hasEnoughSpace(any(Pipeline.class));
 
     pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-        ReplicationFactor.THREE));
+        ReplicationFactor.THREE), StorageTier.getDefaultTier());
 
     pendingOpsMock = mock(ContainerReplicaPendingOps.class);
     containerManager = new ContainerManagerImpl(conf,
@@ -152,7 +153,7 @@ public class TestContainerManagerImpl {
 
     // create an EC pipeline to test for EC containers
     ECReplicationConfig ecReplicationConfig = new ECReplicationConfig(3, 2);
-    pipelineManager.createPipeline(ecReplicationConfig);
+    pipelineManager.createPipeline(ecReplicationConfig, StorageTier.getDefaultTier());
     pipeline = pipelineManager.getPipelines(ecReplicationConfig).iterator().next();
     container = containerManager.getMatchingContainer(sizeRequired, "test", pipeline, Collections.emptySet());
     assertNull(container);
@@ -182,7 +183,7 @@ public class TestContainerManagerImpl {
 
     // create an EC pipeline to test for EC containers
     ECReplicationConfig ecReplicationConfig = new ECReplicationConfig(3, 2);
-    spyPipelineManager.createPipeline(ecReplicationConfig);
+    spyPipelineManager.createPipeline(ecReplicationConfig, StorageTier.getDefaultTier());
     pipeline = spyPipelineManager.getPipelines(ecReplicationConfig).iterator().next();
     container = manager.getMatchingContainer(sizeRequired, "test", pipeline, Collections.emptySet());
     assertNotNull(container);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -861,7 +862,7 @@ public class TestContainerReportHandler {
         NodeStatus.inServiceHealthy()).iterator();
 
     Pipeline pipeline = pipelineManager.createPipeline(
-        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), StorageTier.getDefaultTier());
 
     final DatanodeDetails datanodeOne = nodeIterator.next();
     final DatanodeDetails datanodeTwo = nodeIterator.next();
@@ -1017,7 +1018,7 @@ public class TestContainerReportHandler {
     final ContainerReportHandler reportHandler = new ContainerReportHandler(
         nodeManager, containerManager);
 
-    Pipeline pipeline = pipelineManager.createPipeline(repConfig);
+    Pipeline pipeline = pipelineManager.createPipeline(repConfig, StorageTier.getDefaultTier());
     Map<Integer, DatanodeDetails> dns = new HashMap<>();
     final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
         NodeStatus.inServiceHealthy()).iterator();
@@ -1092,7 +1093,7 @@ public class TestContainerReportHandler {
     final ContainerReportHandler reportHandler = new ContainerReportHandler(
         nodeManager, containerManager);
 
-    Pipeline pipeline = pipelineManager.createPipeline(repConfig);
+    Pipeline pipeline = pipelineManager.createPipeline(repConfig, StorageTier.getDefaultTier());
     Map<Integer, DatanodeDetails> dns = new HashMap<>();
     final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
         NodeStatus.inServiceHealthy()).iterator();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -103,7 +104,7 @@ public class TestContainerStateManager {
                 ReplicationFactor.THREE))
             .setNodes(new ArrayList<>()).build();
     when(pipelineManager.createPipeline(StandaloneReplicationConfig.getInstance(
-        ReplicationFactor.THREE))).thenReturn(pipeline);
+        ReplicationFactor.THREE), StorageTier.getDefaultTier())).thenReturn(pipeline);
     when(pipelineManager.containsPipeline(any(PipelineID.class))).thenReturn(true);
 
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -466,7 +467,7 @@ public class TestIncrementalContainerReportHandler {
 
     RatisReplicationConfig replicationConfig =
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
-    Pipeline pipeline = pipelineManager.createPipeline(replicationConfig);
+    Pipeline pipeline = pipelineManager.createPipeline(replicationConfig, StorageTier.getDefaultTier());
     List<DatanodeDetails> nodes = pipeline.getNodes();
 
     final DatanodeDetails datanodeOne = nodes.get(0);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -41,6 +41,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
@@ -108,7 +109,7 @@ public class TestContainerPlacement {
     pipelineManager = new MockPipelineManager(dbStore,
         scmhaManager, nodeManager);
     pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-        HddsProtos.ReplicationFactor.THREE));
+        HddsProtos.ReplicationFactor.THREE), StorageTier.getDefaultTier());
   }
 
   @AfterEach

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -71,6 +71,7 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -464,7 +465,7 @@ public class TestSCMNodeManager {
           ReplicationConfig.fromProtoTypeAndFactor(
               HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.THREE);
-      scm.getPipelineManager().createPipeline(ratisThree);
+      scm.getPipelineManager().createPipeline(ratisThree, StorageTier.getDefaultTier());
     }, "3 nodes should not have been found for a pipeline.");
     assertThat(ex.getMessage()).contains("Required 3. Found " +
         actualNodeCount);
@@ -477,7 +478,7 @@ public class TestSCMNodeManager {
         HddsProtos.ReplicationFactor.THREE);
     SCMException ex = assertThrows(
         SCMException.class,
-        () -> scm.getPipelineManager().createPipeline(config),
+        () -> scm.getPipelineManager().createPipeline(config, StorageTier.getDefaultTier()),
         "3 nodes should not have been found for a pipeline.");
     assertThat(ex.getMessage())
         .contains("Cannot create pipeline for StorageTier DISK as it would exceed the limit per datanode: " + limit);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -65,15 +65,17 @@ public class MockPipelineManager implements PipelineManager {
   }
 
   @Override
-  public Pipeline createPipeline(ReplicationConfig replicationConfig)
+  public Pipeline createPipeline(ReplicationConfig replicationConfig,
+      StorageTier storageTier)
       throws IOException {
     return createPipeline(replicationConfig, Collections.emptyList(),
-        Collections.emptyList());
+        Collections.emptyList(), storageTier);
   }
 
   @Override
   public Pipeline createPipeline(ReplicationConfig replicationConfig,
-      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
+      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
+      StorageTier storageTier)
       throws IOException {
     Pipeline pipeline;
     if (replicationConfig.getReplicationType()
@@ -85,7 +87,7 @@ public class MockPipelineManager implements PipelineManager {
           ImmutableList.of(MockDatanodeDetails.randomDatanodeDetails(),
               MockDatanodeDetails.randomDatanodeDetails(),
               MockDatanodeDetails.randomDatanodeDetails()),
-          StorageTier.getDefaultTier());
+          storageTier);
     }
 
     stateManager.addPipeline(pipeline.getProtobufMessage(
@@ -182,11 +184,17 @@ public class MockPipelineManager implements PipelineManager {
 
   @Override
   public List<Pipeline> getPipelines(ReplicationConfig replicationConfig,
+      final Pipeline.PipelineState state, StorageTier storageTier) {
+    return stateManager.getPipelines(replicationConfig, state, storageTier);
+  }
+
+  @Override
+  public List<Pipeline> getPipelines(ReplicationConfig replicationConfig,
       final Pipeline.PipelineState state,
       final Collection<DatanodeDetails> excludeDns,
-      final Collection<PipelineID> excludePipelines) {
+      final Collection<PipelineID> excludePipelines, StorageTier storageTier) {
     return stateManager.getPipelines(replicationConfig, state,
-        excludeDns, excludePipelines);
+        excludeDns, excludePipelines, storageTier);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -209,12 +209,12 @@ public class TestPipelineManagerImpl {
         createPipelineManager(true, buffer1);
     assertTrue(pipelineManager.getPipelines().isEmpty());
     Pipeline pipeline1 = pipelineManager.createPipeline(
-        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
     assertEquals(1, pipelineManager.getPipelines().size());
     assertTrue(pipelineManager.containsPipeline(pipeline1.getId()));
 
     Pipeline pipeline2 = pipelineManager.createPipeline(
-        RatisReplicationConfig.getInstance(ReplicationFactor.ONE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.ONE), StorageTier.getDefaultTier());
     assertEquals(2, pipelineManager.getPipelines().size());
     assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
 
@@ -238,7 +238,7 @@ public class TestPipelineManagerImpl {
     assertThat(pipelineManager2.getPipelines()).isNotEmpty();
     assertEquals(3, pipelineManager.getPipelines().size());
     Pipeline pipeline3 = pipelineManager2.createPipeline(
-        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
     buffer2.close();
     assertEquals(4, pipelineManager2.getPipelines().size());
     assertTrue(pipelineManager2.containsPipeline(pipeline3.getId()));
@@ -251,7 +251,8 @@ public class TestPipelineManagerImpl {
     try (PipelineManager pipelineManager = createPipelineManager(false)) {
       assertTrue(pipelineManager.getPipelines().isEmpty());
       assertFailsNotLeader(() -> pipelineManager.createPipeline(
-              RatisReplicationConfig.getInstance(ReplicationFactor.THREE)));
+              RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+              StorageTier.getDefaultTier()));
     }
   }
 
@@ -382,7 +383,7 @@ public class TestPipelineManagerImpl {
           serviceManager, new EventQueue(), scmContext);
       Pipeline pipeline = pipelineManager
           .createPipeline(RatisReplicationConfig
-              .getInstance(ReplicationFactor.THREE));
+              .getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
 
       // pipeline is not healthy until all dns report
       List<DatanodeDetails> nodes = pipeline.getNodes();
@@ -436,7 +437,7 @@ public class TestPipelineManagerImpl {
     List<DatanodeDetails> nodes = localNodeManager.getNodes(NodeStatus.inServiceHealthy());
     assertEquals(nodeCount, nodes.size());
     Pipeline pipeline = pipelineManager.createPipeline(RatisReplicationConfig
-        .getInstance(ReplicationFactor.THREE));
+        .getInstance(ReplicationFactor.THREE), StorageTier.DISK);
     assertEquals(StorageTier.DISK, pipeline.getSupportedStorageTier());
 
     assertFalse(pipelineManager.getPipeline(pipeline.getId()).isHealthy());
@@ -490,7 +491,7 @@ public class TestPipelineManagerImpl {
     for (int i = 0; i < maxPipelineCount; i++) {
       Pipeline pipeline = pipelineManager
           .createPipeline(RatisReplicationConfig
-              .getInstance(ReplicationFactor.THREE));
+              .getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
       assertNotNull(pipeline);
     }
 
@@ -506,7 +507,9 @@ public class TestPipelineManagerImpl {
     //This should fail...
     SCMException e =
         assertThrows(SCMException.class,
-            () -> pipelineManager.createPipeline(RatisReplicationConfig.getInstance(ReplicationFactor.THREE)));
+            () -> pipelineManager.createPipeline(
+                RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+                StorageTier.getDefaultTier()));
     // pipeline creation failed this time.
     assertEquals(ResultCodes.FAILED_TO_FIND_SUITABLE_NODE, e.getResult());
 
@@ -532,7 +535,7 @@ public class TestPipelineManagerImpl {
 
     Pipeline pipeline = pipelineManager
         .createPipeline(RatisReplicationConfig
-            .getInstance(ReplicationFactor.THREE));
+            .getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
     // close manager
     buffer1.close();
     pipelineManager.close();
@@ -580,7 +583,7 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline allocatedPipeline = pipelineManager
         .createPipeline(RatisReplicationConfig
-            .getInstance(ReplicationFactor.THREE));
+            .getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
     // At this point, pipeline is not at OPEN stage.
     assertEquals(Pipeline.PipelineState.ALLOCATED,
         allocatedPipeline.getPipelineState());
@@ -593,7 +596,7 @@ public class TestPipelineManagerImpl {
 
     Pipeline closedPipeline = pipelineManager
         .createPipeline(RatisReplicationConfig
-            .getInstance(ReplicationFactor.THREE));
+            .getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
     pipelineManager.openPipeline(closedPipeline.getId());
     pipelineManager.closePipeline(closedPipeline.getId());
 
@@ -645,7 +648,7 @@ public class TestPipelineManagerImpl {
   public void testScrubOpenWithUnregisteredNodes() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager
-        .createPipeline(new ECReplicationConfig(3, 2));
+        .createPipeline(new ECReplicationConfig(3, 2), StorageTier.getDefaultTier());
     pipelineManager.openPipeline(pipeline.getId());
 
     // Scrubbing the pipelines should not affect this pipeline
@@ -689,7 +692,8 @@ public class TestPipelineManagerImpl {
 
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     assertThrows(IOException.class,
-        () -> pipelineManager.createPipeline(RatisReplicationConfig.getInstance(ReplicationFactor.THREE)),
+        () -> pipelineManager.createPipeline(RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+            StorageTier.getDefaultTier()),
         "Pipelines should not have been created");
     // No pipeline is created.
     assertTrue(pipelineManager.getPipelines().isEmpty());
@@ -698,7 +702,7 @@ public class TestPipelineManagerImpl {
     // raised.
     Pipeline pipeline = pipelineManager
         .createPipeline(RatisReplicationConfig
-            .getInstance(ReplicationFactor.ONE));
+            .getInstance(ReplicationFactor.ONE), StorageTier.getDefaultTier());
     assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.ONE))
@@ -747,7 +751,8 @@ public class TestPipelineManagerImpl {
             SCMDBDefinition.PIPELINES.getTable(dbStore);
     Pipeline pipeline = pipelineManager.createPipeline(
             RatisReplicationConfig
-                .getInstance(HddsProtos.ReplicationFactor.THREE));
+                .getInstance(HddsProtos.ReplicationFactor.THREE),
+            StorageTier.getDefaultTier());
     PipelineID pipelineID = pipeline.getId();
     pipelineManager.addContainerToPipeline(pipelineID, ContainerID.valueOf(1));
     pipelineManager.getStateManager().updatePipelineState(
@@ -770,7 +775,8 @@ public class TestPipelineManagerImpl {
         SCMDBDefinition.PIPELINES.getTable(dbStore);
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig
-            .getInstance(HddsProtos.ReplicationFactor.THREE));
+            .getInstance(HddsProtos.ReplicationFactor.THREE),
+        StorageTier.getDefaultTier());
     PipelineID pipelineID = pipeline.getId();
     pipelineManager.addContainerToPipeline(pipelineID, ContainerID.valueOf(1));
     pipelineManager.getStateManager().updatePipelineState(
@@ -788,7 +794,8 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager.createPipeline(
             RatisReplicationConfig
-                .getInstance(HddsProtos.ReplicationFactor.THREE));
+                .getInstance(HddsProtos.ReplicationFactor.THREE),
+            StorageTier.getDefaultTier());
     PipelineID pipelineID = pipeline.getId();
     ContainerManager containerManager = scm.getContainerManager();
     ContainerInfo containerInfo = HddsTestUtils.
@@ -930,12 +937,12 @@ public class TestPipelineManagerImpl {
 
     // Throw on pipeline creates, so no new pipelines can be created
     doThrow(SCMException.class).when(pipelineManagerSpy)
-        .createPipeline(any(), any(), anyList());
+        .createPipeline(any(), any(), anyList(), any(StorageTier.class));
     provider = new WritableRatisContainerProvider(
         pipelineManagerSpy, containerManager, pipelineChoosingPolicy);
 
     // Add a single pipeline to manager, (in the allocated state)
-    allocatedPipeline = pipelineManager.createPipeline(repConfig);
+    allocatedPipeline = pipelineManager.createPipeline(repConfig, StorageTier.getDefaultTier());
     pipelineManager.getStateManager()
         .updatePipelineState(allocatedPipeline.getId()
             .getProtobuf(), HddsProtos.PipelineState.PIPELINE_ALLOCATED);
@@ -972,7 +979,7 @@ public class TestPipelineManagerImpl {
 
 
     ContainerInfo c = provider.getContainer(1, repConfig,
-        owner, new ExcludeList());
+        owner, new ExcludeList(), StorageTier.getDefaultTier());
     assertEquals(c, container, "Expected container was returned");
 
     // Confirm that waitOnePipelineReady was called on allocated pipelines
@@ -1078,7 +1085,8 @@ public class TestPipelineManagerImpl {
   private static Pipeline assertAllocate(PipelineManagerImpl pipelineManager) {
     Pipeline pipeline = assertDoesNotThrow(
         () -> pipelineManager.createPipeline(
-            RatisReplicationConfig.getInstance(ReplicationFactor.THREE)));
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+            StorageTier.getDefaultTier()));
     assertEquals(1, pipelineManager.getPipelines().size());
     assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     assertEquals(ALLOCATED, pipeline.getPipelineState());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import java.io.File;
@@ -228,6 +227,12 @@ public class TestRatisPipelineProvider {
     OzoneConfiguration pipelineLimitConf = new OzoneConfiguration();
     pipelineLimitConf.setInt(OZONE_SCM_RATIS_PIPELINE_LIMIT, 1);
     init(0, pipelineLimitConf, StorageTier.DISK);
+    // init(0, ...) sets numPipelinePerDatanode=0 which would cause
+    // filterPipelineEngagement to exclude every datanode. Bump it here
+    // before creating the spy so filterPipelineEngagement sees a positive
+    // limit. The provider's datanodePipelineLimit config is still 0, so
+    // the *global* branch of exceedPipelineNumberLimit is what runs.
+    nodeManager.setNumPipelinePerDatanode(5);
     List<DatanodeDetails> diskAndSsdNodes = datanodeList.stream()
         .map(TestRatisPipelineProvider::datanodeInfoWithDiskAndSsd)
         .collect(Collectors.toList());
@@ -236,11 +241,6 @@ public class TestRatisPipelineProvider {
         .when(nodeManagerSpy).getNodes(any(NodeStatus.class));
     doAnswer(invocation -> datanodeInfoWithDiskAndSsd(invocation.getArgument(0)))
         .when(nodeManagerSpy).getDatanodeInfo(any(DatanodeDetails.class));
-    // per-DN pipelineLimit=0 makes filterPipelineEngagement exclude every
-    // node; return a positive limit from the spy so engagement filtering
-    // does not swallow all nodes. The per-DN pipeline limit in the
-    // provider config is still 0, so the *global* branch is what runs.
-    doReturn(5).when(nodeManagerSpy).pipelineLimit(any(DatanodeDetails.class));
     RatisPipelineProvider localProvider = new RatisPipelineProvider(
         nodeManagerSpy, stateManager, pipelineLimitConf, new EventQueue(),
         SCMContext.emptyContext());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import java.io.File;
@@ -239,7 +240,7 @@ public class TestRatisPipelineProvider {
     // node; return a positive limit from the spy so engagement filtering
     // does not swallow all nodes. The per-DN pipeline limit in the
     // provider config is still 0, so the *global* branch is what runs.
-    doAnswer(invocation -> 5).when(nodeManagerSpy).pipelineLimit(any(DatanodeDetails.class));
+    doReturn(5).when(nodeManagerSpy).pipelineLimit(any(DatanodeDetails.class));
     RatisPipelineProvider localProvider = new RatisPipelineProvider(
         nodeManagerSpy, stateManager, pipelineLimitConf, new EventQueue(),
         SCMContext.emptyContext());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -235,6 +235,11 @@ public class TestRatisPipelineProvider {
         .when(nodeManagerSpy).getNodes(any(NodeStatus.class));
     doAnswer(invocation -> datanodeInfoWithDiskAndSsd(invocation.getArgument(0)))
         .when(nodeManagerSpy).getDatanodeInfo(any(DatanodeDetails.class));
+    // per-DN pipelineLimit=0 makes filterPipelineEngagement exclude every
+    // node; return a positive limit from the spy so engagement filtering
+    // does not swallow all nodes. The per-DN pipeline limit in the
+    // provider config is still 0, so the *global* branch is what runs.
+    doAnswer(invocation -> 5).when(nodeManagerSpy).pipelineLimit(any(DatanodeDetails.class));
     RatisPipelineProvider localProvider = new RatisPipelineProvider(
         nodeManagerSpy, stateManager, pipelineLimitConf, new EventQueue(),
         SCMContext.emptyContext());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -223,7 +223,7 @@ public class TestRatisPipelineProvider {
   }
 
   @Test
-  public void testGlobalPipelineNumberLimitIsNotStorageTierAware() throws Exception {
+  public void testGlobalPipelineNumberLimitIsStorageTierAware() throws Exception {
     OzoneConfiguration pipelineLimitConf = new OzoneConfiguration();
     pipelineLimitConf.setInt(OZONE_SCM_RATIS_PIPELINE_LIMIT, 1);
     init(0, pipelineLimitConf, StorageTier.DISK);
@@ -238,6 +238,7 @@ public class TestRatisPipelineProvider {
     RatisPipelineProvider localProvider = new RatisPipelineProvider(
         nodeManagerSpy, stateManager, pipelineLimitConf, new EventQueue(),
         SCMContext.emptyContext());
+    // Fill the DISK tier up to the global limit.
     for (int i = 0; i < 2; i++) {
       addPipeline(diskAndSsdNodes.subList(i * 3, i * 3 + 3),
           Pipeline.PipelineState.OPEN,
@@ -245,11 +246,11 @@ public class TestRatisPipelineProvider {
           StorageTier.DISK);
     }
 
-    SCMException exception = assertThrows(SCMException.class, () ->
-        localProvider.create(
-            RatisReplicationConfig.getInstance(ReplicationFactor.THREE), StorageTier.SSD));
-
-    assertThat(exception.getMessage()).contains("would exceed the limit");
+    // SSD is a distinct tier, so the global limit should not block creation.
+    Pipeline pipeline = localProvider.create(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), StorageTier.SSD);
+    assertPipelineProperties(pipeline, ReplicationFactor.THREE,
+        REPLICATION_TYPE, Pipeline.PipelineState.ALLOCATED, StorageTier.SSD);
   }
 
   private List<DatanodeDetails> createListOfNodes(int count) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -52,6 +52,7 @@ import java.util.stream.IntStream;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -209,7 +210,7 @@ public class TestWritableECContainerProvider {
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < n; i++) {
       ContainerInfo container =
-          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
       assertThat(allocatedContainers)
           .withFailMessage("Provided existing container for request " + i)
           .doesNotContain(container);
@@ -222,7 +223,7 @@ public class TestWritableECContainerProvider {
       throws IOException {
     for (int i = 0; i < 3 * n; i++) {
       ContainerInfo container =
-          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
       assertThat(existing)
           .withFailMessage("Provided new container for request " + i)
           .contains(container);
@@ -237,7 +238,7 @@ public class TestWritableECContainerProvider {
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
-          1, repConfig, OWNER, new ExcludeList());
+          1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
       allocatedContainers.add(container);
     }
     // We have the min limit of pipelines, but then exclude one. It should use
@@ -248,7 +249,7 @@ public class TestWritableECContainerProvider {
         .stream().findFirst().get().getPipelineID();
     exclude.addPipeline(excludedID);
 
-    ContainerInfo c = provider.getContainer(1, repConfig, OWNER, exclude);
+    ContainerInfo c = provider.getContainer(1, repConfig, OWNER, exclude, StorageTier.getDefaultTier());
     assertNotEquals(excludedID, c.getPipelineID());
     assertThat(allocatedContainers).contains(c);
   }
@@ -263,7 +264,7 @@ public class TestWritableECContainerProvider {
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
-          1, repConfig, OWNER, new ExcludeList());
+          1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
       allocatedContainers.add(container);
     }
     // We have the min limit of pipelines, but then exclude them all
@@ -272,7 +273,7 @@ public class TestWritableECContainerProvider {
       exclude.addPipeline(c.getPipelineID());
     }
     assertThrows(IOException.class, () -> provider.getContainer(
-        1, repConfig, OWNER, exclude));
+        1, repConfig, OWNER, exclude, StorageTier.getDefaultTier()));
   }
 
   @ParameterizedTest
@@ -283,7 +284,7 @@ public class TestWritableECContainerProvider {
     providerConf.setMinimumPipelines(1);
     provider = createSubject(policy);
     ContainerInfo container = provider.getContainer(
-        1, repConfig, OWNER, new ExcludeList());
+        1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
 
     ExcludeList exclude = new ExcludeList();
     exclude.addPipeline(container.getPipelineID());
@@ -291,7 +292,7 @@ public class TestWritableECContainerProvider {
         pipelineManager.getPipeline(container.getPipelineID()).getFirstNode());
 
     ContainerInfo newContainer = provider.getContainer(
-        1, repConfig, OWNER, exclude);
+        1, repConfig, OWNER, exclude, StorageTier.getDefaultTier());
     assertNotSame(container, newContainer);
   }
 
@@ -305,7 +306,7 @@ public class TestWritableECContainerProvider {
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
-          1, repConfig, OWNER, new ExcludeList());
+          1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
       allocatedContainers.add(container);
     }
     // We have the min limit of pipelines, but then exclude all the associated
@@ -315,7 +316,7 @@ public class TestWritableECContainerProvider {
       exclude.addConatinerId(c.containerID());
     }
     assertThrows(IOException.class, () -> provider.getContainer(
-        1, repConfig, OWNER, exclude));
+        1, repConfig, OWNER, exclude, StorageTier.getDefaultTier()));
   }
 
   @ParameterizedTest
@@ -327,14 +328,15 @@ public class TestWritableECContainerProvider {
       @Override
       public Pipeline createPipeline(ReplicationConfig repConf,
           List<DatanodeDetails> excludedNodes,
-          List<DatanodeDetails> favoredNodes) throws IOException {
+          List<DatanodeDetails> favoredNodes,
+          StorageTier storageTier) throws IOException {
         throw new IOException("Cannot create pipelines");
       }
     };
     provider = createSubject(policy);
 
     IOException ioException = assertThrows(IOException.class,
-        () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
+        () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier()));
     assertThat(ioException.getMessage())
         .contains("Cannot create pipelines");
   }
@@ -351,25 +353,26 @@ public class TestWritableECContainerProvider {
       @Override
       public Pipeline createPipeline(ReplicationConfig repConf,
           List<DatanodeDetails> excludedNodes,
-          List<DatanodeDetails> favoredNodes)
+          List<DatanodeDetails> favoredNodes,
+          StorageTier storageTier)
           throws IOException {
         if (throwError) {
           throw new RocksDatabaseException("Cannot create pipelines");
         }
         throwError = true;
-        return super.createPipeline(repConfig);
+        return super.createPipeline(repConfig, storageTier);
       }
     };
     provider = createSubject(policy);
 
     IOException ioException = assertThrows(IOException.class,
-        () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
+        () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier()));
     assertThat(ioException.getMessage())
         .contains("Cannot create pipelines");
 
     for (int i = 0; i < 5; i++) {
       ioException = assertThrows(IOException.class,
-          () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
+          () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier()));
       assertThat(ioException.getMessage())
           .contains("Cannot create pipelines");
     }
@@ -392,13 +395,14 @@ public class TestWritableECContainerProvider {
     // We ask for a space of 50 MB, and will actually need 50 MB space.
     ContainerInfo newContainer =
         provider.getContainer(50 * 1024 * 1024, repConfig, OWNER,
-            new ExcludeList());
+            new ExcludeList(), StorageTier.getDefaultTier());
     assertNotNull(newContainer);
     assertThat(allocatedContainers).contains(newContainer);
     // Now get a new container where there is not enough space in the existing
     // and ensure a new container gets created.
     newContainer = provider.getContainer(
-        128 * 1024 * 1024, repConfig, OWNER, new ExcludeList());
+        128 * 1024 * 1024, repConfig, OWNER, new ExcludeList(),
+        StorageTier.getDefaultTier());
     assertNotNull(newContainer);
     assertThat(allocatedContainers).doesNotContain(newContainer);
     // The original pipelines should all be closed, triggered by the lack of
@@ -431,7 +435,7 @@ public class TestWritableECContainerProvider {
     // Now attempt to get a container - any attempt to use an existing with
     // throw PNF and then we must allocate a new one
     ContainerInfo newContainer =
-        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+        provider.getContainer(1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
     assertNotNull(newContainer);
     assertThat(allocatedContainers).doesNotContain(newContainer);
   }
@@ -451,7 +455,7 @@ public class TestWritableECContainerProvider {
     }).when(containerManager).getContainer(any(ContainerID.class));
 
     ContainerInfo newContainer =
-        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+        provider.getContainer(1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
     assertNotNull(newContainer);
     assertThat(allocatedContainers).doesNotContain(newContainer);
 
@@ -473,7 +477,7 @@ public class TestWritableECContainerProvider {
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
-          1, repConfig, OWNER, new ExcludeList());
+          1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
       assertThat(allocatedContainers).doesNotContain(container);
       allocatedContainers.add(container);
       // Remove the container from the pipeline to simulate closing it
@@ -481,7 +485,7 @@ public class TestWritableECContainerProvider {
           container.getPipelineID(), container.containerID());
     }
     ContainerInfo newContainer = provider.getContainer(
-        1, repConfig, OWNER, new ExcludeList());
+        1, repConfig, OWNER, new ExcludeList(), StorageTier.getDefaultTier());
     assertThat(allocatedContainers).doesNotContain(newContainer);
     for (ContainerInfo c : allocatedContainers) {
       Pipeline pipeline = pipelineManager.getPipeline(c.getPipelineID());
@@ -518,7 +522,7 @@ public class TestWritableECContainerProvider {
 
     // expecting a new container to be created
     ContainerInfo containerInfo = provider.getContainer(1, repConfig, OWNER,
-        excludeList);
+        excludeList, StorageTier.getDefaultTier());
     assertThat(allocated).doesNotContain(containerInfo);
     for (ContainerInfo c : allocated) {
       Pipeline pipeline = pipelineManager.getPipeline(c.getPipelineID());
@@ -536,11 +540,12 @@ public class TestWritableECContainerProvider {
 
     // EmptyList should be passed if there are no nodes excluded.
     ContainerInfo container = provider.getContainer(
-        1, repConfig, OWNER, excludeList);
+        1, repConfig, OWNER, excludeList, StorageTier.getDefaultTier());
     assertNotNull(container);
 
     verify(pipelineManagerSpy).createPipeline(repConfig,
-        Collections.emptyList(), Collections.emptyList());
+        Collections.emptyList(), Collections.emptyList(),
+        StorageTier.getDefaultTier());
 
     // If nodes are excluded then the excluded nodes should be passed through to
     // the create pipeline call.
@@ -549,10 +554,10 @@ public class TestWritableECContainerProvider {
         new ArrayList<>(excludeList.getDatanodes());
 
     container = provider.getContainer(
-        1, repConfig, OWNER, excludeList);
+        1, repConfig, OWNER, excludeList, StorageTier.getDefaultTier());
     assertNotNull(container);
     verify(pipelineManagerSpy).createPipeline(repConfig, excludedNodes,
-        Collections.emptyList());
+        Collections.emptyList(), StorageTier.getDefaultTier());
   }
 
   private ContainerInfo createContainer(Pipeline pipeline,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
@@ -24,6 +24,8 @@ import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.OPEN;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,6 +37,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
@@ -78,7 +81,8 @@ class TestWritableRatisContainerProvider {
 
     existingPipelines(pipeline);
 
-    ContainerInfo container = createSubject().getContainer(CONTAINER_SIZE, REPLICATION_CONFIG, OWNER, NO_EXCLUSION);
+    ContainerInfo container = createSubject().getContainer(
+        CONTAINER_SIZE, REPLICATION_CONFIG, OWNER, NO_EXCLUSION, StorageTier.getDefaultTier());
 
     assertSame(existingContainer, container);
     verifyPipelineNotCreated();
@@ -92,7 +96,8 @@ class TestWritableRatisContainerProvider {
     Pipeline pipelineWithoutContainer = MockPipeline.createPipeline(3);
     existingPipelines(pipelineWithoutContainer, pipeline);
 
-    ContainerInfo container = createSubject().getContainer(CONTAINER_SIZE, REPLICATION_CONFIG, OWNER, NO_EXCLUSION);
+    ContainerInfo container = createSubject().getContainer(
+        CONTAINER_SIZE, REPLICATION_CONFIG, OWNER, NO_EXCLUSION, StorageTier.getDefaultTier());
 
     assertSame(existingContainer, container);
     verifyPipelineNotCreated();
@@ -102,7 +107,8 @@ class TestWritableRatisContainerProvider {
   void createsNewContainerIfNoneFound() throws Exception {
     ContainerInfo newContainer = createNewContainerOnDemand();
 
-    ContainerInfo container = createSubject().getContainer(CONTAINER_SIZE, REPLICATION_CONFIG, OWNER, NO_EXCLUSION);
+    ContainerInfo container = createSubject().getContainer(
+        CONTAINER_SIZE, REPLICATION_CONFIG, OWNER, NO_EXCLUSION, StorageTier.getDefaultTier());
 
     assertSame(newContainer, container);
     verifyPipelineCreated();
@@ -113,7 +119,8 @@ class TestWritableRatisContainerProvider {
     throwWhenCreatePipeline();
 
     assertThrows(IOException.class,
-        () -> createSubject().getContainer(CONTAINER_SIZE, REPLICATION_CONFIG, OWNER, NO_EXCLUSION));
+        () -> createSubject().getContainer(
+            CONTAINER_SIZE, REPLICATION_CONFIG, OWNER, NO_EXCLUSION, StorageTier.getDefaultTier()));
 
     verifyPipelineCreated();
   }
@@ -123,7 +130,8 @@ class TestWritableRatisContainerProvider {
   }
 
   private void existingPipelines(List<Pipeline> pipelines) {
-    when(pipelineManager.getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet()))
+    when(pipelineManager.getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet(),
+        StorageTier.getDefaultTier()))
         .thenReturn(pipelines);
   }
 
@@ -141,10 +149,11 @@ class TestWritableRatisContainerProvider {
 
   private ContainerInfo createNewContainerOnDemand() throws IOException {
     Pipeline newPipeline = MockPipeline.createPipeline(3);
-    when(pipelineManager.createPipeline(REPLICATION_CONFIG))
+    when(pipelineManager.createPipeline(eq(REPLICATION_CONFIG), any(StorageTier.class)))
         .thenReturn(newPipeline);
 
-    when(pipelineManager.getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet()))
+    when(pipelineManager.getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet(),
+        StorageTier.getDefaultTier()))
         .thenReturn(emptyList())
         .thenReturn(new ArrayList<>(singletonList(newPipeline)));
 
@@ -152,7 +161,7 @@ class TestWritableRatisContainerProvider {
   }
 
   private void throwWhenCreatePipeline() throws IOException {
-    when(pipelineManager.createPipeline(REPLICATION_CONFIG))
+    when(pipelineManager.createPipeline(REPLICATION_CONFIG, StorageTier.getDefaultTier()))
         .thenThrow(new SCMException(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE));
   }
 
@@ -163,16 +172,18 @@ class TestWritableRatisContainerProvider {
 
   private void verifyPipelineCreated() throws IOException {
     verify(pipelineManager, times(2))
-        .getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet());
+        .getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet(),
+            StorageTier.getDefaultTier());
     verify(pipelineManager)
-        .createPipeline(REPLICATION_CONFIG);
+        .createPipeline(REPLICATION_CONFIG, StorageTier.getDefaultTier());
   }
 
   private void verifyPipelineNotCreated() throws IOException {
     verify(pipelineManager, times(1))
-        .getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet());
+        .getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet(),
+            StorageTier.getDefaultTier());
     verify(pipelineManager, never())
-        .createPipeline(REPLICATION_CONFIG);
+        .createPipeline(REPLICATION_CONFIG, StorageTier.getDefaultTier());
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -154,15 +155,15 @@ public class TestHealthyPipelineSafeModeRule {
       // Create 3 pipelines
       Pipeline pipeline1 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
       pipelineManager.openPipeline(pipeline1.getId());
       Pipeline pipeline2 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
       pipelineManager.openPipeline(pipeline2.getId());
       Pipeline pipeline3 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
       pipelineManager.openPipeline(pipeline3.getId());
 
       // Mark pipeline healthy
@@ -247,15 +248,15 @@ public class TestHealthyPipelineSafeModeRule {
       // Create 3 pipelines
       Pipeline pipeline1 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.ONE));
+              ReplicationFactor.ONE), StorageTier.getDefaultTier());
       pipelineManager.openPipeline(pipeline1.getId());
       Pipeline pipeline2 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
       pipelineManager.openPipeline(pipeline2.getId());
       Pipeline pipeline3 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
       pipelineManager.openPipeline(pipeline3.getId());
 
       // Mark pipelines healthy
@@ -338,13 +339,13 @@ public class TestHealthyPipelineSafeModeRule {
       // blocked once safe mode prechecks have not passed.
       Pipeline pipeline1 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
       Pipeline pipeline2 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
       Pipeline pipeline3 =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
 
       // Start with one healthy open pipeline. Threshold is small at this point.
       pipelineManager.openPipeline(pipeline1.getId());
@@ -446,7 +447,7 @@ public class TestHealthyPipelineSafeModeRule {
       // Create a Ratis pipeline with 3 replicas
       Pipeline pipeline =
           pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
       pipelineManager.openPipeline(pipeline.getId());
       pipeline = pipelineManager.getPipeline(pipeline.getId());
       MockRatisPipelineProvider.markPipelineHealthy(pipeline);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -239,7 +240,7 @@ public class TestOneReplicaPipelineSafeModeRule {
       HddsProtos.ReplicationFactor factor) throws Exception {
     for (int i = 0; i < count; i++) {
       Pipeline pipeline = pipelineManager.createPipeline(
-              RatisReplicationConfig.getInstance(factor));
+              RatisReplicationConfig.getInstance(factor), StorageTier.getDefaultTier());
       pipelineManager.openPipeline(pipeline.getId());
 
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -312,7 +313,7 @@ public class TestSCMSafeModeManager {
       // Create pipeline
       Pipeline pipeline = pipelineManager.createPipeline(
           RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
+              ReplicationFactor.THREE), StorageTier.getDefaultTier());
 
       pipelineManager.openPipeline(pipeline.getId());
       // Mark pipeline healthy
@@ -721,7 +722,7 @@ public class TestSCMSafeModeManager {
 
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(
-            ReplicationFactor.THREE));
+            ReplicationFactor.THREE), StorageTier.getDefaultTier());
 
     pipeline = pipelineManager.getPipeline(pipeline.getId());
     MockRatisPipelineProvider.markPipelineHealthy(pipeline);
@@ -814,7 +815,7 @@ public class TestSCMSafeModeManager {
     assertTrue(scmSafeModeManager.getInSafeMode());
 
     Pipeline pipeline = pipelineManager.createPipeline(
-        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
 
     // Mark pipeline healthy
     pipeline = pipelineManager.getPipeline(pipeline.getId());
@@ -933,7 +934,7 @@ public class TestSCMSafeModeManager {
       assertThat(logCapturer.getOutput()).contains("SCM SafeMode Status | state=PRE_CHECKS_PASSED");
       
       Pipeline pipeline = pipelineManager.createPipeline(
-          RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+          RatisReplicationConfig.getInstance(ReplicationFactor.THREE), StorageTier.getDefaultTier());
       pipeline = pipelineManager.getPipeline(pipeline.getId());
       MockRatisPipelineProvider.markPipelineHealthy(pipeline);
       firePipelineEvent(pipelineManager, pipeline);

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -160,6 +160,7 @@ public class ContainerOperationClient implements ScmClient {
     XceiverClientSpi client = null;
     XceiverClientManager clientManager = getXceiverClientManager();
     try {
+      // TODO Support create Container Command with StorageTier
       ContainerWithPipeline containerWithPipeline =
           storageContainerLocationClient.
               allocateContainer(replicationType, replicationFactor, owner);

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Optional;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -107,7 +108,8 @@ public class TestReconAsPassiveScm {
     UnsupportedOperationException exception = assertThrows(
         UnsupportedOperationException.class,
         () -> reconPipelineManager
-            .createPipeline(RatisReplicationConfig.getInstance(ONE)));
+            .createPipeline(RatisReplicationConfig.getInstance(ONE),
+                StorageTier.getDefaultTier()));
     assertTrue(exception.getMessage()
         .contains("Trying to create pipeline in Recon, which is prohibited!"));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestSafeMode.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.SafeMode;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -117,7 +118,8 @@ class TestSafeMode {
           RatisReplicationConfig.getInstance(THREE);
       assertThrows(IOException.class, () -> cluster.getStorageContainerManager()
           .getWritableContainerFactory()
-          .getContainer(MB, replication, OZONE, new ExcludeList()));
+          .getContainer(MB, replication, OZONE, new ExcludeList(),
+              StorageTier.getDefaultTier()));
     } finally {
       IOUtils.closeQuietly(fs);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -98,7 +99,7 @@ public class  TestMultiRaftSetup {
     // datanode pipeline limit is set to 2, but only one set of 3 pipelines
     // will be created. Further pipeline creation should fail
     assertEquals(1, pipelineManager.getPipelines(RATIS_THREE).size());
-    assertThrows(IOException.class, () -> pipelineManager.createPipeline(RATIS_THREE));
+    assertThrows(IOException.class, () -> pipelineManager.createPipeline(RATIS_THREE, StorageTier.getDefaultTier()));
     shutdown();
   }
 
@@ -119,7 +120,7 @@ public class  TestMultiRaftSetup {
         .filter((dn) -> nodeManager.getPipelinesCount(dn) > 2).collect(
             Collectors.toList());
     assertEquals(1, dns.size());
-    assertThrows(IOException.class, () -> pipelineManager.createPipeline(RATIS_THREE));
+    assertThrows(IOException.class, () -> pipelineManager.createPipeline(RATIS_THREE, StorageTier.getDefaultTier()));
     Collection<PipelineID> pipelineIds = nodeManager.getPipelines(dns.get(0));
     // Only one dataode should have 3 pipelines in total, 1 RATIS ONE pipeline
     // and 2 RATIS 3 pipeline

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -142,7 +143,7 @@ public class TestRatisPipelineCreateAndDestroy {
     // try creating another pipeline now
     SCMException ioe = assertThrows(SCMException.class, () ->
         pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-            ReplicationFactor.THREE)),
+            ReplicationFactor.THREE), StorageTier.getDefaultTier()),
         "pipeline creation should fail after shutting down pipeline");
     assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE, ioe.getResult());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -449,7 +450,7 @@ public class TestContainerCommandsEC {
         new XceiverClientManager(config)) {
       ECReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
       Pipeline newPipeline =
-          scm.getPipelineManager().createPipeline(replicationConfig);
+          scm.getPipelineManager().createPipeline(replicationConfig, StorageTier.getDefaultTier());
       scm.getPipelineManager().activatePipeline(newPipeline.getId());
       final ContainerInfo container = scm.getContainerManager()
           .allocateContainer(replicationConfig, "test");
@@ -538,7 +539,7 @@ public class TestContainerCommandsEC {
              new XceiverClientManager(config)) {
       ECReplicationConfig replicationConfig = new ECReplicationConfig(3, 2);
       Pipeline newPipeline =
-          scm.getPipelineManager().createPipeline(replicationConfig);
+          scm.getPipelineManager().createPipeline(replicationConfig, StorageTier.getDefaultTier());
       scm.getPipelineManager().activatePipeline(newPipeline.getId());
       final ContainerInfo container = scm.getContainerManager()
           .allocateContainer(replicationConfig, "test");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -224,7 +225,7 @@ public class TestHDDSUpgrade {
    */
   private void testPostUpgradePipelineCreation()
       throws IOException, TimeoutException {
-    Pipeline ratisPipeline1 = scmPipelineManager.createPipeline(RATIS_THREE);
+    Pipeline ratisPipeline1 = scmPipelineManager.createPipeline(RATIS_THREE, StorageTier.getDefaultTier());
     scmPipelineManager.openPipeline(ratisPipeline1.getId());
     assertEquals(0,
         scmPipelineManager.getNumberOfContainers(ratisPipeline1.getId()));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Thread a `StorageTier` from the SCM block-allocation RPC down to `PipelineFactory.create`, so callers can request a pipeline (and, via  #10810 , a container) on a specific storage tier. Removes the  `// TODO StoragePolicy replace this StorageTier with the passed  StorageTier` hardcode in `PipelineFactory` that forced every  pipeline creation onto DISK.  

Please describe your PR in detail:
1. Thread StorageTier through the block-allocation RPC and BlockManager
2. Wire StorageTier into PipelineManager and PipelineFactory 

Depends on #10810  (which adds a persisted `StorageTier` field to  `ContainerInfo`)

Now with this PR:
 - OM can now send a tier on `AllocateScmBlock`.                                                                                                                                                          
  - SCM builds a pipeline on that tier (via `RatisPipelineProvider`/`ECPipelineProvider`, already tier-capable  from HDDS-15250).                                                                                                                                                                                      
  - The allocated container inherits the tier from its pipeline (via  #10810) and survives SCM restart.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15249

## How was this patch tested?
Updated and extended tests in `TestBlockManager`, `TestSCMBlockProtocolServer`
