### PR TITLE
HDDS-15688. Retain in-memory PAUSED state when diskBalancer.info write fails on DN state change

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerService.java
@@ -851,16 +851,21 @@ public class DiskBalancerService extends BackgroundService {
     }
 
     if (stateChanged) {
+      DiskBalancerRunningStatus newOperationalState = this.operationalState;
       LOG.info("DiskBalancer operational state changed from {} to {} due to Datanode state update . Persisting.",
-          originalServiceState, this.operationalState);
+          originalServiceState, newOperationalState);
       try {
         writeDiskBalancerInfoTo(getDiskBalancerInfo(), diskBalancerInfoFile);
       } catch (IOException e) {
-        LOG.error("Failed to persist DiskBalancerInfo after state change in nodeStateUpdated. " +
-            "Reverting operational state to {} to maintain consistency.", originalServiceState, e);
-        // Revert state on persistence error to keep in-memory state consistent with last known persisted state.
-        this.operationalState = originalServiceState;
-        LOG.warn("DiskBalancer operational state reverted to {} due to persistence failure.", this.operationalState);
+        if (newOperationalState == DiskBalancerRunningStatus.PAUSED) {
+          LOG.error("Failed to persist DiskBalancerInfo after pausing DiskBalancer due to " +
+              "Datanode state update. Retaining in-memory PAUSED state for safety.", e);
+        } else {
+          LOG.error("Failed to persist DiskBalancerInfo after state change in nodeStateUpdated. " +
+              "Reverting operational state to {} to maintain consistency.", originalServiceState, e);
+          // Revert state on persistence error to keep in-memory state consistent with last known persisted state.
+          this.operationalState = originalServiceState;
+        }
       }
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/diskbalancer/TestDiskBalancerService.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DiskBalancerRunningStatus;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.ozone.container.checksum.ContainerChecksumTreeManager;
@@ -434,6 +435,48 @@ public class TestDiskBalancerService {
 
     assertThat(exception)
         .hasMessageStartingWith("Unable to create DiskBalancerInfo directories: ");
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testNodeStateUpdatedRetainsPausedWhenPersistFails(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    setLayoutAndSchemaForTest(versionInfo);
+    File infoDir = tmpDir.resolve("diskBalancer-pause-persist-failure").toFile();
+    DiskBalancerServiceTestImpl svc =
+        getDiskBalancerService(confWithDiskBalancerInfoDir(infoDir));
+    svc.refresh(new DiskBalancerInfo(DiskBalancerRunningStatus.RUNNING, 10.0d, 100L, 5, true));
+    breakDiskBalancerInfoPersistence(infoDir);
+
+    svc.nodeStateUpdated(NodeOperationalState.DECOMMISSIONING);
+
+    assertEquals(DiskBalancerRunningStatus.PAUSED,
+        svc.getDiskBalancerInfo().getOperationalState());
+    assertTrue(svc.getTasks().isEmpty());
+    svc.shutdown();
+  }
+
+  @ContainerTestVersionInfo.ContainerTest
+  public void testNodeStateUpdatedRevertsToPausedWhenResumePersistFails(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    setLayoutAndSchemaForTest(versionInfo);
+    File infoDir = tmpDir.resolve("diskBalancer-resume-persist-failure").toFile();
+    DiskBalancerServiceTestImpl svc =
+        getDiskBalancerService(confWithDiskBalancerInfoDir(infoDir));
+    svc.refresh(new DiskBalancerInfo(DiskBalancerRunningStatus.PAUSED, 10.0d, 100L, 5, true));
+    breakDiskBalancerInfoPersistence(infoDir);
+
+    svc.nodeStateUpdated(NodeOperationalState.IN_SERVICE);
+
+    assertEquals(DiskBalancerRunningStatus.PAUSED,
+        svc.getDiskBalancerInfo().getOperationalState());
+    assertTrue(svc.getTasks().isEmpty());
+    svc.shutdown();
+  }
+
+  private void breakDiskBalancerInfoPersistence(File infoDir) throws IOException {
+    File infoFile = getDiskBalancerInfoFile(infoDir);
+    FileUtils.deleteQuietly(infoFile);
+    assertTrue(infoFile.mkdirs(), "Failed to replace diskBalancer.info with a directory");
   }
 
   @ContainerTestVersionInfo.ContainerTest


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes a bug where DiskBalancer could keep running on a datanode that is being decommissioned or put into maintenance.

When the datanode state changed, DiskBalancer correctly switched to PAUSED in memory. If saving that state to diskBalancer.info failed, the code switched back to RUNNING. That means container moves could continue on a node that should have stopped background work.

**Fix applied :**
On persist failure in `nodeStateUpdated()`:

1. Pausing (RUNNING → PAUSED): keep PAUSED in memory for safety
2. Resuming (PAUSED → RUNNING): revert to PAUSED if the write fails (unchanged, already safe)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15688

## How was this patch tested?

Added unit test.
