### PR TITLE
HDDS-15919. Fix broken Ozone Enhancement Proposals link in CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ Key paths:
 - [`hadoop-ozone/dev-support/checks/README.md`](./hadoop-ozone/dev-support/checks/README.md)
 - [`hadoop-hdds/dev-support/checkstyle/checkstyle.xml`](./hadoop-hdds/dev-support/checkstyle/checkstyle.xml)
 - [`dev-support/rat/rat-exclusions.txt`](./dev-support/rat/rat-exclusions.txt)
-- [Ozone Enhancement Proposals](https://ozone.apache.org/docs/edge/design/ozone-enhancement-proposals.html)
+- [Ozone Enhancement Proposals](https://github.com/apache/ozone/blob/master/hadoop-hdds/docs/content/design/ozone-enhancement-proposals.md)
 
 ## Security
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ Key paths:
 - [`hadoop-ozone/dev-support/checks/README.md`](./hadoop-ozone/dev-support/checks/README.md)
 - [`hadoop-hdds/dev-support/checkstyle/checkstyle.xml`](./hadoop-hdds/dev-support/checkstyle/checkstyle.xml)
 - [`dev-support/rat/rat-exclusions.txt`](./dev-support/rat/rat-exclusions.txt)
-- [Ozone Enhancement Proposals](https://github.com/apache/ozone/blob/master/hadoop-hdds/docs/content/design/ozone-enhancement-proposals.md)
+- [Ozone Enhancement Proposals](https://ozone.apache.org/docs/next/developer-guide/project/enhancement-proposal)
 
 ## Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ When creating a new jira for any kind of new feature, improvement or bug, please
 
 ## New feature development
 
-For large feature development changes, we use a process called "Ozone Enhancement Proposals" (OEP). This process is designed to ensure that major changes to Ozone are well-designed and have community consensus. If you are planning to propose a significant change, please read the [Ozone Enhancement Proposals](https://ozone.apache.org/docs/edge/design/ozone-enhancement-proposals.html) documentation and create a design document before you start coding. Please note that we only accept design documents in Markdown format; PDF or Google Docs are no longer accepted.
+For large feature development changes, we use a process called "Ozone Enhancement Proposals" (OEP). This process is designed to ensure that major changes to Ozone are well-designed and have community consensus. If you are planning to propose a significant change, please read the [Ozone Enhancement Proposals](https://github.com/apache/ozone/blob/master/hadoop-hdds/docs/content/design/ozone-enhancement-proposals.md) documentation and create a design document before you start coding. Please note that we only accept design documents in Markdown format; PDF or Google Docs are no longer accepted.
 
 ## Contribute your modifications
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ When creating a new jira for any kind of new feature, improvement or bug, please
 
 ## New feature development
 
-For large feature development changes, we use a process called "Ozone Enhancement Proposals" (OEP). This process is designed to ensure that major changes to Ozone are well-designed and have community consensus. If you are planning to propose a significant change, please read the [Ozone Enhancement Proposals](https://github.com/apache/ozone/blob/master/hadoop-hdds/docs/content/design/ozone-enhancement-proposals.md) documentation and create a design document before you start coding. Please note that we only accept design documents in Markdown format; PDF or Google Docs are no longer accepted.
+For large feature development changes, we use a process called "Ozone Enhancement Proposals" (OEP). This process is designed to ensure that major changes to Ozone are well-designed and have community consensus. If you are planning to propose a significant change, please read the [Ozone Enhancement Proposals](https://ozone.apache.org/docs/next/developer-guide/project/enhancement-proposal) documentation and create a design document before you start coding. Please note that we only accept design documents in Markdown format; PDF or Google Docs are no longer accepted.
 
 ## Contribute your modifications
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The New Feature Development section in CONTRIBUTING.md contains a hyperlink that points to a non-existent page
currently pointing to https://ozone.apache.org/docs/edge/design/ozone-enhancement-proposals.html and it is changed to use https://ozone.apache.org/docs/next/developer-guide/project/enhancement-proposal

## What is the link to the Apache JIRA

HDDS-15919

## How was this patch tested?

Tested manually
