### PR TITLE
HDDS-15922. Fix ozone-site config doc workflow reusing stale PR branch

### DIFF
--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -59,16 +59,8 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           
           git clone --depth=1 --branch=master https://github.com/$REPO_OWNER/ozone-site.git ozone-site
-          
-          # Check if $BRANCH_NAME branch exists remotely
           cd ozone-site
-          if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
-            echo "PR branch exists, checking it out for comparison"
-            git fetch --depth=1 origin $BRANCH_NAME
-            git checkout -B $BRANCH_NAME FETCH_HEAD
-          else
-            echo "PR branch does not exist, staying on master for comparison"
-          fi
+          echo "Using master as baseline for doc comparison and PR branch creation"
 
       - name: Check if documentation changed
         if: steps.check-site-repo.outputs.exists == 'true'
@@ -131,12 +123,13 @@ jobs:
         run: |
           cd ozone-site
           
-          echo "Current branch: $(git branch --show-current)"
-          echo "Current commit: $(git rev-parse HEAD)"
+          echo "Baseline branch: master"
+          echo "Baseline commit: $(git rev-parse master)"
           
-          # Create/reset branch at current commit
+          # Always recreate the PR branch from master so merged changes are not replayed.
+          git checkout master
           git checkout -B "$BRANCH_NAME"
-          echo "Created/reset branch $BRANCH_NAME at current commit"
+          echo "Created branch $BRANCH_NAME from master"
           
           git add "$TARGET_FILE"
           

--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -53,6 +53,8 @@ jobs:
       
       - name: Checkout ozone-site repository
         if: steps.check-site-repo.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.OZONE_WEBSITE_BUILD }}
         run: |
           git config --global url."https://asf-ci-deploy:${{ secrets.OZONE_WEBSITE_BUILD }}@github.com/".insteadOf "https://github.com/"
           git config --global user.name 'github-actions[bot]'
@@ -60,7 +62,17 @@ jobs:
           
           git clone --depth=1 --branch=master https://github.com/$REPO_OWNER/ozone-site.git ozone-site
           cd ozone-site
-          echo "Using master as baseline for doc comparison and PR branch creation"
+
+          EXISTING_PR=$(gh pr list --repo "$REPO_OWNER/ozone-site" \
+            --head "$BRANCH_NAME" --base master --json number --jq '.[0].number' || echo "")
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Open PR #$EXISTING_PR exists, checking out branch for comparison"
+            git fetch --depth=1 origin "$BRANCH_NAME"
+            git checkout -B "$BRANCH_NAME" FETCH_HEAD
+          else
+            echo "No open PR, using master as baseline for doc comparison"
+          fi
 
       - name: Check if documentation changed
         if: steps.check-site-repo.outputs.exists == 'true'
@@ -120,30 +132,37 @@ jobs:
       
       - name: Commit and push changes
         if: steps.check-changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.OZONE_WEBSITE_BUILD }}
         run: |
           cd ozone-site
-          
-          echo "Baseline branch: master"
-          echo "Baseline commit: $(git rev-parse master)"
-          
-          # Always recreate the PR branch from master so merged changes are not replayed.
-          git checkout master
-          git checkout -B "$BRANCH_NAME"
-          echo "Created branch $BRANCH_NAME from master"
-          
-          git add "$TARGET_FILE"
-          
-          # Build commit message with JIRA ID if available
+
+          EXISTING_PR=$(gh pr list --repo "$REPO_OWNER/ozone-site" \
+            --head "$BRANCH_NAME" --base master --json number --jq '.[0].number' || echo "")
+
           COMMIT_MSG="[Auto] Update configuration documentation from ozone $SHA"
           if [ -n "$JIRA_ID" ]; then
             COMMIT_MSG="$JIRA_ID. $COMMIT_MSG"
           fi
-          
-          git commit -m "$COMMIT_MSG"
-          
-          echo "Pushing $BRANCH_NAME to origin"
-          git push -f origin "$BRANCH_NAME"
-      
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Open PR #$EXISTING_PR exists, appending commit to preserve history"
+            git fetch --depth=1 origin "$BRANCH_NAME"
+            git checkout -B "$BRANCH_NAME" FETCH_HEAD
+            cp ../Configurations.md "$TARGET_FILE"
+            git add "$TARGET_FILE"
+            git commit -m "$COMMIT_MSG"
+            git push origin "$BRANCH_NAME"
+          else
+            echo "No open PR, recreating branch from master"
+            git checkout master
+            git checkout -B "$BRANCH_NAME"
+            cp ../Configurations.md "$TARGET_FILE"
+            git add "$TARGET_FILE"
+            git commit -m "$COMMIT_MSG"
+            git push -f origin "$BRANCH_NAME"
+          fi
+
       - name: Create or update Pull Request in ozone-site
         if: steps.check-changes.outputs.changed == 'true' && github.repository == 'apache/ozone'
         env:

--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -65,13 +65,16 @@ jobs:
 
           EXISTING_PR=$(gh pr list --repo "$REPO_OWNER/ozone-site" \
             --head "$BRANCH_NAME" --base master --json number --jq '.[0].number' || echo "")
+          echo "EXISTING_PR=$EXISTING_PR" >> $GITHUB_ENV
 
           if [ -n "$EXISTING_PR" ]; then
             echo "Open PR #$EXISTING_PR exists, checking out branch for comparison"
             git fetch --depth=1 origin "$BRANCH_NAME"
             git checkout -B "$BRANCH_NAME" FETCH_HEAD
           else
-            echo "No open PR, using master as baseline for doc comparison"
+            echo "No open PR, creating branch from master"
+            git fetch --depth=1 origin "$BRANCH_NAME" || true
+            git checkout -B "$BRANCH_NAME" master
           fi
 
       - name: Check if documentation changed
@@ -132,36 +135,17 @@ jobs:
       
       - name: Commit and push changes
         if: steps.check-changes.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.OZONE_WEBSITE_BUILD }}
         run: |
           cd ozone-site
-
-          EXISTING_PR=$(gh pr list --repo "$REPO_OWNER/ozone-site" \
-            --head "$BRANCH_NAME" --base master --json number --jq '.[0].number' || echo "")
 
           COMMIT_MSG="[Auto] Update configuration documentation from ozone $SHA"
           if [ -n "$JIRA_ID" ]; then
             COMMIT_MSG="$JIRA_ID. $COMMIT_MSG"
           fi
 
-          if [ -n "$EXISTING_PR" ]; then
-            echo "Open PR #$EXISTING_PR exists, appending commit to preserve history"
-            git fetch --depth=1 origin "$BRANCH_NAME"
-            git checkout -B "$BRANCH_NAME" FETCH_HEAD
-            cp ../Configurations.md "$TARGET_FILE"
-            git add "$TARGET_FILE"
-            git commit -m "$COMMIT_MSG"
-            git push origin "$BRANCH_NAME"
-          else
-            echo "No open PR, recreating branch from master"
-            git checkout master
-            git checkout -B "$BRANCH_NAME"
-            cp ../Configurations.md "$TARGET_FILE"
-            git add "$TARGET_FILE"
-            git commit -m "$COMMIT_MSG"
-            git push -f origin "$BRANCH_NAME"
-          fi
+          git add "$TARGET_FILE"
+          git commit -m "$COMMIT_MSG"
+          git push --force-with-lease origin "$BRANCH_NAME"
 
       - name: Create or update Pull Request in ozone-site
         if: steps.check-changes.outputs.changed == 'true' && github.repository == 'apache/ozone'
@@ -177,10 +161,6 @@ jobs:
           # Generate PR body
           ../ozone-repo/dev-support/ci/pr_body_config_doc.sh \
             "$REPO" "$WORKFLOW" "$RUN_ID" "$REF_NAME" "$SHA" "$JIRA_ID" > pr_body.txt
-          
-          # Check if PR already exists
-          EXISTING_PR=$(gh pr list --repo "$REPO_OWNER/ozone-site" \
-            --head "$BRANCH_NAME" --base master --json number --jq '.[0].number' || echo "")
           
           if [ -n "$EXISTING_PR" ]; then
             echo "Updating existing PR #$EXISTING_PR with a comment"


### PR DESCRIPTION
## What changes were proposed in this pull request?
The update-ozone-site-config-doc workflow in the ozone repo checks out the automated-config-doc-update branch in ozone-site when it still exists after a PR is merged. New commits are added on top of that stale branch, so already-merged changes show up again in the next PR.

Workaround: Delete automated-config-doc-update in ozone-site after each merge.

Fix: Always use master as the baseline - compare doc changes against master, recreate the PR branch from master. Branch deletion after merge should no longer be required.

 

Example:

https://github.com/apache/ozone-site/pull/487 merged commits [68268fa](https://github.com/apache/ozone-site/pull/487/commits/68268fa817be5d3550f22c8dfcc70c7dbcb5d612) and [a8e25a6](https://github.com/apache/ozone-site/pull/487/commits/a8e25a6ab70447c7399210f2aa3b6b2bf3fff464) but branch not deleted.

https://github.com/apache/ozone-site/pull/493 same commits have reappeared here.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15922

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
