### PR TITLE
HDDS-15920. Fix ByteBuffer positioned read behavior at EOF in OzoneFSInputStream

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/MultipartInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/MultipartInputStream.java
@@ -196,6 +196,7 @@ public class MultipartInputStream extends ExtendedInputStream {
     final long oldPos = getPos();
     seek(position);
     try {
+      int remainingBeforeRead = buffer.remaining();
       read(new ByteBufferReader(buffer) {
         @Override
         int readImpl(InputStream inputStream) throws IOException {
@@ -203,6 +204,10 @@ public class MultipartInputStream extends ExtendedInputStream {
               .readFully(getBuffer(), false);
         }
       });
+      if (remainingBeforeRead - buffer.remaining() == 0) {
+        throw new EOFException("EOF encountered at pos: " + position +
+            " for key: " + key);
+      }
     } finally {
       seek(oldPos);
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/MultipartInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/MultipartInputStream.java
@@ -197,6 +197,9 @@ public class MultipartInputStream extends ExtendedInputStream {
     seek(position);
     try {
       int remainingBeforeRead = buffer.remaining();
+      if (remainingBeforeRead == 0) {
+        return true;
+      }
       read(new ByteBufferReader(buffer) {
         @Override
         int readImpl(InputStream inputStream) throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -40,6 +41,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.SequenceFile;
@@ -55,6 +57,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -64,10 +68,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
 
   private OzoneClient client;
-  private FileSystem fs;
   private FileSystem ecFs;
   private Path filePath = null;
   private byte[] data = null;
+  private String uri = null;
 
   @BeforeAll
   void init() throws Exception {
@@ -77,14 +81,15 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 
     // Set the fs.defaultFS and start the filesystem
-    String uri = String.format("%s://%s.%s/",
+    uri = String.format("%s://%s.%s/",
         OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
-    fs =  FileSystem.get(URI.create(uri), cluster().getConf());
-    int fileLen = 30 * 1024 * 1024;
-    data = string2Bytes(RandomStringUtils.secure().nextAlphanumeric(fileLen));
-    filePath = new Path("/" + RandomStringUtils.secure().nextAlphanumeric(5));
-    try (FSDataOutputStream stream = fs.create(filePath)) {
-      stream.write(data);
+    try (FileSystem fs =  FileSystem.get(URI.create(uri), cluster().getConf());) {
+      int fileLen = 30 * 1024 * 1024;
+      data = string2Bytes(RandomStringUtils.secure().nextAlphanumeric(fileLen));
+      filePath = new Path("/" + RandomStringUtils.secure().nextAlphanumeric(5));
+      try (FSDataOutputStream stream = fs.create(filePath)) {
+        stream.write(data);
+      }
     }
 
     // create EC bucket to be used by OzoneFileSystem
@@ -106,12 +111,17 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
 
   @AfterAll
   void shutdown() {
-    closeQuietly(client, fs, ecFs);
+    closeQuietly(client, ecFs);
   }
 
-  @Test
-  public void testO3FSSingleByteRead() throws IOException {
-    try (FSDataInputStream inputStream = fs.open(filePath)) {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testO3FSSingleByteRead(boolean isStreamEnable) throws IOException {
+    OzoneConfiguration conf = cluster().getConf();
+    conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
+
+    try (FileSystem fs = FileSystem.get(URI.create(uri), conf);
+        FSDataInputStream inputStream = fs.open(filePath)) {
       byte[] value = new byte[data.length];
       int i = 0;
       while (true) {
@@ -128,9 +138,13 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
     }
   }
 
-  @Test
-  public void testByteBufferPositionedRead() throws IOException {
-    try (FSDataInputStream inputStream = fs.open(filePath)) {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testByteBufferPositionedRead(boolean isStreamEnable) throws IOException {
+    OzoneConfiguration conf = cluster().getConf();
+    conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
+    try (FileSystem fs = FileSystem.get(URI.create(uri), conf);
+        FSDataInputStream inputStream = fs.open(filePath)) {
       int bufferCapacity = 20;
       ByteBuffer buffer = ByteBuffer.allocate(bufferCapacity);
       long currentPos = inputStream.getPos();
@@ -182,9 +196,12 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = { -1, 30 * 1024 * 1024, 30 * 1024 * 1024 + 1 })
-  public void testByteBufferPositionedReadWithInvalidPosition(int position) throws IOException {
-    try (FSDataInputStream inputStream = fs.open(filePath)) {
+  @MethodSource("isStreamEnableAndData")
+  public void testByteBufferPositionedReadWithInvalidPosition(boolean isStreamEnable, int position) throws IOException {
+    OzoneConfiguration conf = cluster().getConf();
+    conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
+    try (FileSystem fs = FileSystem.get(URI.create(uri), conf);
+         FSDataInputStream inputStream = fs.open(filePath)) {
       long currentPos = inputStream.getPos();
       ByteBuffer buffer = ByteBuffer.allocate(20);
       assertEquals(-1, inputStream.read(position, buffer));
@@ -193,9 +210,13 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
     }
   }
 
-  @Test
-  public void testByteBufferPositionedReadFully() throws IOException {
-    try (FSDataInputStream inputStream = fs.open(filePath)) {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testByteBufferPositionedReadFully(boolean isStreamEnable) throws IOException {
+    OzoneConfiguration conf = cluster().getConf();
+    conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
+    try (FileSystem fs = FileSystem.get(URI.create(uri), conf);
+         FSDataInputStream inputStream = fs.open(filePath)) {
       int bufferCapacity = 20;
       long currentPos = inputStream.getPos();
       ByteBuffer buffer = ByteBuffer.allocate(bufferCapacity);
@@ -235,9 +256,12 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = { -1, 30 * 1024 * 1024, 30 * 1024 * 1024 + 1 })
-  public void testByteBufferPositionedReadFullyWithInvalidPosition(int position) throws IOException {
-    try (FSDataInputStream inputStream = fs.open(filePath)) {
+  @MethodSource("isStreamEnableAndData")
+  public void testByteBufferPositionedReadFullyWithInvalidPosition(boolean isStreamEnable, int position) throws IOException {
+    OzoneConfiguration conf = cluster().getConf();
+    conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
+    try (FileSystem fs = FileSystem.get(URI.create(uri), conf);
+         FSDataInputStream inputStream = fs.open(filePath)) {
       long currentPos = inputStream.getPos();
       ByteBuffer buffer = ByteBuffer.allocate(20);
       assertThrows(EOFException.class, () -> inputStream.readFully(position, buffer));
@@ -246,9 +270,13 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
     }
   }
 
-  @Test
-  public void testO3FSMultiByteRead() throws IOException {
-    try (FSDataInputStream inputStream = fs.open(filePath)) {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testO3FSMultiByteRead(boolean isStreamEnable) throws IOException {
+    OzoneConfiguration conf = cluster().getConf();
+    conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
+    try (FileSystem fs = FileSystem.get(URI.create(uri), conf);
+         FSDataInputStream inputStream = fs.open(filePath)) {
       byte[] value = new byte[data.length];
       byte[] tmp = new byte[1 * 1024 * 1024];
       int i = 0;
@@ -265,10 +293,13 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
     }
   }
 
-  @Test
-  public void testO3FSByteBufferRead() throws IOException {
-    try (FSDataInputStream inputStream = fs.open(filePath)) {
-
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testO3FSByteBufferRead(boolean isStreamEnable) throws IOException {
+    OzoneConfiguration conf = cluster().getConf();
+    conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
+    try (FileSystem fs = FileSystem.get(URI.create(uri), conf);
+         FSDataInputStream inputStream = fs.open(filePath)) {
       ByteBuffer buffer = ByteBuffer.allocate(1024 * 1024);
       int byteRead = inputStream.read(buffer);
 
@@ -281,29 +312,34 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
     }
   }
 
-  @Test
-  public void testSequenceFileReaderSync() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testSequenceFileReaderSync(boolean isStreamEnable) throws IOException {
     File srcfile = new File("src/test/resources/testSequenceFile");
     Path path = new Path("/" + RandomStringUtils.secure().nextAlphanumeric(5));
     InputStream input = new BufferedInputStream(Files.newInputStream(srcfile.toPath()));
 
     // Upload test SequenceFile file
-    FSDataOutputStream output = fs.create(path);
-    IOUtils.copyBytes(input, output, 4096, true);
-    input.close();
+    OzoneConfiguration conf = cluster().getConf();
+    conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
+    try (FileSystem fs = FileSystem.get(URI.create(uri), conf);
+         FSDataOutputStream output = fs.create(path);) {
+      IOUtils.copyBytes(input, output, 4096, true);
+      input.close();
 
-    // Start SequenceFile.Reader test
-    SequenceFile.Reader in = new SequenceFile.Reader(fs, path, cluster().getConf());
-    long blockStart = -1;
-    // EOFException should not occur.
-    in.sync(0);
-    blockStart = in.getPosition();
-    // The behavior should be consistent with HDFS
-    assertEquals(srcfile.length(), blockStart);
-    in.close();
+      // Start SequenceFile.Reader test
+      SequenceFile.Reader in = new SequenceFile.Reader(fs, path, cluster().getConf());
+      long blockStart = -1;
+      // EOFException should not occur.
+      in.sync(0);
+      blockStart = in.getPosition();
+      // The behavior should be consistent with HDFS
+      assertEquals(srcfile.length(), blockStart);
+    }
   }
 
-  @Test
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void testSequenceFileReaderSyncEC() throws IOException {
     File srcfile = new File("src/test/resources/testSequenceFile");
     Path path = new Path("/" + RandomStringUtils.secure().nextAlphanumeric(5));
@@ -323,5 +359,16 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
     // The behavior should be consistent with HDFS
     assertEquals(srcfile.length(), blockStart);
     in.close();
+  }
+
+  static Stream<Arguments> isStreamEnableAndData() {
+    return Stream.of(
+        Arguments.of(false, -1),
+        Arguments.of(false, 30 * 1024 * 1024),
+        Arguments.of(false, 30 * 1024 * 1024 + 1),
+        Arguments.of(true, -1),
+        Arguments.of(true, 30 * 1024 * 1024),
+        Arguments.of(true, 30 * 1024 * 1024 + 1)
+    );
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -256,7 +256,8 @@ public abstract class TestOzoneFSInputStream implements NonHATests.TestCase {
 
   @ParameterizedTest
   @MethodSource("isStreamEnableAndData")
-  public void testByteBufferPositionedReadFullyWithInvalidPosition(boolean isStreamEnable, int position) throws IOException {
+  public void testByteBufferPositionedReadFullyWithInvalidPosition(
+      boolean isStreamEnable, int position) throws IOException {
     OzoneConfiguration conf = cluster().getConf();
     conf.setBoolean("ozone.client.stream.readblock.enable", isStreamEnable);
     try (FileSystem fs = FileSystem.get(URI.create(uri), conf);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
@@ -171,8 +171,14 @@ public class OzoneFSInputStream extends FSInputStream
     }
     if (inputStream instanceof ExtendedInputStream) {
       final int remainingBeforeRead = buf.remaining();
-      if (((ExtendedInputStream) inputStream).readFully(position, buf)) {
-        return remainingBeforeRead - buf.remaining();
+      try {
+        if (((ExtendedInputStream) inputStream).readFully(position, buf)) {
+          return remainingBeforeRead - buf.remaining();
+        }
+      } catch (EOFException e) {
+        if (remainingBeforeRead - buf.remaining() == 0) {
+          return -1;
+        }
       }
     }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
@@ -176,9 +176,7 @@ public class OzoneFSInputStream extends FSInputStream
           return remainingBeforeRead - buf.remaining();
         }
       } catch (EOFException e) {
-        if (remainingBeforeRead - buf.remaining() == 0) {
-          return -1;
-        }
+        return -1;
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When performing positioned reads at or past the End-Of-File (EOF) using OzoneFSInputStream#read(long, ByteBuffer), the stream does not correctly return -1 when no bytes can be read. This violates the standard Hadoop ByteBufferPositionedReadable contract for streams, where a read at EOF should return -1 to indicate that no more data is available.

Specifically, this PR includes the following changes:

- MultipartInputStream: Added validation logic in readFully(long, ByteBuffer) to track remainingBeforeRead. If the buffer's remaining space has not changed after the read operation (meaning 0 bytes were read), it now explicitly throws an EOFException.  
- OzoneFSInputStream: Updated read(long, ByteBuffer) to catch the EOFException from the underlying stream. If caught an EOF, it properly translates this into a -1 return value to indicate EOF.  
- Test Refactoring: Upgraded `TestOzoneFSInputStream` to use `@ParameterizedTest`. This ensures that all read scenarios are tested under both legacy and streaming read paths by toggling the `ozone.client.stream.readblock.enable configuration` (true and false). 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15920

## How was this patch tested?

https://github.com/chungen0126/ozone/actions/runs/29836011097
