### PR TITLE
HDDS-15698. Fix concurrent write and hsync race in BlockOutputStreamEntryPool

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -366,7 +366,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
     }
   }
 
-    synchronized BlockOutputStreamEntry getCurrentStreamEntry() {
+  synchronized BlockOutputStreamEntry getCurrentStreamEntry() {
     if (streamEntries.isEmpty() || streamEntries.size() <= currentStreamIndex) {
       return null;
     } else {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -366,7 +366,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
     }
   }
 
-  BlockOutputStreamEntry getCurrentStreamEntry() {
+    synchronized BlockOutputStreamEntry getCurrentStreamEntry() {
     if (streamEntries.isEmpty() || streamEntries.size() <= currentStreamIndex) {
       return null;
     } else {
@@ -405,7 +405,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
     return bufferPool.computeBufferData();
   }
 
-  void cleanup() {
+  synchronized void cleanup() {
     if (excludeList != null) {
       excludeList.clear();
     }
@@ -426,7 +426,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
     return excludeList;
   }
 
-  boolean isEmpty() {
+  synchronized boolean isEmpty() {
     return streamEntries.isEmpty();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes the TestHSync#testConcurrentWriteHSync, Intermittent IndexOutOfBoundsException due to concurrent write() and hsync() calls. I tried fixing the actual code instaed of test case.
- writer and hsync threads are both active at the same time
- hsync() reaches KeyOutputStream.handleFlushOrClose(...)
- that calls BlockOutputStreamEntryPool.getCurrentStreamEntry()
- if pool state changes in the middle, we get IndexOutOfBoundsException

This bug was caused by concurrent write() and hsync() access to the same block pool state.
streamEntries and currentStreamIndex must be read and updated together, but they were not protected as one atomic unit, so getCurrentStreamEntry() could sometimes see a stale index and throw IndexOutOfBoundsException.
I fixed this by synchronizing the pool methods that read or change this shared state. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15698

## How was this patch tested?
I ran in my fork branch - flaky-test-check workflow, twice for each using master and HDDS-15698 feature branch with my git hash #29e2d3c41cf69f57bf2ad296d7866468b1263411
- two consecutive success in HDDS-15698 
  https://github.com/navinko/ozone/actions/runs/29763317683
  https://github.com/navinko/ozone/actions/runs/29691033247
- two consecutive failure in master
  https://github.com/navinko/ozone/actions/runs/29716260437
  https://github.com/navinko/ozone/actions/runs/29744590973 
  
Successful CI- https://github.com/navinko/ozone/actions/runs/28710748833  
