### PR TITLE
HDDS-15932. Remove usage of internal AWS S3 SDK API in S3KeyGenerator

### DIFF
--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.freon;
 
-import static com.amazonaws.services.s3.internal.SkipMd5CheckStrategy.DISABLE_PUT_OBJECT_MD5_VALIDATION_PROPERTY;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_MULTIPART_MIN_SIZE;
 
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
@@ -101,7 +100,8 @@ public class S3KeyGenerator extends S3EntityGenerator
 
     timer = getMetrics().timer("key-create");
 
-    System.setProperty(DISABLE_PUT_OBJECT_MD5_VALIDATION_PROPERTY, "true");
+    System.setProperty(
+        "com.amazonaws.services.s3.disablePutObjectMD5Validation", "true");
     runTests(this::createKey);
 
     return null;

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/S3KeyGenerator.java
@@ -100,8 +100,7 @@ public class S3KeyGenerator extends S3EntityGenerator
 
     timer = getMetrics().timer("key-create");
 
-    System.setProperty(
-        "com.amazonaws.services.s3.disablePutObjectMD5Validation", "true");
+    System.setProperty("com.amazonaws.services.s3.disablePutObjectMD5Validation", "true");
     runTests(this::createKey);
 
     return null;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR removes the compile-time dependency on the internal AWS S3 SDK class `SkipMd5CheckStrategy` from `S3KeyGenerator`.

Instead of importing the internal constant `DISABLE_PUT_OBJECT_MD5_VALIDATION_PROPERTY`, the generator now sets the equivalent system property directly: `com.amazonaws.services.s3.disablePutObjectMD5Validation`

This preserves the existing behavior while avoiding the use of an API from the AWS SDK's internal package.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15932

## How was this patch tested?

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/29884841702