### PR TITLE
HDDS-15769. Add non-rolling-upgrade callbacks for 2.1.0 and 2.2.0

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -43,6 +43,12 @@ run_test ha     non-rolling-upgrade 2.2.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.2.1 "$OZONE_CURRENT_VERSION"
 # run_test om-ha non-rolling-upgrade 1.1.0 "$OZONE_CURRENT_VERSION"
 
+# Released-to-released upgrades that exercise version-specific callbacks
+# selected by OZONE_UPGRADE_TO. Run these from the release matrix once the
+# target release image is published.
+# run_test ha non-rolling-upgrade 2.0.0 2.1.0
+# run_test ha non-rolling-upgrade 2.1.0 2.2.0
+
 generate_report "upgrade" "$ALL_RESULT_DIR"
 
 exit "$RESULT"

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/2.1.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/2.1.0/callback.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$TEST_DIR"/testlib.sh
+
+with_this_version_pre_finalized() {
+  # 2.1.0 added a new HDDS layout feature (WITNESSED_CONTAINER_DB_PROTO_VALUE)
+  # but no new OM layout feature, so only SCM should be pre-finalized.
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include scmANDpre-finalized upgrade/check-finalization.robot
+}
+
+with_this_version_finalized() {
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
+}

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/2.2.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/2.2.0/callback.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$TEST_DIR"/testlib.sh
+
+with_this_version_pre_finalized() {
+  # 2.2.0 added new OM (SNAPSHOT_DEFRAG) and HDDS (STORAGE_SPACE_DISTRIBUTION)
+  # layout features, so both OM and SCM should be pre-finalized.
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include pre-finalized upgrade/check-finalization.robot
+}
+
+with_this_version_finalized() {
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add missing non-rolling-upgrade callbacks for 2.1.0 and 2.2.0. For more, see [JIRA](https://issues.apache.org/jira/browse/HDDS-15769) description.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15769

## How was this patch tested?

- Ran non-rolling-upgrade from 2.0.0 to 2.1.0
- Ran non-rolling-upgrade from 2.1.0 to 2.2.0