### PR TITLE
HDDS-15933. Remove usage of jersey internal ContainerRequest

### DIFF
--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -177,11 +177,6 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-common</artifactId>
-      <!-- <scope>test</scope> but transitive via jersey-server -->
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestVirtualHostStyleFilter.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestVirtualHostStyleFilter.java
@@ -18,21 +18,28 @@
 package org.apache.hadoop.ozone.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import org.apache.hadoop.fs.InvalidRequestException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.glassfish.jersey.internal.PropertiesDelegate;
-import org.glassfish.jersey.server.ContainerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 
 /**
  * This class test virtual host style mapping conversion to path style.
@@ -51,47 +58,31 @@ public class TestVirtualHostStyleFilter {
     conf.set(S3GatewayConfigKeys.OZONE_S3G_DOMAIN_NAME, s3HttpAddr);
   }
 
-  /**
-   * Create containerRequest object.
-   * @return ContainerRequest
-   * @throws Exception
-   */
-  public ContainerRequest createContainerRequest(String host, String path,
-                                                 String queryParams,
-                                                 boolean virtualHostStyle)
-      throws Exception {
-    URI baseUri = new URI("http://" + s3HttpAddr);
-    URI virtualHostStyleUri;
-    if (path == null && queryParams == null) {
-      virtualHostStyleUri = new URI("http://" + s3HttpAddr);
-    } else if (path != null && queryParams == null) {
-      virtualHostStyleUri = new URI("http://" + s3HttpAddr + path);
-    } else if (path != null && queryParams != null)  {
-      virtualHostStyleUri = new URI("http://" + s3HttpAddr + path +
-          queryParams);
-    } else {
-      virtualHostStyleUri = new URI("http://" + s3HttpAddr  + queryParams);
+  private ContainerRequestContext createRequestContext(String host,
+      String path) {
+    return createRequestContext(host, path, new MultivaluedHashMap<>());
+  }
+
+  private ContainerRequestContext createRequestContext(String host, String path,
+      MultivaluedMap<String, String> queryParams) {
+    URI baseUri = URI.create("http://" + s3HttpAddr);
+    UriBuilder requestUriBuilder = UriBuilder.fromUri(baseUri);
+    if (path != null) {
+      requestUriBuilder.path(path);
     }
-    URI pathStyleUri;
-    if (queryParams == null) {
-      pathStyleUri = new URI("http://" + s3HttpAddr + path);
-    } else {
-      pathStyleUri = new URI("http://" + s3HttpAddr + path + queryParams);
-    }
-    String httpMethod = "DELETE";
-    SecurityContext securityContext = mock(SecurityContext.class);
-    PropertiesDelegate propertiesDelegate = mock(PropertiesDelegate.class);
-    ContainerRequest containerRequest;
-    if (virtualHostStyle) {
-      containerRequest = new ContainerRequest(baseUri, virtualHostStyleUri,
-          httpMethod, securityContext, propertiesDelegate);
-      containerRequest.header(HttpHeaders.HOST, host);
-    } else {
-      containerRequest = new ContainerRequest(baseUri, pathStyleUri,
-          httpMethod, securityContext, propertiesDelegate);
-      containerRequest.header(HttpHeaders.HOST, host);
-    }
-    return containerRequest;
+    queryParams.forEach((key, values) ->
+        requestUriBuilder.queryParam(key, values.toArray()));
+
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getBaseUri()).thenReturn(baseUri);
+    when(uriInfo.getPath()).thenReturn(path == null ? "" : path.substring(1));
+    when(uriInfo.getQueryParameters()).thenReturn(queryParams);
+    when(uriInfo.getRequestUri()).thenReturn(requestUriBuilder.build());
+
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getHeaderString(HttpHeaders.HOST)).thenReturn(host);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    return requestContext;
   }
 
   @Test
@@ -101,11 +92,11 @@ public class TestVirtualHostStyleFilter {
     virtualHostStyleFilter.setConfiguration(conf);
 
 
-    ContainerRequest containerRequest = createContainerRequest("mybucket" +
-            ".localhost:9878", "/myfile", null, true);
-    virtualHostStyleFilter.filter(containerRequest);
+    ContainerRequestContext requestContext = createRequestContext(
+        "mybucket.localhost:9878", "/myfile");
+    virtualHostStyleFilter.filter(requestContext);
     URI expected = new URI("http://" + s3HttpAddr + "/mybucket/myfile");
-    assertEquals(expected, containerRequest.getRequestUri());
+    verify(requestContext).setRequestUri(new URI("http://" + s3HttpAddr), expected);
   }
 
   @Test
@@ -115,12 +106,10 @@ public class TestVirtualHostStyleFilter {
         new VirtualHostStyleFilter();
     virtualHostStyleFilter.setConfiguration(conf);
 
-    ContainerRequest containerRequest = createContainerRequest(s3HttpAddr,
-        "/mybucket/myfile", null, false);
-    virtualHostStyleFilter.filter(containerRequest);
-    URI expected = new URI("http://" + s3HttpAddr +
+    ContainerRequestContext requestContext = createRequestContext(s3HttpAddr,
         "/mybucket/myfile");
-    assertEquals(expected, containerRequest.getRequestUri());
+    virtualHostStyleFilter.filter(requestContext);
+    verify(requestContext, never()).setRequestUri(any(URI.class), any(URI.class));
 
   }
 
@@ -131,11 +120,11 @@ public class TestVirtualHostStyleFilter {
         new VirtualHostStyleFilter();
     virtualHostStyleFilter.setConfiguration(conf);
 
-    ContainerRequest containerRequest = createContainerRequest("mybucket" +
-        ".localhost:9878", null, null, true);
-    virtualHostStyleFilter.filter(containerRequest);
+    ContainerRequestContext requestContext = createRequestContext(
+        "mybucket.localhost:9878", null);
+    virtualHostStyleFilter.filter(requestContext);
     URI expected = new URI("http://" + s3HttpAddr + "/mybucket");
-    assertEquals(expected, containerRequest.getRequestUri());
+    verify(requestContext).setRequestUri(new URI("http://" + s3HttpAddr), expected);
 
   }
 
@@ -145,11 +134,11 @@ public class TestVirtualHostStyleFilter {
         new VirtualHostStyleFilter();
     virtualHostStyleFilter.setConfiguration(conf);
 
-    ContainerRequest containerRequest = createContainerRequest("mybucket" +
-        ".localhost:9878", "/key1", null, true);
-    virtualHostStyleFilter.filter(containerRequest);
+    ContainerRequestContext requestContext = createRequestContext(
+        "mybucket.localhost:9878", "/key1");
+    virtualHostStyleFilter.filter(requestContext);
     URI expected = new URI("http://" + s3HttpAddr + "/mybucket/key1");
-    assertEquals(expected, containerRequest.getRequestUri());
+    verify(requestContext).setRequestUri(new URI("http://" + s3HttpAddr), expected);
   }
 
   @Test
@@ -158,19 +147,24 @@ public class TestVirtualHostStyleFilter {
     VirtualHostStyleFilter virtualHostStyleFilter =
         new VirtualHostStyleFilter();
     virtualHostStyleFilter.setConfiguration(conf);
-    URI expected = new URI("http://" + s3HttpAddr + "/mybucket?prefix=bh");
-    ContainerRequest containerRequest = createContainerRequest("mybucket" +
-        ".localhost:9878", null, "?prefix=bh", true);
-    virtualHostStyleFilter.filter(containerRequest);
-    assertThat(expected.toString())
-        .contains(containerRequest.getRequestUri().toString());
+    URI baseUri = new URI("http://" + s3HttpAddr);
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    queryParams.add("prefix", "bh");
+    ContainerRequestContext requestContext = createRequestContext(
+        "mybucket.localhost:9878", null, queryParams);
+    virtualHostStyleFilter.filter(requestContext);
+    verify(requestContext).setRequestUri(baseUri,
+        new URI("http://" + s3HttpAddr + "/mybucket?prefix=bh"));
 
-    containerRequest = createContainerRequest("mybucket" +
-        ".localhost:9878", null, "?prefix=bh&type=dir", true);
-    virtualHostStyleFilter.filter(containerRequest);
-    expected = new URI("http://" + s3HttpAddr +
-        "/mybucket?prefix=bh&type=dir");
-    assertThat(expected.toString()).contains(containerRequest.getRequestUri().toString());
+    queryParams.add("type", "dir");
+    requestContext = createRequestContext(
+        "mybucket.localhost:9878", null, queryParams);
+    virtualHostStyleFilter.filter(requestContext);
+    ArgumentCaptor<URI> requestUriCaptor = ArgumentCaptor.forClass(URI.class);
+    verify(requestContext).setRequestUri(eq(baseUri), requestUriCaptor.capture());
+    assertThat(requestUriCaptor.getValue().getPath()).isEqualTo("/mybucket");
+    assertThat(requestUriCaptor.getValue().getQuery().split("&"))
+        .containsExactlyInAnyOrder("prefix=bh", "type=dir");
 
   }
 
@@ -180,9 +174,9 @@ public class TestVirtualHostStyleFilter {
                                                     String expectErrorMessage) throws Exception {
     VirtualHostStyleFilter virtualHostStyleFilter = new VirtualHostStyleFilter();
     virtualHostStyleFilter.setConfiguration(conf);
-    ContainerRequest containerRequest = createContainerRequest(hostAddress, null, null, true);
+    ContainerRequestContext requestContext = createRequestContext(hostAddress, null);
     InvalidRequestException exception = assertThrows(InvalidRequestException.class,
-        () -> virtualHostStyleFilter.filter(containerRequest));
+        () -> virtualHostStyleFilter.filter(requestContext));
     assertThat(exception).hasMessageContaining(expectErrorMessage);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`TestVirtualHostStyleFilter` used Jersey's internal `ContainerRequest` implementation to construct requests for testing. This introduced an unnecessary dependency on Jersey implementation details.

This PR:
- replaces `ContainerRequest` with mocked standard JAX-RS `ContainerRequestContext` and `UriInfo` interfaces;
- verifies request URI updates through `ContainerRequestContext#setRequestUri`;
- preserves query parameter coverage without relying on query parameter ordering; and
- removes the unused direct `jersey-common` dependency from `ozone-s3gateway`. The dependency remains available transitively through `jersey-server`.

Generated-by: Codex (GPT-5)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15933

## How was this patch tested?

Local Test
```
mvn -pl :ozone-s3gateway test \
    -Dtest=TestVirtualHostStyleFilter \
    -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/29900380211
