### PR TITLE
HDDS-15944. Add a docker run configuration for Ozone in Intellij

### DIFF
--- a/.run/ozone.run.xml
+++ b/.run/ozone.run.xml
@@ -1,0 +1,36 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="ozone" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="removeVolumesOnComposeDown" value="true" />
+        <option name="secondarySourceFiles">
+          <list>
+            <option value="hadoop-ozone/dist/target/ozone-latest/compose/ozone/monitoring.yaml" />
+            <option value="hadoop-ozone/dist/target/ozone-latest/compose/ozone/profiling.yaml" />
+          </list>
+        </option>
+        <option name="sourceFilePath" value="hadoop-ozone/dist/target/ozone-latest/compose/ozone/docker-compose.yaml" />
+        <upScaledServices>
+          <entry key="datanode" value="3" />
+        </upScaledServices>
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -60,6 +60,8 @@ echo
 
 run rm -rf "ozone-${HDDS_VERSION}"
 run mkdir "ozone-${HDDS_VERSION}"
+# Version-independent symlink to create a stable path to compose files.
+run ln -sfn "ozone-${HDDS_VERSION}" "ozone-latest"
 run cd "ozone-${HDDS_VERSION}"
 
 run cp -p "${ROOT}/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt" "NOTICE.txt"


### PR DESCRIPTION
## What changes were proposed in this pull request?
- This PR adds a docker run configuration to run the Ozone using the docker compose files under https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/compose/ozone from Intellij. 

- To enable this it also creates a symlink from `ozone/hadoop-ozone/dist/target/ozone-latest` to the version numbered ozone build directory such as `ozone/hadoop-ozone/dist/target/ozone-2.3.0-SNAPSHOT`. Without this, a stable link to the compose files across various versions of Ozone cannot be created.  



After this PR:
<img width="339" height="282" alt="Screenshot 2026-07-22 at 3 49 46 PM" src="https://github.com/user-attachments/assets/8618bd5a-3ad6-43bb-8a43-a7349a28b16a" />



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15944

## How was this patch tested?
CI: https://github.com/ptlrs/ozone/actions/runs/29963582054