### PR TITLE
HDDS-15533. DNS refresh on heartbeat failure for DN to SCM

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -39,6 +39,10 @@ public final class HddsConfigKeys {
       "hdds.heartbeat.recon.initial-interval";
   public static final String HDDS_RECON_INITIAL_HEARTBEAT_INTERVAL_DEFAULT =
       "2s";
+  /** Missed heartbeats against one SCM before the DN re-resolves its hostname (HDDS-15533). */
+  public static final String HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD =
+      "hdds.heartbeat.address.refresh.threshold";
+  public static final int HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT = 3;
   public static final String HDDS_NODE_REPORT_INTERVAL =
       "hdds.node.report.interval";
   public static final String HDDS_NODE_REPORT_INTERVAL_DEFAULT =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -40,9 +40,9 @@ public final class HddsConfigKeys {
   public static final String HDDS_RECON_INITIAL_HEARTBEAT_INTERVAL_DEFAULT =
       "2s";
   /** Missed heartbeats against one SCM before the DN re-resolves its hostname (HDDS-15533). */
-  public static final String HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD =
-      "hdds.heartbeat.address.refresh.threshold";
-  public static final int HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT = 3;
+  public static final String HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD =
+      "hdds.heartbeat.address.refresh.missed-count-threshold";
+  public static final int HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD_DEFAULT = 3;
   public static final String HDDS_NODE_REPORT_INTERVAL =
       "hdds.node.report.interval";
   public static final String HDDS_NODE_REPORT_INTERVAL_DEFAULT =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/HostAndPort.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/HostAndPort.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.net;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import org.apache.hadoop.net.NetUtils;
 
@@ -30,14 +31,13 @@ public class HostAndPort {
   private final String hostAndPortString;
   private final int hash;
   /** The address can be updated from time to time. */
-  private final InetSocketAddress address;
+  private volatile InetSocketAddress address;
 
   public HostAndPort(String host, int port) {
     this.host = host;
     this.port = port;
     this.hostAndPortString = host + ":" + port;
     this.hash = host.hashCode() ^ Integer.hashCode(port);
-    // TODO: HDDS-15533 change the address resolution logic and make this.address threadsafe.
     this.address = NetUtils.createSocketAddr(hostAndPortString);
   }
 
@@ -55,6 +55,17 @@ public class HostAndPort {
 
   public InetSocketAddress getAddress() {
     return address;
+  }
+
+  /** Re-resolves host:port; on an IP change swaps the cached address and returns true. */
+  public boolean refresh() {
+    final InetSocketAddress latest = NetUtils.createSocketAddr(hostAndPortString);
+    final InetAddress latestIp = latest.getAddress();
+    if (latestIp == null || latestIp.equals(address.getAddress())) {
+      return false;
+    }
+    address = latest;
+    return true;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/HostAndPort.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/HostAndPort.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.net;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Objects;
 import org.apache.hadoop.net.NetUtils;
 
 /**
@@ -69,7 +70,7 @@ public class HostAndPort {
 
   /** Commits an address re-resolved via {@link #resolveLatest()}. */
   public void setAddress(InetSocketAddress newAddress) {
-    this.address = newAddress;
+    this.address = Objects.requireNonNull(newAddress, "newAddress == null");
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/HostAndPort.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/HostAndPort.java
@@ -57,15 +57,19 @@ public class HostAndPort {
     return address;
   }
 
-  /** Re-resolves host:port; on an IP change swaps the cached address and returns true. */
-  public boolean refresh() {
+  /** Re-resolves host:port and returns the new address if its IP changed, else null. No mutation. */
+  public InetSocketAddress resolveLatest() {
     final InetSocketAddress latest = NetUtils.createSocketAddr(hostAndPortString);
     final InetAddress latestIp = latest.getAddress();
     if (latestIp == null || latestIp.equals(address.getAddress())) {
-      return false;
+      return null;
     }
-    address = latest;
-    return true;
+    return latest;
+  }
+
+  /** Commits an address re-resolved via {@link #resolveLatest()}. */
+  public void setAddress(InetSocketAddress newAddress) {
+    this.address = newAddress;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4007,7 +4007,7 @@
   </property>
 
   <property>
-    <name>hdds.heartbeat.address.refresh.threshold</name>
+    <name>hdds.heartbeat.address.refresh.missed-count-threshold</name>
     <value>3</value>
     <tag>OZONE, DATANODE, HA</tag>
     <description>Consecutive heartbeat failures the DataNode tolerates

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4007,6 +4007,16 @@
   </property>
 
   <property>
+    <name>hdds.heartbeat.address.refresh.threshold</name>
+    <value>3</value>
+    <tag>OZONE, DATANODE, HA</tag>
+    <description>Consecutive heartbeat failures the DataNode tolerates
+      against one SCM endpoint before re-resolving its hostname. Only
+      consulted when ozone.client.failover.resolve-needed is true.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.directory.deleting.service.interval</name>
     <value>1m</value>
     <tag>OZONE, PERFORMANCE, OM, DELETION</tag>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestHostAndPort.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestHostAndPort.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link HostAndPort} address refresh (HDDS-15533).
+ */
+public class TestHostAndPort {
+
+  @Test
+  public void resolveLatestReturnsNullWhenIpUnchanged() {
+    HostAndPort address = new HostAndPort("127.0.0.1", 9861);
+    assertNull(address.resolveLatest());
+  }
+
+  @Test
+  public void setAddressRejectsNull() {
+    HostAndPort address = new HostAndPort("127.0.0.1", 9861);
+    assertThrows(NullPointerException.class, () -> address.setAddress(null));
+  }
+
+  @Test
+  public void setAddressDoesNotChangeIdentity() throws Exception {
+    HostAndPort address = new HostAndPort("127.0.0.1", 9861);
+    InetSocketAddress refreshed =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[]{10, 0, 0, 7}), 9861);
+    address.setAddress(refreshed);
+    assertEquals(refreshed, address.getAddress());
+    // equals/hashCode stay keyed on host:port so the instance remains a stable map key.
+    assertEquals(new HostAndPort("127.0.0.1", 9861), address);
+    assertEquals(new HostAndPort("127.0.0.1", 9861).hashCode(), address.hashCode());
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -152,10 +152,14 @@ public class EndpointStateMachine
    */
   @Override
   public void close() {
-    if (endPoint != null) {
-      endPoint.close();
+    try {
+      if (endPoint != null) {
+        endPoint.close();
+      }
+    } finally {
+      // Always release the executor thread, even if closing the RPC proxy throws.
+      executorService.shutdown();
     }
-    executorService.shutdown();
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -139,38 +139,68 @@ public class SCMConnectionManager
             "Ignoring the request.");
         return;
       }
-
-      Configuration hadoopConfig =
-          LegacyHadoopConfigurationSource.asHadoopConfiguration(this.conf);
-      RPC.setProtocolEngine(
-          hadoopConfig,
-          StorageContainerDatanodeProtocolPB.class,
-          ProtobufRpcEngine.class);
-      long version =
-          RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
-
-      RetryPolicy retryPolicy =
-          RetryPolicies.retryUpToMaximumCountWithFixedSleep(
-              getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf),
-              TimeUnit.MILLISECONDS);
-
-      StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
-          StorageContainerDatanodeProtocolPB.class, version,
-          address.getAddress(), UserGroupInformation.getCurrentUser(), hadoopConfig,
-          NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
-          retryPolicy).getProxy();
-
-      StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
-          new StorageContainerDatanodeProtocolClientSideTranslatorPB(
-              rpcProxy);
-
-      EndpointStateMachine endPoint = new EndpointStateMachine(address,
-          rpcClient, this.conf, threadNamePrefix);
+      EndpointStateMachine endPoint = buildScmEndpoint(address, threadNamePrefix);
       endPoint.setPassive(false);
       scmMachines.put(address, endPoint);
     } finally {
       writeUnlock();
     }
+  }
+
+  private EndpointStateMachine buildScmEndpoint(HostAndPort address, String threadNamePrefix)
+      throws IOException {
+    Configuration hadoopConfig =
+        LegacyHadoopConfigurationSource.asHadoopConfiguration(this.conf);
+    RPC.setProtocolEngine(hadoopConfig, StorageContainerDatanodeProtocolPB.class,
+        ProtobufRpcEngine.class);
+    long version = RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
+    RetryPolicy retryPolicy = RetryPolicies.retryUpToMaximumCountWithFixedSleep(
+        getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf), TimeUnit.MILLISECONDS);
+    StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
+        StorageContainerDatanodeProtocolPB.class, version,
+        address.getAddress(), UserGroupInformation.getCurrentUser(), hadoopConfig,
+        NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
+        retryPolicy).getProxy();
+    StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
+        new StorageContainerDatanodeProtocolClientSideTranslatorPB(rpcProxy);
+    return new EndpointStateMachine(address, rpcClient, this.conf, threadNamePrefix);
+  }
+
+  /**
+   * Re-resolves the active SCM endpoint at {@code address}; on an IP change, rebuilds it under the
+   * same key and closes the stale proxy. Returns true if rebuilt.
+   */
+  public boolean refreshSCMServer(HostAndPort address, String threadNamePrefix)
+      throws IOException {
+    final EndpointStateMachine current;
+    readLock();
+    try {
+      current = scmMachines.get(address);
+      if (current == null || current.isPassive()) {
+        return false;
+      }
+    } finally {
+      readUnlock();
+    }
+    // Resolve outside the lock; refresh() swaps the cached address only on a real IP change.
+    if (!address.refresh()) {
+      return false;
+    }
+    final EndpointStateMachine stale;
+    writeLock();
+    try {
+      if (scmMachines.get(address) != current) {
+        return false;
+      }
+      EndpointStateMachine rebuilt = buildScmEndpoint(address, threadNamePrefix);
+      rebuilt.setPassive(false);
+      scmMachines.put(address, rebuilt);
+      stale = current;
+    } finally {
+      writeUnlock();
+    }
+    stale.close();
+    return true;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -22,8 +22,10 @@ import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryCount;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryInterval;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcTimeOutInMilliseconds;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -139,7 +141,7 @@ public class SCMConnectionManager
             "Ignoring the request.");
         return;
       }
-      EndpointStateMachine endPoint = buildScmEndpoint(address, threadNamePrefix);
+      EndpointStateMachine endPoint = buildScmEndpoint(address, address.getAddress(), threadNamePrefix);
       endPoint.setPassive(false);
       scmMachines.put(address, endPoint);
     } finally {
@@ -147,8 +149,9 @@ public class SCMConnectionManager
     }
   }
 
-  private EndpointStateMachine buildScmEndpoint(HostAndPort address, String threadNamePrefix)
-      throws IOException {
+  @VisibleForTesting
+  EndpointStateMachine buildScmEndpoint(HostAndPort address, InetSocketAddress dialAddress,
+      String threadNamePrefix) throws IOException {
     Configuration hadoopConfig =
         LegacyHadoopConfigurationSource.asHadoopConfiguration(this.conf);
     RPC.setProtocolEngine(hadoopConfig, StorageContainerDatanodeProtocolPB.class,
@@ -158,7 +161,7 @@ public class SCMConnectionManager
         getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf), TimeUnit.MILLISECONDS);
     StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
         StorageContainerDatanodeProtocolPB.class, version,
-        address.getAddress(), UserGroupInformation.getCurrentUser(), hadoopConfig,
+        dialAddress, UserGroupInformation.getCurrentUser(), hadoopConfig,
         NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
         retryPolicy).getProxy();
     StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
@@ -182,8 +185,10 @@ public class SCMConnectionManager
     } finally {
       readUnlock();
     }
-    // Resolve outside the lock; refresh() swaps the cached address only on a real IP change.
-    if (!address.refresh()) {
+    // Resolve outside the lock, but commit the new address only after the replacement is built,
+    // so a build failure or a lost race never leaves the cached address ahead of the live proxy.
+    final InetSocketAddress latest = address.resolveLatest();
+    if (latest == null) {
       return false;
     }
     final EndpointStateMachine stale;
@@ -192,8 +197,9 @@ public class SCMConnectionManager
       if (scmMachines.get(address) != current) {
         return false;
       }
-      EndpointStateMachine rebuilt = buildScmEndpoint(address, threadNamePrefix);
+      EndpointStateMachine rebuilt = buildScmEndpoint(address, latest, threadNamePrefix);
       rebuilt.setPassive(false);
+      address.setAddress(latest);
       scmMachines.put(address, rebuilt);
       stale = current;
     } finally {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -192,6 +192,7 @@ public class SCMConnectionManager
       return false;
     }
     final EndpointStateMachine stale;
+    final InetSocketAddress previous;
     writeLock();
     try {
       if (scmMachines.get(address) != current) {
@@ -199,13 +200,20 @@ public class SCMConnectionManager
       }
       EndpointStateMachine rebuilt = buildScmEndpoint(address, latest, threadNamePrefix);
       rebuilt.setPassive(false);
+      previous = address.getAddress();
       address.setAddress(latest);
       scmMachines.put(address, rebuilt);
       stale = current;
     } finally {
       writeUnlock();
     }
-    stale.close();
+    // The swap is committed; failing to close the stale proxy is cleanup-only, not a refresh failure.
+    try {
+      stale.close();
+    } catch (RuntimeException e) {
+      LOG.warn("Failed to close stale endpoint for {}", address, e);
+    }
+    LOG.info("SCM endpoint {} re-resolved: {} -> {}", address.getHostAndPortString(), previous, latest);
     return true;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.ozone.container.common.states.endpoint;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LIMIT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LIMIT_DEFAULT;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT;
@@ -109,8 +109,8 @@ public class HeartbeatEndpointTask
     }
     this.resolveOnFailureEnabled = conf.getBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY,
         OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT);
-    this.refreshThreshold = Math.max(1, conf.getInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD,
-        HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT));
+    this.refreshThreshold = Math.max(1, conf.getInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD,
+        HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD_DEFAULT));
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -19,8 +19,12 @@ package org.apache.hadoop.ozone.container.common.states.endpoint;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LIMIT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_ACTION_MAX_LIMIT_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_ACTION_MAX_LIMIT_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVersionProto;
 
 import com.google.common.base.Preconditions;
@@ -44,6 +48,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatResponseProto;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.hdds.utils.ConnectionFailureUtils;
 import org.apache.hadoop.hdfs.util.EnumCounters;
 import org.apache.hadoop.ozone.container.common.helpers.DeletedContainerBlocksSummary;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
@@ -77,6 +82,8 @@ public class HeartbeatEndpointTask
   private int maxContainerActionsPerHB;
   private int maxPipelineActionsPerHB;
   private HDDSLayoutVersionManager layoutVersionManager;
+  private final boolean resolveOnFailureEnabled;
+  private final int refreshThreshold;
 
   /**
    * Constructs a SCM heart beat.
@@ -100,6 +107,10 @@ public class HeartbeatEndpointTask
     } else {
       this.layoutVersionManager = context.getParent().getLayoutVersionManager();
     }
+    this.resolveOnFailureEnabled = conf.getBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY,
+        OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_DEFAULT);
+    this.refreshThreshold = Math.max(1, conf.getInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD,
+        HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD_DEFAULT));
   }
 
   /**
@@ -157,10 +168,31 @@ public class HeartbeatEndpointTask
       // put back the reports which failed to be sent
       putBackIncrementalReports(requestBuilder);
       rpcEndpoint.logIfNeeded(ex);
+      maybeRefreshScmAddress(ex);
     } finally {
       rpcEndpoint.unlock();
     }
     return rpcEndpoint.getState();
+  }
+
+  /**
+   * On a connection-class heartbeat failure past the threshold (and when resolve-needed is on),
+   * asks the connection manager to re-resolve this SCM peer and rebuild the endpoint.
+   */
+  private void maybeRefreshScmAddress(IOException heartbeatFailure) {
+    if (!resolveOnFailureEnabled
+        || rpcEndpoint.isPassive()
+        || rpcEndpoint.getMissedCount() < refreshThreshold
+        || !ConnectionFailureUtils.isConnectionFailure(heartbeatFailure)) {
+      return;
+    }
+    try {
+      context.getParent().getConnectionManager()
+          .refreshSCMServer(rpcEndpoint.getAddress(), context.getThreadNamePrefix());
+    } catch (IOException ex) {
+      LOG.warn("Failed to refresh SCM address {} after {} missed heartbeats",
+          rpcEndpoint.getAddress(), rpcEndpoint.getMissedCount(), ex);
+    }
   }
 
   // TODO: Make it generic.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container.common.statemachine;
 
 import static org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates.HEARTBEAT;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
@@ -87,6 +88,26 @@ public class TestSCMConnectionManager {
       // new IP -- the "stuck until restart" state this feature removes.
       Assertions.assertThrows(IOException.class, () -> cm.refreshSCMServer(address, ""));
       Assertions.assertSame(original, cm.getValues().iterator().next());
+      Assertions.assertEquals(before, address.getAddress());
+    }
+  }
+
+  @Test
+  public void refreshAbandonedWhenEndpointRemovedDuringResolve() throws Exception {
+    try (SCMConnectionManager cm =
+             new SCMConnectionManager(new OzoneConfiguration())) {
+      final HostAndPort address = spy(new HostAndPort("127.0.0.1", 9861));
+      cm.addSCMServer(address, "");
+      final InetSocketAddress before = address.getAddress();
+      // resolveLatest runs in the unlocked window between the endpoint snapshot and the write lock;
+      // removing the endpoint right there exercises the lost-race guard deterministically.
+      doAnswer(inv -> {
+        cm.removeSCMServer(address);
+        return NEW_IP;
+      }).when(address).resolveLatest();
+
+      Assertions.assertFalse(cm.refreshSCMServer(address, ""));
+      Assertions.assertTrue(cm.getValues().isEmpty());
       Assertions.assertEquals(before, address.getAddress());
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestSCMConnectionManager.java
@@ -18,7 +18,13 @@
 package org.apache.hadoop.ozone.container.common.statemachine;
 
 import static org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates.HEARTBEAT;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.net.HostAndPort;
 import org.junit.jupiter.api.Assertions;
@@ -28,6 +34,8 @@ import org.junit.jupiter.api.Test;
  * Tests for SCMConnectionManager.
  */
 public class TestSCMConnectionManager {
+
+  private static final InetSocketAddress NEW_IP = newIp();
 
   @Test
   public void testRemoveSCMServerDoesNotMarkEndpointShutdown()
@@ -44,6 +52,68 @@ public class TestSCMConnectionManager {
 
       Assertions.assertTrue(connectionManager.getValues().isEmpty());
       Assertions.assertEquals(HEARTBEAT, endpoint.getState());
+    }
+  }
+
+  @Test
+  public void refreshRebuildsEndpointWhenIpChanges() throws Exception {
+    try (SCMConnectionManager cm =
+             new SCMConnectionManager(new OzoneConfiguration())) {
+      final HostAndPort address = spy(new HostAndPort("127.0.0.1", 9861));
+      cm.addSCMServer(address, "");
+      final EndpointStateMachine original = cm.getValues().iterator().next();
+      doReturn(NEW_IP).when(address).resolveLatest();
+
+      Assertions.assertTrue(cm.refreshSCMServer(address, ""));
+      Assertions.assertNotSame(original, cm.getValues().iterator().next());
+      Assertions.assertEquals(NEW_IP, address.getAddress());
+    }
+  }
+
+  @Test
+  public void refreshBuildFailureLeavesEndpointAndAddressUnchanged()
+      throws Exception {
+    try (FailingConnectionManager cm =
+             new FailingConnectionManager(new OzoneConfiguration())) {
+      final HostAndPort address = spy(new HostAndPort("127.0.0.1", 9861));
+      cm.addSCMServer(address, "");
+      final EndpointStateMachine original = cm.getValues().iterator().next();
+      final InetSocketAddress before = address.getAddress();
+      doReturn(NEW_IP).when(address).resolveLatest();
+      cm.failBuild = true;
+
+      // Build fails after DNS returned a new IP: the live endpoint and the cached address must both
+      // stay unchanged, otherwise the DN dials the stale proxy forever while getAddress() reports the
+      // new IP -- the "stuck until restart" state this feature removes.
+      Assertions.assertThrows(IOException.class, () -> cm.refreshSCMServer(address, ""));
+      Assertions.assertSame(original, cm.getValues().iterator().next());
+      Assertions.assertEquals(before, address.getAddress());
+    }
+  }
+
+  private static InetSocketAddress newIp() {
+    try {
+      return new InetSocketAddress(InetAddress.getByAddress(new byte[]{10, 0, 0, 7}), 9861);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /** SCMConnectionManager whose endpoint build can be forced to fail, to exercise rollback. */
+  private static final class FailingConnectionManager extends SCMConnectionManager {
+    private boolean failBuild;
+
+    FailingConnectionManager(ConfigurationSource conf) {
+      super(conf);
+    }
+
+    @Override
+    EndpointStateMachine buildScmEndpoint(HostAndPort address, InetSocketAddress dialAddress,
+        String threadNamePrefix) throws IOException {
+      if (failBuild) {
+        throw new IOException("simulated build failure");
+      }
+      return super.buildScmEndpoint(address, dialAddress, threadNamePrefix);
     }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.ozone.container.common.states.endpoint;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
 import static org.mockito.Mockito.any;
@@ -57,7 +57,7 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
   public void connectionFailureAtThresholdTriggersRefresh() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
-    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 2);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD, 2);
     SCMConnectionManager cm = runHeartbeat(conf, 3, new ConnectException("refused"));
     verify(cm, times(1)).refreshSCMServer(eq(SCM), any());
   }
@@ -82,7 +82,7 @@ public class TestHeartbeatEndpointTaskDnsRefresh {
   public void belowThresholdDoesNotTriggerRefresh() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
-    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 5);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_MISSED_COUNT_THRESHOLD, 5);
     SCMConnectionManager cm = runHeartbeat(conf, 1, new ConnectException("refused"));
     verify(cm, never()).refreshSCMServer(any(), any());
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTaskDnsRefresh.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.states.endpoint;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD;
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.UUID;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.scm.net.HostAndPort;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.hdfs.util.EnumCounters;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.DatanodeStates;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies a connection-class heartbeat failure past the threshold triggers a DNS re-resolution of
+ * the SCM peer (HDDS-15533); flag-off, application errors, and below-threshold do not.
+ */
+public class TestHeartbeatEndpointTaskDnsRefresh {
+
+  private static final HostAndPort SCM = new HostAndPort("test-scm-1", 9861);
+
+  @Test
+  public void connectionFailureAtThresholdTriggersRefresh() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 2);
+    SCMConnectionManager cm = runHeartbeat(conf, 3, new ConnectException("refused"));
+    verify(cm, times(1)).refreshSCMServer(eq(SCM), any());
+  }
+
+  @Test
+  public void flagOffSuppressesRefresh() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, false);
+    SCMConnectionManager cm = runHeartbeat(conf, 5, new ConnectException("refused"));
+    verify(cm, never()).refreshSCMServer(any(), any());
+  }
+
+  @Test
+  public void applicationErrorDoesNotTriggerRefresh() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    SCMConnectionManager cm = runHeartbeat(conf, 5, new IOException("application-level"));
+    verify(cm, never()).refreshSCMServer(any(), any());
+  }
+
+  @Test
+  public void belowThresholdDoesNotTriggerRefresh() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_CLIENT_FAILOVER_RESOLVE_NEEDED_KEY, true);
+    conf.setInt(HDDS_HEARTBEAT_ADDRESS_REFRESH_THRESHOLD, 5);
+    SCMConnectionManager cm = runHeartbeat(conf, 1, new ConnectException("refused"));
+    verify(cm, never()).refreshSCMServer(any(), any());
+  }
+
+  /**
+   * Drives one heartbeat that fails with {@code failure}, with the endpoint reporting
+   * {@code missedCount} missed heartbeats, and returns the mocked connection manager to verify.
+   */
+  private SCMConnectionManager runHeartbeat(OzoneConfiguration conf, long missedCount,
+      IOException failure) throws Exception {
+    StorageContainerDatanodeProtocolClientSideTranslatorPB proxy =
+        mock(StorageContainerDatanodeProtocolClientSideTranslatorPB.class);
+    when(proxy.sendHeartbeat(any())).thenThrow(failure);
+
+    EndpointStateMachine endpoint = mock(EndpointStateMachine.class);
+    when(endpoint.getEndPoint()).thenReturn(proxy);
+    when(endpoint.getAddress()).thenReturn(SCM);
+    when(endpoint.getMissedCount()).thenReturn(missedCount);
+    when(endpoint.isPassive()).thenReturn(false);
+
+    SCMConnectionManager connectionManager = mock(SCMConnectionManager.class);
+    DatanodeStateMachine dsm = mock(DatanodeStateMachine.class);
+    when(dsm.getConnectionManager()).thenReturn(connectionManager);
+    when(dsm.getQueuedCommandCount())
+        .thenReturn(new EnumCounters<>(SCMCommandProto.Type.class));
+    StateContext context = new StateContext(conf, DatanodeStates.RUNNING, dsm, "");
+
+    HDDSLayoutVersionManager lvm = mock(HDDSLayoutVersionManager.class);
+    when(lvm.getSoftwareLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(lvm.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+
+    DatanodeDetails dn = DatanodeDetails.newBuilder()
+        .setUuid(UUID.randomUUID())
+        .setHostName("localhost")
+        .setIpAddress("127.0.0.1")
+        .build();
+
+    HeartbeatEndpointTask.newBuilder()
+        .setConfig(conf)
+        .setDatanodeDetails(dn)
+        .setContext(context)
+        .setLayoutVersionManager(lvm)
+        .setEndpointStateMachine(endpoint)
+        .build()
+        .call();
+    return connectionManager;
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds DNS refresh on the DN→SCM heartbeat path, completing the `// TODO: HDDS-15533` left in `HostAndPort` by HDDS-15682 (#10612).

#10612 keys SCM-node identity on the stable configured `host:port`, but it resolves the address once and freezes it — so a datanode keeps dialing a dead IP after an SCM pod is rescheduled to a new IP (e.g. Kubernetes). This change:

- **`HostAndPort`** — makes the cached address `volatile` and splits refresh into `resolveLatest()` (pure re-resolve; returns the new address only if the IP changed, never mutates) and `setAddress()` (commit). Identity (`equals`/`hashCode`) stays keyed on host:port, so instances remain stable map keys across refreshes.
- **`SCMConnectionManager.refreshSCMServer()`** — builds the replacement endpoint dialing the candidate address first, then, only on success and under the write lock, commits `setAddress` and swaps the map value under the **same** host:port key; the stale proxy is closed outside the lock and the swap is logged at INFO. A build failure or a lost race with a concurrent `removeSCMServer` commits nothing, so the next heartbeat failure retries cleanly. Because the key is stable there is no re-keying, collision checking, or `StateContext` queue migration.
- **`HeartbeatEndpointTask`** — triggers the refresh on a connection-class heartbeat failure (`ConnectionFailureUtils`) once the consecutive-missed-heartbeat threshold is reached, gated by the existing `ozone.client.failover.resolve-needed` flag. Recon (passive) endpoints are excluded.
- **`EndpointStateMachine.close()`** — shuts the executor down in a `finally` block so a proxy close failure cannot leak the endpoint thread (refresh makes `close()` a recurring runtime path).

Behavior note: the rebuilt endpoint starts at GETVERSION, so the DN re-runs version/register against the refreshed SCM before heartbeating. This is intentional — a rescheduled SCM pod is effectively a fresh process — and matches what a DN restart would do.

New config: `hdds.heartbeat.address.refresh.missed-count-threshold` (default 3). With `ozone.client.failover.resolve-needed=false` (the default), behaviour is unchanged.

### Enabling in Kubernetes

```
ozone.client.failover.resolve-needed = true   # master switch, default false
hdds.heartbeat.address.refresh.missed-count-threshold = 3  # consecutive failures before re-resolve (default)
```

Replaces the earlier stacked attempt (szetszwo/ozone#11) and supersedes the closed #10488, rebuilt directly on `master` after #10612 merged.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-15533

## How was this patch tested?

- `TestHeartbeatEndpointTaskDnsRefresh` (4): a connection-class failure at the threshold triggers the refresh; flag-off, application-level errors, and below-threshold do not.
- `TestSCMConnectionManager` (3 new): successful rebuild on IP change; build failure leaves the endpoint and cached address unchanged (guards the stuck-until-restart regression); a concurrent `removeSCMServer` during the unlocked DNS-resolve window abandons the refresh without committing.
- `TestHostAndPort` (3): `resolveLatest()` no-op on unchanged IP; `setAddress` rejects null; address mutation does not change map-key identity.
- `mvn checkstyle:check` passes on `hadoop-hdds/common` and `hadoop-hdds/container-service`; full build and test suites via CI.

Generated-by: Claude Code (Fable 5)

