### PR TITLE
HDDS-14666. Add multipart upload split table read for Recon

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.recon.tasks;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -150,9 +151,9 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
   public Triple<Long, Long, Long> getTableSizeAndCount(String tableName,
       OMMetadataManager omMetadataManager) throws IOException {
     long count = 0;
-    // [0] = unreplicated size, [1] = replicated size. An array is used so the
-    // running totals can be mutated from the part-iteration lambda below.
-    final long[] sizes = {0L, 0L};
+    // left = unreplicated size, right = replicated size. A mutable pair is used
+    // so the running totals can be updated from the part-iteration lambda below.
+    final MutablePair<Long, Long> sizes = MutablePair.of(0L, 0L);
 
     // uploadId -> parent replication config, for split-schema MPUs. Their parts
     // live in multipartPartsTable but do not carry a replication config, so the
@@ -169,8 +170,8 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
           OmMultipartKeyInfo multipartKeyInfo = kv.getValue();
           if (isLegacySchema(multipartKeyInfo)) {
             forEachLegacyPart(multipartKeyInfo, (dataSize, replicatedSize) -> {
-              sizes[0] += dataSize;
-              sizes[1] += replicatedSize;
+              sizes.setLeft(sizes.getLeft() + dataSize);
+              sizes.setRight(sizes.getRight() + replicatedSize);
             });
           } else {
             // Split schema: parts are stored in multipartPartsTable. Remember
@@ -200,14 +201,15 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
               continue;
             }
             long partDataSize = kv.getValue().getDataSize();
-            sizes[0] += partDataSize;
-            sizes[1] += QuotaUtil.getReplicatedSize(partDataSize, replicationConfig);
+            sizes.setLeft(sizes.getLeft() + partDataSize);
+            sizes.setRight(sizes.getRight()
+                + QuotaUtil.getReplicatedSize(partDataSize, replicationConfig));
           }
         }
       }
     }
 
-    return Triple.of(count, sizes[0], sizes[1]);
+    return Triple.of(count, sizes.getLeft(), sizes.getRight());
   }
 
   /**
@@ -221,8 +223,8 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
   private void applyLegacyPartSizes(OmMultipartKeyInfo multipartKeyInfo, String tableName,
       Map<String, Long> unReplicatedSizeMap, Map<String, Long> replicatedSizeMap, boolean add) {
     forEachLegacyPart(multipartKeyInfo, (dataSize, replicatedSize) -> {
-      updateSize(unReplicatedSizeMap, getUnReplicatedSizeKeyFromTable(tableName), dataSize, add);
-      updateSize(replicatedSizeMap, getReplicatedSizeKeyFromTable(tableName), replicatedSize, add);
+      updateSize(unReplicatedSizeMap, getUnReplicatedSizeKeyFromTable(tableName), dataSize, add, "unreplicated");
+      updateSize(replicatedSizeMap, getReplicatedSizeKeyFromTable(tableName), replicatedSize, add, "replicated");
     });
   }
 
@@ -243,15 +245,20 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
   /**
    * Adds or subtracts {@code delta} from the value stored under {@code key} in
    * {@code sizeMap} (only if the key is already present). Subtraction is clamped
-   * at zero to guard against underflow.
+   * at zero, and an underflow is logged (as it indicates an accounting anomaly,
+   * e.g. a delete/update for a part whose size was never added).
+   *
+   * @param sizeType a human-readable label ("unreplicated"/"replicated") used
+   *                 only in the underflow warning message.
    */
-  private static void updateSize(Map<String, Long> sizeMap, String key, long delta, boolean add) {
+  private static void updateSize(Map<String, Long> sizeMap, String key, long delta, boolean add, String sizeType) {
     sizeMap.computeIfPresent(key, (k, size) -> {
       if (add) {
         return size + delta;
       }
       if (size < delta) {
-        LOG.warn("Attempted to subtract {} from current size {} for {}; clamping to 0.", delta, size, k);
+        LOG.warn("Negative {} size for key: {}. Current: {}, Part: {}. Clamping to 0.",
+            sizeType, k, size, delta);
         return 0L;
       }
       return size - delta;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
@@ -51,18 +51,25 @@ import org.slf4j.LoggerFactory;
  *   {@code uploadId/partNumber}.</li>
  * </ul>
  *
- * <p>The incremental (event) handlers below only see {@code multipartInfoTable}
- * events, whose values embed parts only for the legacy schema. Split-schema part
+ * <p>The event handlers below only access {@code multipartInfoTable} events,
+ * whose values embed parts only for the legacy schema. Split-schema part
  * sizes therefore cannot be accounted incrementally from these events (the
- * handler has no DB access and the event carries no part data); they are
- * reconciled during the periodic reprocess in
- * {@link #getTableSizeAndCount(String, OMMetadataManager)}, which reads the split
- * {@code multipartPartsTable} directly.
+ * handler has no DB access and the event carries no part data).
+ * So they are reconciled during the periodic reprocess in {@link #getTableSizeAndCount(String, OMMetadataManager)},
+ * which reads the split {@code multipartPartsTable} directly.
  */
 public class MultipartInfoInsightHandler implements OmTableHandler {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(MultipartInfoInsightHandler.class);
+
+  /**
+   * Consumes the (unreplicated, replicated) size of a single multipart part.
+   */
+  @FunctionalInterface
+  private interface PartSizeConsumer {
+    void accept(long dataSize, long replicatedSize);
+  }
 
   /**
    * Invoked by the process method to add information on those keys that have
@@ -76,18 +83,7 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
       OmMultipartKeyInfo multipartKeyInfo = (OmMultipartKeyInfo) event.getValue();
       objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
           (k, count) -> count + 1L);
-
-      // Only legacy MPUs embed parts here; split-schema part sizes are
-      // reconciled during reprocess (see class Javadoc).
-      if (isLegacySchema(multipartKeyInfo)) {
-        for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-          ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-          unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
-              (k, size) -> size + omKeyInfo.getDataSize());
-          replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
-              (k, size) -> size + omKeyInfo.getReplicatedSize());
-        }
-      }
+      applyLegacyPartSizes(multipartKeyInfo, tableName, unReplicatedSizeMap, replicatedSizeMap, true);
     } else {
       LOG.warn("Put event does not have the Multipart Key Info for {}.", event.getKey());
     }
@@ -105,32 +101,7 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
       OmMultipartKeyInfo multipartKeyInfo = (OmMultipartKeyInfo) event.getValue();
       objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
           (k, count) -> count > 0 ? count - 1L : 0L);
-
-      // Only legacy MPUs embed parts here; split-schema part sizes are
-      // reconciled during reprocess (see class Javadoc).
-      if (isLegacySchema(multipartKeyInfo)) {
-        for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-          ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-          unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
-              (k, size) -> {
-                long newSize = size > omKeyInfo.getDataSize() ? size - omKeyInfo.getDataSize() : 0L;
-                if (newSize < 0) {
-                  LOG.warn("Negative unreplicated size for key: {}. Original: {}, Part: {}",
-                      k, size, omKeyInfo.getDataSize());
-                }
-                return newSize;
-              });
-          replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
-              (k, size) -> {
-                long newSize = size > omKeyInfo.getReplicatedSize() ? size - omKeyInfo.getReplicatedSize() : 0L;
-                if (newSize < 0) {
-                  LOG.warn("Negative replicated size for key: {}. Original: {}, Part: {}",
-                      k, size, omKeyInfo.getReplicatedSize());
-                }
-                return newSize;
-              });
-        }
-      }
+      applyLegacyPartSizes(multipartKeyInfo, tableName, unReplicatedSizeMap, replicatedSizeMap, false);
     } else {
       LOG.warn("Delete event does not have the Multipart Key Info for {}.", event.getKey());
     }
@@ -150,32 +121,13 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
         return;
       }
 
-      // In Update event the count for the multipart info table will not change. So we
-      // don't need to update the count.
+      // In an Update event the count for the multipart info table does not
+      // change, so only the sizes are adjusted: subtract the old parts and add
+      // the new parts.
       OmMultipartKeyInfo oldMultipartKeyInfo = (OmMultipartKeyInfo) event.getOldValue();
       OmMultipartKeyInfo newMultipartKeyInfo = (OmMultipartKeyInfo) event.getValue();
-
-      // Calculate old sizes (legacy embedded parts only; see class Javadoc).
-      if (isLegacySchema(oldMultipartKeyInfo)) {
-        for (PartKeyInfo partKeyInfo : oldMultipartKeyInfo.getPartKeyInfoMap()) {
-          ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-          unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
-              (k, size) -> size - omKeyInfo.getDataSize());
-          replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
-              (k, size) -> size - omKeyInfo.getReplicatedSize());
-        }
-      }
-
-      // Calculate new sizes (legacy embedded parts only; see class Javadoc).
-      if (isLegacySchema(newMultipartKeyInfo)) {
-        for (PartKeyInfo partKeyInfo : newMultipartKeyInfo.getPartKeyInfoMap()) {
-          ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-          unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
-              (k, size) -> size + omKeyInfo.getDataSize());
-          replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
-              (k, size) -> size + omKeyInfo.getReplicatedSize());
-        }
-      }
+      applyLegacyPartSizes(oldMultipartKeyInfo, tableName, unReplicatedSizeMap, replicatedSizeMap, false);
+      applyLegacyPartSizes(newMultipartKeyInfo, tableName, unReplicatedSizeMap, replicatedSizeMap, true);
     } else {
       LOG.warn("Update event does not have the Multipart Key Info for {}.", event.getKey());
     }
@@ -198,8 +150,9 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
   public Triple<Long, Long, Long> getTableSizeAndCount(String tableName,
       OMMetadataManager omMetadataManager) throws IOException {
     long count = 0;
-    long unReplicatedSize = 0;
-    long replicatedSize = 0;
+    // [0] = unreplicated size, [1] = replicated size. An array is used so the
+    // running totals can be mutated from the part-iteration lambda below.
+    final long[] sizes = {0L, 0L};
 
     // uploadId -> parent replication config, for split-schema MPUs. Their parts
     // live in multipartPartsTable but do not carry a replication config, so the
@@ -215,11 +168,10 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
         if (kv != null && kv.getValue() != null) {
           OmMultipartKeyInfo multipartKeyInfo = kv.getValue();
           if (isLegacySchema(multipartKeyInfo)) {
-            for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-              ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-              unReplicatedSize += omKeyInfo.getDataSize();
-              replicatedSize += omKeyInfo.getReplicatedSize();
-            }
+            forEachLegacyPart(multipartKeyInfo, (dataSize, replicatedSize) -> {
+              sizes[0] += dataSize;
+              sizes[1] += replicatedSize;
+            });
           } else {
             // Split schema: parts are stored in multipartPartsTable. Remember
             // the parent replication config keyed by uploadId (last component
@@ -248,14 +200,62 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
               continue;
             }
             long partDataSize = kv.getValue().getDataSize();
-            unReplicatedSize += partDataSize;
-            replicatedSize += QuotaUtil.getReplicatedSize(partDataSize, replicationConfig);
+            sizes[0] += partDataSize;
+            sizes[1] += QuotaUtil.getReplicatedSize(partDataSize, replicationConfig);
           }
         }
       }
     }
 
-    return Triple.of(count, unReplicatedSize, replicatedSize);
+    return Triple.of(count, sizes[0], sizes[1]);
+  }
+
+  /**
+   * Adds (or subtracts) the sizes of a legacy MPU's embedded parts to the size
+   * maps. Split-schema MPUs carry no embedded parts and are ignored here (their
+   * sizes are reconciled during reprocess; see class Javadoc).
+   *
+   * @param add {@code true} to add the part sizes (PUT / new value in UPDATE),
+   *            {@code false} to subtract them (DELETE / old value in UPDATE).
+   */
+  private void applyLegacyPartSizes(OmMultipartKeyInfo multipartKeyInfo, String tableName,
+      Map<String, Long> unReplicatedSizeMap, Map<String, Long> replicatedSizeMap, boolean add) {
+    forEachLegacyPart(multipartKeyInfo, (dataSize, replicatedSize) -> {
+      updateSize(unReplicatedSizeMap, getUnReplicatedSizeKeyFromTable(tableName), dataSize, add);
+      updateSize(replicatedSizeMap, getReplicatedSizeKeyFromTable(tableName), replicatedSize, add);
+    });
+  }
+
+  /**
+   * Invokes {@code consumer} with the (unreplicated, replicated) size of each
+   * embedded part of a legacy MPU. Does nothing for split-schema MPUs.
+   */
+  private static void forEachLegacyPart(OmMultipartKeyInfo multipartKeyInfo, PartSizeConsumer consumer) {
+    if (!isLegacySchema(multipartKeyInfo)) {
+      return;
+    }
+    for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+      ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+      consumer.accept(omKeyInfo.getDataSize(), omKeyInfo.getReplicatedSize());
+    }
+  }
+
+  /**
+   * Adds or subtracts {@code delta} from the value stored under {@code key} in
+   * {@code sizeMap} (only if the key is already present). Subtraction is clamped
+   * at zero to guard against underflow.
+   */
+  private static void updateSize(Map<String, Long> sizeMap, String key, long delta, boolean add) {
+    sizeMap.computeIfPresent(key, (k, size) -> {
+      if (add) {
+        return size + delta;
+      }
+      if (size < delta) {
+        LOG.warn("Attempted to subtract {} from current size {} for {}; clamping to 0.", delta, size, k);
+        return 0L;
+      }
+      return size - delta;
+    });
   }
 
   private static boolean isLegacySchema(OmMultipartKeyInfo multipartKeyInfo) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
@@ -18,12 +18,18 @@
 package org.apache.hadoop.ozone.recon.tasks;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
 import org.apache.hadoop.ozone.recon.api.types.ReconBasicOmKeyInfo;
 import org.slf4j.Logger;
@@ -32,6 +38,26 @@ import org.slf4j.LoggerFactory;
 /**
  * Manages records in the MultipartInfo Table, updating counts and sizes of
  * multipart upload keys in the backend.
+ *
+ * <p>Multipart uploads are stored in one of two schemas:
+ * <ul>
+ *   <li>Legacy (schemaVersion {@link OmMultipartKeyInfo#LEGACY_SCHEMA_VERSION}):
+ *   the part information is embedded inside the {@code multipartInfoTable} value
+ *   (see {@link OmMultipartKeyInfo#getPartKeyInfoMap()}).</li>
+ *   <li>Split parts-table (schemaVersion
+ *   {@link OmMultipartKeyInfo#SPLIT_PARTS_TABLE_SCHEMA_VERSION}): the
+ *   {@code multipartInfoTable} value carries no embedded parts; each part is a
+ *   separate row in the {@code multipartPartsTable}, keyed by
+ *   {@code uploadId/partNumber}.</li>
+ * </ul>
+ *
+ * <p>The incremental (event) handlers below only see {@code multipartInfoTable}
+ * events, whose values embed parts only for the legacy schema. Split-schema part
+ * sizes therefore cannot be accounted incrementally from these events (the
+ * handler has no DB access and the event carries no part data); they are
+ * reconciled during the periodic reprocess in
+ * {@link #getTableSizeAndCount(String, OMMetadataManager)}, which reads the split
+ * {@code multipartPartsTable} directly.
  */
 public class MultipartInfoInsightHandler implements OmTableHandler {
 
@@ -51,12 +77,16 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
       objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
           (k, count) -> count + 1L);
 
-      for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-        ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-        unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
-            (k, size) -> size + omKeyInfo.getDataSize());
-        replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
-            (k, size) -> size + omKeyInfo.getReplicatedSize());
+      // Only legacy MPUs embed parts here; split-schema part sizes are
+      // reconciled during reprocess (see class Javadoc).
+      if (isLegacySchema(multipartKeyInfo)) {
+        for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+          ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+          unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+              (k, size) -> size + omKeyInfo.getDataSize());
+          replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+              (k, size) -> size + omKeyInfo.getReplicatedSize());
+        }
       }
     } else {
       LOG.warn("Put event does not have the Multipart Key Info for {}.", event.getKey());
@@ -76,26 +106,30 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
       objectCountMap.computeIfPresent(getTableCountKeyFromTable(tableName),
           (k, count) -> count > 0 ? count - 1L : 0L);
 
-      for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-        ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-        unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
-            (k, size) -> {
-              long newSize = size > omKeyInfo.getDataSize() ? size - omKeyInfo.getDataSize() : 0L;
-              if (newSize < 0) {
-                LOG.warn("Negative unreplicated size for key: {}. Original: {}, Part: {}",
-                    k, size, omKeyInfo.getDataSize());
-              }
-              return newSize;
-            });
-        replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
-            (k, size) -> {
-              long newSize = size > omKeyInfo.getReplicatedSize() ? size - omKeyInfo.getReplicatedSize() : 0L;
-              if (newSize < 0) {
-                LOG.warn("Negative replicated size for key: {}. Original: {}, Part: {}",
-                    k, size, omKeyInfo.getReplicatedSize());
-              }
-              return newSize;
-            });
+      // Only legacy MPUs embed parts here; split-schema part sizes are
+      // reconciled during reprocess (see class Javadoc).
+      if (isLegacySchema(multipartKeyInfo)) {
+        for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+          ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+          unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+              (k, size) -> {
+                long newSize = size > omKeyInfo.getDataSize() ? size - omKeyInfo.getDataSize() : 0L;
+                if (newSize < 0) {
+                  LOG.warn("Negative unreplicated size for key: {}. Original: {}, Part: {}",
+                      k, size, omKeyInfo.getDataSize());
+                }
+                return newSize;
+              });
+          replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+              (k, size) -> {
+                long newSize = size > omKeyInfo.getReplicatedSize() ? size - omKeyInfo.getReplicatedSize() : 0L;
+                if (newSize < 0) {
+                  LOG.warn("Negative replicated size for key: {}. Original: {}, Part: {}",
+                      k, size, omKeyInfo.getReplicatedSize());
+                }
+                return newSize;
+              });
+        }
       }
     } else {
       LOG.warn("Delete event does not have the Multipart Key Info for {}.", event.getKey());
@@ -121,22 +155,26 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
       OmMultipartKeyInfo oldMultipartKeyInfo = (OmMultipartKeyInfo) event.getOldValue();
       OmMultipartKeyInfo newMultipartKeyInfo = (OmMultipartKeyInfo) event.getValue();
 
-      // Calculate old sizes
-      for (PartKeyInfo partKeyInfo : oldMultipartKeyInfo.getPartKeyInfoMap()) {
-        ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-        unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
-            (k, size) -> size - omKeyInfo.getDataSize());
-        replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
-            (k, size) -> size - omKeyInfo.getReplicatedSize());
+      // Calculate old sizes (legacy embedded parts only; see class Javadoc).
+      if (isLegacySchema(oldMultipartKeyInfo)) {
+        for (PartKeyInfo partKeyInfo : oldMultipartKeyInfo.getPartKeyInfoMap()) {
+          ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+          unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+              (k, size) -> size - omKeyInfo.getDataSize());
+          replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+              (k, size) -> size - omKeyInfo.getReplicatedSize());
+        }
       }
 
-      // Calculate new sizes
-      for (PartKeyInfo partKeyInfo : newMultipartKeyInfo.getPartKeyInfoMap()) {
-        ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-        unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
-            (k, size) -> size + omKeyInfo.getDataSize());
-        replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
-            (k, size) -> size + omKeyInfo.getReplicatedSize());
+      // Calculate new sizes (legacy embedded parts only; see class Javadoc).
+      if (isLegacySchema(newMultipartKeyInfo)) {
+        for (PartKeyInfo partKeyInfo : newMultipartKeyInfo.getPartKeyInfoMap()) {
+          ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+          unReplicatedSizeMap.computeIfPresent(getUnReplicatedSizeKeyFromTable(tableName),
+              (k, size) -> size + omKeyInfo.getDataSize());
+          replicatedSizeMap.computeIfPresent(getReplicatedSizeKeyFromTable(tableName),
+              (k, size) -> size + omKeyInfo.getReplicatedSize());
+        }
       }
     } else {
       LOG.warn("Update event does not have the Multipart Key Info for {}.", event.getKey());
@@ -148,6 +186,13 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
    * counts for the multipart info table. Additionally, it computes the sizes
    * of both replicated and unreplicated parts that are currently in multipart
    * uploads in the backend.
+   *
+   * <p>This is schema-aware: legacy (schemaVersion 0) part sizes are read from
+   * the embedded {@link OmMultipartKeyInfo#getPartKeyInfoMap()}, while split
+   * (schemaVersion 1) part sizes are summed from the separate
+   * {@code multipartPartsTable}. The count returned is always the number of
+   * multipart uploads (rows in the {@code multipartInfoTable}), regardless of
+   * schema.
    */
   @Override
   public Triple<Long, Long, Long> getTableSizeAndCount(String tableName,
@@ -156,6 +201,12 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
     long unReplicatedSize = 0;
     long replicatedSize = 0;
 
+    // uploadId -> parent replication config, for split-schema MPUs. Their parts
+    // live in multipartPartsTable but do not carry a replication config, so the
+    // parent's config (recorded here) is used to compute their replicated size
+    // in the second pass below.
+    Map<String, ReplicationConfig> splitSchemaUploads = new HashMap<>();
+
     Table<String, OmMultipartKeyInfo> table =
         (Table<String, OmMultipartKeyInfo>) omMetadataManager.getTable(tableName);
     try (TableIterator<String, Table.KeyValue<String, OmMultipartKeyInfo>> iterator = table.iterator()) {
@@ -163,15 +214,60 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
         Table.KeyValue<String, OmMultipartKeyInfo> kv = iterator.next();
         if (kv != null && kv.getValue() != null) {
           OmMultipartKeyInfo multipartKeyInfo = kv.getValue();
-          for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-            ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-            unReplicatedSize += omKeyInfo.getDataSize();
-            replicatedSize += omKeyInfo.getReplicatedSize();
+          if (isLegacySchema(multipartKeyInfo)) {
+            for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+              ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+              unReplicatedSize += omKeyInfo.getDataSize();
+              replicatedSize += omKeyInfo.getReplicatedSize();
+            }
+          } else {
+            // Split schema: parts are stored in multipartPartsTable. Remember
+            // the parent replication config keyed by uploadId (last component
+            // of the multipart key) for the second pass.
+            splitSchemaUploads.put(getUploadIdFromMultipartKey(kv.getKey()),
+                multipartKeyInfo.getReplicationConfig());
           }
           count++;
         }
       }
     }
+
+    // Second pass: sum the sizes of split-schema parts from multipartPartsTable.
+    if (!splitSchemaUploads.isEmpty()) {
+      Table<OmMultipartPartKey, OmMultipartPartInfo> partsTable =
+          omMetadataManager.getMultipartPartsTable();
+      try (TableIterator<OmMultipartPartKey, Table.KeyValue<OmMultipartPartKey, OmMultipartPartInfo>> partIterator =
+               partsTable.iterator()) {
+        while (partIterator.hasNext()) {
+          Table.KeyValue<OmMultipartPartKey, OmMultipartPartInfo> kv = partIterator.next();
+          if (kv != null && kv.getKey() != null && kv.getValue() != null) {
+            ReplicationConfig replicationConfig = splitSchemaUploads.get(kv.getKey().getUploadId());
+            if (replicationConfig == null) {
+              // Part whose parent MPU is not in multipartInfoTable (e.g. an
+              // orphan mid-cleanup). Skip to avoid mis-attributing its size.
+              continue;
+            }
+            long partDataSize = kv.getValue().getDataSize();
+            unReplicatedSize += partDataSize;
+            replicatedSize += QuotaUtil.getReplicatedSize(partDataSize, replicationConfig);
+          }
+        }
+      }
+    }
+
     return Triple.of(count, unReplicatedSize, replicatedSize);
+  }
+
+  private static boolean isLegacySchema(OmMultipartKeyInfo multipartKeyInfo) {
+    return multipartKeyInfo.getSchemaVersion() == OmMultipartKeyInfo.LEGACY_SCHEMA_VERSION;
+  }
+
+  /**
+   * The multipart key is {@code .../uploadId}; the split parts-table rows are
+   * keyed by that same uploadId. Extract it from the last path component.
+   */
+  private static String getUploadIdFromMultipartKey(String multipartKey) {
+    int idx = multipartKey.lastIndexOf(OzoneConsts.OM_KEY_PREFIX);
+    return idx >= 0 ? multipartKey.substring(idx + OzoneConsts.OM_KEY_PREFIX.length()) : multipartKey;
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
@@ -58,12 +58,16 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
@@ -781,6 +785,131 @@ public class TestOmTableInsightTask extends AbstractReconSqlDBTest {
     assertEquals(300L, getUnReplicatedSizeForTable(MULTIPART_INFO_TABLE));
     // each MPU part is replicated using RATIS THREE, total replicated size = 300 bytes * 3 = 900 bytes.
     assertEquals(900L, getReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+  }
+
+  /**
+   * Validates schema-aware reprocess for a split (schemaVersion 1) MPU: the
+   * multipartInfoTable value carries NO embedded parts, so Recon must read the
+   * part sizes from the separate multipartPartsTable, using the parent MPU's
+   * replication config to compute the replicated size.
+   */
+  @Test
+  public void testReprocessForMultipartInfoTableSplitSchema() throws Exception {
+    String uploadID = UUID.randomUUID().toString();
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    // Split-schema MPU: no embedded parts in the multipartInfoTable value.
+    OmMultipartKeyInfo splitMpu = new OmMultipartKeyInfo.Builder()
+        .setObjectID(1L)
+        .setUploadID(uploadID)
+        .setCreationTime(Time.now())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.THREE))
+        .setSchemaVersion(OmMultipartKeyInfo.SPLIT_PARTS_TABLE_SCHEMA_VERSION)
+        .build();
+    String multipartKey = reconOMMetadataManager.getMultipartKey(volumeName, bucketName, keyName, uploadID);
+    reconOMMetadataManager.getMultipartInfoTable().put(multipartKey, splitMpu);
+
+    // 3 parts of 100 bytes each, stored as rows in the split parts table.
+    putSplitSchemaPart(uploadID, volumeName, bucketName, keyName, 1, 100L);
+    putSplitSchemaPart(uploadID, volumeName, bucketName, keyName, 2, 100L);
+    putSplitSchemaPart(uploadID, volumeName, bucketName, keyName, 3, 100L);
+
+    ReconOmTask.TaskResult result = omTableInsightTask.reprocess(reconOMMetadataManager);
+    assertTrue(result.isTaskSuccess());
+
+    // Count is the number of MPU uploads (1), not the number of parts.
+    assertEquals(1L, getCountForTable(MULTIPART_INFO_TABLE));
+    // 3 split-table parts * 100 bytes = 300 bytes unreplicated.
+    assertEquals(300L, getUnReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+    // RATIS THREE: 300 bytes * 3 = 900 bytes replicated.
+    assertEquals(900L, getReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+  }
+
+  /**
+   * Validates schema-aware reprocess when both legacy (schemaVersion 0, embedded
+   * parts) and split (schemaVersion 1, parts in multipartPartsTable) MPUs coexist
+   * in the same DB. Recon must sum both under the multipartInfoTable stats.
+   */
+  @Test
+  public void testReprocessForMultipartInfoTableMixedSchema() throws Exception {
+    // Legacy MPU: 2 embedded parts of 100 bytes.
+    String legacyUploadID = UUID.randomUUID().toString();
+    String legacyVol = UUID.randomUUID().toString();
+    String legacyBucket = UUID.randomUUID().toString();
+    String legacyKey = UUID.randomUUID().toString();
+    OmMultipartKeyInfo legacyMpu = new OmMultipartKeyInfo.Builder()
+        .setObjectID(1L)
+        .setUploadID(legacyUploadID)
+        .setCreationTime(Time.now())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.THREE))
+        // schemaVersion defaults to LEGACY_SCHEMA_VERSION (0).
+        .build();
+    legacyMpu.addPartKeyInfo(createPartKeyInfo(legacyVol, legacyBucket, legacyKey, legacyUploadID, 1, 100L));
+    legacyMpu.addPartKeyInfo(createPartKeyInfo(legacyVol, legacyBucket, legacyKey, legacyUploadID, 2, 100L));
+    reconOMMetadataManager.getMultipartInfoTable().put(
+        reconOMMetadataManager.getMultipartKey(legacyVol, legacyBucket, legacyKey, legacyUploadID), legacyMpu);
+
+    // Split MPU: 3 parts of 100 bytes in the split parts table.
+    String splitUploadID = UUID.randomUUID().toString();
+    String splitVol = UUID.randomUUID().toString();
+    String splitBucket = UUID.randomUUID().toString();
+    String splitKey = UUID.randomUUID().toString();
+    OmMultipartKeyInfo splitMpu = new OmMultipartKeyInfo.Builder()
+        .setObjectID(2L)
+        .setUploadID(splitUploadID)
+        .setCreationTime(Time.now())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.THREE))
+        .setSchemaVersion(OmMultipartKeyInfo.SPLIT_PARTS_TABLE_SCHEMA_VERSION)
+        .build();
+    reconOMMetadataManager.getMultipartInfoTable().put(
+        reconOMMetadataManager.getMultipartKey(splitVol, splitBucket, splitKey, splitUploadID), splitMpu);
+    putSplitSchemaPart(splitUploadID, splitVol, splitBucket, splitKey, 1, 100L);
+    putSplitSchemaPart(splitUploadID, splitVol, splitBucket, splitKey, 2, 100L);
+    putSplitSchemaPart(splitUploadID, splitVol, splitBucket, splitKey, 3, 100L);
+
+    ReconOmTask.TaskResult result = omTableInsightTask.reprocess(reconOMMetadataManager);
+    assertTrue(result.isTaskSuccess());
+
+    // 2 MPU uploads total (1 legacy + 1 split).
+    assertEquals(2L, getCountForTable(MULTIPART_INFO_TABLE));
+    // Legacy 2*100 (embedded) + split 3*100 (parts table) = 500 bytes unreplicated.
+    assertEquals(500L, getUnReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+    // RATIS THREE: 500 bytes * 3 = 1500 bytes replicated.
+    assertEquals(1500L, getReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+  }
+
+  /**
+   * Writes a single split-schema part (an {@link OmMultipartPartInfo}) to the
+   * multipartPartsTable, keyed by {@code uploadId/partNumber}. An ETag is set
+   * because it is mandatory for split-schema parts.
+   */
+  private void putSplitSchemaPart(String uploadID, String volumeName, String bucketName,
+      String keyName, int partNumber, long dataSize) throws IOException {
+    OmKeyInfo partOmKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.THREE))
+        .setDataSize(dataSize)
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setObjectID(UUID.randomUUID().hashCode())
+        .setUpdateID(1L)
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true)))
+        // ETag is mandatory for split-schema parts.
+        .addMetadata(OzoneConsts.ETAG, "etag-" + partNumber)
+        .build();
+    String partName = reconOMMetadataManager.getMultipartKey(volumeName, bucketName, keyName, uploadID);
+    OmMultipartPartInfo partInfo = OmMultipartPartInfo.from(partName, partNumber, partOmKeyInfo);
+    reconOMMetadataManager.getMultipartPartsTable().put(
+        OmMultipartPartKey.of(uploadID, partNumber), partInfo);
   }
 
   public PartKeyInfo createPartKeyInfo(String volumeName, String bucketName,


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-14666. Add multipart upload split table read for Recon

Please describe your PR in detail:

Recon [MultipartInfoInsightHandler](https://github.com/apache/ozone/blob/master/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java) still uses the old flow of reading parts from the part map.
This should be modified accordingly to read from parts map if the schemaVersion: 0 else refer to the multipartPartTable if the schemaVersion: 1. This PR handles this split read behaviour.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14666

## How was this patch tested?
Patch was tested via unit tests