### PR TITLE
HDDS-15950. Fix NPE in S3 lifecycle GET for date-based expiration

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
@@ -479,7 +479,7 @@ public class S3LifecycleConfiguration {
     if (date != null && !date.isEmpty()) {
       expiration.setDate(date);
     }
-    if (ozoneExpiration.getDays() > 0) {
+    if (ozoneExpiration.getDays() != null && ozoneExpiration.getDays() > 0) {
       expiration.setDays(ozoneExpiration.getDays());
     }
 
@@ -497,7 +497,8 @@ public class S3LifecycleConfiguration {
 
     AbortIncompleteMultipartUpload abortIncompleteMultipartUpload = new AbortIncompleteMultipartUpload();
 
-    if (ozoneAbortIncompleteMultipartUpload.getDaysAfterInitiation() > 0) {
+    if (ozoneAbortIncompleteMultipartUpload.getDaysAfterInitiation() != null
+        && ozoneAbortIncompleteMultipartUpload.getDaysAfterInitiation() > 0) {
       abortIncompleteMultipartUpload.setDaysAfterInitiation(
           ozoneAbortIncompleteMultipartUpload.getDaysAfterInitiation());
     }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationGet.java
@@ -21,6 +21,7 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_LIFECYCLE_CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
@@ -124,6 +125,24 @@ public class TestS3LifecycleConfigurationGet {
         .getDaysAfterInitiation().intValue());
   }
 
+  @Test
+  public void testGetLifecycleWithDateBasedExpiration() throws Exception {
+    String bucketName = "bucket1";
+    bucketEndpoint.put(bucketName, getBodyWithDateExpiration());
+    Response r = bucketEndpoint.get(bucketName);
+
+    assertEquals(HTTP_OK, r.getStatus());
+    S3LifecycleConfiguration lcc = (S3LifecycleConfiguration) r.getEntity();
+    assertEquals(1, lcc.getRules().size());
+    S3LifecycleConfiguration.Rule rule = lcc.getRules().get(0);
+
+    assertEquals("expire-on-date", rule.getId());
+    assertEquals("prefix/", rule.getPrefix());
+    assertEquals("Enabled", rule.getStatus());
+    assertEquals("2044-01-19T00:00:00+00:00", rule.getExpiration().getDate());
+    assertNull(rule.getExpiration().getDays());
+  }
+
   private static InputStream getBody() {
     String xml = ("<LifecycleConfiguration xmlns=\"http://s3.amazonaws" +
         ".com/doc/2006-03-01/\">" +
@@ -147,6 +166,19 @@ public class TestS3LifecycleConfigurationGet {
         "<AbortIncompleteMultipartUpload>" +
         "<DaysAfterInitiation>7</DaysAfterInitiation>" +
         "</AbortIncompleteMultipartUpload>" +
+        "</Rule>" +
+        "</LifecycleConfiguration>";
+
+    return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static InputStream getBodyWithDateExpiration() {
+    String xml = "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Rule>" +
+        "<ID>expire-on-date</ID>" +
+        "<Prefix>prefix/</Prefix>" +
+        "<Status>Enabled</Status>" +
+        "<Expiration><Date>2044-01-19T00:00:00+00:00</Date></Expiration>" +
         "</Rule>" +
         "</LifecycleConfiguration>";
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When converting an Ozone lifecycle configuration back to the S3 response model, `convertFromOzoneExpiration` and
`convertFromOzoneAbortIncompleteMultipartUpload` called `getDays()` and `getDaysAfterInitiation()` directly in a `> 0` comparison. These accessors return boxed `Integer` values that are `null` for date-based rules (which
have a `Date` but no `Days`), so unboxing threw a `NullPointerException` on a `GET` of the lifecycle configuration.

This adds a null check before the `> 0` comparison in both methods so date-based expiration rules are returned correctly.

## What is the link to the Apache JIRA

HDDS-15950

## How was this patch tested?

Tested using added unit test