### PR TITLE
HDDS-15934. Remove usage of internal jersey internal InjectionManager

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -231,10 +231,6 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconRestServletModule.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconRestServletModule.java
@@ -23,6 +23,9 @@ import com.google.inject.servlet.ServletModule;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import javax.inject.Inject;
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriBuilder;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -31,10 +34,7 @@ import org.apache.hadoop.ozone.recon.api.filters.ReconAdminFilter;
 import org.apache.hadoop.ozone.recon.api.filters.ReconAuthFilter;
 import org.apache.hadoop.ozone.recon.chatbot.ChatbotConfigKeys;
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.server.spi.Container;
-import org.glassfish.jersey.server.spi.ContainerLifecycleListener;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.jvnet.hk2.guice.bridge.api.GuiceBridge;
 import org.jvnet.hk2.guice.bridge.api.GuiceIntoHK2Bridge;
@@ -125,31 +125,14 @@ public class ReconRestServletModule extends ServletModule {
  * Class to bridge Guice bindings to Jersey hk2 bindings.
  */
 class GuiceResourceConfig extends ResourceConfig {
-  GuiceResourceConfig() {
-    register(new ContainerLifecycleListener() {
-
-      @Override
-      public void onStartup(Container container) {
-        ServletContainer servletContainer = (ServletContainer) container;
-        InjectionManager injectionManager = container.getApplicationHandler()
-            .getInjectionManager();
-        ServiceLocator serviceLocator = injectionManager
-            .getInstance(ServiceLocator.class);
-        GuiceBridge.getGuiceBridge().initializeGuiceBridge(serviceLocator);
-        GuiceIntoHK2Bridge guiceBridge = serviceLocator
-            .getService(GuiceIntoHK2Bridge.class);
-        Injector injector = (Injector) servletContainer.getServletContext()
-            .getAttribute(Injector.class.getName());
-        guiceBridge.bridgeGuiceInjector(injector);
-      }
-
-      @Override
-      public void onReload(Container container) {
-      }
-
-      @Override
-      public void onShutdown(Container container) {
-      }
-    });
+  @Inject
+  GuiceResourceConfig(ServiceLocator serviceLocator,
+      @Context ServletContext servletContext) {
+    GuiceBridge.getGuiceBridge().initializeGuiceBridge(serviceLocator);
+    GuiceIntoHK2Bridge guiceBridge = serviceLocator
+        .getService(GuiceIntoHK2Bridge.class);
+    Injector injector = (Injector) servletContext
+        .getAttribute(Injector.class.getName());
+    guiceBridge.bridgeGuiceInjector(injector);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recon directly uses Jersey's internal `InjectionManager` API to obtain the HK2 `ServiceLocator` when initializing the Guice-to-HK2 bridge. Depending on an internal Jersey API makes this integration sensitive to Jersey implementation changes.

This PR updates `GuiceResourceConfig` to receive the `ServiceLocator` and `ServletContext` through standard dependency injection. The Guice injector is then bridged to HK2 during resource configuration initialization, without registering a container lifecycle listener or accessing Jersey's internal injection API.

The explicit `jersey-common` dependency is also removed because it is no longer required.

Generated-by: Codex (GPT-5)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15934

## How was this patch tested?

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/30013948598