### PR TITLE
HDDS-15956. Fix Flaky TestClientRetryTimeout

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestClientRetryTimeout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestClientRetryTimeout.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Timeout(600)
+@Timeout(900)
 public class TestClientRetryTimeout {
 
   private static final Logger LOG =
@@ -181,9 +181,9 @@ public class TestClientRetryTimeout {
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(7)
         .build();
-    // Seven datanodes plus multiple pipelines can exceed the 120s default on
-    // a loaded CI runner.
-    cluster.setWaitForClusterToBeReadyTimeout(180000);
+    // waitForClusterToBeReady runs waitForSCMToBeReady and then waits for all
+    // datanodes and safe mode; each step can use the full budget.
+    cluster.setWaitForClusterToBeReadyTimeout(300000);
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE,
         180000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestClientRetryTimeout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestClientRetryTimeout.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +84,7 @@ import org.slf4j.LoggerFactory;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Timeout(600)
 public class TestClientRetryTimeout {
 
   private static final Logger LOG =
@@ -150,6 +152,7 @@ public class TestClientRetryTimeout {
     ratisClient.setExponentialPolicyBaseSleep(Duration.ofMillis(500));
     ratisClient.setExponentialPolicyMaxSleep(Duration.ofSeconds(1));
     ratisClient.setExponentialPolicyMaxRetries(1);
+    ratisClient.setMultilinearPolicy("500ms, 2");
     conf.setFromObject(ratisClient);
 
     RatisClientConfig.RaftConfig raftClient =
@@ -178,6 +181,9 @@ public class TestClientRetryTimeout {
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(7)
         .build();
+    // Seven datanodes plus multiple pipelines can exceed the 120s default on
+    // a loaded CI runner.
+    cluster.setWaitForClusterToBeReadyTimeout(180000);
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE,
         180000);


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestClientRetryTimeout is flaky due to timeout. Could setup timeout parameters to prevent it.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15956

## How was this patch tested?

Integration test.

Test runtime breakdown:
```
testWriteToDeadPipelineFailsFast              11.7s
testWatchForCommitWithDeadFollowersFailsFast  33.4s
testWriteWithLeaderFailureFailsFast           40.0s
testEndToEndWriteWithAllDatanodesDownFailsFast 26.4s
```
