### PR TITLE
HDDS-10315. Speed up TestContainerReplication

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -31,7 +31,6 @@ import static org.apache.hadoop.ozone.container.TestHelper.waitForReplicaCount;
 import static org.apache.ozone.test.GenericTestUtils.setLogLevel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.any;
@@ -71,7 +70,6 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
@@ -119,26 +117,30 @@ class TestContainerReplication {
     setLogLevel(SCMContainerPlacementRandom.class, Level.DEBUG);
   }
 
+  /**
+   * Verifies that a closed RATIS THREE container which becomes under-replicated
+   * after a datanode shutdown is restored to three replicas by ReplicationManager,
+   * and that the configured placement policy records the datanode-choose metrics.
+   * Runs once per placement policy in {@link #containerReplicationArguments()}.
+   */
   @ParameterizedTest
   @MethodSource("containerReplicationArguments")
-  void testContainerReplication(String placementPolicyClass) throws Exception {
+  void testRatisContainerReReplicationAfterDatanodeShutdown(String placementPolicyClass) throws Exception {
 
     OzoneConfiguration conf = createConfiguration();
     conf.set(OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY, placementPolicyClass);
-    try (MiniOzoneCluster cluster = newCluster(conf)) {
+    try (MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build()) {
       cluster.waitForClusterToBeReady();
       SCMContainerPlacementMetrics metrics = cluster.getStorageContainerManager().getPlacementMetrics();
       try (OzoneClient client = cluster.newClient()) {
         createTestData(client);
 
-        List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
-        assertThat(keyLocations).isNotEmpty();
         long datanodeChooseAttemptCount = metrics.getDatanodeChooseAttemptCount();
         long datanodeChooseSuccessCount = metrics.getDatanodeChooseSuccessCount();
         long datanodeChooseFallbackCount = metrics.getDatanodeChooseFallbackCount();
         long datanodeRequestCount = metrics.getDatanodeRequestCount();
 
-        OmKeyLocationInfo keyLocation = keyLocations.get(0);
+        OmKeyLocationInfo keyLocation = lookupKeyFirstLocation(cluster);
         long containerID = keyLocation.getContainerID();
         waitForContainerClose(cluster, containerID);
 
@@ -156,13 +158,6 @@ class TestContainerReplication {
     }
   }
 
-  private static MiniOzoneCluster newCluster(OzoneConfiguration conf)
-      throws IOException {
-    return MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(5)
-        .build();
-  }
-
   private static OzoneConfiguration createConfiguration() {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
@@ -177,14 +172,8 @@ class TestContainerReplication {
     return conf;
   }
 
-  // TODO use common helper to create test data
   private void createTestData(OzoneClient client) throws IOException {
-    ObjectStore objectStore = client.getObjectStore();
-    objectStore.createVolume(VOLUME);
-    OzoneVolume volume = objectStore.getVolume(VOLUME);
-    volume.createBucket(BUCKET);
-
-    OzoneBucket bucket = volume.getBucket(BUCKET);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client, VOLUME, BUCKET);
 
     TestDataUtil.createKey(bucket, KEY,
         RatisReplicationConfig.getInstance(THREE),
@@ -192,30 +181,12 @@ class TestContainerReplication {
   }
 
   private byte[] createTestData(OzoneClient client, int size) throws IOException {
-    ObjectStore objectStore = client.getObjectStore();
-    objectStore.createVolume(VOLUME);
-    OzoneVolume volume = objectStore.getVolume(VOLUME);
-    volume.createBucket(BUCKET);
-    OzoneBucket bucket = volume.getBucket(BUCKET);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client, VOLUME, BUCKET);
 
-    byte[] b = new byte[size];
-    b = RandomUtils.secure().randomBytes(b.length);
+    byte[] b = RandomUtils.secure().randomBytes(size);
     TestDataUtil.createKey(bucket, KEY,
         new ECReplicationConfig("RS-3-2-1k"), b);
     return b;
-  }
-
-  private static List<OmKeyLocationInfo> lookupKey(MiniOzoneCluster cluster)
-      throws IOException {
-    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
-        .setVolumeName(VOLUME)
-        .setBucketName(BUCKET)
-        .setKeyName(KEY)
-        .build();
-    OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
-    OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
-    assertNotNull(locations);
-    return locations.getLocationList();
   }
 
   private static OmKeyLocationInfo lookupKeyFirstLocation(MiniOzoneCluster cluster)
@@ -279,7 +250,7 @@ class TestContainerReplication {
     try (MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(4).build()) {
       cluster.waitForClusterToBeReady();
 
-      try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
+      try (OzoneClient client = cluster.newClient()) {
         List<DatanodeDetails> allNodes =
             cluster.getHddsDatanodes().stream()
                 .map(HddsDatanodeService::getDatanodeDetails)
@@ -323,7 +294,7 @@ class TestContainerReplication {
       // Creating Cluster with 5 Nodes
       try (MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build()) {
         cluster.waitForClusterToBeReady();
-        try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
+        try (OzoneClient client = cluster.newClient()) {
           Set<DatanodeDetails> allNodes =
               cluster.getHddsDatanodes().stream().map(HddsDatanodeService::getDatanodeDetails).collect(
                   Collectors.toSet());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -85,7 +85,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -105,12 +104,10 @@ class TestContainerReplication {
       SCMContainerPlacementRandom.class
   );
 
-  static List<Arguments> containerReplicationArguments() {
-    List<Arguments> arguments = new LinkedList<>();
+  static List<String> containerReplicationArguments() {
+    List<String> arguments = new LinkedList<>();
     for (Class<? extends PlacementPolicy> policyClass : POLICIES) {
-      String canonicalName = policyClass.getCanonicalName();
-      arguments.add(Arguments.arguments(canonicalName, true));
-      arguments.add(Arguments.arguments(canonicalName, false));
+      arguments.add(policyClass.getCanonicalName());
     }
     return arguments;
   }
@@ -124,10 +121,9 @@ class TestContainerReplication {
 
   @ParameterizedTest
   @MethodSource("containerReplicationArguments")
-  void testContainerReplication(
-      String placementPolicyClass, boolean legacyEnabled) throws Exception {
+  void testContainerReplication(String placementPolicyClass) throws Exception {
 
-    OzoneConfiguration conf = createConfiguration(legacyEnabled);
+    OzoneConfiguration conf = createConfiguration();
     conf.set(OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY, placementPolicyClass);
     try (MiniOzoneCluster cluster = newCluster(conf)) {
       cluster.waitForClusterToBeReady();
@@ -151,7 +147,7 @@ class TestContainerReplication {
 
         waitForReplicaCount(containerID, 3, cluster);
 
-        Supplier<String> messageSupplier = () -> "policy=" + placementPolicyClass + " legacy=" + legacyEnabled;
+        Supplier<String> messageSupplier = () -> "policy=" + placementPolicyClass;
         assertEquals(datanodeRequestCount + 1, metrics.getDatanodeRequestCount(), messageSupplier);
         assertThat(metrics.getDatanodeChooseAttemptCount()).isGreaterThan(datanodeChooseAttemptCount);
         assertEquals(datanodeChooseSuccessCount + 1, metrics.getDatanodeChooseSuccessCount(), messageSupplier);
@@ -167,7 +163,7 @@ class TestContainerReplication {
         .build();
   }
 
-  private static OzoneConfiguration createConfiguration(boolean enableLegacy) {
+  private static OzoneConfiguration createConfiguration() {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
@@ -278,7 +274,7 @@ class TestContainerReplication {
 
   @Test
   public void testImportedContainerIsClosed() throws Exception {
-    OzoneConfiguration conf = createConfiguration(false);
+    OzoneConfiguration conf = createConfiguration();
     // create a 4 node cluster
     try (MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(4).build()) {
       cluster.waitForClusterToBeReady();
@@ -315,7 +311,7 @@ class TestContainerReplication {
   @Test
   @Flaky("HDDS-11087")
   public void testECContainerReplication() throws Exception {
-    OzoneConfiguration conf = createConfiguration(false);
+    OzoneConfiguration conf = createConfiguration();
     final Map<Integer, Integer> failedReadChunkCountMap = new ConcurrentHashMap<>();
     // Overiding Config to support 1k Chunk size
     conf.set("ozone.replication.allowed-configs", "(^((STANDALONE|RATIS)/(ONE|THREE))|(EC/(3-2|6-3|10-4)-" +

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -39,12 +39,10 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -284,7 +282,7 @@ class TestContainerReplication {
   public void testECContainerReplication() throws Exception {
     OzoneConfiguration conf = createConfiguration();
     final Map<Integer, Integer> failedReadChunkCountMap = new ConcurrentHashMap<>();
-    // Overiding Config to support 1k Chunk size
+    // Overriding Config to support 1k Chunk size
     conf.set("ozone.replication.allowed-configs", "(^((STANDALONE|RATIS)/(ONE|THREE))|(EC/(3-2|6-3|10-4)-" +
         "(512|1024|2048|4096|1)k)$)");
     conf.set(OZONE_SCM_CONTAINER_PLACEMENT_EC_IMPL_KEY, SCMContainerPlacementRackScatter.class.getCanonicalName());
@@ -295,19 +293,6 @@ class TestContainerReplication {
       try (MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build()) {
         cluster.waitForClusterToBeReady();
         try (OzoneClient client = cluster.newClient()) {
-          Set<DatanodeDetails> allNodes =
-              cluster.getHddsDatanodes().stream().map(HddsDatanodeService::getDatanodeDetails).collect(
-                  Collectors.toSet());
-          List<DatanodeDetails> initialNodesWithData = new ArrayList<>();
-          // Keeping 5 DNs and stopping the 6th Node here it is kept in the var extraNodes
-          for (DatanodeDetails dn : allNodes) {
-            if (initialNodesWithData.size() < 5) {
-              initialNodesWithData.add(dn);
-            } else {
-              cluster.shutdownHddsDatanode(dn);
-            }
-          }
-
           // Creating 2 stripes with Chunk Size 1k
           int size = 6 * 1024;
           byte[] originalData = createTestData(client, size);
@@ -316,6 +301,12 @@ class TestContainerReplication {
           final OmKeyLocationInfo keyLocation = lookupKeyFirstLocation(cluster);
           long containerID = keyLocation.getContainerID();
           waitForContainerClose(cluster, containerID);
+
+          // The cluster has 5 datanodes and the key is written as EC RS-3-2 (3 data + 2 parity = 5
+          // replica indices), so every datanode now holds exactly one replica index.
+          List<DatanodeDetails> initialNodesWithData =
+              cluster.getHddsDatanodes().stream().map(HddsDatanodeService::getDatanodeDetails)
+                  .collect(Collectors.toList());
 
           // Forming Replica Index Map
           Map<Integer, DatanodeDetails> replicaIndexMap =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactors the `TestContainerReplication` integration test to reduce runtime and duplication.

Reduce runtime:
- The `legacyEnabled` parameter is no longer used, so drop the `legacyEnabled` parameter dimension:
    - `createConfiguration(boolean enableLegacy)` becomes `createConfiguration()`.    
    - `containerReplicationArguments()` now yields `(policyClass)` instead of (`policyClass, legacyEnabled)`, halving the parameterized runs.  
    - Renamed the test from `testContainerReplication` to `testRatisContainerReReplicationAfterDatanodeShutdown` and added a Javadoc describing what it verifies. 

Cleanup:
- Both createTestData overloads reuse the existing `TestDataUtil.createVolumeAndBucket(...)` helper instead of hand-rolled  volume/bucket setup.
- Replaced  `OzoneClientFactory.getRpcClient(conf)` with `cluster.newClient()`.
- Replaced the one-off `newCluster` helper with the inline `MiniOzoneCluster` builder.
- Removed `lookupKey(...)` helper and folded into the existing `lookupKeyFirstLocation(...)`. Dropped unused imports and a stale TODO.                     
- Simplify `testECContainerReplication` datanode setup. 
- fixes a Overiding → Overriding typo.   

### Original running time (223.7 s)

```
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.container.TestContainerReplication
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 223.7 s -- in org.apache.hadoop.ozone.container.TestContainerReplication
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testECContainerReplication -- Time elapsed: 40.69 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testImportedContainerIsClosed -- Time elapsed: 32.48 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testContainerReplication(String, boolean)[1] -- Time elapsed: 24.52 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testContainerReplication(String, boolean)[2] -- Time elapsed: 24.35 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testContainerReplication(String, boolean)[3] -- Time elapsed: 25.54 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testContainerReplication(String, boolean)[4] -- Time elapsed: 24.42 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testContainerReplication(String, boolean)[5] -- Time elapsed: 24.91 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testContainerReplication(String, boolean)[6] -- Time elapsed: 26.51 s
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:00 min
[INFO] Finished at: 2026-07-23T10:30:16+09:00
[INFO] ------------------------------------------------------------------------
```

### Running time After Refactor (140.8s): 82.9 s faster

```
[INFO] Running org.apache.hadoop.ozone.container.TestContainerReplication
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 140.8 s -- in org.apache.hadoop.ozone.container.TestContainerReplication
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testECContainerReplication -- Time elapsed: 35.28 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testImportedContainerIsClosed -- Time elapsed: 31.83 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testRatisContainerReReplicationAfterDatanodeShutdown(String)[1] -- Time elapsed: 24.40 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testRatisContainerReReplicationAfterDatanodeShutdown(String)[2] -- Time elapsed: 25.11 s
[INFO] org.apache.hadoop.ozone.container.TestContainerReplication.testRatisContainerReReplicationAfterDatanodeShutdown(String)[3] -- Time elapsed: 24.11 s
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10315

## How was this patch tested?

Ran the test suite:

```
mvn -pl :ozone-integration-test test \
-Dtest='org.apache.hadoop.ozone.container.TestContainerReplication' \
-Dsurefire.reportFormat=plain \
-Dsurefire.useFile=false \
-DskipShade -DskipRecon
```

Result: all tests passed.