### PR TITLE
HDDS-15961. Resolve linked bucket source properties consistently

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -406,19 +406,19 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
    */
   public OmBucketInfo withOperationalPropertiesFrom(OmBucketInfo source) {
     return toBuilder()
-        .setDefaultReplicationConfig(source.getDefaultReplicationConfig())
-        .setBucketEncryptionKey(source.getEncryptionKeyInfo())
-        .setIsVersionEnabled(source.getIsVersionEnabled())
         .setStorageType(source.getStorageType())
-        .setQuotaInBytes(source.getQuotaInBytes())
-        .setQuotaInNamespace(source.getQuotaInNamespace())
+        .setIsVersionEnabled(source.getIsVersionEnabled())
+        .setBucketEncryptionKey(source.getEncryptionKeyInfo())
         .setUsedBytes(source.getUsedBytes())
         .setUsedNamespace(source.getUsedNamespace())
+        .setQuotaInBytes(source.getQuotaInBytes())
+        .setQuotaInNamespace(source.getQuotaInNamespace())
         .setSnapshotUsedBytes(source.getSnapshotUsedBytes())
         .setSnapshotUsedNamespace(source.getSnapshotUsedNamespace())
-        .addAllMetadata(source.getMetadata())
         .setBucketLayout(source.getBucketLayout())
+        .setDefaultReplicationConfig(source.getDefaultReplicationConfig())
         .setTags(source.getTags())
+        .addAllMetadata(source.getMetadata())
         .build();
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -407,6 +407,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
   public OmBucketInfo withOperationalPropertiesFrom(OmBucketInfo source) {
     return toBuilder()
         .setDefaultReplicationConfig(source.getDefaultReplicationConfig())
+        .setBucketEncryptionKey(source.getEncryptionKeyInfo())
         .setIsVersionEnabled(source.getIsVersionEnabled())
         .setStorageType(source.getStorageType())
         .setQuotaInBytes(source.getQuotaInBytes())

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -148,6 +148,27 @@ public class TestOmBucketInfo {
   }
 
   @Test
+  public void testWithOperationalPropertiesFromCopiesEncryptionInfo() {
+    BucketEncryptionKeyInfo encryptionKeyInfo =
+        new BucketEncryptionKeyInfo.Builder().setKeyName("key1").build();
+    OmBucketInfo source = OmBucketInfo.newBuilder()
+        .setVolumeName("vol1")
+        .setBucketName("source")
+        .setBucketEncryptionKey(encryptionKeyInfo)
+        .build();
+    OmBucketInfo link = OmBucketInfo.newBuilder()
+        .setVolumeName("vol1")
+        .setBucketName("link")
+        .setSourceVolume("vol1")
+        .setSourceBucket("source")
+        .build();
+
+    OmBucketInfo resolvedLink = link.withOperationalPropertiesFrom(source);
+
+    assertEquals(encryptionKeyInfo, resolvedLink.getEncryptionKeyInfo());
+  }
+
+  @Test
   public void getProtobufMessageEC() {
     OmBucketInfo omBucketInfo =
         OmBucketInfo.newBuilder().setBucketName("bucket").setVolumeName("vol1")

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3061,20 +3061,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (resolvedBucket.isDangling()) {
       return bucketInfo;
     }
-    if (getAclsEnabled()) {
-      try {
-        omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
-            ACLType.READ, resolvedBucket.realVolume(),
-            resolvedBucket.realBucket(), null);
-      } catch (OMException e) {
-        if (e.getResult() == PERMISSION_DENIED) {
-          return bucketInfo;
-        }
-        throw e;
-      }
-    }
     OmBucketInfo realBucket = getResolvedSourceBucket(resolvedBucket, resolvedSourceCache);
-    return bucketInfo.withOperationalPropertiesFrom(realBucket);
+    return realBucket != null
+        ? bucketInfo.withOperationalPropertiesFrom(realBucket)
+        : bucketInfo;
   }
 
   private OmBucketInfo getResolvedSourceBucket(
@@ -3088,6 +3078,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       OmBucketInfo cachedSource = resolvedSourceCache.get(sourceKey);
       if (cachedSource != null) {
         return cachedSource;
+      }
+    }
+    if (getAclsEnabled()) {
+      try {
+        omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+            ACLType.READ, resolvedBucket.realVolume(),
+            resolvedBucket.realBucket(), null);
+      } catch (OMException e) {
+        if (e.getResult() == PERMISSION_DENIED) {
+          return null;
+        }
+        throw e;
       }
     }
     OmBucketInfo realBucket = bucketManager.getBucketInfo(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3062,9 +3062,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return bucketInfo;
     }
     OmBucketInfo realBucket = getResolvedSourceBucket(resolvedBucket, resolvedSourceCache);
-    return realBucket != null
-        ? bucketInfo.withOperationalPropertiesFrom(realBucket)
-        : bucketInfo;
+    return bucketInfo.withOperationalPropertiesFrom(realBucket);
   }
 
   private OmBucketInfo getResolvedSourceBucket(
@@ -3081,16 +3079,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       }
     }
     if (getAclsEnabled()) {
-      try {
-        omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
-            ACLType.READ, resolvedBucket.realVolume(),
-            resolvedBucket.realBucket(), null);
-      } catch (OMException e) {
-        if (e.getResult() == PERMISSION_DENIED) {
-          return null;
-        }
-        throw e;
-      }
+      omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+          ACLType.READ, resolvedBucket.realVolume(),
+          resolvedBucket.realBucket(), null);
     }
     OmBucketInfo realBucket = bucketManager.getBucketInfo(
         resolvedBucket.realVolume(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3062,7 +3062,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return bucketInfo;
     }
     OmBucketInfo realBucket = getResolvedSourceBucket(resolvedBucket, resolvedSourceCache);
-    return bucketInfo.withOperationalPropertiesFrom(realBucket);
+    return realBucket != null
+        ? bucketInfo.withOperationalPropertiesFrom(realBucket)
+        : bucketInfo;
   }
 
   private OmBucketInfo getResolvedSourceBucket(
@@ -3079,9 +3081,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       }
     }
     if (getAclsEnabled()) {
-      omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
-          ACLType.READ, resolvedBucket.realVolume(),
-          resolvedBucket.realBucket(), null);
+      try {
+        omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+            ACLType.READ, resolvedBucket.realVolume(),
+            resolvedBucket.realBucket(), null);
+      } catch (OMException e) {
+        if (e.getResult() == PERMISSION_DENIED) {
+          return null;
+        }
+        throw e;
+      }
     }
     OmBucketInfo realBucket = bucketManager.getBucketInfo(
         resolvedBucket.realVolume(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3061,6 +3061,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (resolvedBucket.isDangling()) {
       return bucketInfo;
     }
+    if (getAclsEnabled()) {
+      try {
+        omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE,
+            ACLType.READ, resolvedBucket.realVolume(),
+            resolvedBucket.realBucket(), null);
+      } catch (OMException e) {
+        if (e.getResult() == PERMISSION_DENIED) {
+          return bucketInfo;
+        }
+        throw e;
+      }
+    }
     OmBucketInfo realBucket = getResolvedSourceBucket(resolvedBucket, resolvedSourceCache);
     return bucketInfo.withOperationalPropertiesFrom(realBucket);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -596,6 +597,34 @@ class TestBucketManagerImpl extends OzoneTestBase {
     assertSame(link, result.get(0));
     assertSame(regular, result.get(1));
     verify(metadataReader).checkAcls(BUCKET, OZONE, READ, sourceVolume, "source", null);
+  }
+
+  @Test
+  void testListBucketsChecksSourceReadAccessOncePerSource() throws Exception {
+    String linkVolume = volumeName();
+    String sourceVolume = volumeName();
+    OmBucketInfo firstLink = createLinkBucketInfo(linkVolume, sourceVolume)
+        .toBuilder()
+        .setBucketName("link1")
+        .build();
+    OmBucketInfo secondLink = createLinkBucketInfo(linkVolume, sourceVolume)
+        .toBuilder()
+        .setBucketName("link2")
+        .build();
+    OmBucketInfo source = createSourceBucketInfo(sourceVolume);
+    BucketManager bucketManager = mock(BucketManager.class);
+    when(bucketManager.listBuckets(linkVolume, "", "", 100, false))
+        .thenReturn(new ArrayList<>(Arrays.asList(firstLink, secondLink)));
+    when(bucketManager.getBucketInfo(sourceVolume, "source")).thenReturn(source);
+    OmMetadataReader metadataReader = mock(OmMetadataReader.class);
+    OzoneManager omSpy = createAclEnabledOmSpy(bucketManager, metadataReader);
+
+    List<OmBucketInfo> result = omSpy.listBuckets(linkVolume, "", "", 100, false);
+
+    assertEquals("sourceValue", result.get(0).getMetadata().get("sourceKey"));
+    assertEquals("sourceValue", result.get(1).getMetadata().get("sourceKey"));
+    verify(metadataReader, times(1))
+        .checkAcls(BUCKET, OZONE, READ, sourceVolume, "source", null);
   }
 
   private static OmBucketInfo createLinkBucketInfo(String linkVolume, String sourceVolume) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -570,8 +570,11 @@ class TestBucketManagerImpl extends OzoneTestBase {
 
     OmBucketInfo result = omSpy.getBucketInfo(linkVolume, "link");
 
-    assertSame(link, result);
+    assertThat(result.getMetadata())
+        .containsEntry("linkKey", "linkValue")
+        .doesNotContainKey("sourceKey");
     verify(metadataReader).checkAcls(BUCKET, OZONE, READ, sourceVolume, "source", null);
+    verify(bucketManager, times(1)).getBucketInfo(sourceVolume, "source");
   }
 
   @Test
@@ -594,9 +597,12 @@ class TestBucketManagerImpl extends OzoneTestBase {
 
     List<OmBucketInfo> result = omSpy.listBuckets(linkVolume, "", "", 100, false);
 
-    assertSame(link, result.get(0));
+    assertThat(result.get(0).getMetadata())
+        .containsEntry("linkKey", "linkValue")
+        .doesNotContainKey("sourceKey");
     assertSame(regular, result.get(1));
     verify(metadataReader).checkAcls(BUCKET, OZONE, READ, sourceVolume, "source", null);
+    verify(bucketManager, times(1)).getBucketInfo(sourceVolume, "source");
   }
 
   @Test
@@ -658,7 +664,7 @@ class TestBucketManagerImpl extends OzoneTestBase {
     OzoneManager omSpy = spy(omTestManagers.getOzoneManager());
     HddsWhiteboxTestUtils.setInternalState(omSpy, "bucketManager", bucketManager);
     HddsWhiteboxTestUtils.setInternalState(omSpy, "omMetadataReader", metadataReader);
-    doReturn(true).when(omSpy).getAclsEnabled();
+    when(omSpy.getAclsEnabled()).thenReturn(true);
     AuditMessage auditMessage = mock(AuditMessage.class);
     when(auditMessage.getOp()).thenReturn("READ_BUCKET");
     doReturn(auditMessage).when(omSpy).buildAuditMessageForSuccess(any(), anyMap());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -556,7 +556,7 @@ class TestBucketManagerImpl extends OzoneTestBase {
   }
 
   @Test
-  void testGetBucketInfoDoesNotCopySourcePropertiesWithoutReadAccess() throws Exception {
+  void testGetBucketInfoFailsWithoutSourceReadAccess() throws Exception {
     String linkVolume = volumeName();
     String sourceVolume = volumeName();
     OmBucketInfo link = createLinkBucketInfo(linkVolume, sourceVolume);
@@ -568,11 +568,10 @@ class TestBucketManagerImpl extends OzoneTestBase {
     denySourceRead(metadataReader, sourceVolume);
     OzoneManager omSpy = createAclEnabledOmSpy(bucketManager, metadataReader);
 
-    OmBucketInfo result = omSpy.getBucketInfo(linkVolume, "link");
+    OMException exception = assertThrows(OMException.class,
+        () -> omSpy.getBucketInfo(linkVolume, "link"));
 
-    assertThat(result.getMetadata())
-        .containsEntry("linkKey", "linkValue")
-        .doesNotContainKey("sourceKey");
+    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
     verify(metadataReader).checkAcls(BUCKET, OZONE, READ, sourceVolume, "source", null);
     verify(bucketManager, times(1)).getBucketInfo(sourceVolume, "source");
   }
@@ -666,8 +665,10 @@ class TestBucketManagerImpl extends OzoneTestBase {
     HddsWhiteboxTestUtils.setInternalState(omSpy, "omMetadataReader", metadataReader);
     when(omSpy.getAclsEnabled()).thenReturn(true);
     AuditMessage auditMessage = mock(AuditMessage.class);
-    when(auditMessage.getOp()).thenReturn("READ_BUCKET");
-    doReturn(auditMessage).when(omSpy).buildAuditMessageForSuccess(any(), anyMap());
+    lenient().when(auditMessage.getOp()).thenReturn("READ_BUCKET");
+    lenient().doReturn(auditMessage).when(omSpy).buildAuditMessageForSuccess(any(), anyMap());
+    lenient().doReturn(auditMessage).when(omSpy)
+        .buildAuditMessageForFailure(any(), anyMap(), any(Throwable.class));
     return omSpy;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -556,7 +556,7 @@ class TestBucketManagerImpl extends OzoneTestBase {
   }
 
   @Test
-  void testGetBucketInfoFailsWithoutSourceReadAccess() throws Exception {
+  void testGetBucketInfoReturnsLinkWithoutSourceReadAccess() throws Exception {
     String linkVolume = volumeName();
     String sourceVolume = volumeName();
     OmBucketInfo link = createLinkBucketInfo(linkVolume, sourceVolume);
@@ -568,10 +568,11 @@ class TestBucketManagerImpl extends OzoneTestBase {
     denySourceRead(metadataReader, sourceVolume);
     OzoneManager omSpy = createAclEnabledOmSpy(bucketManager, metadataReader);
 
-    OMException exception = assertThrows(OMException.class,
-        () -> omSpy.getBucketInfo(linkVolume, "link"));
+    OmBucketInfo result = omSpy.getBucketInfo(linkVolume, "link");
 
-    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
+    assertThat(result.getMetadata())
+        .containsEntry("linkKey", "linkValue")
+        .doesNotContainKey("sourceKey");
     verify(metadataReader).checkAcls(BUCKET, OZONE, READ, sourceVolume, "source", null);
     verify(bucketManager, times(1)).getBucketInfo(sourceVolume, "source");
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -18,18 +18,29 @@
 package org.apache.hadoop.ozone.om;
 
 import static java.util.Collections.singletonMap;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.BUCKET;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.crypto.key.KeyProvider;
@@ -41,7 +52,9 @@ import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
@@ -539,5 +552,87 @@ class TestBucketManagerImpl extends OzoneTestBase {
         listedObsLink.getDefaultReplicationConfig().getReplicationConfig());
     assertEquals(volume, listedObsLink.getSourceVolume());
     assertEquals("obs-source", listedObsLink.getSourceBucket());
+  }
+
+  @Test
+  void testGetBucketInfoDoesNotCopySourcePropertiesWithoutReadAccess() throws Exception {
+    String linkVolume = volumeName();
+    String sourceVolume = volumeName();
+    OmBucketInfo link = createLinkBucketInfo(linkVolume, sourceVolume);
+    OmBucketInfo source = createSourceBucketInfo(sourceVolume);
+    BucketManager bucketManager = mock(BucketManager.class);
+    when(bucketManager.getBucketInfo(linkVolume, "link")).thenReturn(link);
+    when(bucketManager.getBucketInfo(sourceVolume, "source")).thenReturn(source);
+    OmMetadataReader metadataReader = mock(OmMetadataReader.class);
+    denySourceRead(metadataReader, sourceVolume);
+    OzoneManager omSpy = createAclEnabledOmSpy(bucketManager, metadataReader);
+
+    OmBucketInfo result = omSpy.getBucketInfo(linkVolume, "link");
+
+    assertSame(link, result);
+    verify(metadataReader).checkAcls(BUCKET, OZONE, READ, sourceVolume, "source", null);
+  }
+
+  @Test
+  void testListBucketsDoesNotCopySourcePropertiesWithoutReadAccess() throws Exception {
+    String linkVolume = volumeName();
+    String sourceVolume = volumeName();
+    OmBucketInfo link = createLinkBucketInfo(linkVolume, sourceVolume);
+    OmBucketInfo source = createSourceBucketInfo(sourceVolume);
+    OmBucketInfo regular = OmBucketInfo.newBuilder()
+        .setVolumeName(linkVolume)
+        .setBucketName("regular")
+        .build();
+    BucketManager bucketManager = mock(BucketManager.class);
+    when(bucketManager.listBuckets(linkVolume, "", "", 100, false))
+        .thenReturn(new ArrayList<>(Arrays.asList(link, regular)));
+    when(bucketManager.getBucketInfo(sourceVolume, "source")).thenReturn(source);
+    OmMetadataReader metadataReader = mock(OmMetadataReader.class);
+    denySourceRead(metadataReader, sourceVolume);
+    OzoneManager omSpy = createAclEnabledOmSpy(bucketManager, metadataReader);
+
+    List<OmBucketInfo> result = omSpy.listBuckets(linkVolume, "", "", 100, false);
+
+    assertSame(link, result.get(0));
+    assertSame(regular, result.get(1));
+    verify(metadataReader).checkAcls(BUCKET, OZONE, READ, sourceVolume, "source", null);
+  }
+
+  private static OmBucketInfo createLinkBucketInfo(String linkVolume, String sourceVolume) {
+    return OmBucketInfo.newBuilder()
+        .setVolumeName(linkVolume)
+        .setBucketName("link")
+        .setSourceVolume(sourceVolume)
+        .setSourceBucket("source")
+        .addAllMetadata(singletonMap("linkKey", "linkValue"))
+        .build();
+  }
+
+  private static OmBucketInfo createSourceBucketInfo(String sourceVolume) {
+    return OmBucketInfo.newBuilder()
+        .setVolumeName(sourceVolume)
+        .setBucketName("source")
+        .addAllMetadata(singletonMap("sourceKey", "sourceValue"))
+        .build();
+  }
+
+  private static void denySourceRead(OmMetadataReader metadataReader, String sourceVolume) throws IOException {
+    doAnswer(invocation -> {
+      if (sourceVolume.equals(invocation.getArgument(3)) && "source".equals(invocation.getArgument(4))) {
+        throw new OMException("denied", ResultCodes.PERMISSION_DENIED);
+      }
+      return null;
+    }).when(metadataReader).checkAcls(any(), any(), any(), any(), any(), any());
+  }
+
+  private OzoneManager createAclEnabledOmSpy(BucketManager bucketManager, OmMetadataReader metadataReader) {
+    OzoneManager omSpy = spy(omTestManagers.getOzoneManager());
+    HddsWhiteboxTestUtils.setInternalState(omSpy, "bucketManager", bucketManager);
+    HddsWhiteboxTestUtils.setInternalState(omSpy, "omMetadataReader", metadataReader);
+    doReturn(true).when(omSpy).getAclsEnabled();
+    AuditMessage auditMessage = mock(AuditMessage.class);
+    when(auditMessage.getOp()).thenReturn("READ_BUCKET");
+    doReturn(auditMessage).when(omSpy).buildAuditMessageForSuccess(any(), anyMap());
+    return omSpy;
   }
 }


### PR DESCRIPTION
Generated-by: Codex (GPT-5.6 Sol)

## What changes were proposed in this pull request?

HDDS-9117 changed `getBucketInfo` so linked buckets return selected operational properties from their resolved source bucket. HDDS-15624 extracted this behavior into shared logic and applied it to `listBuckets`.

This patch addresses the remaining inconsistencies:

- Check `READ` access on the resolved source bucket before copying its operational properties into a linked bucket response. If source `READ` access is denied, both `getBucketInfo` and `listBuckets` return the stored link information without copying source operational properties; `listBuckets` continues processing the remaining entries.
- Reuse successfully authorized source bucket information within one `listBuckets` call when multiple links resolve to the same source.
- Copy `BucketEncryptionKeyInfo` from the resolved source bucket.
- Keep the operational property setter order consistent with `OmBucketInfo#toBuilder`.

The link bucket's identity fields—including its volume, bucket name, owner, source path, ACLs, timestamps, and object/update IDs—remain unchanged. `listBuckets` also continues processing subsequent entries when a link cannot be enriched.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15961

## How was this patch tested?

The following test cases were added:

- `TestOmBucketInfo#testWithOperationalPropertiesFromCopiesEncryptionInfo`
- `TestBucketManagerImpl#testGetBucketInfoReturnsLinkWithoutSourceReadAccess`
- `TestBucketManagerImpl#testListBucketsDoesNotCopySourcePropertiesWithoutReadAccess`
- `TestBucketManagerImpl#testListBucketsChecksSourceReadAccessOncePerSource`

