### PR TITLE
HDDS-15958. Return InvalidURI for unreadable S3 object keys on GetObject

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -1338,6 +1338,26 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     }
   }
 
+  /**
+   * Adapted from ceph s3-tests test_object_read_unreadable.
+   */
+  @Test
+  public void testGetObjectUnreadableKey() {
+    final String bucketName = getBucketName();
+    s3Client.createBucket(bucketName);
+
+    String unreadableKey = new String(new byte[] {(byte) 0xae, (byte) 0x8a, '-'},
+        StandardCharsets.ISO_8859_1);
+
+    AmazonServiceException ase = assertThrows(AmazonServiceException.class,
+        () -> s3Client.getObject(bucketName, unreadableKey));
+
+    assertEquals(ErrorType.Client, ase.getErrorType());
+    assertEquals(400, ase.getStatusCode());
+    assertEquals(S3ErrorTable.INVALID_URI.getCode(), ase.getErrorCode());
+    assertEquals(S3ErrorTable.INVALID_URI.getErrorMessage(), ase.getErrorMessage());
+  }
+
   static Stream<Arguments> onlyTagKeyCasesV1() {
     Map<String, String> fooBarEmptyBar = new HashMap<>();
     fooBarEmptyBar.put("foo", "bar");

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -588,6 +588,25 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     assertEquals(304, exception.statusCode());
   }
 
+  /**
+   * Adapted from ceph s3-tests test_object_read_unreadable.
+   */
+  @Test
+  public void testGetObjectUnreadableKey() {
+    final String bucketName = getBucketName();
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    String unreadableKey = new String(new byte[] {(byte) 0xae, (byte) 0x8a, '-'},
+        StandardCharsets.ISO_8859_1);
+
+    S3Exception exception = assertThrows(S3Exception.class,
+        () -> s3Client.getObjectAsBytes(b -> b.bucket(bucketName).key(unreadableKey)));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals(S3ErrorTable.INVALID_URI.getCode(), exception.awsErrorDetails().errorCode());
+    assertEquals(S3ErrorTable.INVALID_URI.getErrorMessage(), exception.awsErrorDetails().errorMessage());
+  }
+
   @Test
   public void testHeadObjectIfMatch() {
     final String bucketName = getBucketName();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -31,6 +31,7 @@ import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_CLIENT_BU
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_TAG;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_URI;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.AWS_TAG_PREFIX;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_HEADER_PREFIX;
@@ -615,6 +616,23 @@ public abstract class EndpointBase {
     ResultCodes result = ex.getResult();
     return result == ResultCodes.PERMISSION_DENIED
         || result == ResultCodes.INVALID_TOKEN;
+  }
+
+  /**
+   * Reject object keys that cannot be represented in a valid URI. AWS S3 returns
+   * InvalidURI for unreadable keys (non-printable ASCII 128-255) before lookup.
+   */
+  protected void validateObjectKeyUri(String keyPath) throws OS3Exception {
+    if (keyPath == null || keyPath.indexOf('\uFFFD') >= 0) {
+      throw newError(INVALID_URI, keyPath);
+    }
+
+    for (int i = 0; i < keyPath.length(); i++) {
+      char c = keyPath.charAt(i);
+      if (c >= 0x80 && c <= 0xFF) {
+        throw newError(INVALID_URI, keyPath);
+      }
+    }
   }
 
   protected ReplicationConfig getReplicationConfig(OzoneBucket ozoneBucket) throws OS3Exception {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -620,7 +620,7 @@ public abstract class EndpointBase {
 
   /**
    * Reject object keys that cannot be represented in a valid URI. AWS S3 returns
-   * InvalidURI for unreadable keys (non-printable ASCII 128-255) before lookup.
+   * InvalidURI for keys containing malformed UTF-8 or ISO control characters.
    */
   protected void validateObjectKeyUri(String keyPath) throws OS3Exception {
     if (keyPath == null || keyPath.indexOf('\uFFFD') >= 0) {
@@ -628,8 +628,7 @@ public abstract class EndpointBase {
     }
 
     for (int i = 0; i < keyPath.length(); i++) {
-      char c = keyPath.charAt(i);
-      if (c >= 0x80 && c <= 0xFF) {
+      if (Character.isISOControl(keyPath.charAt(i))) {
         throw newError(INVALID_URI, keyPath);
       }
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -364,6 +364,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
   ) throws IOException, OS3Exception {
     ObjectRequestContext context = new ObjectRequestContext(S3GAction.GET_KEY, bucketName);
     try {
+      validateObjectKeyUri(keyPath);
       return handler.handleGetRequest(context, keyPath);
     } catch (OMException ex) {
       throw newError(bucketName, keyPath, ex);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -126,8 +126,17 @@ public class TestObjectGet {
     String unreadableKey = new String(new byte[] {(byte) 0xae, (byte) 0x8a, '-'}, ISO_8859_1);
     assertErrorResponse(INVALID_URI, () -> get(rest, BUCKET_NAME, unreadableKey));
 
-    String malformedUtf8Key = new String(new byte[] {(byte) 0xae, (byte) 0x8a, '-'}, UTF_8);
+    String malformedUtf8Key = new String(new byte[] {(byte) 0xff}, UTF_8);
     assertErrorResponse(INVALID_URI, () -> get(rest, BUCKET_NAME, malformedUtf8Key));
+  }
+
+  @Test
+  public void testGetValidUnicodeKey() throws Exception {
+    String unicodeKey = "café.txt";
+    assertSucceeds(() -> put(rest, BUCKET_NAME, unicodeKey, CONTENT));
+    Response response = get(rest, BUCKET_NAME, unicodeKey);
+    assertEquals(String.valueOf(CONTENT.length()),
+        response.getHeaderString("Content-Length"));
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -17,12 +17,15 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertSucceeds;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.get;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.put;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_URI;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_KEY;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_HEADER_PREFIX;
@@ -116,6 +119,15 @@ public class TestObjectGet {
     rest.queryParamsForTest().setInt(S3Consts.QueryParams.PART_NUMBER, -1);
     assertErrorResponse(INVALID_ARGUMENT,
         () -> get(rest, BUCKET_NAME, KEY_NAME));
+  }
+
+  @Test
+  public void testGetUnreadableKey() {
+    String unreadableKey = new String(new byte[] {(byte) 0xae, (byte) 0x8a, '-'}, ISO_8859_1);
+    assertErrorResponse(INVALID_URI, () -> get(rest, BUCKET_NAME, unreadableKey));
+
+    String malformedUtf8Key = new String(new byte[] {(byte) 0xae, (byte) 0x8a, '-'}, UTF_8);
+    assertErrorResponse(INVALID_URI, () -> get(rest, BUCKET_NAME, malformedUtf8Key));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
S3 Gateway returns `404 NoSuchKey` for GetObject requests with unreadable/invalid object keys, instead of `400 InvalidURI `as AWS S3 does.

Ozone already defines the correct error in S3ErrorTable.INVALID_URI but never uses it:
`INVALID_URI("InvalidURI", "Couldn't parse the specified URI.", HTTP_BAD_REQUEST)`

The key **\xae\x8a**- contains non-printable high bytes (\x80–\xff) that Ozone cannot store and that AWS treats as an invalid URI. S3G should reject it before OM lookup.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15958
## How was this patch tested?

Add Unit and Integration Tests.