### PR TITLE
HDDS-15963. Fix EC degraded read NPE caused by CodecRegistry depending on TCCL in isolated ClassLoader

### DIFF
--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/CodecRegistry.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/CodecRegistry.java
@@ -51,7 +51,8 @@ public final class CodecRegistry {
     coderMap = new HashMap<>();
     coderNameMap = new HashMap<>();
     final ServiceLoader<RawErasureCoderFactory> coderFactories =
-        ServiceLoader.load(RawErasureCoderFactory.class);
+        ServiceLoader.load(RawErasureCoderFactory.class,
+            CodecRegistry.class.getClassLoader());
     updateCoders(coderFactories);
   }
 

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/TestCodecRegistryTcclIsolation.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/TestCodecRegistryTcclIsolation.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ozone.erasurecode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.ozone.erasurecode.rawcoder.RSRawErasureCoderFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that CodecRegistry does not depend on the thread context class loader
+ * (TCCL) for discovering RawErasureCoderFactory providers.
+ *
+ * <p>CodecRegistry is an eagerly-initialized singleton, so this test must run
+ * in its own JVM (e.g. reuseForks=false) as the first test to touch
+ * CodecRegistry, otherwise initialization already happened under the normal
+ * TCCL and the test passes vacuously.
+ */
+public class TestCodecRegistryTcclIsolation {
+
+  @Test
+  public void testRegistryLoadsWithoutTccl() {
+    ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(new ClassLoader(null) {
+      });
+      String[] rsCoderNames = CodecRegistry.getInstance()
+          .getCoderNames(ECReplicationConfig.EcCodec.RS.name().toLowerCase());
+      assertThat(rsCoderNames).isNotNull();
+      assertThat(rsCoderNames).isNotEmpty();
+      assertThat(rsCoderNames).contains(RSRawErasureCoderFactory.CODER_NAME);
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalTccl);
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes a `NullPointerException` during EC degraded reads when the Ozone client runs inside an isolated plugin class loader (e.g. Trino Hive connector).

Normal reads succeed, but when a DataNode is unavailable, the EC degraded read path fails with:

```
java.lang.NullPointerException:
Cannot read the array length because "<local3>" is null
    at org.apache.ozone.erasurecode.rawcoder.util.CodecUtil
        .createRawDecoderWithFallback(CodecUtil.java:90)
```

Root cause: `CodecRegistry` loads coder factories via `ServiceLoader.load(RawErasureCoderFactory.class)`, which uses the **thread context class loader (TCCL)**. In Trino's isolated plugin class loader, the TCCL cannot see the Ozone `META-INF/services` providers, so `getCoderNames("rs")` returns `null`, causing the NPE in `CodecUtil`. Spark works because its TCCL can see the Ozone providers.

**Fix:** Use `CodecRegistry`'s own class loader instead of the TCCL:

```java
ServiceLoader.load(RawErasureCoderFactory.class,
    CodecRegistry.class.getClassLoader());
```

No changes to the singleton pattern, registration logic, native coder priority, fallback order, or public API.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15963

## How was this patch tested?

- Added `TestCodecRegistryTcclIsolation#testRegistryLoadsWithoutTccl` in a separate test class to ensure it runs in its own JVM as the first test to touch `CodecRegistry`, avoiding vacuous passes when the eager singleton is already initialized under the normal TCCL by other tests. Sets TCCL to an empty `ClassLoader(null)` before first `CodecRegistry` initialization, then verifies `getCoderNames("rs")` is non-null, non-empty, and contains `rs_java`. Restores TCCL in `finally`.
- Confirmed the test fails when the fix is reverted.
