### PR TITLE
HDDS-15966. Fix flaky TestScmHAFinalization#testSnapshotFinalization

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/HddsUpgradeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/HddsUpgradeTestUtils.java
@@ -143,8 +143,7 @@ public final class HddsUpgradeTestUtils {
             "Requiring DB key to flush? {}",
         scm.getSCMNodeId(), scm.checkLeader(), exitedSafemode, isFinalized, dbKeyFlushed, waitForDBKeyFlush);
 
-    // Safemode status is included for logging purposes, but is not required for SCM to finalize.
-    // If the leader is out of safemode, it can instruct followers still in safemode to finalize over Ratis.
+    // Safemode exit status is included for logging purposes, but SCMs can still finalize while in safemode.
     return isFinalized && (!waitForDBKeyFlush || dbKeyFlushed);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/HddsUpgradeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/HddsUpgradeTestUtils.java
@@ -143,6 +143,8 @@ public final class HddsUpgradeTestUtils {
             "Requiring DB key to flush? {}",
         scm.getSCMNodeId(), scm.checkLeader(), exitedSafemode, isFinalized, dbKeyFlushed, waitForDBKeyFlush);
 
-    return exitedSafemode && isFinalized && (!waitForDBKeyFlush || dbKeyFlushed);
+    // Safemode status is included for logging purposes, but is not required for SCM to finalize.
+    // If the leader is out of safemode, it can instruct followers still in safemode to finalize over Ratis.
+    return isFinalized && (!waitForDBKeyFlush || dbKeyFlushed);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Failed [here](https://github.com/apache/ozone/actions/runs/30091265211/job/89481626603?pr=10678) with a timeout at:
```
	at org.apache.ozone.test.GenericTestUtils.waitFor(GenericTestUtils.java:137)
	at org.apache.hadoop.hdds.upgrade.HddsUpgradeTestUtils.waitForScmToFinalize(HddsUpgradeTestUtils.java:125)
	at org.apache.hadoop.hdds.upgrade.HddsUpgradeTestUtils.waitForScmsToFinalize(HddsUpgradeTestUtils.java:119)
	at org.apache.hadoop.hdds.upgrade.TestScmHAFinalization.testSnapshotFinalization(TestScmHAFinalization.java:173)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
```

Logs show that it timed out waiting for scm2 to exit safemode. Safemode exit is this is no longer required for SCM finalization in the new upgrade framework, it is only required to instruct OMs to finalize which is not covered by this test. We can remove the safemode check from the wait.

## What is the link to the Apache JIRA

HDDS-15966

## How was this patch tested?

100 runs on my fork: https://github.com/errose28/ozone/actions/runs/30111725666/job/89543515225
This run was built off #10678 in case the failure was caused by the PR's changes. The test passed with a fix independent of the PR though.