### PR TITLE
HDDS-15968. Exempt design pull requests from stale bot

### DIFF
--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           stale-pr-label: 'stale'
+          exempt-pr-labels: 'design'
           exempt-draft-pr: false
           days-before-issue-stale: -1
           days-before-pr-stale: 21


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR exempts pull requests carrying the `design` label from the stale bot.

It is normal for design PRs to remain open for a very long time. Periodically removing the `stale` label from these PRs creates unnecessary maintenance work for contributors and maintainers.

The `exempt-pr-labels` option is configured with the `design` label. This prevents design PRs from being marked stale or automatically closed while leaving stale processing unchanged for all other PRs.

Reference: https://github.com/actions/stale/blob/1e223db275d687790206a7acac4d1a11bd6fe629/README.md#exempt-pr-labels

This intends to be a QoL improvement, motivated by cases such as https://github.com/apache/ozone/pull/9664#issuecomment-4997723490.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15968

## How was this patch tested?

- n/a