### PR TITLE
HDDS-15935. Extract ExportFileManager and document container export directory layout

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/UUIDUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/UUIDUtil.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.util;
 
 import java.security.SecureRandom;
 import java.util.Random;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 /**
@@ -45,6 +46,14 @@ public final class UUIDUtil {
     bytes[8]  &= 0x3f;
     bytes[8]  |= 0x80;
     return bytes;
+  }
+
+  public static boolean isValidUuidString(String value) {
+    try {
+      return value.equals(UUID.fromString(value).toString());
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
   }
 
   private UUIDUtil() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
@@ -31,8 +31,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.ozone.util.UUIDUtil;
 import org.apache.ratis.util.AtomicFileOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +81,7 @@ final class ExportFileManager {
   static final String EXPORT_ARCHIVE_SUFFIX = ".tar.gz";
   static final String EXPORT_ARCHIVE_TMP_SUFFIX = EXPORT_ARCHIVE_SUFFIX + AtomicFileOutputStream.TMP_EXTENSION;
   static final String EXPORT_LOCK_NAME = "in_use.lock";
+  private static final int ARCHIVE_TIMESTAMP_LENGTH = 16;
 
   private final String exportDirectory;
   private FileLock exportDirectoryLock;
@@ -127,13 +128,13 @@ final class ExportFileManager {
     exportDirectoryLock = null;
   }
 
-  File resolveArchiveFile(ExportScope scope, String fileTimestamp, String jobId) {
+  File resolveArchiveFile(ExportScope scope, String archiveTimestamp, ExportJob.Id jobId) {
     return new File(exportDirectory, String.format("container-ids-%s-%s%s%s%s",
-        scope.getValue(), fileTimestamp, EXPORT_ARCHIVE_JOB_INFIX, jobId, EXPORT_ARCHIVE_SUFFIX));
+        scope.getValue(), archiveTimestamp, EXPORT_ARCHIVE_JOB_INFIX, jobId.getValue(), EXPORT_ARCHIVE_SUFFIX));
   }
 
-  File resolveArchiveTempFile(ExportScope scope, String fileTimestamp, String jobId) {
-    return AtomicFileOutputStream.getTemporaryFile(resolveArchiveFile(scope, fileTimestamp, jobId));
+  File resolveArchiveTempFile(ExportScope scope, String archiveTimestamp, ExportJob.Id jobId) {
+    return AtomicFileOutputStream.getTemporaryFile(resolveArchiveFile(scope, archiveTimestamp, jobId));
   }
 
   /**
@@ -146,7 +147,8 @@ final class ExportFileManager {
     if (matches == null || matches.length == 0) {
       return Collections.emptyList();
     }
-    Arrays.sort(matches, Comparator.comparingLong(File::lastModified));
+    Arrays.sort(matches, Comparator.comparing(
+        file -> archiveTimestampFromArchiveFileName(file.getName())));
     List<String> archivePaths = new ArrayList<>(matches.length);
     for (File archive : matches) {
       archivePaths.add(archive.getAbsolutePath());
@@ -154,7 +156,17 @@ final class ExportFileManager {
     return archivePaths;
   }
 
-  static String jobIdFromArchiveFileName(String fileName) {
+  static String archiveTimestampFromArchiveFileName(String fileName) {
+    int jobIndex = fileName.lastIndexOf(EXPORT_ARCHIVE_JOB_INFIX);
+    if (jobIndex < ARCHIVE_TIMESTAMP_LENGTH + 1
+            || !fileName.endsWith(EXPORT_ARCHIVE_SUFFIX)
+            || fileName.endsWith(EXPORT_ARCHIVE_TMP_SUFFIX)) {
+      return null;
+    }
+    return fileName.substring(jobIndex - ARCHIVE_TIMESTAMP_LENGTH, jobIndex);
+  }
+
+  static ExportJob.Id jobIdFromArchiveFileName(String fileName) {
     if (!fileName.endsWith(EXPORT_ARCHIVE_SUFFIX)) {
       return null;
     }
@@ -164,7 +176,7 @@ final class ExportFileManager {
       return null;
     }
     String jobId = nameWithoutSuffix.substring(jobIndex + EXPORT_ARCHIVE_JOB_INFIX.length());
-    return isUuidDirectoryName(jobId) ? jobId : null;
+    return UUIDUtil.isValidUuidString(jobId) ? ExportJob.Id.of(jobId) : null;
   }
 
   void deleteExportTar(String tarPath) {
@@ -208,23 +220,15 @@ final class ExportFileManager {
     }
   }
 
-  static String exportJobDirName(String jobId) {
-    return EXPORT_JOB_DIR_PREFIX + jobId;
+  static String exportJobDirName(ExportJob.Id jobId) {
+    return EXPORT_JOB_DIR_PREFIX + jobId.getValue();
   }
 
-  private static String jobIdFromExportDirName(String dirName) {
+  private static ExportJob.Id jobIdFromExportDirName(String dirName) {
     if (!dirName.startsWith(EXPORT_JOB_DIR_PREFIX)) {
       return null;
     }
     String jobId = dirName.substring(EXPORT_JOB_DIR_PREFIX.length());
-    return isUuidDirectoryName(jobId) ? jobId : null;
-  }
-
-  private static boolean isUuidDirectoryName(String directoryName) {
-    try {
-      return directoryName.equals(UUID.fromString(directoryName).toString());
-    } catch (IllegalArgumentException e) {
-      return false;
-    }
+    return UUIDUtil.isValidUuidString(jobId) ? ExportJob.Id.of(jobId) : null;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
@@ -46,48 +46,38 @@ import org.slf4j.LoggerFactory;
  *
  * <p>While a job runs, shard text files are written under {@code export_{jobId}/}. The archive is
  * created only after all shards are written. The export manager writes
- * {@code container-ids-{scope}-{timestamp}.tar.gz.tmp} and atomically renames it to
+ * {@code container-ids-{scope}-{timestamp}_job{jobId}.tar.gz.tmp} and atomically renames it to
  * {@code .tar.gz} on close ({@link AtomicFileOutputStream}), so a partial {@code .tar.gz} is
- * never visible. {@link #lock()} is used to exclude concurrent writers.
+ * never visible. {@link #lock()} uses {@code in_use.lock} to exclude concurrent writers.
  *
  * <pre>
  * {exportDirectory}/
  * ├── in_use.lock
- * ├── {jobId}.in-progress
- * ├── container-ids-{scope}-{timestamp}.tar.gz
- * ├── container-ids-{scope}-{timestamp}.tar.gz.tmp
+ * ├── container-ids-{scope}-{timestamp}_job{jobId}.tar.gz
+ * ├── container-ids-{scope}-{timestamp}_job{jobId}.tar.gz.tmp
  * └── export_{jobId}/
  *     ├── container-ids-{scope}-{timestamp}-part001.txt
  *     └── ...
  * </pre>
  *
- * <p><b>When {@code export_{jobId}/} is deleted:</b> the export manager deletes it after the
- * archive is committed, or during {@link #cleanupFailedArtifacts} on failure or cancel.
- * On startup, {@link #start()} deletes a leftover {@code export_{jobId}/} when no in-progress
- * marker remains. If the marker still exists, {@link #start()} deletes {@code export_{jobId}/}
- * together with the marker and any {@code .tar.gz.tmp} for that incomplete job.
+ * <p><b>Incomplete work</b> ({@code export_{jobId}/} and {@code .tar.gz.tmp}) is removed by
+ * {@link #cleanupFailedJob(Path, File)} on failure or cancel, and by {@link #start()} for every
+ * leftover directory and temp file after SCM restart. Completed {@code .tar.gz} files are kept.
  *
- * <p><b>When {@code .tar.gz.tmp} is deleted:</b> only the temporary file is removed for
- * incomplete work; a partial {@code .tar.gz} is never written. {@link #cleanupFailedArtifacts}
- * deletes {@code .tar.gz.tmp} for failed or cancelled jobs. {@link #start()} deletes
- * {@code .tar.gz.tmp} for jobs that still have an in-progress marker.
+ * <p><b>Completed {@code .tar.gz}</b> remains on disk until the export manager evicts it
+ * ({@code maxTerminalJobs} in {@code ContainerExportManager}) via {@link #deleteExportTar(String)}.
  *
- * <p><b>When completed {@code .tar.gz} is deleted:</b> completed archives remain on disk until
- * the export manager evicts them ({@code maxTerminalJobs} in {@code ContainerExportManager}).
- *
- * <p><b>SCM restart:</b> in-memory job status is lost and {@code jobId} cannot be recovered from
- * the archive file name. {@link #listCompletedArchivePaths()} returns existing {@code tarPath}
- * values (oldest first) so {@code ContainerExportManager} can rebuild terminal-job eviction state.
- * Jobs with an in-progress marker are treated as incomplete: {@link #start()} removes the marker,
- * {@code export_{jobId}/}, and any {@code .tar.gz.tmp}, and the operator re-submits the export
- * on the new leader.
+ * <p><b>SCM restart:</b> in-memory job status is lost. {@link #start()} clears incomplete work;
+ * {@link #listCompletedArchivePaths()} returns existing {@code tarPath} values (oldest first);
+ * {@link #jobIdFromArchiveFileName(String)} parses {@code jobId} for terminal-job rebuild in
+ * {@code ContainerExportManager}.
  */
 final class ExportFileManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExportFileManager.class);
 
-  static final String IN_PROGRESS_MARKER_SUFFIX = ".in-progress";
   static final String EXPORT_JOB_DIR_PREFIX = "export_";
+  static final String EXPORT_ARCHIVE_JOB_INFIX = "_job";
   static final String EXPORT_ARCHIVE_SUFFIX = ".tar.gz";
   static final String EXPORT_ARCHIVE_TMP_SUFFIX = EXPORT_ARCHIVE_SUFFIX + AtomicFileOutputStream.TMP_EXTENSION;
   static final String EXPORT_LOCK_NAME = "in_use.lock";
@@ -105,7 +95,7 @@ final class ExportFileManager {
 
   void start() throws IOException {
     Files.createDirectories(Paths.get(exportDirectory));
-    cleanupOrphanedExportArtifacts();
+    removeIncompleteWorkOnStartup();
   }
 
   void lock() throws IOException {
@@ -137,13 +127,13 @@ final class ExportFileManager {
     exportDirectoryLock = null;
   }
 
-  File resolveArchiveFile(ExportScope scope, String fileTimestamp) {
-    return new File(exportDirectory,
-        String.format("container-ids-%s-%s%s", scope.getValue(), fileTimestamp, EXPORT_ARCHIVE_SUFFIX));
+  File resolveArchiveFile(ExportScope scope, String fileTimestamp, String jobId) {
+    return new File(exportDirectory, String.format("container-ids-%s-%s%s%s%s",
+        scope.getValue(), fileTimestamp, EXPORT_ARCHIVE_JOB_INFIX, jobId, EXPORT_ARCHIVE_SUFFIX));
   }
 
-  File resolveArchiveTempFile(ExportScope scope, String fileTimestamp) {
-    return AtomicFileOutputStream.getTemporaryFile(resolveArchiveFile(scope, fileTimestamp));
+  File resolveArchiveTempFile(ExportScope scope, String fileTimestamp, String jobId) {
+    return AtomicFileOutputStream.getTemporaryFile(resolveArchiveFile(scope, fileTimestamp, jobId));
   }
 
   /**
@@ -164,12 +154,17 @@ final class ExportFileManager {
     return archivePaths;
   }
 
-  void markExportInProgress(String jobId) throws IOException {
-    Files.createFile(inProgressMarkerFile(jobId).toPath());
-  }
-
-  void clearExportInProgress(String jobId) {
-    FileUtils.deleteQuietly(inProgressMarkerFile(jobId));
+  static String jobIdFromArchiveFileName(String fileName) {
+    if (!fileName.endsWith(EXPORT_ARCHIVE_SUFFIX)) {
+      return null;
+    }
+    String nameWithoutSuffix = fileName.substring(0, fileName.length() - EXPORT_ARCHIVE_SUFFIX.length());
+    int jobIndex = nameWithoutSuffix.lastIndexOf(EXPORT_ARCHIVE_JOB_INFIX);
+    if (jobIndex < 0) {
+      return null;
+    }
+    String jobId = nameWithoutSuffix.substring(jobIndex + EXPORT_ARCHIVE_JOB_INFIX.length());
+    return isUuidDirectoryName(jobId) ? jobId : null;
   }
 
   void deleteExportTar(String tarPath) {
@@ -183,74 +178,34 @@ final class ExportFileManager {
     FileUtils.deleteQuietly(AtomicFileOutputStream.getTemporaryFile(archive));
   }
 
-  void cleanupFailedArtifacts(Path jobDir, File archiveFile, String jobId) {
+  void cleanupFailedJob(Path jobDir, File archiveFile) {
     if (jobDir != null) {
       FileUtils.deleteQuietly(jobDir.toFile());
     }
     if (archiveFile != null) {
       FileUtils.deleteQuietly(AtomicFileOutputStream.getTemporaryFile(archiveFile));
-      FileUtils.deleteQuietly(archiveFile);
     }
-    clearExportInProgress(jobId);
   }
 
-  private void cleanupOrphanedExportArtifacts() {
+  private void removeIncompleteWorkOnStartup() {
     File exportDir = new File(exportDirectory);
     File[] children = exportDir.listFiles();
-    if (children == null) {
-      return;
-    }
-    for (File child : children) {
-      if (child.isFile() && child.getName().endsWith(IN_PROGRESS_MARKER_SUFFIX)) {
-        String jobId = child.getName().substring(
-            0, child.getName().length() - IN_PROGRESS_MARKER_SUFFIX.length());
-        if (isUuidDirectoryName(jobId)) {
-          removeIncompleteExportArtifacts(jobId);
-        }
-      }
-    }
-    for (File child : children) {
-      if (child.isDirectory()) {
-        String jobId = jobIdFromExportDirName(child.getName());
-        if (jobId == null) {
-          continue;
-        }
-        if (inProgressMarkerFile(jobId).exists()) {
-          removeIncompleteExportArtifacts(jobId);
-        } else {
+    if (children != null) {
+      for (File child : children) {
+        if (child.isDirectory() && jobIdFromExportDirName(child.getName()) != null) {
           FileUtils.deleteQuietly(child);
+          LOG.debug("Removed incomplete container export job directory: {}", child.getAbsolutePath());
         }
       }
     }
-    deleteOrphanArchiveTempFiles();
-  }
-
-  private void removeIncompleteExportArtifacts(String jobId) {
-    LOG.info("Removing incomplete container export artifacts for job {}", jobId);
-    FileUtils.deleteQuietly(inProgressMarkerFile(jobId));
-    deleteOrphanArchiveTempFiles();
-    File jobDir = new File(exportDirectory, exportJobDirName(jobId));
-    if (jobDir.isDirectory()) {
-      FileUtils.deleteQuietly(jobDir);
-      LOG.debug("Removed orphaned container export job directory: {}", jobDir.getAbsolutePath());
-    }
-  }
-
-  private void deleteOrphanArchiveTempFiles() {
-    File exportDir = new File(exportDirectory);
     File[] tempFiles = exportDir.listFiles((dir, fileName) -> fileName.endsWith(EXPORT_ARCHIVE_TMP_SUFFIX));
-    if (tempFiles == null) {
-      return;
-    }
-    for (File tempFile : tempFiles) {
-      if (FileUtils.deleteQuietly(tempFile)) {
-        LOG.debug("Removed incomplete container export archive temp file: {}", tempFile.getName());
+    if (tempFiles != null) {
+      for (File tempFile : tempFiles) {
+        if (FileUtils.deleteQuietly(tempFile)) {
+          LOG.debug("Removed incomplete container export archive temp file: {}", tempFile.getName());
+        }
       }
     }
-  }
-
-  private File inProgressMarkerFile(String jobId) {
-    return new File(exportDirectory, jobId + IN_PROGRESS_MARKER_SUFFIX);
   }
 
   static String exportJobDirName(String jobId) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
@@ -46,17 +46,17 @@ import org.slf4j.LoggerFactory;
  *
  * <p>While a job runs, shard text files are written under {@code export_{jobId}/}. The archive is
  * created only after all shards are written. The export manager writes
- * {@code container-ids-{scope}-{timestamp}_job{jobId}.tar.gz.tmp} and atomically renames it to
+ * {@code container-ids_{scope}_{timestamp}_job{jobId}.tar.gz.tmp} and atomically renames it to
  * {@code .tar.gz} on close ({@link AtomicFileOutputStream}), so a partial {@code .tar.gz} is
  * never visible. {@link #lock()} uses {@code in_use.lock} to exclude concurrent writers.
  *
  * <pre>
  * {exportDirectory}/
  * ├── in_use.lock
- * ├── container-ids-{scope}-{timestamp}_job{jobId}.tar.gz
- * ├── container-ids-{scope}-{timestamp}_job{jobId}.tar.gz.tmp
+ * ├── container-ids_{scope}_{timestamp}_job{jobId}.tar.gz
+ * ├── container-ids_{scope}_{timestamp}_job{jobId}.tar.gz.tmp
  * └── export_{jobId}/
- *     ├── container-ids-{scope}-{timestamp}-part001.txt
+ *     ├── container-ids_{scope}_{metadataTimestamp}_part001.txt
  *     └── ...
  * </pre>
  *
@@ -129,7 +129,7 @@ final class ExportFileManager {
   }
 
   File resolveArchiveFile(ExportScope scope, String archiveTimestamp, ExportJob.Id jobId) {
-    return new File(exportDirectory, String.format("container-ids-%s-%s%s%s%s",
+    return new File(exportDirectory, String.format("container-ids_%s_%s%s%s%s",
         scope.getValue(), archiveTimestamp, EXPORT_ARCHIVE_JOB_INFIX, jobId.getValue(), EXPORT_ARCHIVE_SUFFIX));
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
@@ -19,12 +19,21 @@ package org.apache.hadoop.hdds.scm.container.export;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
+import org.apache.ratis.util.AtomicFileOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,36 +42,45 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The export directory ({@code exportDirectory}, typically {@code {scm.db.dirs}/exports})
  * uses the layout below. The manager gzip-compresses the archive ({@code .tar.gz}) so operators
- * can stream entries with {@code zcat}
- * 
+ * can stream entries with {@code zcat}.
+ *
+ * <p>While a job runs, shard text files are written under {@code export_{jobId}/}. The archive is
+ * created only after all shards are written. The export manager writes
+ * {@code container-ids-{scope}-{timestamp}.tar.gz.tmp} and atomically renames it to
+ * {@code .tar.gz} on close ({@link AtomicFileOutputStream}), so a partial {@code .tar.gz} is
+ * never visible. {@link #lock()} is used to exclude concurrent writers.
+ *
  * <pre>
  * {exportDirectory}/
+ * ├── in_use.lock
  * ├── {jobId}.in-progress
- * ├── container-ids-{scope}-{timestamp}-{jobId}.tar.gz
+ * ├── container-ids-{scope}-{timestamp}.tar.gz
+ * ├── container-ids-{scope}-{timestamp}.tar.gz.tmp
  * └── export_{jobId}/
  *     ├── container-ids-{scope}-{timestamp}-part001.txt
  *     └── ...
  * </pre>
  *
- * <p>{@code export_{jobId}/} holds shard text files while the job appends them into the archive.
- *
  * <p><b>When {@code export_{jobId}/} is deleted:</b> the export manager deletes it after the
- * archive closes successfully, or during {@link #cleanupFailedArtifacts} on failure or cancel.
+ * archive is committed, or during {@link #cleanupFailedArtifacts} on failure or cancel.
  * On startup, {@link #start()} deletes a leftover {@code export_{jobId}/} when no in-progress
  * marker remains. If the marker still exists, {@link #start()} deletes {@code export_{jobId}/}
- * together with the marker and any partial archive for that job id.
+ * together with the marker and any {@code .tar.gz.tmp} for that incomplete job.
  *
- * <p><b>When {@code .tar.gz} is deleted:</b> {@link #cleanupFailedArtifacts} deletes partial
- * archives for failed or cancelled jobs. {@link #start()} deletes partial archives for jobs that
- * still have an in-progress marker. Completed archives remain on disk until the export manager
- * evicts the job from memory ({@code maxTerminalJobs} in {@code ContainerExportManager}) or an
- * operator deletes them manually. After SCM restart, in-memory eviction state is lost, so
- * completed archives persist until manual cleanup.
+ * <p><b>When {@code .tar.gz.tmp} is deleted:</b> only the temporary file is removed for
+ * incomplete work; a partial {@code .tar.gz} is never written. {@link #cleanupFailedArtifacts}
+ * deletes {@code .tar.gz.tmp} for failed or cancelled jobs. {@link #start()} deletes
+ * {@code .tar.gz.tmp} for jobs that still have an in-progress marker.
  *
- * <p><b>SCM restart while a job runs:</b> the in-progress marker and {@code export_{jobId}/}
- * remain on disk, but in-memory job status is lost. {@link #start()} treats the job as incomplete,
- * removes the marker, workspace, and any partial {@code .tar.gz} for that job id, and the
- * operator re-submits the export on the new leader.
+ * <p><b>When completed {@code .tar.gz} is deleted:</b> completed archives remain on disk until
+ * the export manager evicts them ({@code maxTerminalJobs} in {@code ContainerExportManager}).
+ *
+ * <p><b>SCM restart:</b> in-memory job status is lost and {@code jobId} cannot be recovered from
+ * the archive file name. {@link #listCompletedArchivePaths()} returns existing {@code tarPath}
+ * values (oldest first) so {@code ContainerExportManager} can rebuild terminal-job eviction state.
+ * Jobs with an in-progress marker are treated as incomplete: {@link #start()} removes the marker,
+ * {@code export_{jobId}/}, and any {@code .tar.gz.tmp}, and the operator re-submits the export
+ * on the new leader.
  */
 final class ExportFileManager {
 
@@ -71,8 +89,11 @@ final class ExportFileManager {
   static final String IN_PROGRESS_MARKER_SUFFIX = ".in-progress";
   static final String EXPORT_JOB_DIR_PREFIX = "export_";
   static final String EXPORT_ARCHIVE_SUFFIX = ".tar.gz";
+  static final String EXPORT_ARCHIVE_TMP_SUFFIX = EXPORT_ARCHIVE_SUFFIX + AtomicFileOutputStream.TMP_EXTENSION;
+  static final String EXPORT_LOCK_NAME = "in_use.lock";
 
   private final String exportDirectory;
+  private FileLock exportDirectoryLock;
 
   ExportFileManager(String exportDirectory) {
     this.exportDirectory = Objects.requireNonNull(exportDirectory, "exportDirectory == null");
@@ -87,10 +108,60 @@ final class ExportFileManager {
     cleanupOrphanedExportArtifacts();
   }
 
-  String resolveTarPath(ExportScope scope, String fileTimestamp, String jobId) {
-    String archiveFileName = String.format("container-ids-%s-%s-%s%s",
-        scope.getValue(), fileTimestamp, jobId, EXPORT_ARCHIVE_SUFFIX);
-    return exportDirectory + File.separator + archiveFileName;
+  void lock() throws IOException {
+    if (exportDirectoryLock != null) {
+      return;
+    }
+    File lockFile = new File(exportDirectory, EXPORT_LOCK_NAME);
+    RandomAccessFile lockAccessFile = new RandomAccessFile(lockFile, "rws");
+    try {
+      FileLock lock = lockAccessFile.getChannel().tryLock();
+      if (lock == null) {
+        lockAccessFile.close();
+        throw new OverlappingFileLockException();
+      }
+      exportDirectoryLock = lock;
+      LOG.debug("Acquired container export directory lock {}", lockFile.getAbsolutePath());
+    } catch (OverlappingFileLockException | IOException e) {
+      lockAccessFile.close();
+      throw new IOException("Failed to lock container export directory " + exportDirectory, e);
+    }
+  }
+
+  void unlock() throws IOException {
+    if (exportDirectoryLock == null) {
+      return;
+    }
+    exportDirectoryLock.release();
+    exportDirectoryLock.channel().close();
+    exportDirectoryLock = null;
+  }
+
+  File resolveArchiveFile(ExportScope scope, String fileTimestamp) {
+    return new File(exportDirectory,
+        String.format("container-ids-%s-%s%s", scope.getValue(), fileTimestamp, EXPORT_ARCHIVE_SUFFIX));
+  }
+
+  File resolveArchiveTempFile(ExportScope scope, String fileTimestamp) {
+    return AtomicFileOutputStream.getTemporaryFile(resolveArchiveFile(scope, fileTimestamp));
+  }
+
+  /**
+   * Returns completed archive paths ({@code tarPath} in {@code ExportJob.Status}), oldest first.
+   */
+  List<String> listCompletedArchivePaths() {
+    File exportDir = new File(exportDirectory);
+    File[] matches = exportDir.listFiles((dir, fileName) -> fileName.endsWith(EXPORT_ARCHIVE_SUFFIX)
+        && !fileName.endsWith(EXPORT_ARCHIVE_TMP_SUFFIX));
+    if (matches == null || matches.length == 0) {
+      return Collections.emptyList();
+    }
+    Arrays.sort(matches, Comparator.comparingLong(File::lastModified));
+    List<String> archivePaths = new ArrayList<>(matches.length);
+    for (File archive : matches) {
+      archivePaths.add(archive.getAbsolutePath());
+    }
+    return archivePaths;
   }
 
   void markExportInProgress(String jobId) throws IOException {
@@ -105,18 +176,20 @@ final class ExportFileManager {
     if (tarPath == null) {
       return;
     }
-    File tar = new File(tarPath);
-    if (tar.isFile() && FileUtils.deleteQuietly(tar)) {
-      LOG.debug("Removed container export archive: {}", tar.getName());
+    File archive = new File(tarPath);
+    if (archive.isFile() && FileUtils.deleteQuietly(archive)) {
+      LOG.debug("Removed container export archive: {}", archive.getName());
     }
+    FileUtils.deleteQuietly(AtomicFileOutputStream.getTemporaryFile(archive));
   }
 
-  void cleanupFailedArtifacts(Path jobDir, File tarFile, String jobId) {
+  void cleanupFailedArtifacts(Path jobDir, File archiveFile, String jobId) {
     if (jobDir != null) {
       FileUtils.deleteQuietly(jobDir.toFile());
     }
-    if (tarFile != null) {
-      FileUtils.deleteQuietly(tarFile);
+    if (archiveFile != null) {
+      FileUtils.deleteQuietly(AtomicFileOutputStream.getTemporaryFile(archiveFile));
+      FileUtils.deleteQuietly(archiveFile);
     }
     clearExportInProgress(jobId);
   }
@@ -149,31 +222,31 @@ final class ExportFileManager {
         }
       }
     }
+    deleteOrphanArchiveTempFiles();
   }
 
   private void removeIncompleteExportArtifacts(String jobId) {
     LOG.info("Removing incomplete container export artifacts for job {}", jobId);
     FileUtils.deleteQuietly(inProgressMarkerFile(jobId));
-    File tar = findTarForJobId(jobId);
-    if (tar != null) {
-      FileUtils.deleteQuietly(tar);
-      LOG.info("Removed incomplete container export archive for job {}: {}", jobId, tar.getName());
-    }
+    deleteOrphanArchiveTempFiles();
     File jobDir = new File(exportDirectory, exportJobDirName(jobId));
     if (jobDir.isDirectory()) {
       FileUtils.deleteQuietly(jobDir);
-      LOG.info("Removed orphaned container export job directory: {}", jobDir.getAbsolutePath());
+      LOG.debug("Removed orphaned container export job directory: {}", jobDir.getAbsolutePath());
     }
   }
 
-  private File findTarForJobId(String jobId) {
+  private void deleteOrphanArchiveTempFiles() {
     File exportDir = new File(exportDirectory);
-    String suffix = "-" + jobId + EXPORT_ARCHIVE_SUFFIX;
-    File[] matches = exportDir.listFiles((dir, fileName) -> fileName.endsWith(suffix));
-    if (matches == null || matches.length == 0) {
-      return null;
+    File[] tempFiles = exportDir.listFiles((dir, fileName) -> fileName.endsWith(EXPORT_ARCHIVE_TMP_SUFFIX));
+    if (tempFiles == null) {
+      return;
     }
-    return matches[0];
+    for (File tempFile : tempFiles) {
+      if (FileUtils.deleteQuietly(tempFile)) {
+        LOG.debug("Removed incomplete container export archive temp file: {}", tempFile.getName());
+      }
+    }
   }
 
   private File inProgressMarkerFile(String jobId) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
@@ -30,26 +30,48 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Manages on-disk paths and artifacts for container ID export jobs.
- * Layout under the export directory ({@code {exportDirectory}}, typically {@code {scm.db.dirs}/exports}):
- * <p>
+ *
+ * <p>The export directory ({@code exportDirectory}, typically {@code {scm.db.dirs}/exports})
+ * uses the layout below. The manager gzip-compresses the archive ({@code .tar.gz}) so operators
+ * can stream entries with {@code zcat}
+ * 
+ * <pre>
  * {exportDirectory}/
- *   {jobId}.in-progress                             // marker while a job is running
- *   container-ids-{scope}-{timestamp}-{jobId}.tar   // completed export archive
- *   export-{jobId}/                                 // per-job workspace (removed on success)
- *     work/
- *       container-ids-{scope}-{timestamp}-part001.txt
- *       ...
- * <p>
- * Shard text files are written under {@code export-{jobId}/work/}, appended into the TAR at
- * {@code {exportDirectory}}, then the manager deletes the workspace. The manager clears the
- * {@code .in-progress} marker only after the TAR closes successfully. On startup, the manager
- * removes orphaned markers, workspaces, and partial TAR files for the same job id together.
+ * ├── {jobId}.in-progress
+ * ├── container-ids-{scope}-{timestamp}-{jobId}.tar.gz
+ * └── export_{jobId}/
+ *     ├── container-ids-{scope}-{timestamp}-part001.txt
+ *     └── ...
+ * </pre>
+ *
+ * <p>{@code export_{jobId}/} holds shard text files while the job appends them into the archive.
+ *
+ * <p><b>When {@code export_{jobId}/} is deleted:</b> the export manager deletes it after the
+ * archive closes successfully, or during {@link #cleanupFailedArtifacts} on failure or cancel.
+ * On startup, {@link #start()} deletes a leftover {@code export_{jobId}/} when no in-progress
+ * marker remains. If the marker still exists, {@link #start()} deletes {@code export_{jobId}/}
+ * together with the marker and any partial archive for that job id.
+ *
+ * <p><b>When {@code .tar.gz} is deleted:</b> {@link #cleanupFailedArtifacts} deletes partial
+ * archives for failed or cancelled jobs. {@link #start()} deletes partial archives for jobs that
+ * still have an in-progress marker. Completed archives remain on disk until the export manager
+ * evicts the job from memory ({@code maxTerminalJobs} in {@code ContainerExportManager}) or an
+ * operator deletes them manually. After SCM restart, in-memory eviction state is lost, so
+ * completed archives persist until manual cleanup.
+ *
+ * <p><b>SCM restart while a job runs:</b> the in-progress marker and {@code export_{jobId}/}
+ * remain on disk, but in-memory job status is lost. {@link #start()} treats the job as incomplete,
+ * removes the marker, workspace, and any partial {@code .tar.gz} for that job id, and the
+ * operator re-submits the export on the new leader.
  */
 final class ExportFileManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExportFileManager.class);
+
   static final String IN_PROGRESS_MARKER_SUFFIX = ".in-progress";
-  static final String EXPORT_JOB_DIR_PREFIX = "export-";
+  static final String EXPORT_JOB_DIR_PREFIX = "export_";
+  static final String EXPORT_ARCHIVE_SUFFIX = ".tar.gz";
+
   private final String exportDirectory;
 
   ExportFileManager(String exportDirectory) {
@@ -66,8 +88,9 @@ final class ExportFileManager {
   }
 
   String resolveTarPath(ExportScope scope, String fileTimestamp, String jobId) {
-    String tarFileName = String.format("container-ids-%s-%s-%s.tar", scope.getValue(), fileTimestamp, jobId);
-    return exportDirectory + File.separator + tarFileName;
+    String archiveFileName = String.format("container-ids-%s-%s-%s%s",
+        scope.getValue(), fileTimestamp, jobId, EXPORT_ARCHIVE_SUFFIX);
+    return exportDirectory + File.separator + archiveFileName;
   }
 
   void markExportInProgress(String jobId) throws IOException {
@@ -84,7 +107,7 @@ final class ExportFileManager {
     }
     File tar = new File(tarPath);
     if (tar.isFile() && FileUtils.deleteQuietly(tar)) {
-      LOG.debug("Removed container export TAR: {}", tar.getName());
+      LOG.debug("Removed container export archive: {}", tar.getName());
     }
   }
 
@@ -134,19 +157,19 @@ final class ExportFileManager {
     File tar = findTarForJobId(jobId);
     if (tar != null) {
       FileUtils.deleteQuietly(tar);
-      LOG.info("Removed incomplete container export TAR for job {}: {}", jobId, tar.getName());
+      LOG.info("Removed incomplete container export archive for job {}: {}", jobId, tar.getName());
     }
-    File jobWorkDir = new File(exportDirectory, exportJobDirName(jobId));
-    if (jobWorkDir.isDirectory()) {
-      FileUtils.deleteQuietly(jobWorkDir);
-      LOG.info("Removed orphaned container export work directory: {}", jobWorkDir.getAbsolutePath());
+    File jobDir = new File(exportDirectory, exportJobDirName(jobId));
+    if (jobDir.isDirectory()) {
+      FileUtils.deleteQuietly(jobDir);
+      LOG.info("Removed orphaned container export job directory: {}", jobDir.getAbsolutePath());
     }
   }
 
   private File findTarForJobId(String jobId) {
     File exportDir = new File(exportDirectory);
-    File[] matches = exportDir.listFiles(
-        (dir, fileName) -> fileName.endsWith("-" + jobId + ".tar"));
+    String suffix = "-" + jobId + EXPORT_ARCHIVE_SUFFIX;
+    File[] matches = exportDir.listFiles((dir, fileName) -> fileName.endsWith(suffix));
     if (matches == null || matches.length == 0) {
       return null;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportFileManager.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.export;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages on-disk paths and artifacts for container ID export jobs.
+ * Layout under the export directory ({@code {exportDirectory}}, typically {@code {scm.db.dirs}/exports}):
+ * <p>
+ * {exportDirectory}/
+ *   {jobId}.in-progress                             // marker while a job is running
+ *   container-ids-{scope}-{timestamp}-{jobId}.tar   // completed export archive
+ *   export-{jobId}/                                 // per-job workspace (removed on success)
+ *     work/
+ *       container-ids-{scope}-{timestamp}-part001.txt
+ *       ...
+ * <p>
+ * Shard text files are written under {@code export-{jobId}/work/}, appended into the TAR at
+ * {@code {exportDirectory}}, then the manager deletes the workspace. The manager clears the
+ * {@code .in-progress} marker only after the TAR closes successfully. On startup, the manager
+ * removes orphaned markers, workspaces, and partial TAR files for the same job id together.
+ */
+final class ExportFileManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExportFileManager.class);
+  static final String IN_PROGRESS_MARKER_SUFFIX = ".in-progress";
+  static final String EXPORT_JOB_DIR_PREFIX = "export-";
+  private final String exportDirectory;
+
+  ExportFileManager(String exportDirectory) {
+    this.exportDirectory = Objects.requireNonNull(exportDirectory, "exportDirectory == null");
+  }
+
+  String getExportDirectory() {
+    return exportDirectory;
+  }
+
+  void start() throws IOException {
+    Files.createDirectories(Paths.get(exportDirectory));
+    cleanupOrphanedExportArtifacts();
+  }
+
+  String resolveTarPath(ExportScope scope, String fileTimestamp, String jobId) {
+    String tarFileName = String.format("container-ids-%s-%s-%s.tar", scope.getValue(), fileTimestamp, jobId);
+    return exportDirectory + File.separator + tarFileName;
+  }
+
+  void markExportInProgress(String jobId) throws IOException {
+    Files.createFile(inProgressMarkerFile(jobId).toPath());
+  }
+
+  void clearExportInProgress(String jobId) {
+    FileUtils.deleteQuietly(inProgressMarkerFile(jobId));
+  }
+
+  void deleteExportTar(String tarPath) {
+    if (tarPath == null) {
+      return;
+    }
+    File tar = new File(tarPath);
+    if (tar.isFile() && FileUtils.deleteQuietly(tar)) {
+      LOG.debug("Removed container export TAR: {}", tar.getName());
+    }
+  }
+
+  void cleanupFailedArtifacts(Path jobDir, File tarFile, String jobId) {
+    if (jobDir != null) {
+      FileUtils.deleteQuietly(jobDir.toFile());
+    }
+    if (tarFile != null) {
+      FileUtils.deleteQuietly(tarFile);
+    }
+    clearExportInProgress(jobId);
+  }
+
+  private void cleanupOrphanedExportArtifacts() {
+    File exportDir = new File(exportDirectory);
+    File[] children = exportDir.listFiles();
+    if (children == null) {
+      return;
+    }
+    for (File child : children) {
+      if (child.isFile() && child.getName().endsWith(IN_PROGRESS_MARKER_SUFFIX)) {
+        String jobId = child.getName().substring(
+            0, child.getName().length() - IN_PROGRESS_MARKER_SUFFIX.length());
+        if (isUuidDirectoryName(jobId)) {
+          removeIncompleteExportArtifacts(jobId);
+        }
+      }
+    }
+    for (File child : children) {
+      if (child.isDirectory()) {
+        String jobId = jobIdFromExportDirName(child.getName());
+        if (jobId == null) {
+          continue;
+        }
+        if (inProgressMarkerFile(jobId).exists()) {
+          removeIncompleteExportArtifacts(jobId);
+        } else {
+          FileUtils.deleteQuietly(child);
+        }
+      }
+    }
+  }
+
+  private void removeIncompleteExportArtifacts(String jobId) {
+    LOG.info("Removing incomplete container export artifacts for job {}", jobId);
+    FileUtils.deleteQuietly(inProgressMarkerFile(jobId));
+    File tar = findTarForJobId(jobId);
+    if (tar != null) {
+      FileUtils.deleteQuietly(tar);
+      LOG.info("Removed incomplete container export TAR for job {}: {}", jobId, tar.getName());
+    }
+    File jobWorkDir = new File(exportDirectory, exportJobDirName(jobId));
+    if (jobWorkDir.isDirectory()) {
+      FileUtils.deleteQuietly(jobWorkDir);
+      LOG.info("Removed orphaned container export work directory: {}", jobWorkDir.getAbsolutePath());
+    }
+  }
+
+  private File findTarForJobId(String jobId) {
+    File exportDir = new File(exportDirectory);
+    File[] matches = exportDir.listFiles(
+        (dir, fileName) -> fileName.endsWith("-" + jobId + ".tar"));
+    if (matches == null || matches.length == 0) {
+      return null;
+    }
+    return matches[0];
+  }
+
+  private File inProgressMarkerFile(String jobId) {
+    return new File(exportDirectory, jobId + IN_PROGRESS_MARKER_SUFFIX);
+  }
+
+  static String exportJobDirName(String jobId) {
+    return EXPORT_JOB_DIR_PREFIX + jobId;
+  }
+
+  private static String jobIdFromExportDirName(String dirName) {
+    if (!dirName.startsWith(EXPORT_JOB_DIR_PREFIX)) {
+      return null;
+    }
+    String jobId = dirName.substring(EXPORT_JOB_DIR_PREFIX.length());
+    return isUuidDirectoryName(jobId) ? jobId : null;
+  }
+
+  private static boolean isUuidDirectoryName(String directoryName) {
+    try {
+      return directoryName.equals(UUID.fromString(directoryName).toString());
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportJob.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportJob.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.export;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Container ID export job identifier.
+ */
+public final class ExportJob {
+
+  /**
+   * Unique job identifier.
+   */
+  public static final class Id {
+    private final String value;
+
+    private Id(String value) {
+      this.value = Objects.requireNonNull(value, "value == null");
+    }
+
+    public static Id newId() {
+      return new Id(UUID.randomUUID().toString());
+    }
+
+    public static Id of(String value) {
+      return new Id(value);
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof Id)) {
+        return false;
+      }
+      return value.equals(((Id) obj).value);
+    }
+
+    @Override
+    public int hashCode() {
+      return value.hashCode();
+    }
+  }
+
+  private ExportJob() {
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.export;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
+
+/**
+ * Container listing filters for an export job.
+ * An export job filters containers by {@link ContainerHealthState}, {@link LifeCycleState} or both.
+ * Example TAR name:
+ * {@code container-ids-health-MISSING_lifecycle-OPEN-20260101T120000Z-{jobId}.tar}
+ */
+public final class ExportScope {
+
+  private final LifeCycleState lifeCycleState;
+  private final ContainerHealthState healthState;
+  private final String value;
+
+  private ExportScope(LifeCycleState lifeCycleState, ContainerHealthState healthState, String value) {
+    this.lifeCycleState = lifeCycleState;
+    this.healthState = healthState;
+    this.value = value;
+  }
+
+  public static ExportScope of(LifeCycleState lifeCycleState, ContainerHealthState healthState) {
+    StringBuilder sb = new StringBuilder();
+    if (healthState != null) {
+      sb.append("health-").append(healthState.name());
+    }
+    if (lifeCycleState != null) {
+      if (sb.length() > 0) {
+        sb.append('_');
+      }
+      sb.append("lifecycle-").append(lifeCycleState.name());
+    }
+    return new ExportScope(lifeCycleState, healthState, sb.toString());
+  }
+
+  public LifeCycleState getLifeCycleState() {
+    return lifeCycleState;
+  }
+
+  public ContainerHealthState getHealthState() {
+    return healthState;
+  }
+
+  /**
+   * Stable filter name segment used in export TAR and shard file names.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
  * Container listing filters for an export job.
  * An export job filters containers by {@link ContainerHealthState}, {@link LifeCycleState} or both.
  * Example TAR name:
- * {@code container-ids-health-MISSING_lifecycle-OPEN-20260101T120000Z-{jobId}.tar}
+ * {@code container-ids-health-MISSING_lifecycle-OPEN-20260101T120000Z-{jobId}.tar.gz}
  */
 public final class ExportScope {
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
  * Container listing filters for an export job.
  * An export job filters containers by {@link ContainerHealthState}, {@link LifeCycleState} or both.
  * Example archive name:
- * {@code container-ids-health-MISSING_lifecycle-OPEN-20260101T120000Z_job{jobId}.tar.gz}
+ * {@code container-ids_health-MISSING_lifecycle-OPEN_20260101T120000Z_job{jobId}.tar.gz}
  */
 public final class ExportScope {
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
 /**
  * Container listing filters for an export job.
  * An export job filters containers by {@link ContainerHealthState}, {@link LifeCycleState} or both.
- * Example TAR name:
- * {@code container-ids-health-MISSING_lifecycle-OPEN-20260101T120000Z-{jobId}.tar.gz}
+ * Example archive name:
+ * {@code container-ids-health-MISSING_lifecycle-OPEN-20260101T120000Z.tar.gz}
  */
 public final class ExportScope {
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
  * Container listing filters for an export job.
  * An export job filters containers by {@link ContainerHealthState}, {@link LifeCycleState} or both.
  * Example archive name:
- * {@code container-ids-health-MISSING_lifecycle-OPEN-20260101T120000Z.tar.gz}
+ * {@code container-ids-health-MISSING_lifecycle-OPEN-20260101T120000Z_job{jobId}.tar.gz}
  */
 public final class ExportScope {
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/ExportScope.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
  */
 public final class ExportScope {
 
+  private static final String ANY = "ANY";
   private final LifeCycleState lifeCycleState;
   private final ContainerHealthState healthState;
   private final String value;
@@ -39,17 +40,10 @@ public final class ExportScope {
   }
 
   public static ExportScope of(LifeCycleState lifeCycleState, ContainerHealthState healthState) {
-    StringBuilder sb = new StringBuilder();
-    if (healthState != null) {
-      sb.append("health-").append(healthState.name());
-    }
-    if (lifeCycleState != null) {
-      if (sb.length() > 0) {
-        sb.append('_');
-      }
-      sb.append("lifecycle-").append(lifeCycleState.name());
-    }
-    return new ExportScope(lifeCycleState, healthState, sb.toString());
+    String health = healthState != null ? healthState.name() : ANY;
+    String lifecycle = lifeCycleState != null ? lifeCycleState.name() : ANY;
+    String value = "health-" + health + "_lifecycle-" + lifecycle;
+    return new ExportScope(lifeCycleState, healthState, value);
   }
 
   public LifeCycleState getLifeCycleState() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/package-info.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/export/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains classes related to container export.
+ */
+package org.apache.hadoop.hdds.scm.container.export;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,14 +66,17 @@ public class TestExportFileManager {
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
     File olderArchive = fileManager.resolveArchiveFile(scope, "20260101T120000Z");
     assertTrue(olderArchive.createNewFile());
+    assertTrue(olderArchive.setLastModified(1_000L));
     File newerArchive = fileManager.resolveArchiveFile(scope, "20260101T120001Z");
     assertTrue(newerArchive.createNewFile());
+    assertTrue(newerArchive.setLastModified(2_000L));
     File tempArchive = fileManager.resolveArchiveTempFile(scope, "20260101T120002Z");
     assertTrue(tempArchive.createNewFile());
 
-    assertEquals(2, fileManager.listCompletedArchivePaths().size());
-    assertEquals(olderArchive.getAbsolutePath(), fileManager.listCompletedArchivePaths().get(0));
-    assertEquals(newerArchive.getAbsolutePath(), fileManager.listCompletedArchivePaths().get(1));
+    List<String> completedPaths = fileManager.listCompletedArchivePaths();
+    assertEquals(2, completedPaths.size());
+    assertEquals(olderArchive.getAbsolutePath(), completedPaths.get(0));
+    assertEquals(newerArchive.getAbsolutePath(), completedPaths.get(1));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
@@ -62,7 +62,7 @@ public class TestExportFileManager {
     ExportJob.Id jobId = ExportJob.Id.newId();
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
     File archive = fileManager.resolveArchiveFile(scope, "20260101T120000Z", jobId);
-    assertTrue(archive.getName().contains("health-MISSING_lifecycle-ANY-20260101T120000Z"));
+    assertTrue(archive.getName().contains("health-MISSING_lifecycle-ANY_20260101T120000Z"));
     assertTrue(archive.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + jobId.getValue()
         + ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
   }
@@ -78,16 +78,16 @@ public class TestExportFileManager {
   @Test
   public void testJobIdFromArchiveFileName() {
     String jobId = UUID.randomUUID().toString();
-    String fileName = "container-ids-health-MISSING_lifecycle-ANY-20260101T120000Z"
+    String fileName = "container-ids_health-MISSING_lifecycle-ANY_20260101T120000Z"
         + ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX;
     assertEquals(ExportJob.Id.of(jobId), ExportFileManager.jobIdFromArchiveFileName(fileName));
-    assertNull(ExportFileManager.jobIdFromArchiveFileName("container-ids-health-MISSING_lifecycle-ANY-20260101T120000Z"
+    assertNull(ExportFileManager.jobIdFromArchiveFileName("container-ids_health-MISSING_lifecycle-ANY_20260101T120000Z"
         + ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
   }
 
   @Test
   public void testArchiveTimestampFromArchiveFileName() {
-    String fileName = "container-ids-health-MISSING_lifecycle-ANY-20260101T120000Z"
+    String fileName = "container-ids_health-MISSING_lifecycle-ANY_20260101T120000Z"
         + ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + UUID.randomUUID() + ExportFileManager.EXPORT_ARCHIVE_SUFFIX;
     assertEquals("20260101T120000Z", ExportFileManager.archiveTimestampFromArchiveFileName(fileName));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.export;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link ExportFileManager}.
+ */
+public class TestExportFileManager {
+
+  @TempDir
+  private File tempDir;
+
+  private ExportFileManager fileManager;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    fileManager = new ExportFileManager(tempDir.getAbsolutePath());
+    fileManager.start();
+  }
+
+  @Test
+  public void testResolveTarPath() {
+    String jobId = UUID.randomUUID().toString();
+    ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
+    String tarPath = fileManager.resolveTarPath(scope, "20260101T120000Z", jobId);
+    assertTrue(tarPath.endsWith("container-ids-health-MISSING-20260101T120000Z-" + jobId + ".tar"));
+  }
+
+  @Test
+  public void testOrphanWorkDirRemovedOnStartup() throws Exception {
+    String jobId = UUID.randomUUID().toString();
+    Path orphan = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId)).resolve("work");
+    Files.createDirectories(orphan);
+
+    fileManager.start();
+
+    assertFalse(Files.exists(orphan));
+  }
+
+  @Test
+  public void testIncompleteExportArtifactsRemovedOnStartup() throws Exception {
+    String jobId = UUID.randomUUID().toString();
+    Path jobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId)).resolve("work");
+    Files.createDirectories(jobDir);
+    File partialTar = new File(tempDir, "container-ids-health-MISSING-20260101T000000Z-" + jobId + ".tar");
+    assertTrue(partialTar.createNewFile());
+    File inProgress = new File(tempDir, jobId + ExportFileManager.IN_PROGRESS_MARKER_SUFFIX);
+    assertTrue(inProgress.createNewFile());
+
+    fileManager.start();
+
+    assertFalse(Files.exists(jobDir));
+    assertFalse(partialTar.exists());
+    assertFalse(inProgress.exists());
+  }
+
+  @Test
+  public void testOrphanWorkDirWithoutMarkerDoesNotDeleteCompletedTar() throws Exception {
+    String jobId = UUID.randomUUID().toString();
+    File completedTar = new File(tempDir, "container-ids-health-MISSING-20260101T000000Z-" + jobId + ".tar");
+    assertTrue(completedTar.createNewFile());
+    Path orphanWorkDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
+    Files.createDirectories(orphanWorkDir.resolve("work"));
+
+    fileManager.start();
+
+    assertTrue(completedTar.exists());
+    assertFalse(Files.exists(orphanWorkDir));
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
@@ -50,26 +50,28 @@ public class TestExportFileManager {
     String jobId = UUID.randomUUID().toString();
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
     String tarPath = fileManager.resolveTarPath(scope, "20260101T120000Z", jobId);
-    assertTrue(tarPath.endsWith("container-ids-health-MISSING-20260101T120000Z-" + jobId + ".tar"));
+    assertTrue(tarPath.endsWith(
+        "container-ids-health-MISSING-20260101T120000Z-" + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
   }
 
   @Test
-  public void testOrphanWorkDirRemovedOnStartup() throws Exception {
+  public void testOrphanJobDirRemovedOnStartup() throws Exception {
     String jobId = UUID.randomUUID().toString();
-    Path orphan = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId)).resolve("work");
-    Files.createDirectories(orphan);
+    Path orphanJobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
+    Files.createDirectories(orphanJobDir);
 
     fileManager.start();
 
-    assertFalse(Files.exists(orphan));
+    assertFalse(Files.exists(orphanJobDir));
   }
 
   @Test
   public void testIncompleteExportArtifactsRemovedOnStartup() throws Exception {
     String jobId = UUID.randomUUID().toString();
-    Path jobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId)).resolve("work");
+    Path jobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
     Files.createDirectories(jobDir);
-    File partialTar = new File(tempDir, "container-ids-health-MISSING-20260101T000000Z-" + jobId + ".tar");
+    File partialTar = new File(tempDir,
+        "container-ids-health-MISSING-20260101T000000Z-" + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX);
     assertTrue(partialTar.createNewFile());
     File inProgress = new File(tempDir, jobId + ExportFileManager.IN_PROGRESS_MARKER_SUFFIX);
     assertTrue(inProgress.createNewFile());
@@ -82,16 +84,17 @@ public class TestExportFileManager {
   }
 
   @Test
-  public void testOrphanWorkDirWithoutMarkerDoesNotDeleteCompletedTar() throws Exception {
+  public void testOrphanJobDirWithoutMarkerDoesNotDeleteCompletedTar() throws Exception {
     String jobId = UUID.randomUUID().toString();
-    File completedTar = new File(tempDir, "container-ids-health-MISSING-20260101T000000Z-" + jobId + ".tar");
+    File completedTar = new File(tempDir,
+        "container-ids-health-MISSING-20260101T000000Z-" + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX);
     assertTrue(completedTar.createNewFile());
-    Path orphanWorkDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
-    Files.createDirectories(orphanWorkDir.resolve("work"));
+    Path orphanJobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
+    Files.createDirectories(orphanJobDir);
 
     fileManager.start();
 
     assertTrue(completedTar.exists());
-    assertFalse(Files.exists(orphanWorkDir));
+    assertFalse(Files.exists(orphanJobDir));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,17 +50,26 @@ public class TestExportFileManager {
   }
 
   @Test
+  public void testExportScopeUsesAnyForNullFilters() {
+    assertEquals("health-MISSING_lifecycle-ANY",
+        ExportScope.of(null, ContainerHealthState.MISSING).getValue());
+    assertEquals("health-ANY_lifecycle-OPEN",
+        ExportScope.of(LifeCycleState.OPEN, null).getValue());
+  }
+
+  @Test
   public void testResolveArchiveFile() {
-    String jobId = UUID.randomUUID().toString();
+    ExportJob.Id jobId = ExportJob.Id.newId();
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
     File archive = fileManager.resolveArchiveFile(scope, "20260101T120000Z", jobId);
-    assertTrue(archive.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + jobId
+    assertTrue(archive.getName().contains("health-MISSING_lifecycle-ANY-20260101T120000Z"));
+    assertTrue(archive.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + jobId.getValue()
         + ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
   }
 
   @Test
   public void testResolveArchiveTempFile() {
-    String jobId = UUID.randomUUID().toString();
+    ExportJob.Id jobId = ExportJob.Id.newId();
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
     File tempFile = fileManager.resolveArchiveTempFile(scope, "20260101T120000Z", jobId);
     assertTrue(tempFile.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_TMP_SUFFIX));
@@ -68,25 +78,32 @@ public class TestExportFileManager {
   @Test
   public void testJobIdFromArchiveFileName() {
     String jobId = UUID.randomUUID().toString();
-    String fileName = "container-ids-health-MISSING-20260101T120000Z"
+    String fileName = "container-ids-health-MISSING_lifecycle-ANY-20260101T120000Z"
         + ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX;
-    assertEquals(jobId, ExportFileManager.jobIdFromArchiveFileName(fileName));
-    assertNull(ExportFileManager.jobIdFromArchiveFileName("container-ids-health-MISSING-20260101T120000Z"
+    assertEquals(ExportJob.Id.of(jobId), ExportFileManager.jobIdFromArchiveFileName(fileName));
+    assertNull(ExportFileManager.jobIdFromArchiveFileName("container-ids-health-MISSING_lifecycle-ANY-20260101T120000Z"
         + ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
+  }
+
+  @Test
+  public void testArchiveTimestampFromArchiveFileName() {
+    String fileName = "container-ids-health-MISSING_lifecycle-ANY-20260101T120000Z"
+        + ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + UUID.randomUUID() + ExportFileManager.EXPORT_ARCHIVE_SUFFIX;
+    assertEquals("20260101T120000Z", ExportFileManager.archiveTimestampFromArchiveFileName(fileName));
   }
 
   @Test
   public void testListCompletedArchivePaths() throws Exception {
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
-    String olderJobId = UUID.randomUUID().toString();
+    ExportJob.Id olderJobId = ExportJob.Id.newId();
     File olderArchive = fileManager.resolveArchiveFile(scope, "20260101T120000Z", olderJobId);
     assertTrue(olderArchive.createNewFile());
-    assertTrue(olderArchive.setLastModified(1_000L));
-    String newerJobId = UUID.randomUUID().toString();
+    assertTrue(olderArchive.setLastModified(2_000L));
+    ExportJob.Id newerJobId = ExportJob.Id.newId();
     File newerArchive = fileManager.resolveArchiveFile(scope, "20260101T120001Z", newerJobId);
     assertTrue(newerArchive.createNewFile());
-    assertTrue(newerArchive.setLastModified(2_000L));
-    String tempJobId = UUID.randomUUID().toString();
+    assertTrue(newerArchive.setLastModified(1_000L));
+    ExportJob.Id tempJobId = ExportJob.Id.newId();
     File tempArchive = fileManager.resolveArchiveTempFile(scope, "20260101T120002Z", tempJobId);
     assertTrue(tempArchive.createNewFile());
 
@@ -98,7 +115,7 @@ public class TestExportFileManager {
 
   @Test
   public void testOrphanJobDirRemovedOnStartup() throws Exception {
-    String jobId = UUID.randomUUID().toString();
+    ExportJob.Id jobId = ExportJob.Id.newId();
     Path orphanJobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
     Files.createDirectories(orphanJobDir);
 
@@ -109,7 +126,7 @@ public class TestExportFileManager {
 
   @Test
   public void testIncompleteExportArtifactsRemovedOnStartup() throws Exception {
-    String jobId = UUID.randomUUID().toString();
+    ExportJob.Id jobId = ExportJob.Id.newId();
     Path jobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
     Files.createDirectories(jobDir);
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
@@ -124,7 +141,7 @@ public class TestExportFileManager {
 
   @Test
   public void testOrphanJobDirDoesNotDeleteCompletedTar() throws Exception {
-    String jobId = UUID.randomUUID().toString();
+    ExportJob.Id jobId = ExportJob.Id.newId();
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
     File completedArchive = fileManager.resolveArchiveFile(scope, "20260101T000000Z", jobId);
     assertTrue(completedArchive.createNewFile());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.container.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -49,28 +50,44 @@ public class TestExportFileManager {
 
   @Test
   public void testResolveArchiveFile() {
+    String jobId = UUID.randomUUID().toString();
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
-    File archive = fileManager.resolveArchiveFile(scope, "20260101T120000Z");
-    assertTrue(archive.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
+    File archive = fileManager.resolveArchiveFile(scope, "20260101T120000Z", jobId);
+    assertTrue(archive.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + jobId
+        + ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
   }
 
   @Test
   public void testResolveArchiveTempFile() {
+    String jobId = UUID.randomUUID().toString();
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
-    File tempFile = fileManager.resolveArchiveTempFile(scope, "20260101T120000Z");
+    File tempFile = fileManager.resolveArchiveTempFile(scope, "20260101T120000Z", jobId);
     assertTrue(tempFile.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_TMP_SUFFIX));
+  }
+
+  @Test
+  public void testJobIdFromArchiveFileName() {
+    String jobId = UUID.randomUUID().toString();
+    String fileName = "container-ids-health-MISSING-20260101T120000Z"
+        + ExportFileManager.EXPORT_ARCHIVE_JOB_INFIX + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX;
+    assertEquals(jobId, ExportFileManager.jobIdFromArchiveFileName(fileName));
+    assertNull(ExportFileManager.jobIdFromArchiveFileName("container-ids-health-MISSING-20260101T120000Z"
+        + ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
   }
 
   @Test
   public void testListCompletedArchivePaths() throws Exception {
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
-    File olderArchive = fileManager.resolveArchiveFile(scope, "20260101T120000Z");
+    String olderJobId = UUID.randomUUID().toString();
+    File olderArchive = fileManager.resolveArchiveFile(scope, "20260101T120000Z", olderJobId);
     assertTrue(olderArchive.createNewFile());
     assertTrue(olderArchive.setLastModified(1_000L));
-    File newerArchive = fileManager.resolveArchiveFile(scope, "20260101T120001Z");
+    String newerJobId = UUID.randomUUID().toString();
+    File newerArchive = fileManager.resolveArchiveFile(scope, "20260101T120001Z", newerJobId);
     assertTrue(newerArchive.createNewFile());
     assertTrue(newerArchive.setLastModified(2_000L));
-    File tempArchive = fileManager.resolveArchiveTempFile(scope, "20260101T120002Z");
+    String tempJobId = UUID.randomUUID().toString();
+    File tempArchive = fileManager.resolveArchiveTempFile(scope, "20260101T120002Z", tempJobId);
     assertTrue(tempArchive.createNewFile());
 
     List<String> completedPaths = fileManager.listCompletedArchivePaths();
@@ -96,23 +113,20 @@ public class TestExportFileManager {
     Path jobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
     Files.createDirectories(jobDir);
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
-    File partialArchiveTemp = fileManager.resolveArchiveTempFile(scope, "20260101T000000Z");
+    File partialArchiveTemp = fileManager.resolveArchiveTempFile(scope, "20260101T000000Z", jobId);
     assertTrue(partialArchiveTemp.createNewFile());
-    File inProgress = new File(tempDir, jobId + ExportFileManager.IN_PROGRESS_MARKER_SUFFIX);
-    assertTrue(inProgress.createNewFile());
 
     fileManager.start();
 
     assertFalse(Files.exists(jobDir));
     assertFalse(partialArchiveTemp.exists());
-    assertFalse(inProgress.exists());
   }
 
   @Test
-  public void testOrphanJobDirWithoutMarkerDoesNotDeleteCompletedTar() throws Exception {
+  public void testOrphanJobDirDoesNotDeleteCompletedTar() throws Exception {
     String jobId = UUID.randomUUID().toString();
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
-    File completedArchive = fileManager.resolveArchiveFile(scope, "20260101T000000Z");
+    File completedArchive = fileManager.resolveArchiveFile(scope, "20260101T000000Z", jobId);
     assertTrue(completedArchive.createNewFile());
     Path orphanJobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
     Files.createDirectories(orphanJobDir);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/export/TestExportFileManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.container.export;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,12 +47,32 @@ public class TestExportFileManager {
   }
 
   @Test
-  public void testResolveTarPath() {
-    String jobId = UUID.randomUUID().toString();
+  public void testResolveArchiveFile() {
     ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
-    String tarPath = fileManager.resolveTarPath(scope, "20260101T120000Z", jobId);
-    assertTrue(tarPath.endsWith(
-        "container-ids-health-MISSING-20260101T120000Z-" + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
+    File archive = fileManager.resolveArchiveFile(scope, "20260101T120000Z");
+    assertTrue(archive.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_SUFFIX));
+  }
+
+  @Test
+  public void testResolveArchiveTempFile() {
+    ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
+    File tempFile = fileManager.resolveArchiveTempFile(scope, "20260101T120000Z");
+    assertTrue(tempFile.getName().endsWith(ExportFileManager.EXPORT_ARCHIVE_TMP_SUFFIX));
+  }
+
+  @Test
+  public void testListCompletedArchivePaths() throws Exception {
+    ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
+    File olderArchive = fileManager.resolveArchiveFile(scope, "20260101T120000Z");
+    assertTrue(olderArchive.createNewFile());
+    File newerArchive = fileManager.resolveArchiveFile(scope, "20260101T120001Z");
+    assertTrue(newerArchive.createNewFile());
+    File tempArchive = fileManager.resolveArchiveTempFile(scope, "20260101T120002Z");
+    assertTrue(tempArchive.createNewFile());
+
+    assertEquals(2, fileManager.listCompletedArchivePaths().size());
+    assertEquals(olderArchive.getAbsolutePath(), fileManager.listCompletedArchivePaths().get(0));
+    assertEquals(newerArchive.getAbsolutePath(), fileManager.listCompletedArchivePaths().get(1));
   }
 
   @Test
@@ -70,31 +91,31 @@ public class TestExportFileManager {
     String jobId = UUID.randomUUID().toString();
     Path jobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
     Files.createDirectories(jobDir);
-    File partialTar = new File(tempDir,
-        "container-ids-health-MISSING-20260101T000000Z-" + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX);
-    assertTrue(partialTar.createNewFile());
+    ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
+    File partialArchiveTemp = fileManager.resolveArchiveTempFile(scope, "20260101T000000Z");
+    assertTrue(partialArchiveTemp.createNewFile());
     File inProgress = new File(tempDir, jobId + ExportFileManager.IN_PROGRESS_MARKER_SUFFIX);
     assertTrue(inProgress.createNewFile());
 
     fileManager.start();
 
     assertFalse(Files.exists(jobDir));
-    assertFalse(partialTar.exists());
+    assertFalse(partialArchiveTemp.exists());
     assertFalse(inProgress.exists());
   }
 
   @Test
   public void testOrphanJobDirWithoutMarkerDoesNotDeleteCompletedTar() throws Exception {
     String jobId = UUID.randomUUID().toString();
-    File completedTar = new File(tempDir,
-        "container-ids-health-MISSING-20260101T000000Z-" + jobId + ExportFileManager.EXPORT_ARCHIVE_SUFFIX);
-    assertTrue(completedTar.createNewFile());
+    ExportScope scope = ExportScope.of(null, ContainerHealthState.MISSING);
+    File completedArchive = fileManager.resolveArchiveFile(scope, "20260101T000000Z");
+    assertTrue(completedArchive.createNewFile());
     Path orphanJobDir = tempDir.toPath().resolve(ExportFileManager.exportJobDirName(jobId));
     Files.createDirectories(orphanJobDir);
 
     fileManager.start();
 
-    assertTrue(completedTar.exists());
+    assertTrue(completedArchive.exists());
     assertFalse(Files.exists(orphanJobDir));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Document on-disk export layout under `{scm.db.dirs}/exports`.
- Centralize markers, TAR paths, startup orphan cleanup, failure cleanup in `ExportFileManager`

Part **3** in splitting [HDDS-15496](https://issues.apache.org/jira/browse/HDDS-15496) https://github.com/apache/ozone/pull/10673 container ID export.

https://github.com/apache/ozone/pull/10813 will rebase to delegate file operations here after this merges.

## What is the link to the Apache JIRA
[HDDS-15935](https://issues.apache.org/jira/browse/HDDS-15935)

## How was this patch tested?
Added tests in `TestExportFileManager`.
