### PR TITLE
HDDS-15984. [STS] Improve s3:prefix Condition handling and reject unsupported AssumeRole parameters

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/iam/IamSessionPolicyResolver.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/iam/IamSessionPolicyResolver.java
@@ -309,7 +309,12 @@ public final class IamSessionPolicyResolver {
             ERROR_PREFIX + "Invalid Condition operator value structure - " + operatorValue, MALFORMED_POLICY_DOCUMENT);
       }
 
-      final String keyName = operatorValue.fieldNames().hasNext() ? operatorValue.fieldNames().next() : null;
+      if (operatorValue.size() != 1) {
+        throw new OMException(
+            ERROR_PREFIX + "Only one Condition key is supported per operator", NOT_SUPPORTED_OPERATION);
+      }
+
+      final String keyName = operatorValue.fieldNames().next();
       if (!"s3:prefix".equalsIgnoreCase(keyName)) {
         throw new OMException(ERROR_PREFIX + "Unsupported Condition key name - " + keyName, NOT_SUPPORTED_OPERATION);
       }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/acl/iam/TestIamSessionPolicyResolver.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/acl/iam/TestIamSessionPolicyResolver.java
@@ -139,6 +139,36 @@ public class TestIamSessionPolicyResolver {
   }
 
   @Test
+  public void testMultipleConditionKeysWithPrefixFirstThrows() {
+    final String json = "{\n" +
+        "  \"Statement\": [{\n" +
+        "    \"Effect\": \"Allow\",\n" +
+        "    \"Action\": \"s3:ListBucket\",\n" +
+        "    \"Resource\": \"arn:aws:s3:::b\",\n" +
+        "    \"Condition\": { \"StringEquals\": { \"s3:prefix\": \"x\", \"aws:SourceIp\": \"1.2.3.4\" } }\n" +
+        "  }]\n" +
+        "}";
+
+    expectResolveThrowsForBothAuthorizers(
+        json, "IAM session policy: Only one Condition key is supported per operator", NOT_SUPPORTED_OPERATION);
+  }
+
+  @Test
+  public void testMultipleConditionKeysWithUnsupportedKeyFirstThrows() {
+    final String json = "{\n" +
+        "  \"Statement\": [{\n" +
+        "    \"Effect\": \"Allow\",\n" +
+        "    \"Action\": \"s3:ListBucket\",\n" +
+        "    \"Resource\": \"arn:aws:s3:::b\",\n" +
+        "    \"Condition\": { \"StringEquals\": { \"aws:SourceIp\": \"1.2.3.4\", \"s3:prefix\": \"x\" } }\n" +
+        "  }]\n" +
+        "}";
+
+    expectResolveThrowsForBothAuthorizers(
+        json, "IAM session policy: Only one Condition key is supported per operator", NOT_SUPPORTED_OPERATION);
+  }
+
+  @Test
   public void testUnsupportedEffectThrows() {
     final String json = "{\n" +
         "  \"Statement\": [{\n" +

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3sts/S3STSEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3sts/S3STSEndpoint.java
@@ -163,18 +163,20 @@ public class S3STSEndpoint extends S3STSEndpointBase {
   @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   @Produces(MediaType.APPLICATION_XML)
   public Response post(Form form) throws OS3Exception {
-    final MultivaluedMap<String, String> formParams = form == null ? null : form.asMap();
-    final String action = formParams == null ? null : formParams.getFirst("Action");
-    final String roleArn = formParams == null ? null : formParams.getFirst("RoleArn");
-    final String roleSessionName = formParams == null ? null : formParams.getFirst("RoleSessionName");
-    final Integer durationSeconds =
-        parseIntegerOrNull(formParams == null ? null : formParams.getFirst("DurationSeconds"));
-    final String version = formParams == null ? null : formParams.getFirst("Version");
-    final String awsIamSessionPolicy = formParams == null ? null : formParams.getFirst("Policy");
+    if (form == null) {
+      return unknownOperationExceptionResponse();
+    }
 
-    final Set<String> formParamNames = formParams == null ? Collections.emptySet() : formParams.keySet();
+    final MultivaluedMap<String, String> formParams = form.asMap();
+    final String action = formParams.getFirst("Action");
+    final String roleArn = formParams.getFirst("RoleArn");
+    final String roleSessionName = formParams.getFirst("RoleSessionName");
+    final Integer durationSeconds = parseIntegerOrNull(formParams.getFirst("DurationSeconds"));
+    final String version = formParams.getFirst("Version");
+    final String awsIamSessionPolicy = formParams.getFirst("Policy");
+
     return handleSTSRequest(
-        formParamNames, action, roleArn, roleSessionName, durationSeconds, version, awsIamSessionPolicy);
+        formParams.keySet(), action, roleArn, roleSessionName, durationSeconds, version, awsIamSessionPolicy);
   }
 
   private Response handleSTSRequest(Set<String> paramNamesToValidate, String action, String roleArn,
@@ -184,10 +186,7 @@ public class S3STSEndpoint extends S3STSEndpointBase {
     try {
       if (action == null) {
         // Amazon STS has a different structure for the XML error response when the action is missing
-        return Response.status(BAD_REQUEST)
-            .entity("<UnknownOperationException/>")
-            .type(MediaType.APPLICATION_XML)
-            .build();
+        return unknownOperationExceptionResponse();
       }
 
       switch (action) {
@@ -366,9 +365,14 @@ public class S3STSEndpoint extends S3STSEndpointBase {
   }
 
   private static boolean isAllowedAssumeRoleParameter(String paramName) {
-    return StringUtils.isBlank(paramName)
-        || ASSUME_ROLE_ALLOWED_PARAMS.contains(paramName)
-        || Strings.CI.startsWith(paramName, SIGV4_PARAM_PREFIX);
+    return ASSUME_ROLE_ALLOWED_PARAMS.contains(paramName) || Strings.CI.startsWith(paramName, SIGV4_PARAM_PREFIX);
+  }
+
+  private static Response unknownOperationExceptionResponse() {
+    return Response.status(BAD_REQUEST)
+        .entity("<UnknownOperationException/>")
+        .type(MediaType.APPLICATION_XML)
+        .build();
   }
 
   private static boolean isAwsValidButNotImplementedAssumeRoleParameter(String paramName) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3sts/S3STSEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3sts/S3STSEndpoint.java
@@ -28,27 +28,34 @@ import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.STS_UNSUPPORTED_
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.STS_VALIDATION_ERROR;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
-import javax.ws.rs.FormParam;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.hadoop.ozone.audit.S3GAction;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.AssumeRoleResponseInfo;
@@ -87,6 +94,19 @@ public class S3STSEndpoint extends S3STSEndpointBase {
   private static final String GET_ACCESS_KEY_INFO_ACTION = "GetAccessKeyInfo";
 
   private static final String EXPECTED_VERSION = "2011-06-15";
+
+  private static final String SIGV4_PARAM_PREFIX = "X-Amz-";
+
+  private static final Set<String> ASSUME_ROLE_ALLOWED_PARAMS = ImmutableSet.of(
+      "Action", "RoleArn", "RoleSessionName", "DurationSeconds", "Version", "Policy");
+
+  private static final String POLICY_ARNS_MEMBER_PREFIX = "PolicyArns.member.";
+  private static final String PROVIDED_CONTEXTS_MEMBER_PREFIX = "ProvidedContexts.member.";
+  private static final String TAGS_MEMBER_PREFIX = "Tags.member.";
+  private static final String TRANSITIVE_TAG_KEYS_MEMBER_PREFIX = "TransitiveTagKeys.member.";
+
+  private static final Set<String> AWS_VALID_ASSUME_ROLE_OPTIONAL_PARAMS = ImmutableSet.of(
+      "ExternalId", "SerialNumber", "SourceIdentity", "TokenCode");
 
   // JAXBContext is relatively expensive to create and is threadsafe, so cache and reuse
   private static final JAXBContext JAXB_CONTEXT;
@@ -128,35 +148,37 @@ public class S3STSEndpoint extends S3STSEndpointBase {
       @QueryParam("Version") String version,
       @QueryParam("Policy") String awsIamSessionPolicy) throws OS3Exception {
 
-    return handleSTSRequest(action, roleArn, roleSessionName, durationSeconds, version, awsIamSessionPolicy);
+    return handleSTSRequest(
+        getQueryParameters().keySet(), action, roleArn, roleSessionName, durationSeconds, version, awsIamSessionPolicy);
   }
 
   /**
    * STS endpoint that handles POST requests with form data.
    * AWS STS typically uses POST requests with form-encoded parameters.
    *
-   * @param action The STS action to perform
-   * @param roleArn The ARN of the role to assume
-   * @param roleSessionName Session name for the role
-   * @param durationSeconds Duration of the token validity
-   * @param version AWS STS API version
+   * @param form form-encoded request parameters
    * @return Response containing STS response XML or error
    */
   @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
   @Produces(MediaType.APPLICATION_XML)
-  public Response post(
-      @FormParam("Action") String action,
-      @FormParam("RoleArn") String roleArn,
-      @FormParam("RoleSessionName") String roleSessionName,
-      @FormParam("DurationSeconds") Integer durationSeconds,
-      @FormParam("Version") String version,
-      @FormParam("Policy") String awsIamSessionPolicy) throws OS3Exception {
+  public Response post(Form form) throws OS3Exception {
+    final MultivaluedMap<String, String> formParams = form == null ? null : form.asMap();
+    final String action = formParams == null ? null : formParams.getFirst("Action");
+    final String roleArn = formParams == null ? null : formParams.getFirst("RoleArn");
+    final String roleSessionName = formParams == null ? null : formParams.getFirst("RoleSessionName");
+    final Integer durationSeconds =
+        parseIntegerOrNull(formParams == null ? null : formParams.getFirst("DurationSeconds"));
+    final String version = formParams == null ? null : formParams.getFirst("Version");
+    final String awsIamSessionPolicy = formParams == null ? null : formParams.getFirst("Policy");
 
-    return handleSTSRequest(action, roleArn, roleSessionName, durationSeconds, version, awsIamSessionPolicy);
+    final Set<String> formParamNames = formParams == null ? Collections.emptySet() : formParams.keySet();
+    return handleSTSRequest(
+        formParamNames, action, roleArn, roleSessionName, durationSeconds, version, awsIamSessionPolicy);
   }
 
-  private Response handleSTSRequest(String action, String roleArn, String roleSessionName,
-      Integer durationSeconds, String version, String awsIamSessionPolicy) throws OS3Exception {
+  private Response handleSTSRequest(Set<String> paramNamesToValidate, String action, String roleArn,
+      String roleSessionName, Integer durationSeconds, String version, String awsIamSessionPolicy) throws OS3Exception {
     final String requestId = requestIdentifier.getRequestId();
     // NOTE: invalid, missing or unsupported actions are not added to the audit log
     try {
@@ -170,7 +192,8 @@ public class S3STSEndpoint extends S3STSEndpointBase {
 
       switch (action) {
       case ASSUME_ROLE_ACTION:
-        return handleAssumeRole(roleArn, roleSessionName, durationSeconds, awsIamSessionPolicy, version, requestId);
+        return handleAssumeRole(
+            paramNamesToValidate, roleArn, roleSessionName, durationSeconds, awsIamSessionPolicy, version, requestId);
       // These operations are not supported yet
       case GET_SESSION_TOKEN_ACTION:
       case ASSUME_ROLE_WITH_SAML_ACTION:
@@ -193,8 +216,8 @@ public class S3STSEndpoint extends S3STSEndpointBase {
     }
   }
 
-  private Response handleAssumeRole(String roleArn, String roleSessionName, Integer durationSeconds,
-      String awsIamSessionPolicy, String version, String requestId) throws OSTSException {
+  private Response handleAssumeRole(Set<String> paramNamesToValidate, String roleArn, String roleSessionName,
+      Integer durationSeconds, String awsIamSessionPolicy, String version, String requestId) throws OSTSException {
     final String action = "AssumeRole";
     final Map<String, String> auditParams = getAuditParameters();
     S3STSUtils.addAssumeRoleAuditParams(
@@ -207,6 +230,16 @@ public class S3STSEndpoint extends S3STSEndpointBase {
       final OSTSException exception = new OSTSException(STS_INVALID_ACTION)
           .withMessage("Could not find operation " + action + " for version " +
               (version == null ? "NO_VERSION_SPECIFIED.  Expected version is: " + EXPECTED_VERSION : version));
+      getAuditLogger().logWriteFailure(buildAuditMessageForFailure(S3GAction.ASSUME_ROLE, auditParams, exception));
+      throw exception;
+    }
+
+    final AssumeRoleParamValidationResult assumeRoleParamValidationResult = validateAssumeRoleParameters(
+        paramNamesToValidate);
+    if (!assumeRoleParamValidationResult.getNotImplementedOptionalParams().isEmpty()) {
+      final OSTSException exception = new OSTSException(STS_UNSUPPORTED_OPERATION).withMessage(
+          "AssumeRole optional parameter(s) not implemented: " +
+              String.join(", ", assumeRoleParamValidationResult.getNotImplementedOptionalParams()));
       getAuditLogger().logWriteFailure(buildAuditMessageForFailure(S3GAction.ASSUME_ROLE, auditParams, exception));
       throw exception;
     }
@@ -240,6 +273,11 @@ public class S3STSEndpoint extends S3STSEndpointBase {
       S3STSUtils.validateSessionPolicy(awsIamSessionPolicy);
     } catch (OMException e) {
       validationErrors.add(e.getMessage());
+    }
+
+    if (!assumeRoleParamValidationResult.getUnsupportedParams().isEmpty()) {
+      validationErrors.add("Unsupported AssumeRole parameter(s): " + String.join(", ",
+          assumeRoleParamValidationResult.getUnsupportedParams()));
     }
 
     final int numValidationErrors = validationErrors.size();
@@ -300,6 +338,87 @@ public class S3STSEndpoint extends S3STSEndpointBase {
     } catch (Exception e) {
       getAuditLogger().logWriteFailure(buildAuditMessageForFailure(S3GAction.ASSUME_ROLE, auditParams, e));
       throw e;
+    }
+  }
+
+  private AssumeRoleParamValidationResult validateAssumeRoleParameters(Set<String> paramNamesToValidate) {
+    if (paramNamesToValidate == null || paramNamesToValidate.isEmpty()) {
+      return AssumeRoleParamValidationResult.empty();
+    }
+
+    final List<String> notImplementedOptionalParams = new ArrayList<>();
+    final List<String> unsupportedParams = new ArrayList<>();
+    for (String paramName : paramNamesToValidate) {
+      if (isAllowedAssumeRoleParameter(paramName)) {
+        continue;
+      }
+
+      if (isAwsValidButNotImplementedAssumeRoleParameter(paramName)) {
+        notImplementedOptionalParams.add(paramName);
+      } else {
+        unsupportedParams.add(paramName);
+      }
+    }
+
+    Collections.sort(notImplementedOptionalParams);
+    Collections.sort(unsupportedParams);
+    return new AssumeRoleParamValidationResult(notImplementedOptionalParams, unsupportedParams);
+  }
+
+  private static boolean isAllowedAssumeRoleParameter(String paramName) {
+    return StringUtils.isBlank(paramName)
+        || ASSUME_ROLE_ALLOWED_PARAMS.contains(paramName)
+        || Strings.CI.startsWith(paramName, SIGV4_PARAM_PREFIX);
+  }
+
+  private static boolean isAwsValidButNotImplementedAssumeRoleParameter(String paramName) {
+    if (StringUtils.isBlank(paramName)) {
+      return false;
+    }
+    if (AWS_VALID_ASSUME_ROLE_OPTIONAL_PARAMS.contains(paramName)) {
+      return true;
+    }
+
+    return Strings.CI.startsWith(paramName, POLICY_ARNS_MEMBER_PREFIX)
+        || Strings.CI.startsWith(paramName, PROVIDED_CONTEXTS_MEMBER_PREFIX)
+        || Strings.CI.startsWith(paramName, TAGS_MEMBER_PREFIX)
+        || Strings.CI.startsWith(paramName, TRANSITIVE_TAG_KEYS_MEMBER_PREFIX);
+  }
+
+  private static Integer parseIntegerOrNull(String value) throws OSTSException {
+    if (StringUtils.isBlank(value)) {
+      return null;
+    }
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw new OSTSException(STS_VALIDATION_ERROR)
+          .withMessage("1 validation error detected: Invalid Value: DurationSeconds must be a number");
+    }
+  }
+
+  private static final class AssumeRoleParamValidationResult {
+    private static final AssumeRoleParamValidationResult EMPTY = new AssumeRoleParamValidationResult(
+        Collections.emptyList(), Collections.emptyList());
+
+    private final List<String> notImplementedOptionalParams;
+    private final List<String> unsupportedParams;
+
+    private AssumeRoleParamValidationResult(List<String> notImplementedOptionalParams, List<String> unsupportedParams) {
+      this.notImplementedOptionalParams = notImplementedOptionalParams;
+      this.unsupportedParams = unsupportedParams;
+    }
+
+    private static AssumeRoleParamValidationResult empty() {
+      return EMPTY;
+    }
+
+    private List<String> getNotImplementedOptionalParams() {
+      return notImplementedOptionalParams;
+    }
+
+    private List<String> getUnsupportedParams() {
+      return unsupportedParams;
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3sts/S3STSEndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3sts/S3STSEndpointBase.java
@@ -23,6 +23,8 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -132,5 +134,13 @@ public class S3STSEndpointBase implements Auditor {
 
   protected Map<String, String> getAuditParameters() {
     return AuditUtils.getAuditParameters(context);
+  }
+
+  protected MultivaluedMap<String, String> getQueryParameters() {
+    if (context == null || context.getUriInfo() == null) {
+      return new MultivaluedHashMap<>();
+    }
+    final MultivaluedMap<String, String> params = context.getUriInfo().getQueryParameters();
+    return params == null ? new MultivaluedHashMap<>() : params;
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3sts/TestS3STSEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3sts/TestS3STSEndpoint.java
@@ -145,8 +145,7 @@ public class TestS3STSEndpoint {
     setBaseAssumeRoleFormParameters();
     formParameters.param("ExternalId", "external-id");
 
-    final OSTSException ex = assertThrows(
-        OSTSException.class, () -> endpoint.post(formParameters));
+    final OSTSException ex = assertThrows(OSTSException.class, () -> endpoint.post(formParameters).close());
 
     assertEquals(501, ex.getHttpCode());
     verify(auditLogger).logWriteFailure(any(AuditMessage.class));
@@ -219,8 +218,7 @@ public class TestS3STSEndpoint {
     setBaseAssumeRoleFormParameters();
     formParameters.param("TotallyUnknownParam", "y");
 
-    final OSTSException ex = assertThrows(
-        OSTSException.class, () -> endpoint.post(formParameters));
+    final OSTSException ex = assertThrows(OSTSException.class, () -> endpoint.post(formParameters).close());
 
     assertEquals(400, ex.getHttpCode());
     verify(auditLogger).logWriteFailure(any(AuditMessage.class));
@@ -234,6 +232,40 @@ public class TestS3STSEndpoint {
   }
 
   @Test
+  public void testStsAssumeRoleRejectsBlankParameterNameForGetMethod() throws Exception {
+    setAssumeRoleQueryParameters("", "x");
+
+    final OSTSException ex = assertThrows(
+        OSTSException.class, () -> endpoint.get("AssumeRole", ROLE_ARN, ROLE_SESSION_NAME, 3600, "2011-06-15", null));
+
+    assertEquals(400, ex.getHttpCode());
+    verify(auditLogger).logWriteFailure(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteSuccess(any(AuditMessage.class));
+    verify(objectStore, never()).assumeRole(anyString(), anyString(), anyInt(), any(), anyString());
+
+    ex.setRequestId(REQUEST_ID);
+    assertStsErrorXml(
+        ex.toXml(), STS_NS, "Sender", "ValidationError", "Unsupported AssumeRole parameter(s): ");
+  }
+
+  @Test
+  public void testStsAssumeRoleRejectsBlankParameterNameForPostMethod() throws Exception {
+    setBaseAssumeRoleFormParameters();
+    formParameters.param("", "x");
+
+    final OSTSException ex = assertThrows(OSTSException.class, () -> endpoint.post(formParameters).close());
+
+    assertEquals(400, ex.getHttpCode());
+    verify(auditLogger).logWriteFailure(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteSuccess(any(AuditMessage.class));
+    verify(objectStore, never()).assumeRole(anyString(), anyString(), anyInt(), any(), anyString());
+
+    ex.setRequestId(REQUEST_ID);
+    assertStsErrorXml(
+        ex.toXml(), STS_NS, "Sender", "ValidationError", "Unsupported AssumeRole parameter(s): ");
+  }
+
+  @Test
   public void testStsAssumeRoleIgnoresUnknownQueryStringParameterForPostMethod() {
     queryParameters.add("foo", "bar");
 
@@ -241,6 +273,7 @@ public class TestS3STSEndpoint {
     // Query string parameters should not affect validation results.
     setBaseAssumeRoleFormParameters();
     final Response response = endpoint.post(formParameters);
+    response.close();
 
     assertEquals(200, response.getStatus());
     verify(auditLogger).logWriteSuccess(any(AuditMessage.class));
@@ -254,8 +287,7 @@ public class TestS3STSEndpoint {
     formParameters.param("Signature", "signature");
     formParameters.param("Expires", "3600");
 
-    final OSTSException ex = assertThrows(
-        OSTSException.class, () -> endpoint.post(formParameters));
+    final OSTSException ex = assertThrows(OSTSException.class, () -> endpoint.post(formParameters).close());
 
     assertEquals(400, ex.getHttpCode());
     verify(auditLogger).logWriteFailure(any(AuditMessage.class));
@@ -355,6 +387,22 @@ public class TestS3STSEndpoint {
     final Document doc = parseXml(errorMessage);
     final Element root = doc.getDocumentElement();
     assertEquals("UnknownOperationException", root.getLocalName());
+  }
+
+  @Test
+  public void testStsNullFormForPostMethod() throws Exception {
+    final Response response = endpoint.post(null);
+
+    assertEquals(400, response.getStatus());
+    verifyNoInteractions(auditLogger);
+    final String errorMessage = (String) response.getEntity();
+    assertEquals("<UnknownOperationException/>", errorMessage);
+
+    final Document doc = parseXml(errorMessage);
+    final Element root = doc.getDocumentElement();
+    assertEquals("UnknownOperationException", root.getLocalName());
+
+    response.close();
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3sts/TestS3STSEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3sts/TestS3STSEndpoint.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.time.Instant;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -68,6 +69,8 @@ public class TestS3STSEndpoint {
   private S3STSEndpoint endpoint;
   private ObjectStore objectStore;
   private AuditLogger auditLogger;
+  private MultivaluedHashMap<String, String> queryParameters;
+  private Form formParameters;
   private static final String ROLE_ARN = "arn:aws:iam::123456789012:role/test-role";
   private static final String ROLE_SESSION_NAME = "test-session";
   private static final String ROLE_USER_ARN = "arn:aws:sts::123456789012:assumed-role/test-role/" + ROLE_SESSION_NAME;
@@ -87,7 +90,9 @@ public class TestS3STSEndpoint {
     final UriInfo uriInfo = mock(UriInfo.class);
     when(context.getUriInfo()).thenReturn(uriInfo);
     when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>());
-    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    queryParameters = new MultivaluedHashMap<>();
+    when(uriInfo.getQueryParameters()).thenReturn(queryParameters);
+    formParameters = new Form();
 
     // Stub assumeRole to return deterministic credentials.
     objectStore = mock(ObjectStore.class);
@@ -115,6 +120,152 @@ public class TestS3STSEndpoint {
         .setStringToSign("dummy-string")
         .build();
     endpoint.setSignatureInfo(signatureInfo);
+  }
+
+  @Test
+  public void testStsAssumeRoleRejectsUnsupportedParameterForGetMethod() throws Exception {
+    setAssumeRoleQueryParameters("PolicyArns.member.1", "arn:aws:iam::123456789012:policy/test-policy");
+
+    final OSTSException ex = assertThrows(
+        OSTSException.class, () -> endpoint.get("AssumeRole", ROLE_ARN, ROLE_SESSION_NAME, 3600, "2011-06-15", null));
+
+    assertEquals(501, ex.getHttpCode());
+    verify(auditLogger).logWriteFailure(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteSuccess(any(AuditMessage.class));
+    verify(objectStore, never()).assumeRole(anyString(), anyString(), anyInt(), any(), anyString());
+
+    ex.setRequestId(REQUEST_ID);
+    assertStsErrorXml(
+        ex.toXml(), STS_NS, "Sender", "UnsupportedOperation",
+        "AssumeRole optional parameter(s) not implemented: PolicyArns.member.1");
+  }
+
+  @Test
+  public void testStsAssumeRoleRejectsUnsupportedParameterForPostMethod() throws Exception {
+    setBaseAssumeRoleFormParameters();
+    formParameters.param("ExternalId", "external-id");
+
+    final OSTSException ex = assertThrows(
+        OSTSException.class, () -> endpoint.post(formParameters));
+
+    assertEquals(501, ex.getHttpCode());
+    verify(auditLogger).logWriteFailure(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteSuccess(any(AuditMessage.class));
+    verify(objectStore, never()).assumeRole(anyString(), anyString(), anyInt(), any(), anyString());
+
+    ex.setRequestId(REQUEST_ID);
+    assertStsErrorXml(
+        ex.toXml(), STS_NS, "Sender", "UnsupportedOperation",
+        "AssumeRole optional parameter(s) not implemented: ExternalId");
+  }
+
+  @Test
+  public void testStsAssumeRoleAllowsSupportedParametersForGetMethod() {
+    setAssumeRoleQueryParameters(
+        "Action", "AssumeRole",
+        "RoleArn", ROLE_ARN,
+        "RoleSessionName", ROLE_SESSION_NAME,
+        "DurationSeconds", "3600",
+        "Version", "2011-06-15");
+
+    final Response response = endpoint.get("AssumeRole", ROLE_ARN, ROLE_SESSION_NAME, 3600, "2011-06-15", null);
+
+    assertEquals(200, response.getStatus());
+    verify(auditLogger).logWriteSuccess(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteFailure(any(AuditMessage.class));
+  }
+
+  @Test
+  public void testStsAssumeRoleAllowsSignatureParametersForGetMethod() {
+    setAssumeRoleQueryParameters(
+        "Action", "AssumeRole",
+        "RoleArn", ROLE_ARN,
+        "RoleSessionName", ROLE_SESSION_NAME,
+        "DurationSeconds", "3600",
+        "Version", "2011-06-15",
+        "X-Amz-Algorithm", "AWS4-HMAC-SHA256",
+        "X-Amz-Credential", "test-user/20260101/us-east-1/sts/aws4_request",
+        "X-Amz-Date", "20260101T000000Z",
+        "X-Amz-Expires", "3600",
+        "X-Amz-SignedHeaders", "host",
+        "X-Amz-Signature", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+    final Response response = endpoint.get("AssumeRole", ROLE_ARN, ROLE_SESSION_NAME, 3600, "2011-06-15", null);
+
+    assertEquals(200, response.getStatus());
+    verify(auditLogger).logWriteSuccess(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteFailure(any(AuditMessage.class));
+  }
+
+  @Test
+  public void testStsAssumeRoleRejectsUnknownParameterForGetMethod() throws Exception {
+    setAssumeRoleQueryParameters("TotallyUnknownParam", "x");
+
+    final OSTSException ex = assertThrows(
+        OSTSException.class, () -> endpoint.get("AssumeRole", ROLE_ARN, ROLE_SESSION_NAME, 3600, "2011-06-15", null));
+
+    assertEquals(400, ex.getHttpCode());
+    verify(auditLogger).logWriteFailure(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteSuccess(any(AuditMessage.class));
+    verify(objectStore, never()).assumeRole(anyString(), anyString(), anyInt(), any(), anyString());
+
+    ex.setRequestId(REQUEST_ID);
+    assertStsErrorXml(
+        ex.toXml(), STS_NS, "Sender", "ValidationError", "Unsupported AssumeRole parameter(s): TotallyUnknownParam");
+  }
+
+  @Test
+  public void testStsAssumeRoleRejectsUnknownParameterForPostMethod() throws Exception {
+    setBaseAssumeRoleFormParameters();
+    formParameters.param("TotallyUnknownParam", "y");
+
+    final OSTSException ex = assertThrows(
+        OSTSException.class, () -> endpoint.post(formParameters));
+
+    assertEquals(400, ex.getHttpCode());
+    verify(auditLogger).logWriteFailure(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteSuccess(any(AuditMessage.class));
+    verify(objectStore, never()).assumeRole(anyString(), anyString(), anyInt(), any(), anyString());
+
+    ex.setRequestId(REQUEST_ID);
+    assertStsErrorXml(
+        ex.toXml(), STS_NS, "Sender", "ValidationError",
+        "Unsupported AssumeRole parameter(s): TotallyUnknownParam");
+  }
+
+  @Test
+  public void testStsAssumeRoleIgnoresUnknownQueryStringParameterForPostMethod() {
+    queryParameters.add("foo", "bar");
+
+    // For POST requests, only body (form) parameters should be validated.
+    // Query string parameters should not affect validation results.
+    setBaseAssumeRoleFormParameters();
+    final Response response = endpoint.post(formParameters);
+
+    assertEquals(200, response.getStatus());
+    verify(auditLogger).logWriteSuccess(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteFailure(any(AuditMessage.class));
+  }
+
+  @Test
+  public void testStsAssumeRoleRejectsUnsupportedSigningParametersForPostMethod() throws Exception {
+    setBaseAssumeRoleFormParameters();
+    formParameters.param("AWSAccessKeyId", "test-user");
+    formParameters.param("Signature", "signature");
+    formParameters.param("Expires", "3600");
+
+    final OSTSException ex = assertThrows(
+        OSTSException.class, () -> endpoint.post(formParameters));
+
+    assertEquals(400, ex.getHttpCode());
+    verify(auditLogger).logWriteFailure(any(AuditMessage.class));
+    verify(auditLogger, never()).logWriteSuccess(any(AuditMessage.class));
+    verify(objectStore, never()).assumeRole(anyString(), anyString(), anyInt(), any(), anyString());
+
+    ex.setRequestId(REQUEST_ID);
+    assertStsErrorXml(
+        ex.toXml(), STS_NS, "Sender", "ValidationError",
+        "Unsupported AssumeRole parameter(s): AWSAccessKeyId, Expires, Signature");
   }
 
   @Test
@@ -157,8 +308,9 @@ public class TestS3STSEndpoint {
 
   @Test
   public void testStsAssumeRoleValidForPostMethod() throws Exception {
+    setBaseAssumeRoleFormParameters();
     //noinspection resource
-    final Response response = endpoint.post("AssumeRole", ROLE_ARN, ROLE_SESSION_NAME, 3600, "2011-06-15", null);
+    final Response response = endpoint.post(formParameters);
 
     assertEquals(200, response.getStatus());
     verify(auditLogger).logWriteSuccess(any(AuditMessage.class));
@@ -561,6 +713,29 @@ public class TestS3STSEndpoint {
     assertTrue(message.contains("Invalid character '/' in RoleSessionName"));
     assertTrue(message.contains(
         "'policy' failed to satisfy constraint: Member must have length less than or equal to 2048"));
+  }
+
+  private void setAssumeRoleQueryParameters(String... nameValuePairs) {
+    queryParameters.clear();
+    for (int i = 0; i < nameValuePairs.length; i += 2) {
+      queryParameters.add(nameValuePairs[i], nameValuePairs[i + 1]);
+    }
+  }
+
+  private void setBaseAssumeRoleFormParameters() {
+    setAssumeRoleFormParameters(
+        "Action", "AssumeRole",
+        "RoleArn", ROLE_ARN,
+        "RoleSessionName", ROLE_SESSION_NAME,
+        "DurationSeconds", "3600",
+        "Version", "2011-06-15");
+  }
+
+  private void setAssumeRoleFormParameters(String... nameValuePairs) {
+    formParameters = new Form();
+    for (int i = 0; i < nameValuePairs.length; i += 2) {
+      formParameters.param(nameValuePairs[i], nameValuePairs[i + 1]);
+    }
   }
 
   private static Document parseXml(String xml) throws Exception {


### PR DESCRIPTION
Please describe your PR in detail:
* Currently, the following invalid session policy is being silently ignored instead of rejected, so this ticket will improve the handling:

```
{
    "Version":"2012-10-17",
    "Statement":[
      {
        "Effect":"Allow",
        "Action":"s3:ListBucket",
        "Resource":"arn:aws:s3:::my-bucket",
        "Condition":{
          "StringEquals":{
            "s3:prefix":"logs/*",
            "aws:username":"admin"
          }
        }
      }
    ]
  }
  ```

Separately, currently unsupported AssumeRole api parameters are being ignored rather than being rejected. This ticket will improve that as well.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15984

## How was this patch tested?
unit tests and smoke tests
