### PR TITLE
HDDS-15990. Remove setExclusiveManualCompaction from CompactionService

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactDBUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/CompactDBUtil.java
@@ -47,7 +47,8 @@ public final class CompactDBUtil {
       options.setBottommostLevelCompaction(compactionType);
       LOG.info("Compacting column family: {} with {} bottommost level compaction",
           tableName, options.bottommostLevelCompaction());
-      options.setExclusiveManualCompaction(true);
+      // Note that setExclusiveManualCompaction should not be set to true
+      // since this can cause write stall in high write throughput cluster. See HDDS-15990.
       RocksDatabase rocksDatabase =
           ((RDBStore) omMetadataManager.getStore()).getDb();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should remove setExclusiveManualCompaction so that automatic compactions can still compact L0 -> L1 files and prevent write stalls.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15990

## How was this patch tested?

CI.

https://github.com/ivandika3/ozone/actions/runs/30231577577