### PR TITLE
HDDS-16001. Add missing sections in pom.xml files to fix invalid testCompile configurations in IntelliJ.

### DIFF
--- a/.run/FreonStandalone.run.xml
+++ b/.run/FreonStandalone.run.xml
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="FreonStandalone" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.freon.Freon" />
-    <module name="ozone-tools" />
+    <module name="ozone-freon" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml rk" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">

--- a/.run/ScmRoles.run.xml
+++ b/.run/ScmRoles.run.xml
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ScmRoles" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.admin.OzoneAdmin" />
-    <module name="ozone-tools" />
+    <module name="ozone-cli-admin" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml scm roles -id=scm-group" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">

--- a/hadoop-hdds/cli-common/pom.xml
+++ b/hadoop-hdds/cli-common/pom.xml
@@ -95,6 +95,17 @@
               </compilerArgs>
             </configuration>
           </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -340,6 +340,19 @@
                   </compilerArgs>
                 </configuration>
               </execution>
+              <execution>
+                <id>default-testCompile</id>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <phase>test-compile</phase>
+                <configuration>
+                  <compilerArgs>
+                    <arg>-h</arg>
+                    <arg>${project.build.directory}/native/javah</arg>
+                  </compilerArgs>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>

--- a/hadoop-ozone/cli-admin/pom.xml
+++ b/hadoop-ozone/cli-admin/pom.xml
@@ -194,6 +194,17 @@
               </compilerArgs>
             </configuration>
           </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hadoop-ozone/cli-debug/pom.xml
+++ b/hadoop-ozone/cli-debug/pom.xml
@@ -290,6 +290,17 @@
               </compilerArgs>
             </configuration>
           </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hadoop-ozone/cli-repair/pom.xml
+++ b/hadoop-ozone/cli-repair/pom.xml
@@ -229,6 +229,17 @@
               </compilerArgs>
             </configuration>
           </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hadoop-ozone/cli-shell/pom.xml
+++ b/hadoop-ozone/cli-shell/pom.xml
@@ -182,6 +182,17 @@
               </compilerArgs>
             </configuration>
           </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hadoop-ozone/freon/pom.xml
+++ b/hadoop-ozone/freon/pom.xml
@@ -194,6 +194,17 @@
               </compilerArgs>
             </configuration>
           </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -201,6 +201,17 @@
               </compilerArgs>
             </configuration>
           </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hadoop-ozone/vapor/pom.xml
+++ b/hadoop-ozone/vapor/pom.xml
@@ -206,6 +206,17 @@
               </compilerArgs>
             </configuration>
           </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1841,6 +1841,17 @@
                 </compilerArgs>
               </configuration>
             </execution>
+            <execution>
+              <id>default-testCompile</id>
+              <goals>
+                <goal>testCompile</goal>
+              </goals>
+              <configuration>
+                <compilerArgs>
+                  <arg>-AartifactId=${project.artifactId}</arg>
+                </compilerArgs>
+              </configuration>
+            </execution>
           </executions>
         </plugin>
         <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?
The run configurations in Intellij are invalid. This can be seen from the little red cross marks on the run configurations. The error says that the class in the run configuration doesn't exist in the class path.

Since Intellij 2025.1 release, the way Intellij processes pom files has changed. It creates separate .main and .test modules in Maven projects.

See https://youtrack.jetbrains.com/projects/IDEA/issues/IDEA-371535/Confusing-separate-.main-and-.test-modules-in-Maven-projects

If there is a difference between the main and test configurations, then Intellij will create separate main and test modules. As such the default classpath won't work. The run configurations are pointing to classes which are not in the default classpath but instead in the classpath with the .main suffix. 

This PR adds a `default-testCompile` for the test sections to bring them on par with the main configurations. After this Intellij doesn't split the module into `main` and `test` and the existing run configurations become valid again. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16001


## How was this patch tested?
Tested locally 
CI: https://github.com/ptlrs/ozone/actions/runs/30307554649