### PR TITLE
HDDS-16002. Rearrange IntelliJ run configurations into groups for better organization

### DIFF
--- a/.run/Datanode1-ha.run.xml
+++ b/.run/Datanode1-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Datanode1-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="Datanode1-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/datanode1 --set hdds.datanode.dir=/tmp/datanode1/storage" />

--- a/.run/Datanode1.run.xml
+++ b/.run/Datanode1.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Datanode1" type="Application" factoryName="Application">
+  <configuration default="false" name="Datanode1" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --set ozone.metadata.dirs=/tmp/datanode1 --set hdds.datanode.dir=/tmp/datanode1/storage" />

--- a/.run/Datanode2-ha.run.xml
+++ b/.run/Datanode2-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Datanode2-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="Datanode2-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/datanode2 --set hdds.datanode.dir=/tmp/datanode2/storage --set hdds.datanode.http-address=127.0.0.1:10021 --set hdds.container.ratis.ipc.port=10022 --set hdds.container.ipc.port=10023 --set hdds.container.ratis.server.port=10024 --set hdds.container.ratis.admin.port=10025 --set hdds.datanode.replication.port=10026 --set hdds.container.ratis.datastream.port=10027 --set hdds.datanode.client.port=10028" />

--- a/.run/Datanode2.run.xml
+++ b/.run/Datanode2.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Datanode2" type="Application" factoryName="Application">
+  <configuration default="false" name="Datanode2" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --set ozone.metadata.dirs=/tmp/datanode2 --set hdds.datanode.dir=/tmp/datanode2/storage --set hdds.datanode.http-address=127.0.0.1:10021 --set hdds.container.ratis.ipc.port=10022 --set hdds.container.ipc.port=10023 --set hdds.container.ratis.server.port=10024 --set hdds.container.ratis.admin.port=10025 --set hdds.datanode.replication.port=10026 --set hdds.container.ratis.datastream.port=10027 --set hdds.datanode.client.port=10028" />

--- a/.run/Datanode3-ha.run.xml
+++ b/.run/Datanode3-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Datanode3-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="Datanode3-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/datanode3 --set hdds.datanode.dir=/tmp/datanode3/storage --set hdds.datanode.http-address=127.0.0.1:10031 --set hdds.container.ratis.ipc.port=10032 --set hdds.container.ipc.port=10033 --set hdds.container.ratis.server.port=10034 --set hdds.container.ratis.admin.port=10035 --set hdds.datanode.replication.port=10036 --set hdds.container.ratis.datastream.port=10037 --set hdds.datanode.client.port=10038" />

--- a/.run/Datanode3.run.xml
+++ b/.run/Datanode3.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Datanode3" type="Application" factoryName="Application">
+  <configuration default="false" name="Datanode3" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --set ozone.metadata.dirs=/tmp/datanode3 --set hdds.datanode.dir=/tmp/datanode3/storage --set hdds.datanode.http-address=127.0.0.1:10031 --set hdds.container.ratis.ipc.port=10032 --set hdds.container.ipc.port=10033 --set hdds.container.ratis.server.port=10034 --set hdds.container.ratis.admin.port=10035 --set hdds.datanode.replication.port=10036 --set hdds.container.ratis.datastream.port=10037 --set hdds.datanode.client.port=10038" />

--- a/.run/FreonStandalone.run.xml
+++ b/.run/FreonStandalone.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="FreonStandalone" type="Application" factoryName="Application">
+  <configuration default="false" name="FreonStandalone" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.freon.Freon" />
     <module name="ozone-tools" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml rk" />

--- a/.run/OzoneFsShell-ha.run.xml
+++ b/.run/OzoneFsShell-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OzoneFsShell-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="OzoneFsShell-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <envs>
       <env name="OZONE_CONF_DIR" value="$PROJECT_DIR$/hadoop-ozone/dev-support/intellij" />
     </envs>

--- a/.run/OzoneFsShell.run.xml
+++ b/.run/OzoneFsShell.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OzoneFsShell" type="Application" factoryName="Application">
+  <configuration default="false" name="OzoneFsShell" type="Application" factoryName="Application" folderName="ozone">
     <envs>
       <env name="OZONE_CONF_DIR" value="$PROJECT_DIR$/hadoop-ozone/dev-support/intellij" />
     </envs>

--- a/.run/OzoneManager-ha.run.xml
+++ b/.run/OzoneManager-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OzoneManager-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="OzoneManager-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.om.OzoneManagerStarter" />
     <module name="ozone-manager" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml" />

--- a/.run/OzoneManager.run.xml
+++ b/.run/OzoneManager.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OzoneManager" type="Application" factoryName="Application">
+  <configuration default="false" name="OzoneManager" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.om.OzoneManagerStarter" />
     <module name="ozone-manager" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml" />

--- a/.run/OzoneManagerInit-ha.run.xml
+++ b/.run/OzoneManagerInit-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OzoneManagerInit-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="OzoneManagerInit-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.om.OzoneManagerStarter" />
     <module name="ozone-manager" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --init" />

--- a/.run/OzoneManagerInit.run.xml
+++ b/.run/OzoneManagerInit.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OzoneManagerInit" type="Application" factoryName="Application">
+  <configuration default="false" name="OzoneManagerInit" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.om.OzoneManagerStarter" />
     <module name="ozone-manager" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --init" />

--- a/.run/OzoneShell-ha.run.xml
+++ b/.run/OzoneShell-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OzoneShell-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="OzoneShell-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.shell.OzoneShell" />
     <module name="ozone-cli-shell" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml volume create /vol1" />

--- a/.run/OzoneShell.run.xml
+++ b/.run/OzoneShell.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="OzoneShell" type="Application" factoryName="Application">
+  <configuration default="false" name="OzoneShell" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.shell.OzoneShell" />
     <module name="ozone-cli-shell" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml volume create /vol1" />

--- a/.run/PrimordialSCM-ha.run.xml
+++ b/.run/PrimordialSCM-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="PrimordialSCM-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="PrimordialSCM-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hdds-server-scm" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.scm.node.id=scm1 --set ozone.metadata.dirs=/tmp/scm1 --set ozone.scm.http-address=127.0.0.1:19876" />

--- a/.run/PrimordialSCMInit-ha.run.xml
+++ b/.run/PrimordialSCMInit-ha.run.xml
@@ -15,10 +15,10 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="PrimordialSCMInit-ha" type="Application" factoryName="Application" nameIsGenerated="false">
+  <configuration default="false" name="PrimordialSCMInit-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hdds-server-scm" />
-    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/scm1 --set ozone.scm.node.id=scm1 --set ozone.scm.http-address=127.0.0.1:19876 --init" />"
+    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/scm1 --set ozone.scm.node.id=scm1 --set ozone.scm.http-address=127.0.0.1:19876 --init" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">
       <pattern>

--- a/.run/Recon-ha.run.xml
+++ b/.run/Recon-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Recon-ha" type="Application" factoryName="Application">
+  <configuration default="false" name="Recon-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.recon.ReconServer" />
     <module name="ozone-recon" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml" />

--- a/.run/Recon.run.xml
+++ b/.run/Recon.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Recon" type="Application" factoryName="Application">
+  <configuration default="false" name="Recon" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.recon.ReconServer" />
     <module name="ozone-recon" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml" />

--- a/.run/S3Gateway.run.xml
+++ b/.run/S3Gateway.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="S3Gateway" type="Application" factoryName="Application">
+  <configuration default="false" name="S3Gateway" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.s3.Gateway" />
     <module name="ozone-s3gateway" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml" />

--- a/.run/Scm2-ha.run.xml
+++ b/.run/Scm2-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Scm2-ha" type="Application" factoryName="Application" nameIsGenerated="false">
+  <configuration default="false" name="Scm2-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hdds-server-scm" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/scm2 --set ozone.scm.node.id=scm2 --set ozone.scm.http-address=127.0.0.1:29876" />

--- a/.run/Scm2Bootstrap-ha.run.xml
+++ b/.run/Scm2Bootstrap-ha.run.xml
@@ -15,10 +15,10 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Scm2Bootstrap-ha" type="Application" factoryName="Application" nameIsGenerated="false">
+  <configuration default="false" name="Scm2Bootstrap-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hdds-server-scm" />
-    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/scm2 --set ozone.scm.node.id=scm2 --set ozone.scm.http-address=127.0.0.1:29876 --bootstrap" />"
+    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/scm2 --set ozone.scm.node.id=scm2 --set ozone.scm.http-address=127.0.0.1:29876 --bootstrap" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">
       <pattern>

--- a/.run/Scm3-ha.run.xml
+++ b/.run/Scm3-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Scm3-ha" type="Application" factoryName="Application" nameIsGenerated="false">
+  <configuration default="false" name="Scm3-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hdds-server-scm" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/scm3 --set ozone.scm.node.id=scm3 --set ozone.scm.http-address=127.0.0.1:39876" />

--- a/.run/Scm3Bootstrap-ha.run.xml
+++ b/.run/Scm3Bootstrap-ha.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Scm3Bootstrap-ha" type="Application" factoryName="Application" nameIsGenerated="false">
+  <configuration default="false" name="Scm3Bootstrap-ha" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hdds-server-scm" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/scm3 --set ozone.scm.node.id=scm3 --set ozone.scm.http-address=127.0.0.1:39876 --bootstrap" />

--- a/.run/ScmRoles.run.xml
+++ b/.run/ScmRoles.run.xml
@@ -15,9 +15,9 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="ScmRoles" type="Application" factoryName="Application">
+  <configuration default="false" name="ScmRoles" type="Application" factoryName="Application" folderName="ozone-ha">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.admin.OzoneAdmin" />
-    <module name="ozone-tools" />
+    <module name="ozone-cli-admin" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml scm roles -id=scm-group" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">

--- a/.run/StorageContainerManager.run.xml
+++ b/.run/StorageContainerManager.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="StorageContainerManager" type="Application" factoryName="Application" nameIsGenerated="false">
+  <configuration default="false" name="StorageContainerManager" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hdds-server-scm" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml" />

--- a/.run/StorageContainerManagerInit.run.xml
+++ b/.run/StorageContainerManagerInit.run.xml
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="StorageContainerManagerInit" type="Application" factoryName="Application" nameIsGenerated="false">
+  <configuration default="false" name="StorageContainerManagerInit" type="Application" factoryName="Application" folderName="ozone">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter" />
     <module name="hdds-server-scm" />
     <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --init" />


### PR DESCRIPTION
## What changes were proposed in this pull request?
The existing Intellij run configurations are scattered. All HA and non-HA configurations are dumped at the same level. Also, there is no ordering within the configurations. 

Ozone needs to be started in a specific sequence. SCM init, SCM, OM init, OM, DNs and finally others. The configurations could be rearranged in that specific ordered instead of forcing a user to hunt for them.

This PR:
1. Creates groups for HA and non-HA configurations 
2. Rearranges the configurations into their respective groups
3. Removes redundant config values `nameIsGenerated="false"`

After this PR:
<img width="330" height="367" alt="Screenshot 2026-07-27 at 3 09 11 PM" src="https://github.com/user-attachments/assets/0ed3c7e8-5bb4-4cf2-b5db-4014fff99e25" />


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16002

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Tested locally
CI: https://github.com/ptlrs/ozone/actions/runs/30309294702