### PR TITLE
HDDS-15954. Document ozone daemonlog command

### DIFF
--- a/hadoop-hdds/docs/content/tools/LogsInOzone.md
+++ b/hadoop-hdds/docs/content/tools/LogsInOzone.md
@@ -102,7 +102,7 @@ ozone daemonlog -getlevel <host:port> <logger-name> [-protocol http|https]
 ozone daemonlog -setlevel <host:port> <logger-name> <level> [-protocol http|https]
 ```
 
-The `<host:port>` value is the daemon HTTP address. For example, the default HTTP ports are `9874` for Ozone Manager, `9876` for Storage Container Manager, `9882` for Datanode, `9878` for S3 Gateway, and `9888` for Recon.
+The `<host:port>` value is the daemon HTTP address. For example, the default HTTP ports are `9874` for Ozone Manager, `9876` for Storage Container Manager, `9882` for Datanode, `19878` for the S3 Gateway web admin server, and `9888` for Recon.
 
 The following example checks the effective log level for the SCM event queue logger:
 

--- a/hadoop-hdds/docs/content/tools/LogsInOzone.md
+++ b/hadoop-hdds/docs/content/tools/LogsInOzone.md
@@ -93,6 +93,37 @@ rootLogger.level = debug
 
 After saving the file and restarting the service, the service will start logging more detailed debug information.
 
+### Changing Service Log Levels at Runtime
+
+Use `ozone daemonlog` to inspect or change the log level of a running Ozone daemon without restarting it. The command talks to the daemon's HTTP endpoint and is useful when you need temporary debug logging while troubleshooting a live service.
+
+```bash
+ozone daemonlog -getlevel <host:port> <logger-name> [-protocol http|https]
+ozone daemonlog -setlevel <host:port> <logger-name> <level> [-protocol http|https]
+```
+
+The `<host:port>` value is the daemon HTTP address. For example, the default HTTP ports are `9874` for Ozone Manager, `9876` for Storage Container Manager, `9882` for Datanode, `9878` for S3 Gateway, and `9888` for Recon.
+
+The following example checks the effective log level for the SCM event queue logger:
+
+```bash
+ozone daemonlog -getlevel scm.example.com:9876 org.apache.hadoop.hdds.server.events.EventQueue
+```
+
+To increase the same logger to `DEBUG`:
+
+```bash
+ozone daemonlog -setlevel scm.example.com:9876 org.apache.hadoop.hdds.server.events.EventQueue DEBUG
+```
+
+After collecting the required debug information, reset the logger to its previous level:
+
+```bash
+ozone daemonlog -setlevel scm.example.com:9876 org.apache.hadoop.hdds.server.events.EventQueue INFO
+```
+
+The change applies to the running daemon process. To make a log level change persistent across restarts, update the service's `log4j.properties` file instead.
+
 ### Enabling Debug Logs for CLI Tools
 
 To enable debug logging for Ozone CLI tools (e.g., `ozone sh volume create`), you can set the `OZONE_ROOT_LOGGER` environment variable to `debug`:

--- a/hadoop-hdds/docs/content/tools/_index.md
+++ b/hadoop-hdds/docs/content/tools/_index.md
@@ -53,6 +53,7 @@ Admin commands:
    * **admin** -  Collects admin and developer related commands related to the 
    ozone components.
    * **insight** - Generic tool to display filtered log, metrics or configs to help debuging. See [the observability]({{< ref "feature/Observability.md" >}}) page for more information.
+   * **daemonlog** - Gets or sets the runtime log level of Ozone daemon loggers through their HTTP endpoints.
    * **classpath** - Prints the class path needed to get the hadoop jar and the
     required libraries.
    * **dtutil**    - Operations related to delegation tokens


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request documents the existing `ozone daemonlog` command in the Ozone logging tools documentation. It explains how to get and set runtime log levels for Ozone daemon loggers through their HTTP endpoints, and adds examples for checking, increasing, and resetting a logger level.

It also adds `daemonlog` to the tools overview page so users can discover the command from the CLI tools list.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15954

## How was this patch tested?

```bash
git diff --check
./hadoop-ozone/dev-support/checks/docs.sh
```