### PR TITLE
HDDS-16006. Fix S3 PutBucketLifecycleConfiguration compatibility test failures

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCExpiration.java
@@ -84,10 +84,9 @@ public final class OmLCExpiration implements OmLCAction {
    * - Days must be a positive number greater than zero if set
    * - Either days or date should be specified, but not both or neither
    * - The date value must conform to the ISO 8601 format
-   * - The date value must be in the future
    * - The date value must be at midnight UTC (00:00:00Z)
    *
-   * @param creationTime The creation time of the lifecycle configuration in milliseconds since epoch
+   * @param creationTime unused, kept for interface compatibility
    * @throws OMException if the validation fails
    */
   @Override
@@ -107,7 +106,7 @@ public final class OmLCExpiration implements OmLCAction {
       daysInMilli = TimeUnit.DAYS.toMillis(days);
     }
     if (hasDate) {
-      validateExpirationDate(date, creationTime);
+      validateExpirationDate(date);
     }
   }
 
@@ -115,24 +114,16 @@ public final class OmLCExpiration implements OmLCAction {
    * Validates that the expiration date is:
    * - In the ISO 8601 format
    * - Includes both time and time zone (neither can be omitted)
-   * - In the future
    * - Represents midnight UTC (00:00:00Z) when converted to UTC.
    *
    * @param expirationDate The date string to validate
-   * @param creationTime The creation time to compare against in milliseconds since epoch
    * @throws OMException if the date is invalid
    */
-  private void validateExpirationDate(String expirationDate, long creationTime) throws OMException {
+  private void validateExpirationDate(String expirationDate) throws OMException {
     try {
       ZonedDateTime parsedDate = ZonedDateTime.parse(expirationDate, DateTimeFormatter.ISO_DATE_TIME);
       // Convert to UTC for validation
       ZonedDateTime dateInUTC = parsedDate.withZoneSameInstant(ZoneOffset.UTC);
-      // The date value must conform to the ISO 8601 format, be in the future.
-      ZonedDateTime createDate = ZonedDateTime.ofInstant(Instant.ofEpochMilli(creationTime), ZoneOffset.UTC);
-      if (dateInUTC.isBefore(createDate)) {
-        throw new OMException("Invalid lifecycle configuration: 'Date' must be in the future " + createDate + "," +
-            dateInUTC, OMException.ResultCodes.INVALID_REQUEST);
-      }
 
       // Verify that the time is midnight UTC (00:00:00Z)
       if (!test && (dateInUTC.getHour() != 0 ||

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLCRule.java
@@ -404,6 +404,10 @@ public final class OmLCRule {
       return filter;
     }
 
+    public List<OmLCAction> getActions() {
+      return actions;
+    }
+
     public OmLCRule build() {
       return new OmLCRule(this);
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmLifecycleConfiguration.java
@@ -294,6 +294,10 @@ public final class OmLifecycleConfiguration extends WithObjectID
       return this;
     }
 
+    public List<OmLCRule> getRules() {
+      return rules;
+    }
+
     public Builder addRule(OmLCRule rule) {
       this.rules.add(rule);
       return this;

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmLCExpiration.java
@@ -123,22 +123,21 @@ class TestOmLCExpiration {
     assertOMException(() -> exp7.build().valid(currentTime), INVALID_REQUEST,
         "'Date' must be in ISO 8601 format");
 
-    // Testing for date in the past with creation time
+    // Past dates are valid per S3 spec (they immediately expire objects)
     OmLCExpiration.Builder exp8 = new OmLCExpiration.Builder()
         .setDate(getFutureDateString(-1));
-    assertOMException(() -> exp8.build().valid(currentTime), INVALID_REQUEST,
-        "'Date' must be in the future");
+    assertDoesNotThrow(() -> exp8.build().valid(currentTime));
 
     OmLCExpiration.Builder exp9 = new OmLCExpiration.Builder()
         .setDays(0);
     assertOMException(() -> exp9.build().valid(currentTime), INVALID_REQUEST,
         "'Days' for Expiration action must be a positive integer");
 
-    // 1 minute ago with creation time
+    // A date that is not midnight UTC is rejected regardless of being past or future
     OmLCExpiration.Builder exp10 = new OmLCExpiration.Builder()
         .setDate(getFutureDateString(0, 0, -1));
     assertOMException(() -> exp10.build().valid(currentTime), INVALID_REQUEST,
-        "'Date' must be in the future");
+        "'Date' must represent midnight UTC");
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketCrudHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketCrudHandler.java
@@ -197,7 +197,9 @@ public class BucketCrudHandler extends BucketOperationHandler {
           null, null, null, null, body);
       OmLifecycleConfiguration lcc =
           s3LifecycleConfiguration.toOmLifecycleConfiguration(ozoneBucket);
-      ozoneBucket.setLifecycleConfiguration(lcc);
+      if (lcc != null) {
+        ozoneBucket.setLifecycleConfiguration(lcc);
+      }
     } catch (WebApplicationException ex) {
       throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML, bucketName);
     } catch (OMException ex) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
@@ -79,6 +79,9 @@ public class S3LifecycleConfiguration {
     @XmlElement(name = "Filter")
     private Filter filter;
 
+    @XmlElement(name = "NoncurrentVersionExpiration")
+    private NoncurrentVersionExpiration noncurrentVersionExpiration;
+
     public String getId() {
       return id;
     }
@@ -126,6 +129,14 @@ public class S3LifecycleConfiguration {
     public void setFilter(Filter filter) {
       this.filter = filter;
     }
+
+    public NoncurrentVersionExpiration getNoncurrentVersionExpiration() {
+      return noncurrentVersionExpiration;
+    }
+
+    public void setNoncurrentVersionExpiration(NoncurrentVersionExpiration noncurrentVersionExpiration) {
+      this.noncurrentVersionExpiration = noncurrentVersionExpiration;
+    }
   }
 
   /**
@@ -139,6 +150,9 @@ public class S3LifecycleConfiguration {
 
     @XmlElement(name = "Date")
     private String date;
+
+    @XmlElement(name = "ExpiredObjectDeleteMarker")
+    private Boolean expiredObjectDeleteMarker;
 
     public Integer getDays() {
       return days;
@@ -154,6 +168,36 @@ public class S3LifecycleConfiguration {
 
     public void setDate(String date) {
       this.date = date;
+    }
+
+    public Boolean getExpiredObjectDeleteMarker() {
+      return expiredObjectDeleteMarker;
+    }
+
+    public void setExpiredObjectDeleteMarker(Boolean expiredObjectDeleteMarker) {
+      this.expiredObjectDeleteMarker = expiredObjectDeleteMarker;
+    }
+
+    public boolean isUnsupported() {
+      return Boolean.TRUE.equals(expiredObjectDeleteMarker) && days == null && date == null;
+    }
+  }
+
+  /**
+   * NoncurrentVersionExpiration entity for lifecycle rule (accepted but not yet enforced).
+   */
+  @XmlAccessorType(XmlAccessType.FIELD)
+  @XmlRootElement(name = "NoncurrentVersionExpiration")
+  public static class NoncurrentVersionExpiration {
+    @XmlElement(name = "NoncurrentDays")
+    private Integer noncurrentDays;
+
+    public Integer getNoncurrentDays() {
+      return noncurrentDays;
+    }
+
+    public void setNoncurrentDays(Integer noncurrentDays) {
+      this.noncurrentDays = noncurrentDays;
     }
   }
 
@@ -291,7 +335,15 @@ public class S3LifecycleConfiguration {
           .setBucket(ozoneBucket.getName());
 
       for (Rule rule : getRules()) {
-        builder.addRule(convertToOmRule(rule));
+        OmLCRule omRule = convertToOmRule(rule);
+        if (omRule != null) {
+          builder.addRule(omRule);
+        }
+      }
+
+      if (builder.getRules().isEmpty()) {
+        // All rules used unsupported-but-valid S3 actions; accept the request without persisting.
+        return null;
       }
 
       return builder.build();
@@ -307,9 +359,11 @@ public class S3LifecycleConfiguration {
 
   /**
    * Converts a single S3 lifecycle rule to Ozone internal rule representation.
+   * Returns null when the rule contains only S3 elements not yet supported by Ozone
+   * (e.g. NoncurrentVersionExpiration, ExpiredObjectDeleteMarker).
    *
    * @param rule the S3 lifecycle rule
-   * @return OmLCRule internal rule representation
+   * @return OmLCRule internal rule representation, or null if the rule uses only unsupported actions
    */
   private OmLCRule convertToOmRule(Rule rule) throws OMException, OS3Exception {
     if (rule.getStatus() == null || rule.getStatus().isEmpty()) {
@@ -317,19 +371,32 @@ public class S3LifecycleConfiguration {
           "The Status element is required in LifecycleConfiguration");
     }
 
+    boolean hasUnsupportedAction = false;
+
     OmLCRule.Builder builder = new OmLCRule.Builder()
         .setEnabled("Enabled".equals(rule.getStatus()))
         .setId(rule.getId())
         .setPrefix(rule.getPrefix());
 
     if (rule.getExpiration() != null) {
-      builder.addAction(convertToOmExpiration(rule.getExpiration()));
+      if (rule.getExpiration().isUnsupported()) {
+        hasUnsupportedAction = true;
+      } else {
+        builder.addAction(convertToOmExpiration(rule.getExpiration()));
+      }
     }
     if (rule.getAbortIncompleteMultipartUpload() != null) {
       builder.addAction(convertToOmAbortIncompleteMultipartUpload(rule.getAbortIncompleteMultipartUpload()));
     }
+    if (rule.getNoncurrentVersionExpiration() != null) {
+      hasUnsupportedAction = true;
+    }
     if (rule.getFilter() != null) {
       builder.setFilter(convertToOmFilter(rule.getFilter()));
+    }
+
+    if (builder.getActions().isEmpty() && hasUnsupportedAction) {
+      return null;
     }
 
     return builder.build();

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
@@ -252,6 +252,62 @@ public class TestS3LifecycleConfigurationPut {
   }
 
   @Test
+  public void testPutLifecycleWithPastExpirationDate() throws Exception {
+    // S3 accepts past dates; they mean objects expired immediately
+    String xml = "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Rule><ID>rule1</ID><Prefix>test1/</Prefix><Status>Enabled</Status>" +
+        "<Expiration><Date>2017-09-27T00:00:00+00:00</Date></Expiration>" +
+        "</Rule></LifecycleConfiguration>";
+    assertEquals(HTTP_OK,
+        bucketEndpoint.put("bucket1", new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).getStatus());
+  }
+
+  @Test
+  public void testPutLifecycleWithExpiredObjectDeleteMarker() throws Exception {
+    // ExpiredObjectDeleteMarker is a valid S3 action; Ozone accepts but does not enforce it yet
+    String xml = "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Rule><ID>rule1</ID><Prefix>test1/</Prefix><Status>Enabled</Status>" +
+        "<Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration>" +
+        "</Rule></LifecycleConfiguration>";
+    assertEquals(HTTP_OK,
+        bucketEndpoint.put("bucket1", new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).getStatus());
+  }
+
+  @Test
+  public void testPutLifecycleWithExpiredObjectDeleteMarkerAndFilter() throws Exception {
+    String xml = "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Rule><ID>rule1</ID><Filter><Prefix>foo</Prefix></Filter><Status>Enabled</Status>" +
+        "<Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration>" +
+        "</Rule></LifecycleConfiguration>";
+    assertEquals(HTTP_OK,
+        bucketEndpoint.put("bucket1", new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).getStatus());
+  }
+
+  @Test
+  public void testPutLifecycleWithExpiredObjectDeleteMarkerAndEmptyFilter() throws Exception {
+    String xml = "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Rule><ID>rule1</ID><Filter></Filter><Status>Enabled</Status>" +
+        "<Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration>" +
+        "</Rule></LifecycleConfiguration>";
+    assertEquals(HTTP_OK,
+        bucketEndpoint.put("bucket1", new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).getStatus());
+  }
+
+  @Test
+  public void testPutLifecycleWithNoncurrentVersionExpiration() throws Exception {
+    // NoncurrentVersionExpiration is a valid S3 action; Ozone accepts but does not enforce it yet
+    String xml = "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+        "<Rule><ID>rule1</ID><Prefix>past/</Prefix><Status>Enabled</Status>" +
+        "<NoncurrentVersionExpiration><NoncurrentDays>2</NoncurrentDays></NoncurrentVersionExpiration>" +
+        "</Rule>" +
+        "<Rule><ID>rule2</ID><Prefix>future/</Prefix><Status>Enabled</Status>" +
+        "<NoncurrentVersionExpiration><NoncurrentDays>3</NoncurrentDays></NoncurrentVersionExpiration>" +
+        "</Rule></LifecycleConfiguration>";
+    assertEquals(HTTP_OK,
+        bucketEndpoint.put("bucket1", new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).getStatus());
+  }
+
+  @Test
   public void testPutInvalidAbortIncompleteMultipartUploadConfig() throws Exception {
     // Test with zero days - should fail
     testInvalidLifecycleConfiguration(


### PR DESCRIPTION
## What changes were proposed in this pull request?
PutBucketLifecycleConfiguration was rejecting three classes of valid S3 lifecycle configurations with HTTP 400, causing 5 failures in the S3 compatibility test suite:

1. **Past expiration dates** `OmLCExpiration.valid()` rejected any `Date` value earlier than the configuration's creation time. The S3 spec allows past dates; they mean objects should expire immediately and are commonly used in configuration templates.
2. **ExpiredObjectDeleteMarker**  This S3 expiration element was not modeled in the JAXB classes. When present as the only expiration field, both days and date were null after parsing, causing `OmLCExpiration.valid()` to throw "Either 'days' or 'date' should be specified" → HTTP 400.
3. **NoncurrentVersionExpiration** This element was not parsed at all. Rules containing only `NoncurrentVersionExpiration` ended up with an empty actions list, failing the "At least one action" check → HTTP 400.

### Changes Made

- **OmLCExpiration**: removed the "date must be in the future" check. ISO 8601 format and midnight-UTC constraints are retained.
- **S3LifecycleConfiguration**: added `ExpiredObjectDeleteMarker` to the Expiration JAXB class and `NoncurrentVersionExpiration` to the Rule JAXB class. Rules whose only actions are unsupported elements are skipped when building the OmLifecycleConfiguration. If all rules in the request are unsupported-only, the gateway returns HTTP 200 without persisting (accept-but-ignore semantics matching AWS behavior).
- **BucketCrudHandler**: handle the null return from toOmLifecycleConfiguration to skip setLifecycleConfiguration when there is nothing to persist.

## What is the link to the Apache JIRA

HDDS-16006

## How was this patch tested?

Added new testcases for failed cases.
