### PR TITLE
HDDS-15922. (addendum) Fix ozone-site config doc workflow reusing stale PR branch

### DIFF
--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -60,7 +60,13 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           
-          git clone --depth=1 --branch=master https://github.com/$REPO_OWNER/ozone-site.git ozone-site
+          BRANCH_EXISTS=""
+          if git clone --depth=1 --branch="$BRANCH_NAME" https://github.com/$REPO_OWNER/ozone-site.git ozone-site; then
+            BRANCH_EXISTS="true"
+          else
+            git clone --depth=1 --branch=master https://github.com/$REPO_OWNER/ozone-site.git ozone-site
+          fi
+
           cd ozone-site
 
           EXISTING_PR=$(gh pr list --repo "$REPO_OWNER/ozone-site" \
@@ -68,13 +74,14 @@ jobs:
           echo "EXISTING_PR=$EXISTING_PR" >> $GITHUB_ENV
 
           if [ -n "$EXISTING_PR" ]; then
-            echo "Open PR #$EXISTING_PR exists, checking out branch for comparison"
-            git fetch --depth=1 origin "$BRANCH_NAME"
-            git checkout -B "$BRANCH_NAME" FETCH_HEAD
+            echo "Open PR #$EXISTING_PR exists"
+          else if [[ -n "$BRANCH_EXISTS" ]]; then
+            echo "No open PR, but branch exists, resetting to master"
+            git fetch --depth 1 origin master:master
+            git reset --hard master
           else
-            echo "No open PR, creating branch from master"
-            git fetch --depth=1 origin "$BRANCH_NAME" || true
-            git checkout -B "$BRANCH_NAME" master
+            echo "No open PR or branch, creating from master"
+            git checkout -b "$BRANCH_NAME" master
           fi
 
       - name: Check if documentation changed

--- a/.github/workflows/update-ozone-site-config-doc.yml
+++ b/.github/workflows/update-ozone-site-config-doc.yml
@@ -75,7 +75,7 @@ jobs:
 
           if [ -n "$EXISTING_PR" ]; then
             echo "Open PR #$EXISTING_PR exists"
-          else if [[ -n "$BRANCH_EXISTS" ]]; then
+          elif [[ -n "$BRANCH_EXISTS" ]]; then
             echo "No open PR, but branch exists, resetting to master"
             git fetch --depth 1 origin master:master
             git reset --hard master


### PR DESCRIPTION
## What changes were proposed in this pull request?

Automated config doc update [failed](https://github.com/apache/ozone/actions/runs/30352161330/job/90255214835#step:8:21) after #10826 due to missing remote-tracking branch.

This is fixed by trying to clone `automated-config-doc-update` first instead of `master`.  This ensures we have the remote-tracking branch for if it exists.  We don't need tracking branch for `master`.

Reset `automated-config-doc-update` to `master` if exists but PR does not.

https://issues.apache.org/jira/browse/HDDS-15922

## How was this patch tested?

Tested steps from CLI manually:

```bash
$ git clone --depth=1 --branch=automated-config-doc-update https://github.com/apache/ozone-site.git ozone-site
Cloning into 'ozone-site'...
remote: Enumerating objects: 1230, done.
remote: Counting objects: 100% (1230/1230), done.
remote: Compressing objects: 100% (772/772), done.
remote: Total 1230 (delta 560), reused 870 (delta 454), pack-reused 0 (from 0)
Receiving objects: 100% (1230/1230), 89.50 MiB | 23.43 MiB/s, done.
Resolving deltas: 100% (560/560), done.

$ cd ozone-site

$ git fetch --depth 1 origin master:master
remote: Enumerating objects: 215, done.
remote: Counting objects: 100% (215/215), done.
remote: Compressing objects: 100% (147/147), done.
remote: Total 154 (delta 48), reused 76 (delta 6), pack-reused 0 (from 0)
Receiving objects: 100% (154/154), 15.76 MiB | 19.75 MiB/s, done.
Resolving deltas: 100% (48/48), completed with 39 local objects.
From https://github.com/apache/ozone-site
 * [new branch]      master     -> master

$ git reset --hard master
HEAD is now at 68b4186 HDDS-15171. [Auto] Update configuration documentation (#493)

$ git push --dry-run --force-with-lease origin automated-config-doc-update 
To https://github.com/apache/ozone-site.git
 + 27b3fe8...68b4186 automated-config-doc-update -> automated-config-doc-update (forced update)
```

If branch does not exists:

```bash
$ git clone --depth=1 --branch=no-such-branch https://github.com/apache/ozone-site.git ozone-site 
Cloning into 'ozone-site'...
warning: Could not find remote branch no-such-branch to clone.
fatal: Remote branch no-such-branch not found in upstream origin

$ git clone --depth=1 --branch=master https://github.com/apache/ozone-site.git ozone-site
Cloning into 'ozone-site'...
remote: Enumerating objects: 1323, done.
remote: Counting objects: 100% (1323/1323), done.
remote: Compressing objects: 100% (863/863), done.
remote: Total 1323 (delta 568), reused 934 (delta 456), pack-reused 0 (from 0)
Receiving objects: 100% (1323/1323), 105.24 MiB | 24.76 MiB/s, done.
Resolving deltas: 100% (568/568), done.

$ cd ozone-site

$ git checkout -b "no-such-branch" master
Switched to a new branch 'no-such-branch'

$ git push --dry-run --force-with-lease origin no-such-branch                            
To https://github.com/apache/ozone-site.git
 * [new branch]      no-such-branch -> no-such-branch
```