### PR TITLE
HDDS-16009. Switch zizmor check to ubuntu-24.04

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   zizmor:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
     steps:


### PR DESCRIPTION
## What changes were proposed in this pull request?

zizmor check uses ubuntu-latest, while other workflows use ubuntu-24.04.  Switch zizmor check to ubuntu-24.04 for consistency.

https://issues.apache.org/jira/browse/HDDS-16009

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/30372536920/job/90319840994#step:1:16
