### PR TITLE
HDDS-16005. Make DeleteBucketLifecycle idempotent on missing config

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot
@@ -56,10 +56,8 @@ Delete bucket lifecycle configuration
     ${result} =         Execute AWSS3APICli and checkrc     get-bucket-lifecycle-configuration --bucket ${bucket}    255
                         Should contain          ${result}           NoSuchLifecycleConfiguration
 
-Delete bucket non-lifecycle configuration
+Delete bucket lifecycle configuration when none exists
     [tags]    no-bucket-type
     ${bucket} =         Create bucket
     ${result} =         Execute AWSS3APICli     delete-bucket-lifecycle --bucket ${bucket}
                         Should Be Empty         ${result}
-    ${result} =         Execute AWSS3APICli and checkrc     get-bucket-lifecycle-configuration --bucket ${bucket}    255
-                        Should contain          ${result}           NoSuchLifecycleConfiguration

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot
@@ -55,3 +55,11 @@ Delete bucket lifecycle configuration
                         Should Be Empty         ${result}
     ${result} =         Execute AWSS3APICli and checkrc     get-bucket-lifecycle-configuration --bucket ${bucket}    255
                         Should contain          ${result}           NoSuchLifecycleConfiguration
+
+Delete bucket non-lifecycle configuration
+    [tags]    no-bucket-type
+    ${bucket} =         Create bucket
+    ${result} =         Execute AWSS3APICli     delete-bucket-lifecycle --bucket ${bucket}
+                        Should Be Empty         ${result}
+    ${result} =         Execute AWSS3APICli and checkrc     get-bucket-lifecycle-configuration --bucket ${bucket}    255
+                        Should contain          ${result}           NoSuchLifecycleConfiguration

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -2136,8 +2136,8 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
 
     // Test delete lifecycle for a bucket, while doesn't have lifecycle
     assertNull(s3Client.getBucketLifecycleConfiguration(bucketName));
-    assertThrows(AmazonServiceException.class,
-        () -> s3Client.deleteBucketLifecycleConfiguration(bucketName));
+    // Idempotent delete: no exception expected even without an existing config
+    s3Client.deleteBucketLifecycleConfiguration(bucketName);
 
     // First create a lifecycle configuration
     BucketLifecycleConfiguration configuration = new BucketLifecycleConfiguration();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketCrudHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketCrudHandler.java
@@ -159,7 +159,7 @@ public class BucketCrudHandler extends BucketOperationHandler {
       // DeleteBucketLifecycle is idempotent: deleting a missing config
       // must still return 204, not 404 — same as normal key deletion.
       if (ex.getResult() != OMException.ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND) {
-        throw ex;
+        throw S3ErrorTable.newError(bucketName, ex);
       }
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketCrudHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketCrudHandler.java
@@ -156,11 +156,11 @@ public class BucketCrudHandler extends BucketOperationHandler {
     try {
       context.getVolume().getBucket(bucketName).deleteLifecycleConfiguration();
     } catch (OMException ex) {
-      if (ex.getResult() == OMException.ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND) {
-        throw S3ErrorTable.newError(
-            S3ErrorTable.NO_SUCH_LIFECYCLE_CONFIGURATION, bucketName);
+      // DeleteBucketLifecycle is idempotent: deleting a missing config
+      // must still return 204, not 404 — same as normal key deletion.
+      if (ex.getResult() != OMException.ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND) {
+        throw ex;
       }
-      throw ex;
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationDelete.java
@@ -55,8 +55,12 @@ public class TestS3LifecycleConfigurationDelete {
   @Test
   public void testDeleteNonExistentLifecycleConfiguration()
       throws Exception {
+    String bucketName = "bucket1";
+    Response r = bucketEndpoint.delete(bucketName);
+    assertEquals(HTTP_NO_CONTENT, r.getStatus());
+
     try {
-      bucketEndpoint.delete("bucket1");
+      bucketEndpoint.get(bucketName);
       fail();
     } catch (OS3Exception ex) {
       assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationDelete.java
@@ -55,18 +55,10 @@ public class TestS3LifecycleConfigurationDelete {
   @Test
   public void testDeleteNonExistentLifecycleConfiguration()
       throws Exception {
-    String bucketName = "bucket1";
-    Response r = bucketEndpoint.delete(bucketName);
+    // DeleteBucketLifecycle is idempotent: deleting a non-existent
+    // configuration must succeed with 204, not fail with 404.
+    Response r = bucketEndpoint.delete("bucket1");
     assertEquals(HTTP_NO_CONTENT, r.getStatus());
-
-    try {
-      bucketEndpoint.get(bucketName);
-      fail();
-    } catch (OS3Exception ex) {
-      assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());
-      assertEquals(NO_SUCH_LIFECYCLE_CONFIGURATION.getCode(),
-              ex.getCode());
-    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DeleteBucketLifecycle` in the S3 Gateway did not comply with the AWS S3 API contract: per the AWS spec, this operation must be idempotent and return `204 No Content` even when no lifecycle configuration exists on the bucket. Instead, `BucketCrudHandler#deleteLifecycleConfiguration` caught the `OMException` with result code `LIFECYCLE_CONFIGURATION_NOT_FOUND` and re-threw it as a `NO_SUCH_LIFECYCLE_CONFIGURATION` S3 error, returning `404 Not Found` to the client. This also caused the `s3-tests` `lifecycle_delete` compatibility test to fail.

The fix inverts the condition in the `catch` block: the handler now only re-throws when the `OMException` result code is **not** `LIFECYCLE_CONFIGURATION_NOT_FOUND`. When the lifecycle configuration is missing, the method returns normally, so the caller (`deleteBucketLifecycleConfiguration`) proceeds to its existing `Response.noContent().build()` and the client gets `204`, matching the behavior of normal key deletion elsewhere in the S3 Gateway (see `ObjectEndpoint#delete`), which already treats a missing target as a no-op for the same reason.

`TestS3LifecycleConfigurationDelete#testDeleteNonExistentLifecycleConfiguration` was updated to assert the new contract: deleting a lifecycle configuration on a bucket that never had one now expects `204`, instead of expecting an `OS3Exception` with `404`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16005

## How was this patch tested?

https://github.com/NickJavaDev88/ozone/actions/runs/30441394294
