### PR TITLE
HDDS-16014. [Ozone Versioning] [T3] Enabled Write Path

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -299,6 +299,7 @@ public final class OzoneConsts {
   public static final String STORAGE_TYPE = "storageType";
   public static final String RESOURCE_TYPE = "resourceType";
   public static final String IS_VERSION_ENABLED = "isVersionEnabled";
+  public static final String VERSIONING_STATUS = "versioningStatus";
   public static final String CREATION_TIME = "creationTime";
   public static final String MODIFICATION_TIME = "modificationTime";
   public static final String DATA_SIZE = "dataSize";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -180,6 +180,15 @@ public final class OzoneConsts {
 
   public static final String OM_KEY_PREFIX = "/";
   public static final String DOUBLE_SLASH_OM_KEY_PREFIX  = "//";
+  /**
+   * Separates a key name from the versionId suffix in versionedKeyTable DB keys.
+   * OM_KEY_PREFIX cannot be used: OBJECT_STORE key names contain '/' verbatim, so
+   * a key's versions would interleave with the versions of keys nested under it.
+   * 0x00 is the minimum byte value, so {keyName} + this separator can never be a
+   * prefix of {keyName} + "/". Written as an octal escape because a literal
+   * unicode escape for NUL is expanded by the Java lexer before parsing.
+   */
+  public static final String OM_VERSIONED_KEY_SEPARATOR = "\0";
   public static final String OM_USER_PREFIX = "$";
   public static final String OM_S3_PREFIX = "S3:";
   public static final String OM_S3_CALLER_CONTEXT_PREFIX = "S3Auth:S3G|";
@@ -299,6 +308,7 @@ public final class OzoneConsts {
   public static final String STORAGE_TYPE = "storageType";
   public static final String RESOURCE_TYPE = "resourceType";
   public static final String IS_VERSION_ENABLED = "isVersionEnabled";
+  public static final String VERSIONING_STATUS = "versioningStatus";
   public static final String CREATION_TIME = "creationTime";
   public static final String MODIFICATION_TIME = "modificationTime";
   public static final String DATA_SIZE = "dataSize";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -180,6 +180,15 @@ public final class OzoneConsts {
 
   public static final String OM_KEY_PREFIX = "/";
   public static final String DOUBLE_SLASH_OM_KEY_PREFIX  = "//";
+  /**
+   * Separates a key name from the versionId suffix in versionedKeyTable DB keys.
+   * OM_KEY_PREFIX cannot be used: OBJECT_STORE key names contain '/' verbatim, so
+   * a key's versions would interleave with the versions of keys nested under it.
+   * 0x00 is the minimum byte value, so {keyName} + this separator can never be a
+   * prefix of {keyName} + "/". Written as an octal escape because a literal
+   * unicode escape for NUL is expanded by the Java lexer before parsing.
+   */
+  public static final String OM_VERSIONED_KEY_SEPARATOR = "\0";
   public static final String OM_USER_PREFIX = "$";
   public static final String OM_S3_PREFIX = "S3:";
   public static final String OM_S3_CALLER_CONTEXT_PREFIX = "S3Auth:S3G|";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -309,6 +309,11 @@ public final class OzoneConsts {
   public static final String RESOURCE_TYPE = "resourceType";
   public static final String IS_VERSION_ENABLED = "isVersionEnabled";
   public static final String VERSIONING_STATUS = "versioningStatus";
+  // Audit keys for the object versions a write creates, demotes or removes.
+  public static final String VERSION_ID = "versionId";
+  public static final String SUPERSEDED_VERSION_ID = "supersededVersionId";
+  public static final String DELETED_VERSION_ID = "deletedVersionId";
+  public static final String PROMOTED_VERSION_ID = "promotedVersionId";
   public static final String CREATION_TIME = "creationTime";
   public static final String MODIFICATION_TIME = "modificationTime";
   public static final String DATA_SIZE = "dataSize";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -5169,7 +5169,9 @@
     <tag>OZONE, OM</tag>
     <description>
       Implementation of org.apache.hadoop.ozone.om.helpers.VersionIdGenerator used to assign the
-      versionId of an object version. The default uses the index of the committing transaction.
+      versionId of an object version. The default uses the index of the committing transaction;
+      PinnedFirstVersionIdGenerator additionally pins the first version of every key to a reserved
+      sentinel, so that it can be referenced without listing the key's versions first.
       The setting is cluster-wide and may be changed on a running cluster; a write whose generated
       versionId already exists on the key is rejected, and the existing version has to be deleted
       before that id can be written again.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -5163,4 +5163,16 @@
     <tag>OZONE, RATIS, OM</tag>
     <description>The maximum number of events that can be pending in OM Ratis.</description>
   </property>
+  <property>
+    <name>ozone.om.versioning.version-id-generator</name>
+    <value>org.apache.hadoop.ozone.om.helpers.TransactionIndexVersionIdGenerator</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      Implementation of org.apache.hadoop.ozone.om.helpers.VersionIdGenerator used to assign the
+      versionId of an object version. The default uses the index of the committing transaction.
+      The setting is cluster-wide and may be changed on a running cluster; a write whose generated
+      versionId already exists on the key is rejected, and the existing version has to be deleted
+      before that id can be written again.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -5293,7 +5293,10 @@
     <description>
       Implementation of org.apache.hadoop.ozone.om.helpers.VersionIdGenerator used to propose the
       versionId of an object version. The default numbers a version with the time it was written,
-      through the same scheme Ozone uses for block local IDs.
+      through the same scheme Ozone uses for block local IDs;
+      org.apache.hadoop.ozone.om.helpers.PinnedFirstVersionIdGenerator additionally pins the first
+      version of every key to a reserved sentinel, so that it can be referenced without listing the
+      key's versions first.
       The setting is cluster-wide and read when an OM starts, so a change takes effect on every
       bucket once the OMs have been restarted; it is not recorded in bucket metadata. Keys written
       under a previous generator keep the ids they were given: a proposal is taken as a floor when

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -5286,4 +5286,19 @@
       ozone.lifecycle.service.state.save.keys.processed is satisfied.
     </description>
   </property>
+  <property>
+    <name>ozone.om.versioning.version-id-generator</name>
+    <value>org.apache.hadoop.ozone.om.helpers.UniqueIdVersionIdGenerator</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      Implementation of org.apache.hadoop.ozone.om.helpers.VersionIdGenerator used to propose the
+      versionId of an object version. The default numbers a version with the time it was written,
+      through the same scheme Ozone uses for block local IDs.
+      The setting is cluster-wide and read when an OM starts, so a change takes effect on every
+      bucket once the OMs have been restarted; it is not recorded in bucket metadata. Keys written
+      under a previous generator keep the ids they were given: a proposal is taken as a floor when
+      the version is applied, so a generator proposing ids below those a previous one handed out
+      delays the new numbering on the affected keys rather than disordering them.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.TransactionIndexVersionIdGenerator;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.ratis.util.TimeDuration;
 
 /**
@@ -714,6 +716,11 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_RATIS_EVENTS_MAX_LIMIT =
       "ozone.om.ratis.events.max.limit";
   public static final int OZONE_OM_RATIS_EVENTS_MAX_LIMIT_DEFAULT = 100;
+
+  public static final String OZONE_OM_VERSIONING_VERSION_ID_GENERATOR =
+      "ozone.om.versioning.version-id-generator";
+  public static final Class<? extends VersionIdGenerator>
+      OZONE_OM_VERSIONING_VERSION_ID_GENERATOR_DEFAULT = TransactionIndexVersionIdGenerator.class;
 
   /**
    * Never constructed.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.UniqueIdVersionIdGenerator;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.ratis.util.TimeDuration;
 import org.rocksdb.CompactRangeOptions.BottommostLevelCompaction;
 
@@ -767,6 +769,11 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_RATIS_EVENTS_MAX_LIMIT =
       "ozone.om.ratis.events.max.limit";
   public static final int OZONE_OM_RATIS_EVENTS_MAX_LIMIT_DEFAULT = 100;
+
+  public static final String OZONE_OM_VERSIONING_VERSION_ID_GENERATOR =
+      "ozone.om.versioning.version-id-generator";
+  public static final Class<? extends VersionIdGenerator>
+      OZONE_OM_VERSIONING_VERSION_ID_GENERATOR_DEFAULT = UniqueIdVersionIdGenerator.class;
 
   /**
    * Never constructed.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BucketVersioningStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BucketVersioningStatus.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketVersioningStatusProto;
+
+/**
+ * S3-compatible bucket versioning state machine:
+ * UNVERSIONED -&gt; ENABLED &lt;-&gt; SUSPENDED.
+ * Once versioning has been enabled, a bucket can never return to UNVERSIONED.
+ */
+public enum BucketVersioningStatus {
+  UNVERSIONED,
+  ENABLED,
+  SUSPENDED;
+
+  public static BucketVersioningStatus fromProto(BucketVersioningStatusProto proto) {
+    switch (proto) {
+    case VERSIONING_ENABLED:
+      return ENABLED;
+    case VERSIONING_SUSPENDED:
+      return SUSPENDED;
+    case UNVERSIONED:
+    default:
+      return UNVERSIONED;
+    }
+  }
+
+  public BucketVersioningStatusProto toProto() {
+    switch (this) {
+    case ENABLED:
+      return BucketVersioningStatusProto.VERSIONING_ENABLED;
+    case SUSPENDED:
+      return BucketVersioningStatusProto.VERSIONING_SUSPENDED;
+    default:
+      return BucketVersioningStatusProto.UNVERSIONED;
+    }
+  }
+
+  /** Maps the legacy isVersionEnabled flag of buckets without an explicit status. */
+  public static BucketVersioningStatus fromVersionEnabledFlag(boolean isVersionEnabled) {
+    return isVersionEnabled ? ENABLED : UNVERSIONED;
+  }
+
+  /** The legacy isVersionEnabled flag value kept in sync with this status. */
+  public boolean toVersionEnabledFlag() {
+    return this == ENABLED;
+  }
+
+  /**
+   * Whether a bucket may transition from this status to {@code target}.
+   * The only forbidden transition is back to UNVERSIONED after versioning
+   * has been enabled or suspended (matches the S3 state machine).
+   */
+  public boolean canTransitionTo(BucketVersioningStatus target) {
+    return this == UNVERSIONED || target != UNVERSIONED;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BucketVersioningStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BucketVersioningStatus.java
@@ -52,11 +52,6 @@ public enum BucketVersioningStatus {
     }
   }
 
-  /** Maps the legacy isVersionEnabled flag of buckets without an explicit status. */
-  public static BucketVersioningStatus fromVersionEnabledFlag(boolean isVersionEnabled) {
-    return isVersionEnabled ? ENABLED : UNVERSIONED;
-  }
-
   /** The legacy isVersionEnabled flag value kept in sync with this status. */
   public boolean toVersionEnabledFlag() {
     return this == ENABLED;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -45,6 +45,11 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
    */
   private final Boolean isVersionEnabled;
   /**
+   * S3-compatible versioning status; null when not being changed.
+   * Takes precedence over isVersionEnabled when both are set.
+   */
+  private final BucketVersioningStatus versioningStatus;
+  /**
    * Type of storage to be used for this bucket.
    * [RAM_DISK, SSD, DISK, ARCHIVE]
    */
@@ -73,6 +78,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     this.volumeName = b.volumeName;
     this.bucketName = b.bucketName;
     this.isVersionEnabled = b.isVersionEnabled;
+    this.versioningStatus = b.versioningStatus;
     this.storageType = b.storageType;
     this.ownerName = b.ownerName;
     this.defaultReplicationConfig = b.defaultReplicationConfig;
@@ -106,6 +112,14 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
    */
   public Boolean getIsVersionEnabled() {
     return isVersionEnabled;
+  }
+
+  /**
+   * Returns the requested versioning status, or null if not being changed.
+   * @return BucketVersioningStatus
+   */
+  public BucketVersioningStatus getVersioningStatus() {
+    return versioningStatus;
   }
 
   /**
@@ -227,6 +241,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     private String volumeName;
     private String bucketName;
     private Boolean isVersionEnabled;
+    private BucketVersioningStatus versioningStatus;
     private StorageType storageType;
     private boolean quotaInBytesSet = false;
     private long quotaInBytes;
@@ -258,6 +273,11 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
 
     public Builder setIsVersionEnabled(Boolean versionFlag) {
       this.isVersionEnabled = versionFlag;
+      return this;
+    }
+
+    public Builder setVersioningStatus(BucketVersioningStatus status) {
+      this.versioningStatus = status;
       return this;
     }
 
@@ -339,6 +359,9 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     if (isVersionEnabled != null) {
       builder.setIsVersionEnabled(isVersionEnabled);
     }
+    if (versioningStatus != null) {
+      builder.setVersioningStatus(versioningStatus.toProto());
+    }
     if (storageType != null) {
       builder.setStorageType(storageType.toProto());
     }
@@ -380,6 +403,10 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
 
     if (bucketArgs.hasIsVersionEnabled()) {
       builder.setIsVersionEnabled(bucketArgs.getIsVersionEnabled());
+    }
+    if (bucketArgs.hasVersioningStatus()) {
+      builder.setVersioningStatus(
+          BucketVersioningStatus.fromProto(bucketArgs.getVersioningStatus()));
     }
     if (bucketArgs.hasStorageType()) {
       builder.setStorageType(StorageType.valueOf(bucketArgs.getStorageType()));

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -204,6 +204,9 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
         getMetadata().get(OzoneConsts.GDPR_FLAG));
     auditMap.put(OzoneConsts.IS_VERSION_ENABLED,
                 String.valueOf(this.isVersionEnabled));
+    if (this.versioningStatus != null) {
+      auditMap.put(OzoneConsts.VERSIONING_STATUS, this.versioningStatus.name());
+    }
     if (this.storageType != null) {
       auditMap.put(OzoneConsts.STORAGE_TYPE, this.storageType.name());
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -59,9 +59,13 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
    */
   private final ImmutableList<OzoneAcl> acls;
   /**
-   * Bucket Version flag.
+   * Bucket Version flag, kept in sync with versioningStatus (ENABLED -> true).
    */
   private final boolean isVersionEnabled;
+  /**
+   * S3-compatible versioning status; authoritative over isVersionEnabled.
+   */
+  private final BucketVersioningStatus versioningStatus;
   /**
    * Type of storage to be used for this bucket.
    * [RAM_DISK, SSD, DISK, ARCHIVE]
@@ -118,7 +122,9 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
     this.volumeName = b.volumeName;
     this.bucketName = b.bucketName;
     this.acls = b.acls.build();
-    this.isVersionEnabled = b.isVersionEnabled;
+    this.versioningStatus = b.versioningStatus != null ? b.versioningStatus
+        : BucketVersioningStatus.fromVersionEnabledFlag(b.isVersionEnabled);
+    this.isVersionEnabled = this.versioningStatus.toVersionEnabledFlag();
     this.storageType = b.storageType;
     this.creationTime = b.creationTime;
     this.modificationTime = b.modificationTime;
@@ -171,6 +177,14 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
    */
   public boolean getIsVersionEnabled() {
     return isVersionEnabled;
+  }
+
+  /**
+   * Returns the S3-compatible versioning status; never null.
+   * @return BucketVersioningStatus
+   */
+  public BucketVersioningStatus getVersioningStatus() {
+    return versioningStatus;
   }
 
   /**
@@ -379,6 +393,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setBucketName(bucketName)
         .setStorageType(storageType)
         .setIsVersionEnabled(isVersionEnabled)
+        .setVersioningStatus(versioningStatus)
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
         .setBucketEncryptionKey(bekInfo)
@@ -404,6 +419,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
     private String bucketName;
     private final AclListBuilder acls;
     private boolean isVersionEnabled;
+    private BucketVersioningStatus versioningStatus;
     private StorageType storageType = StorageType.DISK;
     private long creationTime;
     private long modificationTime;
@@ -462,6 +478,22 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
 
     public Builder setIsVersionEnabled(boolean versionFlag) {
       this.isVersionEnabled = versionFlag;
+      // Keep versioningStatus in sync for callers that only know the legacy
+      // flag; an explicitly SUSPENDED status is preserved on disable.
+      if (versionFlag) {
+        this.versioningStatus = BucketVersioningStatus.ENABLED;
+      } else if (versioningStatus != BucketVersioningStatus.SUSPENDED) {
+        this.versioningStatus = BucketVersioningStatus.UNVERSIONED;
+      }
+      return this;
+    }
+
+    /** No-op when status is null (e.g. records without the new field). */
+    public Builder setVersioningStatus(BucketVersioningStatus status) {
+      if (status != null) {
+        this.versioningStatus = status;
+        this.isVersionEnabled = status.toVersionEnabledFlag();
+      }
       return this;
     }
 
@@ -600,6 +632,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setBucketName(bucketName)
         .addAllAcls(OzoneAclUtil.toProtobuf(acls))
         .setIsVersionEnabled(isVersionEnabled)
+        .setVersioningStatus(versioningStatus.toProto())
         .setStorageType(storageType.toProto())
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
@@ -657,6 +690,9 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setAcls(bucketInfo.getAclsList().stream().map(
             OzoneAcl::fromProtobuf).collect(Collectors.toList()))
         .setIsVersionEnabled(bucketInfo.getIsVersionEnabled())
+        .setVersioningStatus(bucketInfo.hasVersioningStatus()
+            ? BucketVersioningStatus.fromProto(bucketInfo.getVersioningStatus())
+            : null)
         .setStorageType(StorageType.valueOf(bucketInfo.getStorageType()))
         .setCreationTime(bucketInfo.getCreationTime())
         .setUsedBytes(bucketInfo.getUsedBytes())
@@ -763,6 +799,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         bucketName.equals(that.bucketName) &&
         Objects.equals(acls, that.acls) &&
         Objects.equals(isVersionEnabled, that.isVersionEnabled) &&
+        versioningStatus == that.versioningStatus &&
         storageType == that.storageType &&
         getObjectID() == that.getObjectID() &&
         getUpdateID() == that.getUpdateID() &&
@@ -791,6 +828,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         ", bucketName='" + bucketName + "'" +
         ", acls=" + acls +
         ", isVersionEnabled=" + isVersionEnabled +
+        ", versioningStatus=" + versioningStatus +
         ", storageType=" + storageType +
         ", creationTime=" + creationTime +
         ", bekInfo=" + bekInfo +

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -352,6 +352,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         (this.acls != null) ? this.acls.toString() : null);
     auditMap.put(OzoneConsts.IS_VERSION_ENABLED,
         String.valueOf(this.isVersionEnabled));
+    auditMap.put(OzoneConsts.VERSIONING_STATUS, this.versioningStatus.name());
     auditMap.put(OzoneConsts.STORAGE_TYPE,
         (this.storageType != null) ? this.storageType.name() : null);
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -122,9 +122,14 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
     this.volumeName = b.volumeName;
     this.bucketName = b.bucketName;
     this.acls = b.acls.build();
-    this.versioningStatus = b.versioningStatus != null ? b.versioningStatus
-        : BucketVersioningStatus.fromVersionEnabledFlag(b.isVersionEnabled);
-    this.isVersionEnabled = this.versioningStatus.toVersionEnabledFlag();
+    // A null versioningStatus means the bucket carries no S3 versioning status
+    // at all, mirroring the optional proto field: such a bucket is driven by the
+    // legacy isVersionEnabled flag alone. The flag is derived from the status
+    // only when a status was actually set, so that a legacy client enabling
+    // versioning does not silently opt an existing bucket into S3 versioning.
+    this.versioningStatus = b.versioningStatus;
+    this.isVersionEnabled = b.versioningStatus != null
+        ? b.versioningStatus.toVersionEnabledFlag() : b.isVersionEnabled;
     this.storageType = b.storageType;
     this.creationTime = b.creationTime;
     this.modificationTime = b.modificationTime;
@@ -180,11 +185,24 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
   }
 
   /**
-   * Returns the S3-compatible versioning status; never null.
+   * Returns the S3-compatible versioning status; never null. A bucket that only
+   * carries the legacy isVersionEnabled flag is UNVERSIONED as far as S3
+   * versioning is concerned: the legacy flag selects the in-record block version
+   * list, which is a different feature.
    * @return BucketVersioningStatus
    */
   public BucketVersioningStatus getVersioningStatus() {
-    return versioningStatus;
+    return versioningStatus != null
+        ? versioningStatus : BucketVersioningStatus.UNVERSIONED;
+  }
+
+  /**
+   * Whether an S3 versioning status was explicitly set on this bucket, as
+   * opposed to the bucket carrying only the legacy isVersionEnabled flag.
+   * @return whether the optional status field is present
+   */
+  public boolean hasVersioningStatus() {
+    return versioningStatus != null;
   }
 
   /**
@@ -352,6 +370,8 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         (this.acls != null) ? this.acls.toString() : null);
     auditMap.put(OzoneConsts.IS_VERSION_ENABLED,
         String.valueOf(this.isVersionEnabled));
+    auditMap.put(OzoneConsts.VERSIONING_STATUS,
+        this.versioningStatus != null ? this.versioningStatus.name() : null);
     auditMap.put(OzoneConsts.STORAGE_TYPE,
         (this.storageType != null) ? this.storageType.name() : null);
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
@@ -423,6 +443,11 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
     return toBuilder()
         .setStorageType(source.getStorageType())
         .setIsVersionEnabled(source.getIsVersionEnabled())
+        // Only when the real bucket actually carries a status: copying the
+        // value getVersioningStatus() derives for a legacy bucket would give
+        // the link an explicit status the real bucket does not have.
+        .setVersioningStatus(source.hasVersioningStatus()
+            ? source.getVersioningStatus() : null)
         .setBucketEncryptionKey(source.getEncryptionKeyInfo())
         .setUsedBytes(source.getUsedBytes())
         .setUsedNamespace(source.getUsedNamespace())
@@ -502,15 +527,14 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
       return this;
     }
 
+    /**
+     * Sets the legacy flag only. It deliberately does not derive a
+     * versioningStatus: a legacy client enabling versioning must not opt the
+     * bucket into S3 versioning semantics. Deriving the status is the job of
+     * OMBucketSetPropertyRequest, where an actual state transition is requested.
+     */
     public Builder setIsVersionEnabled(boolean versionFlag) {
       this.isVersionEnabled = versionFlag;
-      // Keep versioningStatus in sync for callers that only know the legacy
-      // flag; an explicitly SUSPENDED status is preserved on disable.
-      if (versionFlag) {
-        this.versioningStatus = BucketVersioningStatus.ENABLED;
-      } else if (versioningStatus != BucketVersioningStatus.SUSPENDED) {
-        this.versioningStatus = BucketVersioningStatus.UNVERSIONED;
-      }
       return this;
     }
 
@@ -658,7 +682,6 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setBucketName(bucketName)
         .addAllAcls(OzoneAclUtil.toProtobuf(acls))
         .setIsVersionEnabled(isVersionEnabled)
-        .setVersioningStatus(versioningStatus.toProto())
         .setStorageType(storageType.toProto())
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
@@ -672,6 +695,12 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setQuotaInNamespace(quotaInNamespace)
         .setSnapshotUsedBytes(snapshotUsedBytes)
         .setSnapshotUsedNamespace(snapshotUsedNamespace);
+    // Written only when actually set, so that hasVersioningStatus() keeps
+    // telling a legacy-flag bucket apart from an S3-versioned one after a
+    // round trip through RocksDB.
+    if (versioningStatus != null) {
+      bib.setVersioningStatus(versioningStatus.toProto());
+    }
     if (bucketLayout != null) {
       bib.setBucketLayout(bucketLayout.toProto());
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -206,6 +206,19 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
   }
 
   /**
+   * Whether S3-compatible versioning is in effect, i.e. whether a write keeps
+   * the previous current version as a separate record in the versionedKeyTable.
+   * True for status ENABLED on an OBJECT_STORE bucket; buckets of other layouts
+   * carrying the legacy isVersionEnabled flag keep the legacy in-record block
+   * version behaviour.
+   * @return whether writes create versionedKeyTable records
+   */
+  public boolean isS3VersioningEnabled() {
+    return versioningStatus == BucketVersioningStatus.ENABLED
+        && bucketLayout == BucketLayout.OBJECT_STORE;
+  }
+
+  /**
    * Returns the type of storage to be used.
    * @return StorageType
    */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -59,9 +59,13 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
    */
   private final ImmutableList<OzoneAcl> acls;
   /**
-   * Bucket Version flag.
+   * Bucket Version flag, kept in sync with versioningStatus (ENABLED -> true).
    */
   private final boolean isVersionEnabled;
+  /**
+   * S3-compatible versioning status; authoritative over isVersionEnabled.
+   */
+  private final BucketVersioningStatus versioningStatus;
   /**
    * Type of storage to be used for this bucket.
    * [RAM_DISK, SSD, DISK, ARCHIVE]
@@ -118,7 +122,9 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
     this.volumeName = b.volumeName;
     this.bucketName = b.bucketName;
     this.acls = b.acls.build();
-    this.isVersionEnabled = b.isVersionEnabled;
+    this.versioningStatus = b.versioningStatus != null ? b.versioningStatus
+        : BucketVersioningStatus.fromVersionEnabledFlag(b.isVersionEnabled);
+    this.isVersionEnabled = this.versioningStatus.toVersionEnabledFlag();
     this.storageType = b.storageType;
     this.creationTime = b.creationTime;
     this.modificationTime = b.modificationTime;
@@ -171,6 +177,14 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
    */
   public boolean getIsVersionEnabled() {
     return isVersionEnabled;
+  }
+
+  /**
+   * Returns the S3-compatible versioning status; never null.
+   * @return BucketVersioningStatus
+   */
+  public BucketVersioningStatus getVersioningStatus() {
+    return versioningStatus;
   }
 
   /**
@@ -379,6 +393,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setBucketName(bucketName)
         .setStorageType(storageType)
         .setIsVersionEnabled(isVersionEnabled)
+        .setVersioningStatus(versioningStatus)
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
         .setBucketEncryptionKey(bekInfo)
@@ -430,6 +445,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
     private String bucketName;
     private final AclListBuilder acls;
     private boolean isVersionEnabled;
+    private BucketVersioningStatus versioningStatus;
     private StorageType storageType = StorageType.DISK;
     private long creationTime;
     private long modificationTime;
@@ -488,6 +504,22 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
 
     public Builder setIsVersionEnabled(boolean versionFlag) {
       this.isVersionEnabled = versionFlag;
+      // Keep versioningStatus in sync for callers that only know the legacy
+      // flag; an explicitly SUSPENDED status is preserved on disable.
+      if (versionFlag) {
+        this.versioningStatus = BucketVersioningStatus.ENABLED;
+      } else if (versioningStatus != BucketVersioningStatus.SUSPENDED) {
+        this.versioningStatus = BucketVersioningStatus.UNVERSIONED;
+      }
+      return this;
+    }
+
+    /** No-op when status is null (e.g. records without the new field). */
+    public Builder setVersioningStatus(BucketVersioningStatus status) {
+      if (status != null) {
+        this.versioningStatus = status;
+        this.isVersionEnabled = status.toVersionEnabledFlag();
+      }
       return this;
     }
 
@@ -626,6 +658,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setBucketName(bucketName)
         .addAllAcls(OzoneAclUtil.toProtobuf(acls))
         .setIsVersionEnabled(isVersionEnabled)
+        .setVersioningStatus(versioningStatus.toProto())
         .setStorageType(storageType.toProto())
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
@@ -683,6 +716,9 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setAcls(bucketInfo.getAclsList().stream().map(
             OzoneAcl::fromProtobuf).collect(Collectors.toList()))
         .setIsVersionEnabled(bucketInfo.getIsVersionEnabled())
+        .setVersioningStatus(bucketInfo.hasVersioningStatus()
+            ? BucketVersioningStatus.fromProto(bucketInfo.getVersioningStatus())
+            : null)
         .setStorageType(StorageType.valueOf(bucketInfo.getStorageType()))
         .setCreationTime(bucketInfo.getCreationTime())
         .setUsedBytes(bucketInfo.getUsedBytes())
@@ -789,6 +825,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         bucketName.equals(that.bucketName) &&
         Objects.equals(acls, that.acls) &&
         Objects.equals(isVersionEnabled, that.isVersionEnabled) &&
+        versioningStatus == that.versioningStatus &&
         storageType == that.storageType &&
         getObjectID() == that.getObjectID() &&
         getUpdateID() == that.getUpdateID() &&
@@ -817,6 +854,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         ", bucketName='" + bucketName + "'" +
         ", acls=" + acls +
         ", isVersionEnabled=" + isVersionEnabled +
+        ", versioningStatus=" + versioningStatus +
         ", storageType=" + storageType +
         ", creationTime=" + creationTime +
         ", bekInfo=" + bekInfo +

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -122,9 +122,14 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
     this.volumeName = b.volumeName;
     this.bucketName = b.bucketName;
     this.acls = b.acls.build();
-    this.versioningStatus = b.versioningStatus != null ? b.versioningStatus
-        : BucketVersioningStatus.fromVersionEnabledFlag(b.isVersionEnabled);
-    this.isVersionEnabled = this.versioningStatus.toVersionEnabledFlag();
+    // A null versioningStatus means the bucket carries no S3 versioning status
+    // at all, mirroring the optional proto field: such a bucket is driven by the
+    // legacy isVersionEnabled flag alone. The flag is derived from the status
+    // only when a status was actually set, so that a legacy client enabling
+    // versioning does not silently opt an existing bucket into S3 versioning.
+    this.versioningStatus = b.versioningStatus;
+    this.isVersionEnabled = b.versioningStatus != null
+        ? b.versioningStatus.toVersionEnabledFlag() : b.isVersionEnabled;
     this.storageType = b.storageType;
     this.creationTime = b.creationTime;
     this.modificationTime = b.modificationTime;
@@ -180,11 +185,24 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
   }
 
   /**
-   * Returns the S3-compatible versioning status; never null.
+   * Returns the S3-compatible versioning status; never null. A bucket that only
+   * carries the legacy isVersionEnabled flag is UNVERSIONED as far as S3
+   * versioning is concerned: the legacy flag selects the in-record block version
+   * list, which is a different feature.
    * @return BucketVersioningStatus
    */
   public BucketVersioningStatus getVersioningStatus() {
-    return versioningStatus;
+    return versioningStatus != null
+        ? versioningStatus : BucketVersioningStatus.UNVERSIONED;
+  }
+
+  /**
+   * Whether an S3 versioning status was explicitly set on this bucket, as
+   * opposed to the bucket carrying only the legacy isVersionEnabled flag.
+   * @return whether the optional status field is present
+   */
+  public boolean hasVersioningStatus() {
+    return versioningStatus != null;
   }
 
   /**
@@ -352,7 +370,8 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         (this.acls != null) ? this.acls.toString() : null);
     auditMap.put(OzoneConsts.IS_VERSION_ENABLED,
         String.valueOf(this.isVersionEnabled));
-    auditMap.put(OzoneConsts.VERSIONING_STATUS, this.versioningStatus.name());
+    auditMap.put(OzoneConsts.VERSIONING_STATUS,
+        this.versioningStatus != null ? this.versioningStatus.name() : null);
     auditMap.put(OzoneConsts.STORAGE_TYPE,
         (this.storageType != null) ? this.storageType.name() : null);
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
@@ -477,15 +496,14 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
       return this;
     }
 
+    /**
+     * Sets the legacy flag only. It deliberately does not derive a
+     * versioningStatus: a legacy client enabling versioning must not opt the
+     * bucket into S3 versioning semantics. Deriving the status is the job of
+     * OMBucketSetPropertyRequest, where an actual state transition is requested.
+     */
     public Builder setIsVersionEnabled(boolean versionFlag) {
       this.isVersionEnabled = versionFlag;
-      // Keep versioningStatus in sync for callers that only know the legacy
-      // flag; an explicitly SUSPENDED status is preserved on disable.
-      if (versionFlag) {
-        this.versioningStatus = BucketVersioningStatus.ENABLED;
-      } else if (versioningStatus != BucketVersioningStatus.SUSPENDED) {
-        this.versioningStatus = BucketVersioningStatus.UNVERSIONED;
-      }
       return this;
     }
 
@@ -633,7 +651,6 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setBucketName(bucketName)
         .addAllAcls(OzoneAclUtil.toProtobuf(acls))
         .setIsVersionEnabled(isVersionEnabled)
-        .setVersioningStatus(versioningStatus.toProto())
         .setStorageType(storageType.toProto())
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
@@ -647,6 +664,12 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
         .setQuotaInNamespace(quotaInNamespace)
         .setSnapshotUsedBytes(snapshotUsedBytes)
         .setSnapshotUsedNamespace(snapshotUsedNamespace);
+    // Written only when actually set, so that hasVersioningStatus() keeps
+    // telling a legacy-flag bucket apart from an S3-versioned one after a
+    // round trip through RocksDB.
+    if (versioningStatus != null) {
+      bib.setVersioningStatus(versioningStatus.toProto());
+    }
     if (bucketLayout != null) {
       bib.setBucketLayout(bucketLayout.toProto());
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -513,6 +513,9 @@ public final class OmKeyInfo extends WithParentObjectId
         ", isFile=" + isFile +
         ", fileName='" + fileName + '\'' +
         ", acls=" + acls +
+        ", versionId=" + versionId +
+        ", isDeleteMarker=" + isDeleteMarker +
+        ", isNullVersion=" + isNullVersion +
         '}';
   }
 
@@ -1014,7 +1017,10 @@ public final class OmKeyInfo extends WithParentObjectId
         Objects.equals(getMetadata(), omKeyInfo.getMetadata()) &&
         Objects.equals(acls, omKeyInfo.acls) &&
         Objects.equals(getTags(), omKeyInfo.getTags()) &&
-        getObjectID() == omKeyInfo.getObjectID();
+        getObjectID() == omKeyInfo.getObjectID() &&
+        Objects.equals(versionId, omKeyInfo.versionId) &&
+        isDeleteMarker == omKeyInfo.isDeleteMarker &&
+        isNullVersion == omKeyInfo.isNullVersion;
 
     if (isEqual && checkUpdateID) {
       isEqual = getUpdateID() == omKeyInfo.getUpdateID();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -112,6 +112,15 @@ public final class OmKeyInfo extends WithParentObjectId
   // been modified.
   private final Long expectedDataGeneration;
 
+  // S3-compatible object versioning. versionId is assigned once from the
+  // committing transaction's index when a version is created, then frozen;
+  // absent on records that predate versioning support (treated as the null
+  // version). A delete marker has isDeleteMarker set and no data blocks.
+  // isNullVersion marks the single overwritable "null version" slot per key.
+  private final Long versionId;
+  private final boolean isDeleteMarker;
+  private final boolean isNullVersion;
+
   private OmKeyInfo(Builder b) {
     super(b);
     this.volumeName = b.volumeName;
@@ -130,6 +139,9 @@ public final class OmKeyInfo extends WithParentObjectId
     this.ownerName = b.ownerName;
     this.tags = b.tags.build();
     this.expectedDataGeneration = b.expectedDataGeneration;
+    this.versionId = b.versionId;
+    this.isDeleteMarker = b.isDeleteMarker;
+    this.isNullVersion = b.isNullVersion;
   }
 
   /**
@@ -469,6 +481,22 @@ public final class OmKeyInfo extends WithParentObjectId
     return fileChecksum;
   }
 
+  /**
+   * @return the object version identity, or null for records that predate
+   * versioning support (treated as the null version).
+   */
+  public Long getVersionId() {
+    return versionId;
+  }
+
+  public boolean isDeleteMarker() {
+    return isDeleteMarker;
+  }
+
+  public boolean isNullVersion() {
+    return isNullVersion;
+  }
+
   @Override
   public String toString() {
     return "OmKeyInfo{" +
@@ -511,6 +539,9 @@ public final class OmKeyInfo extends WithParentObjectId
     private boolean isFile;
     private final MapBuilder<String, String> tags;
     private Long expectedDataGeneration = null;
+    private Long versionId = null;
+    private boolean isDeleteMarker;
+    private boolean isNullVersion;
 
     public Builder() {
       this.acls = AclListBuilder.empty();
@@ -533,6 +564,9 @@ public final class OmKeyInfo extends WithParentObjectId
       this.fileChecksum = obj.fileChecksum;
       this.isFile = obj.isFile;
       this.expectedDataGeneration = obj.expectedDataGeneration;
+      this.versionId = obj.versionId;
+      this.isDeleteMarker = obj.isDeleteMarker;
+      this.isNullVersion = obj.isNullVersion;
       this.tags = MapBuilder.of(obj.tags);
       obj.keyLocationVersions.forEach(keyLocationVersion ->
           this.omKeyLocationInfoGroups.add(
@@ -704,6 +738,21 @@ public final class OmKeyInfo extends WithParentObjectId
       return this;
     }
 
+    public Builder setVersionId(Long versionId) {
+      this.versionId = versionId;
+      return this;
+    }
+
+    public Builder setDeleteMarker(boolean deleteMarker) {
+      this.isDeleteMarker = deleteMarker;
+      return this;
+    }
+
+    public Builder setNullVersion(boolean nullVersion) {
+      this.isNullVersion = nullVersion;
+      return this;
+    }
+
     @Override
     protected void validate() {
       super.validate();
@@ -855,6 +904,16 @@ public final class OmKeyInfo extends WithParentObjectId
     if (ownerName != null) {
       kb.setOwnerName(ownerName);
     }
+    if (versionId != null) {
+      kb.setVersionId(versionId);
+    }
+    // only persisted when set, to keep records without versioning unchanged
+    if (isDeleteMarker) {
+      kb.setIsDeleteMarker(true);
+    }
+    if (isNullVersion) {
+      kb.setIsNullVersion(true);
+    }
     return kb.build();
   }
 
@@ -908,6 +967,15 @@ public final class OmKeyInfo extends WithParentObjectId
 
     if (keyInfo.hasOwnerName()) {
       builder.setOwnerName(keyInfo.getOwnerName());
+    }
+    if (keyInfo.hasVersionId()) {
+      builder.setVersionId(keyInfo.getVersionId());
+    }
+    if (keyInfo.hasIsDeleteMarker()) {
+      builder.setDeleteMarker(keyInfo.getIsDeleteMarker());
+    }
+    if (keyInfo.hasIsNullVersion()) {
+      builder.setNullVersion(keyInfo.getIsNullVersion());
     }
     return builder;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -112,6 +112,16 @@ public final class OmKeyInfo extends WithParentObjectId
   // been modified.
   private final Long expectedDataGeneration;
 
+  // S3-compatible object versioning. versionId is allocated once when a
+  // version is written and then frozen, and increases within a key so its
+  // versions can be ordered newest first; absent on records that predate
+  // versioning support (treated as the null version). A delete marker has
+  // isDeleteMarker set and no data blocks. isNullVersion marks the single
+  // overwritable "null version" slot per key.
+  private final Long versionId;
+  private final boolean isDeleteMarker;
+  private final boolean isNullVersion;
+
   private OmKeyInfo(Builder b) {
     super(b);
     this.volumeName = b.volumeName;
@@ -130,6 +140,9 @@ public final class OmKeyInfo extends WithParentObjectId
     this.ownerName = b.ownerName;
     this.tags = b.tags.build();
     this.expectedDataGeneration = b.expectedDataGeneration;
+    this.versionId = b.versionId;
+    this.isDeleteMarker = b.isDeleteMarker;
+    this.isNullVersion = b.isNullVersion;
   }
 
   /**
@@ -469,6 +482,22 @@ public final class OmKeyInfo extends WithParentObjectId
     return fileChecksum;
   }
 
+  /**
+   * @return the object version identity, or null for records that predate
+   * versioning support (treated as the null version).
+   */
+  public Long getVersionId() {
+    return versionId;
+  }
+
+  public boolean isDeleteMarker() {
+    return isDeleteMarker;
+  }
+
+  public boolean isNullVersion() {
+    return isNullVersion;
+  }
+
   @Override
   public String toString() {
     return "OmKeyInfo{" +
@@ -511,6 +540,9 @@ public final class OmKeyInfo extends WithParentObjectId
     private boolean isFile;
     private final MapBuilder<String, String> tags;
     private Long expectedDataGeneration = null;
+    private Long versionId = null;
+    private boolean isDeleteMarker;
+    private boolean isNullVersion;
 
     public Builder() {
       this.acls = AclListBuilder.empty();
@@ -533,6 +565,9 @@ public final class OmKeyInfo extends WithParentObjectId
       this.fileChecksum = obj.fileChecksum;
       this.isFile = obj.isFile;
       this.expectedDataGeneration = obj.expectedDataGeneration;
+      this.versionId = obj.versionId;
+      this.isDeleteMarker = obj.isDeleteMarker;
+      this.isNullVersion = obj.isNullVersion;
       this.tags = MapBuilder.of(obj.tags);
       obj.keyLocationVersions.forEach(keyLocationVersion ->
           this.omKeyLocationInfoGroups.add(
@@ -704,6 +739,21 @@ public final class OmKeyInfo extends WithParentObjectId
       return this;
     }
 
+    public Builder setVersionId(Long versionId) {
+      this.versionId = versionId;
+      return this;
+    }
+
+    public Builder setDeleteMarker(boolean deleteMarker) {
+      this.isDeleteMarker = deleteMarker;
+      return this;
+    }
+
+    public Builder setNullVersion(boolean nullVersion) {
+      this.isNullVersion = nullVersion;
+      return this;
+    }
+
     @Override
     protected void validate() {
       super.validate();
@@ -855,6 +905,16 @@ public final class OmKeyInfo extends WithParentObjectId
     if (ownerName != null) {
       kb.setOwnerName(ownerName);
     }
+    if (versionId != null) {
+      kb.setVersionId(versionId);
+    }
+    // only persisted when set, to keep records without versioning unchanged
+    if (isDeleteMarker) {
+      kb.setIsDeleteMarker(true);
+    }
+    if (isNullVersion) {
+      kb.setIsNullVersion(true);
+    }
     return kb.build();
   }
 
@@ -908,6 +968,15 @@ public final class OmKeyInfo extends WithParentObjectId
 
     if (keyInfo.hasOwnerName()) {
       builder.setOwnerName(keyInfo.getOwnerName());
+    }
+    if (keyInfo.hasVersionId()) {
+      builder.setVersionId(keyInfo.getVersionId());
+    }
+    if (keyInfo.hasIsDeleteMarker()) {
+      builder.setDeleteMarker(keyInfo.getIsDeleteMarker());
+    }
+    if (keyInfo.hasIsNullVersion()) {
+      builder.setNullVersion(keyInfo.getIsNullVersion());
     }
     return builder;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -514,6 +514,9 @@ public final class OmKeyInfo extends WithParentObjectId
         ", isFile=" + isFile +
         ", fileName='" + fileName + '\'' +
         ", acls=" + acls +
+        ", versionId=" + versionId +
+        ", isDeleteMarker=" + isDeleteMarker +
+        ", isNullVersion=" + isNullVersion +
         '}';
   }
 
@@ -1015,7 +1018,10 @@ public final class OmKeyInfo extends WithParentObjectId
         Objects.equals(getMetadata(), omKeyInfo.getMetadata()) &&
         Objects.equals(acls, omKeyInfo.acls) &&
         Objects.equals(getTags(), omKeyInfo.getTags()) &&
-        getObjectID() == omKeyInfo.getObjectID();
+        getObjectID() == omKeyInfo.getObjectID() &&
+        Objects.equals(versionId, omKeyInfo.versionId) &&
+        isDeleteMarker == omKeyInfo.isDeleteMarker &&
+        isNullVersion == omKeyInfo.isNullVersion;
 
     if (isEqual && checkUpdateID) {
       isEqual = getUpdateID() == omKeyInfo.getUpdateID();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/PinnedFirstVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/PinnedFirstVersionIdGenerator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Pins the first version of every key to {@link #FIRST_VERSION_ID} and uses the
+ * committing transaction's index for every later version, exactly like
+ * {@link TransactionIndexVersionIdGenerator}. Clusters configured with this
+ * generator can reference the first version of a key without listing it first.
+ *
+ * <p>Holds no allocator state either: a key is on its first version exactly
+ * when keyTable holds no current version for it, which the write path looks up
+ * anyway.
+ *
+ * <p>The sentinel is smaller than any transaction index, so the first version
+ * sorts at the old end of the key's version sequence, as the versionedKeyTable
+ * layout requires.
+ *
+ * <p>Known trade-off: once every version of a key is permanently deleted, a
+ * recreated key takes the sentinel again, so an external reference to the first
+ * version resolves to the new content. Later versions are transaction indices
+ * and are never reused.
+ */
+public class PinnedFirstVersionIdGenerator implements VersionIdGenerator {
+
+  @Override
+  public long generateVersionId(long transactionLogIndex, boolean hasCurrentVersion) {
+    if (!hasCurrentVersion) {
+      return FIRST_VERSION_ID;
+    }
+    Preconditions.checkArgument(transactionLogIndex > FIRST_VERSION_ID,
+        "Transaction index " + transactionLogIndex
+            + " is a reserved versionId, expected greater than " + FIRST_VERSION_ID);
+    return transactionLogIndex;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/PinnedFirstVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/PinnedFirstVersionIdGenerator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+/**
+ * Numbers versions like {@link UniqueIdVersionIdGenerator}, except that a key's
+ * first version takes {@link #FIRST_VERSION_ID}, so it can be referenced
+ * without listing the key's versions first.
+ *
+ * <p>Known trade-off: once every version of a key has been permanently deleted,
+ * a recreated key takes the sentinel again, so an external reference to the
+ * first version resolves to the new content.
+ */
+public class PinnedFirstVersionIdGenerator extends UniqueIdVersionIdGenerator {
+
+  /**
+   * Id of a pinned first version. Smaller than any proposed id, so such a
+   * version sorts at the old end of the key's versions.
+   */
+  public static final long FIRST_VERSION_ID = 1L;
+
+  @Override
+  public long versionIdFor(long proposedVersionId, boolean hasCurrentVersion) {
+    return hasCurrentVersion ? proposedVersionId : FIRST_VERSION_ID;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TransactionIndexVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TransactionIndexVersionIdGenerator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Uses the index of the committing transaction as the versionId, the default
+ * generator. Holds no allocator state, so a version costs no read or write
+ * beyond the commit itself.
+ */
+public class TransactionIndexVersionIdGenerator implements VersionIdGenerator {
+
+  @Override
+  public long generateVersionId(long transactionLogIndex, boolean hasCurrentVersion) {
+    Preconditions.checkArgument(transactionLogIndex > FIRST_VERSION_ID,
+        "Transaction index " + transactionLogIndex
+            + " is a reserved versionId, expected greater than " + FIRST_VERSION_ID);
+    return transactionLogIndex;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/UniqueIdVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/UniqueIdVersionIdGenerator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.hdds.utils.UniqueId;
+
+/**
+ * Numbers a version with the time it was written, through the scheme Ozone
+ * already uses for block local IDs: {@code currentTimeMillis << 16} with a
+ * 16-bit counter separating ids proposed inside one millisecond.
+ *
+ * <p>Needs no allocator state and no coordination. It does not promise the
+ * per-key ordering the versionedKeyTable needs — the counter can run out, and a
+ * clock can step backwards — which {@code VersionIdAllocator} establishes by
+ * taking a proposal as a floor.
+ */
+public class UniqueIdVersionIdGenerator implements VersionIdGenerator {
+
+  @Override
+  public long generateVersionId() {
+    return UniqueId.next();
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/VersionIdGenerator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/VersionIdGenerator.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.util.ReflectionUtils;
+
+/**
+ * Assigns the versionId of an object version when the version is committed.
+ *
+ * <p>Deployments differ in whether they need a version identity that can be
+ * constructed without listing, so the implementation is chosen per cluster
+ * through {@link OMConfigKeys#OZONE_OM_VERSIONING_VERSION_ID_GENERATOR}.
+ * Implementations must be public, have a public no-argument constructor, and
+ * satisfy the constraints that the versionedKeyTable layout and version
+ * promotion rely on:
+ *
+ * <ul>
+ *   <li>ids increase within a key: a version created later has a larger id;</li>
+ *   <li>an id is assigned once when the version is created and never changes
+ *       afterwards, so that external references stay valid;</li>
+ *   <li>{@link #NULL_VERSION_ID} is reserved and is never generated.</li>
+ * </ul>
+ *
+ * <p>The generator is cluster-wide and may be changed on a running cluster, so
+ * these constraints hold per generator but not necessarily across a change of
+ * generator. Colliding ids are rejected at commit time rather than prevented
+ * here; see {@code VersionIdAllocator}.
+ */
+public interface VersionIdGenerator {
+
+  /**
+   * Reserved id of the null version slot, rendered as the literal "null" by
+   * the S3 layer. Never returned by a generator.
+   */
+  long NULL_VERSION_ID = 0L;
+
+  /**
+   * Reserved id of the pinned first version of a key, a separate slot from
+   * {@link #NULL_VERSION_ID}. Only assigned by generators that pin the first
+   * version of a key; it is smaller than any transaction index, so such a
+   * version sorts at the old end of the key's version sequence.
+   */
+  long FIRST_VERSION_ID = 1L;
+
+  /**
+   * Generates the versionId to freeze on a version being committed.
+   *
+   * @param transactionLogIndex index of the committing OM Ratis transaction
+   * @param hasCurrentVersion whether keyTable already holds a current version
+   *     of the key being committed. The write path looks the current version up
+   *     anyway, so generators that treat the first version of a key specially
+   *     need no read of their own.
+   * @return the versionId of the new version
+   */
+  long generateVersionId(long transactionLogIndex, boolean hasCurrentVersion);
+
+  /**
+   * Instantiates the generator configured for this cluster.
+   *
+   * @throws RuntimeException if the configured class cannot be instantiated
+   */
+  static VersionIdGenerator fromConfiguration(ConfigurationSource conf) {
+    Class<? extends VersionIdGenerator> generatorClass = conf.getClass(
+        OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR,
+        OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR_DEFAULT,
+        VersionIdGenerator.class);
+    return ReflectionUtils.newInstance(generatorClass, null);
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/VersionIdGenerator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/VersionIdGenerator.java
@@ -32,16 +32,22 @@ import org.apache.hadoop.util.ReflectionUtils;
  * promotion rely on:
  *
  * <ul>
- *   <li>ids increase within a key: a version created later has a larger id;</li>
+ *   <li>ids strictly increase within a key: for one generator, the id of a
+ *       version created later is always greater than the id of every version of
+ *       that key created before it, never equal and never smaller. The
+ *       versionedKeyTable ordering and version promotion depend on this;</li>
  *   <li>an id is assigned once when the version is created and never changes
  *       afterwards, so that external references stay valid;</li>
  *   <li>{@link #NULL_VERSION_ID} is reserved and is never generated.</li>
  * </ul>
  *
- * <p>The generator is cluster-wide and may be changed on a running cluster, so
- * these constraints hold per generator but not necessarily across a change of
- * generator. Colliding ids are rejected at commit time rather than prevented
- * here; see {@code VersionIdAllocator}.
+ * <p>The first constraint binds one generator, not a sequence of them: the
+ * generator is cluster-wide and may be changed on a running cluster, and the
+ * new one knows nothing of the ids the old one handed out.
+ * {@code VersionIdAllocator} enforces the constraint at commit time and refuses
+ * a write whose id does not come after the key's current version, so a change
+ * of generator fails loudly on affected keys instead of corrupting their
+ * version order.
  */
 public interface VersionIdGenerator {
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/VersionIdGenerator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/VersionIdGenerator.java
@@ -38,7 +38,8 @@ import org.apache.hadoop.util.ReflectionUtils;
  *       versionedKeyTable ordering and version promotion depend on this;</li>
  *   <li>an id is assigned once when the version is created and never changes
  *       afterwards, so that external references stay valid;</li>
- *   <li>{@link #NULL_VERSION_ID} is reserved and is never generated.</li>
+ *   <li>{@link #UNSET_VERSION_ID} and {@link #FIRST_VERSION_ID} are reserved
+ *       and are never generated.</li>
  * </ul>
  *
  * <p>The first constraint binds one generator, not a sequence of them: the
@@ -52,16 +53,22 @@ import org.apache.hadoop.util.ReflectionUtils;
 public interface VersionIdGenerator {
 
   /**
-   * Reserved id of the null version slot, rendered as the literal "null" by
-   * the S3 layer. Never returned by a generator.
+   * Unset value of the optional versionId field, carried by records written
+   * before versioning existed. Reserved, and never returned by a generator.
+   *
+   * <p>This is not the id of the null version: a null version carries a
+   * normally generated id like any other version and is identified by the
+   * {@code isNullVersion} attribute instead. Pinning it to a fixed low value
+   * would misorder a null created between two versioned writes, which is the
+   * middle version of the key rather than its oldest.
    */
-  long NULL_VERSION_ID = 0L;
+  long UNSET_VERSION_ID = 0L;
 
   /**
-   * Reserved id of the pinned first version of a key, a separate slot from
-   * {@link #NULL_VERSION_ID}. Only assigned by generators that pin the first
-   * version of a key; it is smaller than any transaction index, so such a
-   * version sorts at the old end of the key's version sequence.
+   * Reserved id of the pinned first version of a key. Only assigned by
+   * generators that pin the first version of a key; it is smaller than any
+   * transaction index, so such a version sorts at the old end of the key's
+   * version sequence.
    */
   long FIRST_VERSION_ID = 1L;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/VersionIdGenerator.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/VersionIdGenerator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.util.ReflectionUtils;
+
+/**
+ * Numbers an object version.
+ *
+ * <p>The id is proposed on the OM that received the request, in preExecute, so
+ * it travels in the replicated request and every OM applies a version that is
+ * already numbered. Nothing about it depends on the transaction carrying the
+ * write, or on OM being replicated by Ratis.
+ *
+ * <p>Implementations must be public with a public no-argument constructor, and
+ * are selected cluster-wide by
+ * {@link OMConfigKeys#OZONE_OM_VERSIONING_VERSION_ID_GENERATOR}.
+ */
+public interface VersionIdGenerator {
+
+  /**
+   * Unset value of the optional versionId field, carried by records written
+   * before versioning existed. Never proposed.
+   *
+   * <p>Not the id of the null version, which carries a proposed id like any
+   * other version and is marked by {@code isNullVersion} instead.
+   */
+  long UNSET_VERSION_ID = 0L;
+
+  /** @return the id to propose for a version being created. */
+  long generateVersionId();
+
+  /**
+   * The id a version takes when applied, given what was proposed for it. A
+   * generator that numbers some versions specially decides that here, where
+   * whether the key already has a version is settled under the write's lock.
+   *
+   * @param proposedVersionId the id the request carried
+   * @param hasCurrentVersion whether keyTable already holds a version of the key
+   */
+  default long versionIdFor(long proposedVersionId, boolean hasCurrentVersion) {
+    return proposedVersionId;
+  }
+
+  /**
+   * Instantiates the generator configured for this cluster.
+   *
+   * @throws RuntimeException if the configured class cannot be instantiated
+   */
+  static VersionIdGenerator fromConfiguration(ConfigurationSource conf) {
+    Class<? extends VersionIdGenerator> generatorClass = conf.getClass(
+        OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR,
+        OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR_DEFAULT,
+        VersionIdGenerator.class);
+    return ReflectionUtils.newInstance(generatorClass, null);
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
@@ -66,6 +66,32 @@ public class TestOmBucketArgs {
   }
 
   @Test
+  public void testVersioningStatusIsSetCorrectly() {
+    OmBucketArgs bucketArgs = OmBucketArgs.newBuilder()
+        .setBucketName("bucket")
+        .setVolumeName("volume")
+        .build();
+
+    OmBucketArgs argsFromProto = OmBucketArgs.getFromProtobuf(
+        bucketArgs.getProtobuf());
+
+    // absent means "not being changed"
+    assertNull(argsFromProto.getVersioningStatus());
+
+    bucketArgs = OmBucketArgs.newBuilder()
+        .setBucketName("bucket")
+        .setVolumeName("volume")
+        .setVersioningStatus(BucketVersioningStatus.SUSPENDED)
+        .build();
+
+    argsFromProto = OmBucketArgs.getFromProtobuf(
+        bucketArgs.getProtobuf());
+
+    assertEquals(BucketVersioningStatus.SUSPENDED,
+        argsFromProto.getVersioningStatus());
+  }
+
+  @Test
   public void testDefaultReplicationConfigIsSetCorrectly() {
     OmBucketArgs bucketArgs = OmBucketArgs.newBuilder()
         .setBucketName("bucket")

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.StorageType;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -52,6 +53,91 @@ public class TestOmBucketInfo {
 
     assertEquals(bucket,
         OmBucketInfo.getFromProtobuf(bucket.getProtobuf()));
+  }
+
+  @Test
+  public void versioningStatusDerivedFromLegacyFlag() {
+    // Records written before the versioningStatus field existed deserialize
+    // unchanged: the status is derived from the legacy isVersionEnabled flag.
+    OzoneManagerProtocolProtos.BucketInfo oldRecord =
+        OzoneManagerProtocolProtos.BucketInfo.newBuilder()
+            .setVolumeName("vol1")
+            .setBucketName("bucket")
+            .setIsVersionEnabled(false)
+            .setStorageType(HddsProtos.StorageTypeProto.DISK)
+            .build();
+    OmBucketInfo bucket = OmBucketInfo.getFromProtobuf(oldRecord);
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
+        bucket.getVersioningStatus());
+    assertFalse(bucket.getIsVersionEnabled());
+    assertEquals(bucket, OmBucketInfo.getFromProtobuf(bucket.getProtobuf()));
+
+    oldRecord = oldRecord.toBuilder().setIsVersionEnabled(true).build();
+    bucket = OmBucketInfo.getFromProtobuf(oldRecord);
+    assertEquals(BucketVersioningStatus.ENABLED,
+        bucket.getVersioningStatus());
+    assertTrue(bucket.getIsVersionEnabled());
+    assertEquals(bucket, OmBucketInfo.getFromProtobuf(bucket.getProtobuf()));
+  }
+
+  @Test
+  public void versioningStatusProtobufConversion() {
+    // SUSPENDED is not representable by the legacy flag alone, so it must
+    // survive a proto round trip via the new field.
+    OmBucketInfo bucket = OmBucketInfo.newBuilder()
+        .setBucketName("bucket")
+        .setVolumeName("vol1")
+        .setVersioningStatus(BucketVersioningStatus.SUSPENDED)
+        .build();
+    assertFalse(bucket.getIsVersionEnabled());
+
+    OmBucketInfo recovered = OmBucketInfo.getFromProtobuf(bucket.getProtobuf());
+    assertEquals(BucketVersioningStatus.SUSPENDED,
+        recovered.getVersioningStatus());
+    assertFalse(recovered.getIsVersionEnabled());
+    assertEquals(bucket, recovered);
+  }
+
+  @Test
+  public void builderKeepsVersioningStatusAndLegacyFlagInSync() {
+    OmBucketInfo.Builder builder = OmBucketInfo.newBuilder()
+        .setBucketName("bucket")
+        .setVolumeName("vol1");
+
+    // default is UNVERSIONED
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
+        builder.build().getVersioningStatus());
+
+    // legacy true -> ENABLED
+    builder.setIsVersionEnabled(true);
+    assertEquals(BucketVersioningStatus.ENABLED,
+        builder.build().getVersioningStatus());
+    assertTrue(builder.build().getIsVersionEnabled());
+
+    // explicit SUSPENDED forces the legacy flag to false
+    builder.setVersioningStatus(BucketVersioningStatus.SUSPENDED);
+    assertEquals(BucketVersioningStatus.SUSPENDED,
+        builder.build().getVersioningStatus());
+    assertFalse(builder.build().getIsVersionEnabled());
+
+    // legacy false does not clobber an explicitly SUSPENDED status
+    builder.setIsVersionEnabled(false);
+    assertEquals(BucketVersioningStatus.SUSPENDED,
+        builder.build().getVersioningStatus());
+
+    // a null status is a no-op (records without the new field)
+    builder.setVersioningStatus(null);
+    assertEquals(BucketVersioningStatus.SUSPENDED,
+        builder.build().getVersioningStatus());
+
+    // legacy false on a never-enabled bucket stays UNVERSIONED
+    OmBucketInfo unversioned = OmBucketInfo.newBuilder()
+        .setBucketName("bucket")
+        .setVolumeName("vol1")
+        .setIsVersionEnabled(false)
+        .build();
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
+        unversioned.getVersioningStatus());
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -56,9 +56,11 @@ public class TestOmBucketInfo {
   }
 
   @Test
-  public void versioningStatusDerivedFromLegacyFlag() {
+  public void legacyFlagDoesNotImplyAnS3VersioningStatus() {
     // Records written before the versioningStatus field existed deserialize
-    // unchanged: the status is derived from the legacy isVersionEnabled flag.
+    // unchanged and keep carrying the legacy flag alone. The legacy flag
+    // selects the in-record block version list, which is a different feature
+    // from S3 versioning, so it must not be promoted to a status.
     OzoneManagerProtocolProtos.BucketInfo oldRecord =
         OzoneManagerProtocolProtos.BucketInfo.newBuilder()
             .setVolumeName("vol1")
@@ -67,6 +69,7 @@ public class TestOmBucketInfo {
             .setStorageType(HddsProtos.StorageTypeProto.DISK)
             .build();
     OmBucketInfo bucket = OmBucketInfo.getFromProtobuf(oldRecord);
+    assertFalse(bucket.hasVersioningStatus());
     assertEquals(BucketVersioningStatus.UNVERSIONED,
         bucket.getVersioningStatus());
     assertFalse(bucket.getIsVersionEnabled());
@@ -74,9 +77,13 @@ public class TestOmBucketInfo {
 
     oldRecord = oldRecord.toBuilder().setIsVersionEnabled(true).build();
     bucket = OmBucketInfo.getFromProtobuf(oldRecord);
-    assertEquals(BucketVersioningStatus.ENABLED,
+    assertFalse(bucket.hasVersioningStatus());
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
         bucket.getVersioningStatus());
     assertTrue(bucket.getIsVersionEnabled());
+    // the absent status survives the round trip, so a re-serialized legacy
+    // record is still distinguishable from an S3-versioned one
+    assertFalse(bucket.getProtobuf().hasVersioningStatus());
     assertEquals(bucket, OmBucketInfo.getFromProtobuf(bucket.getProtobuf()));
   }
 
@@ -104,40 +111,33 @@ public class TestOmBucketInfo {
         .setBucketName("bucket")
         .setVolumeName("vol1");
 
-    // default is UNVERSIONED
+    // no status set at all
+    assertFalse(builder.build().hasVersioningStatus());
     assertEquals(BucketVersioningStatus.UNVERSIONED,
         builder.build().getVersioningStatus());
 
-    // legacy true -> ENABLED
+    // the legacy flag sets only itself: no status is derived from it
     builder.setIsVersionEnabled(true);
-    assertEquals(BucketVersioningStatus.ENABLED,
+    assertFalse(builder.build().hasVersioningStatus());
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
         builder.build().getVersioningStatus());
     assertTrue(builder.build().getIsVersionEnabled());
 
-    // explicit SUSPENDED forces the legacy flag to false
+    // an explicit status is authoritative and drives the legacy flag
     builder.setVersioningStatus(BucketVersioningStatus.SUSPENDED);
+    assertTrue(builder.build().hasVersioningStatus());
     assertEquals(BucketVersioningStatus.SUSPENDED,
         builder.build().getVersioningStatus());
     assertFalse(builder.build().getIsVersionEnabled());
 
-    // legacy false does not clobber an explicitly SUSPENDED status
-    builder.setIsVersionEnabled(false);
-    assertEquals(BucketVersioningStatus.SUSPENDED,
-        builder.build().getVersioningStatus());
+    // ENABLED shows up as true to clients that only know the legacy flag
+    builder.setVersioningStatus(BucketVersioningStatus.ENABLED);
+    assertTrue(builder.build().getIsVersionEnabled());
 
     // a null status is a no-op (records without the new field)
     builder.setVersioningStatus(null);
-    assertEquals(BucketVersioningStatus.SUSPENDED,
+    assertEquals(BucketVersioningStatus.ENABLED,
         builder.build().getVersioningStatus());
-
-    // legacy false on a never-enabled bucket stays UNVERSIONED
-    OmBucketInfo unversioned = OmBucketInfo.newBuilder()
-        .setBucketName("bucket")
-        .setVolumeName("vol1")
-        .setIsVersionEnabled(false)
-        .build();
-    assertEquals(BucketVersioningStatus.UNVERSIONED,
-        unversioned.getVersioningStatus());
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -114,6 +115,33 @@ public class TestOmKeyInfo {
         (ECReplicationConfig) recovered.getReplicationConfig();
     assertEquals(3, config.getData());
     assertEquals(2, config.getParity());
+  }
+
+  @Test
+  public void protobufConversionWithVersioningFields() {
+    // records without versioning fields keep them unset after a round trip
+    OmKeyInfo key = createOmKeyInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+    OzoneManagerProtocolProtos.KeyInfo proto = key.getProtobuf(ClientVersion.CURRENT_VERSION);
+    assertFalse(proto.hasVersionId());
+    assertFalse(proto.hasIsDeleteMarker());
+    assertFalse(proto.hasIsNullVersion());
+    OmKeyInfo recovered = OmKeyInfo.getFromProtobuf(proto);
+    assertNull(recovered.getVersionId());
+    assertFalse(recovered.isDeleteMarker());
+    assertFalse(recovered.isNullVersion());
+
+    // versioning fields survive a round trip and the copy constructor
+    key = createOmKeyInfo(RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
+        .toBuilder()
+        .setVersionId(4242L)
+        .setDeleteMarker(true)
+        .setNullVersion(true)
+        .build();
+    recovered = OmKeyInfo.getFromProtobuf(key.getProtobuf(ClientVersion.CURRENT_VERSION));
+    assertEquals(4242L, recovered.getVersionId());
+    assertTrue(recovered.isDeleteMarker());
+    assertTrue(recovered.isNullVersion());
   }
 
   private OmKeyInfo createOmKeyInfo(ReplicationConfig replicationConfig) {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -142,6 +142,13 @@ public class TestOmKeyInfo {
     assertEquals(4242L, recovered.getVersionId());
     assertTrue(recovered.isDeleteMarker());
     assertTrue(recovered.isNullVersion());
+
+    // records differing only in a versioning field must not compare equal
+    OmKeyInfo plain = createOmKeyInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+    assertNotEquals(plain, plain.toBuilder().setVersionId(1L).build());
+    assertNotEquals(plain, plain.toBuilder().setDeleteMarker(true).build());
+    assertNotEquals(plain, plain.toBuilder().setNullVersion(true).build());
   }
 
   private OmKeyInfo createOmKeyInfo(ReplicationConfig replicationConfig) {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
@@ -48,7 +48,9 @@ public class TestVersionIdGenerator {
 
   @ParameterizedTest
   @MethodSource("generators")
-  void generatedIdsIncreaseWithTheTransactionIndex(VersionIdGenerator generator) {
+  void generatedIdsStrictlyIncreaseWithinAKey(VersionIdGenerator generator) {
+    // The contract every generator owes VersionIdAllocator: over the life of a
+    // key, ids only ever go up, starting from the key's first version.
     long previous = generator.generateVersionId(FIRST_USABLE_INDEX, false);
     for (long index = FIRST_USABLE_INDEX + 1; index < 100; index++) {
       long current = generator.generateVersionId(index, true);

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
@@ -43,7 +43,8 @@ public class TestVersionIdGenerator {
 
   /** Every generator shipped with Ozone; extended as generators are added. */
   static Stream<VersionIdGenerator> generators() {
-    return Stream.of(new TransactionIndexVersionIdGenerator());
+    return Stream.of(new TransactionIndexVersionIdGenerator(),
+        new PinnedFirstVersionIdGenerator());
   }
 
   @ParameterizedTest
@@ -66,6 +67,7 @@ public class TestVersionIdGenerator {
   void generatedIdsNeverCollideWithReservedIds(VersionIdGenerator generator) {
     for (long index = FIRST_USABLE_INDEX; index < 100; index++) {
       assertNotEquals(NULL_VERSION_ID, generator.generateVersionId(index, true));
+      assertNotEquals(NULL_VERSION_ID, generator.generateVersionId(index, false));
     }
     // A transaction index that lands on a reserved id is a misconfiguration of
     // the Ratis log rather than something to silently work around.
@@ -101,6 +103,41 @@ public class TestVersionIdGenerator {
 
     assertEquals(7, generator.generateVersionId(7, false));
     assertEquals(7, generator.generateVersionId(7, true));
+  }
+
+  @Test
+  void pinnedFirstPinsOnlyTheFirstVersionOfAKey() {
+    VersionIdGenerator generator = new PinnedFirstVersionIdGenerator();
+
+    assertEquals(FIRST_VERSION_ID, generator.generateVersionId(7, false));
+    assertEquals(7, generator.generateVersionId(7, true));
+  }
+
+  @Test
+  void pinnedFirstSentinelIsOlderThanEveryTransactionIndex() {
+    VersionIdGenerator generator = new PinnedFirstVersionIdGenerator();
+    long first = generator.generateVersionId(FIRST_USABLE_INDEX, false);
+
+    for (long index = FIRST_USABLE_INDEX; index < 100; index++) {
+      assertTrue(first < generator.generateVersionId(index, true),
+          "sentinel " + first + " is not older than the version at transaction " + index);
+    }
+  }
+
+  @Test
+  void pinnedFirstSentinelIsNotTheNullVersion() {
+    assertNotEquals(NULL_VERSION_ID,
+        new PinnedFirstVersionIdGenerator().generateVersionId(7, false));
+  }
+
+  @Test
+  void pinnedFirstGeneratorIsSelectableByConfiguration() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR,
+        PinnedFirstVersionIdGenerator.class.getName());
+
+    assertInstanceOf(PinnedFirstVersionIdGenerator.class,
+        VersionIdGenerator.fromConfiguration(conf));
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import static org.apache.hadoop.ozone.om.helpers.VersionIdGenerator.FIRST_VERSION_ID;
+import static org.apache.hadoop.ozone.om.helpers.VersionIdGenerator.NULL_VERSION_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests the constraints every {@link VersionIdGenerator} has to satisfy, and
+ * how the cluster-wide generator is selected.
+ */
+public class TestVersionIdGenerator {
+
+  /** The first transaction index that is not a reserved versionId. */
+  private static final long FIRST_USABLE_INDEX = FIRST_VERSION_ID + 1;
+
+  /** Every generator shipped with Ozone; extended as generators are added. */
+  static Stream<VersionIdGenerator> generators() {
+    return Stream.of(new TransactionIndexVersionIdGenerator());
+  }
+
+  @ParameterizedTest
+  @MethodSource("generators")
+  void generatedIdsIncreaseWithTheTransactionIndex(VersionIdGenerator generator) {
+    long previous = generator.generateVersionId(FIRST_USABLE_INDEX, false);
+    for (long index = FIRST_USABLE_INDEX + 1; index < 100; index++) {
+      long current = generator.generateVersionId(index, true);
+      assertTrue(previous < current,
+          "versionId " + current + " generated for transaction " + index
+              + " does not exceed " + previous);
+      previous = current;
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("generators")
+  void generatedIdsNeverCollideWithReservedIds(VersionIdGenerator generator) {
+    for (long index = FIRST_USABLE_INDEX; index < 100; index++) {
+      assertNotEquals(NULL_VERSION_ID, generator.generateVersionId(index, true));
+    }
+    // A transaction index that lands on a reserved id is a misconfiguration of
+    // the Ratis log rather than something to silently work around.
+    assertThrows(IllegalArgumentException.class,
+        () -> generator.generateVersionId(NULL_VERSION_ID, true));
+    assertThrows(IllegalArgumentException.class,
+        () -> generator.generateVersionId(FIRST_VERSION_ID, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("generators")
+  void generationIsDeterministic(VersionIdGenerator generator) {
+    assertEquals(generator.generateVersionId(4242, true),
+        generator.generateVersionId(4242, true));
+    assertEquals(generator.generateVersionId(4242, false),
+        generator.generateVersionId(4242, false));
+  }
+
+  @Test
+  void reservedIdsDoNotCollide() {
+    assertNotEquals(NULL_VERSION_ID, FIRST_VERSION_ID);
+  }
+
+  @Test
+  void transactionIndexGeneratorIsTheDefault() {
+    assertInstanceOf(TransactionIndexVersionIdGenerator.class,
+        VersionIdGenerator.fromConfiguration(new OzoneConfiguration()));
+  }
+
+  @Test
+  void transactionIndexIgnoresWhetherTheKeyHasACurrentVersion() {
+    VersionIdGenerator generator = new TransactionIndexVersionIdGenerator();
+
+    assertEquals(7, generator.generateVersionId(7, false));
+    assertEquals(7, generator.generateVersionId(7, true));
+  }
+
+  @Test
+  void generatorClassIsReadFromConfiguration() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR,
+        TransactionIndexVersionIdGenerator.class.getName());
+
+    assertInstanceOf(TransactionIndexVersionIdGenerator.class,
+        VersionIdGenerator.fromConfiguration(conf));
+  }
+
+  @Test
+  void unknownGeneratorClassIsRejected() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR,
+        "org.apache.hadoop.ozone.om.helpers.NoSuchVersionIdGenerator");
+
+    assertThrows(RuntimeException.class, () -> VersionIdGenerator.fromConfiguration(conf));
+  }
+
+  @Test
+  void generatorClassNotImplementingTheInterfaceIsRejected() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR,
+        String.class.getName());
+
+    assertThrows(RuntimeException.class, () -> VersionIdGenerator.fromConfiguration(conf));
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 import static org.apache.hadoop.ozone.om.helpers.VersionIdGenerator.FIRST_VERSION_ID;
-import static org.apache.hadoop.ozone.om.helpers.VersionIdGenerator.NULL_VERSION_ID;
+import static org.apache.hadoop.ozone.om.helpers.VersionIdGenerator.UNSET_VERSION_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -66,13 +66,13 @@ public class TestVersionIdGenerator {
   @MethodSource("generators")
   void generatedIdsNeverCollideWithReservedIds(VersionIdGenerator generator) {
     for (long index = FIRST_USABLE_INDEX; index < 100; index++) {
-      assertNotEquals(NULL_VERSION_ID, generator.generateVersionId(index, true));
-      assertNotEquals(NULL_VERSION_ID, generator.generateVersionId(index, false));
+      assertNotEquals(UNSET_VERSION_ID, generator.generateVersionId(index, true));
+      assertNotEquals(UNSET_VERSION_ID, generator.generateVersionId(index, false));
     }
     // A transaction index that lands on a reserved id is a misconfiguration of
     // the Ratis log rather than something to silently work around.
     assertThrows(IllegalArgumentException.class,
-        () -> generator.generateVersionId(NULL_VERSION_ID, true));
+        () -> generator.generateVersionId(UNSET_VERSION_ID, true));
     assertThrows(IllegalArgumentException.class,
         () -> generator.generateVersionId(FIRST_VERSION_ID, true));
   }
@@ -88,7 +88,7 @@ public class TestVersionIdGenerator {
 
   @Test
   void reservedIdsDoNotCollide() {
-    assertNotEquals(NULL_VERSION_ID, FIRST_VERSION_ID);
+    assertNotEquals(UNSET_VERSION_ID, FIRST_VERSION_ID);
   }
 
   @Test
@@ -125,8 +125,8 @@ public class TestVersionIdGenerator {
   }
 
   @Test
-  void pinnedFirstSentinelIsNotTheNullVersion() {
-    assertNotEquals(NULL_VERSION_ID,
+  void pinnedFirstSentinelIsNotTheUnsetId() {
+    assertNotEquals(UNSET_VERSION_ID,
         new PinnedFirstVersionIdGenerator().generateVersionId(7, false));
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests the generators that propose a versionId, and the configuration that
+ * selects one.
+ */
+public class TestVersionIdGenerator {
+
+  /** Every generator, so the contract below is checked against all of them. */
+  static Stream<VersionIdGenerator> generators() {
+    return Stream.of(new UniqueIdVersionIdGenerator());
+  }
+
+  /**
+   * The contract every generator owes: ids come out strictly increasing, and
+   * above the reserved unset value. A clock can still break this across OMs,
+   * which is what the allocator's floor is for.
+   */
+  @ParameterizedTest
+  @MethodSource("generators")
+  void proposedIdsStrictlyIncrease(VersionIdGenerator generator) {
+    long previous = VersionIdGenerator.UNSET_VERSION_ID;
+
+    for (int i = 0; i < 10000; i++) {
+      final long versionId = generator.generateVersionId();
+      assertTrue(versionId > previous,
+          "proposed " + versionId + " after " + previous);
+      previous = versionId;
+    }
+  }
+
+  @Test
+  void theProposedIdReadsAsTheTimeOfTheWrite() {
+    final long before = System.currentTimeMillis();
+    final long versionId = new UniqueIdVersionIdGenerator().generateVersionId();
+    final long after = System.currentTimeMillis();
+
+    final long millis = versionId >> Short.SIZE;
+    assertTrue(millis >= before && millis <= after,
+        "versionId " + versionId + " does not read as a millisecond between "
+            + before + " and " + after);
+  }
+
+  /**
+   * The default generator keeps nothing of its own, so a fresh instance picks
+   * up where the last one left off and no OM has to carry allocator state.
+   */
+  @Test
+  void theDefaultGeneratorHoldsNoState() {
+    final long first = new UniqueIdVersionIdGenerator().generateVersionId();
+    final long second = new UniqueIdVersionIdGenerator().generateVersionId();
+
+    assertTrue(second > first, "expected " + second + " to come after " + first);
+  }
+
+  /** By default the applied id is simply the one that was proposed. */
+  @Test
+  void theProposalStandsUnlessAGeneratorSaysOtherwise() {
+    final VersionIdGenerator generator = new UniqueIdVersionIdGenerator();
+
+    assertEquals(5000L, generator.versionIdFor(5000L, false));
+    assertEquals(5000L, generator.versionIdFor(5000L, true));
+  }
+
+  @Test
+  void timeBasedIdsAreTheClusterDefault() {
+    assertInstanceOf(UniqueIdVersionIdGenerator.class,
+        VersionIdGenerator.fromConfiguration(new OzoneConfiguration()));
+  }
+
+  @Test
+  void theGeneratorIsSelectedByClassName() {
+    assertInstanceOf(FixedVersionIdGenerator.class,
+        VersionIdGenerator.fromConfiguration(
+            configuredWith(FixedVersionIdGenerator.class.getName())));
+  }
+
+  @Test
+  void anUnknownGeneratorClassIsRejected() {
+    assertThrows(RuntimeException.class,
+        () -> VersionIdGenerator.fromConfiguration(
+            configuredWith("org.apache.hadoop.ozone.om.helpers.NoSuchThing")));
+  }
+
+  @Test
+  void aClassThatIsNotAGeneratorIsRejected() {
+    assertThrows(RuntimeException.class,
+        () -> VersionIdGenerator.fromConfiguration(
+            configuredWith(String.class.getName())));
+  }
+
+  private static OzoneConfiguration configuredWith(String generatorClass) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR,
+        generatorClass);
+    return conf;
+  }
+
+  /** A generator that exists only to be named in configuration. */
+  public static class FixedVersionIdGenerator implements VersionIdGenerator {
+    @Override
+    public long generateVersionId() {
+      return 1L;
+    }
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestVersionIdGenerator.java
@@ -37,7 +37,8 @@ public class TestVersionIdGenerator {
 
   /** Every generator, so the contract below is checked against all of them. */
   static Stream<VersionIdGenerator> generators() {
-    return Stream.of(new UniqueIdVersionIdGenerator());
+    return Stream.of(new UniqueIdVersionIdGenerator(),
+        new PinnedFirstVersionIdGenerator());
   }
 
   /**
@@ -91,6 +92,44 @@ public class TestVersionIdGenerator {
     assertEquals(5000L, generator.versionIdFor(5000L, true));
   }
 
+  /** Only a key's first version is special; later ones are numbered normally. */
+  @Test
+  void onlyTheFirstVersionIsPinned() {
+    final VersionIdGenerator generator = new PinnedFirstVersionIdGenerator();
+
+    assertEquals(PinnedFirstVersionIdGenerator.FIRST_VERSION_ID,
+        generator.versionIdFor(5000L, false));
+    assertEquals(5000L, generator.versionIdFor(5000L, true));
+  }
+
+  /**
+   * versionedKeyTable orders versions by Long.MAX_VALUE - versionId, so the
+   * sentinel has to stay below every proposed id to sort at the old end of the
+   * key.
+   */
+  @Test
+  void theSentinelSortsBeforeEveryProposedId() {
+    final long sentinel = PinnedFirstVersionIdGenerator.FIRST_VERSION_ID;
+    final long proposed =
+        new PinnedFirstVersionIdGenerator().generateVersionId();
+
+    assertTrue(sentinel < proposed,
+        "sentinel " + sentinel + " does not sort before " + proposed);
+    assertTrue(Long.MAX_VALUE - sentinel > Long.MAX_VALUE - proposed,
+        "the sentinel does not sort at the old end of the key");
+  }
+
+  /**
+   * The null version is marked by isNullVersion and carries a proposed id like
+   * any other version, so nothing of it is reserved; the sentinel only has to
+   * stay clear of the unset value a pre-versioning record carries.
+   */
+  @Test
+  void theSentinelDoesNotCollideWithTheNullSlot() {
+    assertTrue(PinnedFirstVersionIdGenerator.FIRST_VERSION_ID
+        > VersionIdGenerator.UNSET_VERSION_ID);
+  }
+
   @Test
   void timeBasedIdsAreTheClusterDefault() {
     assertInstanceOf(UniqueIdVersionIdGenerator.class,
@@ -102,6 +141,13 @@ public class TestVersionIdGenerator {
     assertInstanceOf(FixedVersionIdGenerator.class,
         VersionIdGenerator.fromConfiguration(
             configuredWith(FixedVersionIdGenerator.class.getName())));
+  }
+
+  @Test
+  void thePinnedGeneratorIsSelectedByClassName() {
+    assertInstanceOf(PinnedFirstVersionIdGenerator.class,
+        VersionIdGenerator.fromConfiguration(configuredWith(
+            PinnedFirstVersionIdGenerator.class.getName())));
   }
 
   @Test

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1234,6 +1234,15 @@ message KeyInfo {
   // This allows a key to be created an committed atomically if the original has not
   // been modified.
     optional uint64 expectedDataGeneration = 22;
+  // S3-compatible object versioning fields. versionId identifies an object
+  // version: assigned once from the committing transaction's index when the
+  // version is created, then frozen. A delete marker is a record with
+  // isDeleteMarker set and no data blocks. isNullVersion marks the single
+  // overwritable "null version" slot per key (writes while versioning is
+  // suspended, or objects that predate enabling versioning).
+    optional uint64 versionId = 23;
+    optional bool isDeleteMarker = 24;
+    optional bool isNullVersion = 25;
 }
 
 // KeyInfoProtoLight is a lightweight subset of KeyInfo message containing

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -808,12 +808,26 @@ message BucketInfo {
     optional uint64 snapshotUsedNamespace = 22;
     // TODO: S3 bucket tags persisted in OM DB; set by PutBucketTagging, read by GetBucketTagging.
     repeated hadoop.hdds.KeyValue tags = 23;
+    // S3-compatible object versioning status. When absent, derived from
+    // isVersionEnabled (true -> VERSIONING_ENABLED, false -> UNVERSIONED).
+    optional BucketVersioningStatusProto versioningStatus = 24;
 }
 
 enum BucketLayoutProto {
     LEGACY = 1;
     FILE_SYSTEM_OPTIMIZED = 2;
     OBJECT_STORE = 3;
+}
+
+/**
+ * S3-compatible bucket versioning state machine:
+ * UNVERSIONED -> VERSIONING_ENABLED <-> VERSIONING_SUSPENDED.
+ * Once enabled, a bucket can never return to UNVERSIONED.
+ */
+enum BucketVersioningStatusProto {
+    UNVERSIONED = 1;
+    VERSIONING_ENABLED = 2;
+    VERSIONING_SUSPENDED = 3;
 }
 
 /**
@@ -883,6 +897,9 @@ message BucketArgs {
     optional BucketEncryptionInfoProto bekInfo = 12;
     // TODO: Tag payload for PutBucketTagging only.
     repeated hadoop.hdds.KeyValue tags = 13;
+    // S3-compatible object versioning status. Takes precedence over
+    // isVersionEnabled when both are set.
+    optional BucketVersioningStatusProto versioningStatus = 14;
 }
 
 message PrefixInfo {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -818,8 +818,11 @@ message BucketInfo {
     optional uint64 snapshotUsedBytes = 21;
     optional uint64 snapshotUsedNamespace = 22;
     repeated hadoop.hdds.KeyValue tags = 23;
-    // S3-compatible object versioning status. When absent, derived from
-    // isVersionEnabled (true -> VERSIONING_ENABLED, false -> UNVERSIONED).
+    // S3-compatible object versioning status. When absent the bucket carries
+    // no S3 versioning status at all: it reads as UNVERSIONED whatever
+    // isVersionEnabled says, and that flag alone drives the legacy in-record
+    // block version list. When set it is authoritative, and isVersionEnabled
+    // is kept in sync with it (VERSIONING_ENABLED -> true).
     optional BucketVersioningStatusProto versioningStatus = 24;
 }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1484,6 +1484,11 @@ message DeleteKeyArgs {
     required string bucketName = 2;
     repeated string keys = 3;
     repeated uint64 updateIDs = 4; // each key's update ID when key is identified for deletion
+    // S3-compatible object versioning: the versionId proposed for the delete
+    // markers this request creates. One is enough for the whole batch, because
+    // a versionId only has to increase within a single key; the applying OM
+    // raises it per key against that key's current version.
+    optional uint64 proposedVersionId = 5;
 }
 
 message DeleteKeyError {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1243,6 +1243,16 @@ message KeyInfo {
   // This allows a key to be created an committed atomically if the original has not
   // been modified.
     optional uint64 expectedDataGeneration = 22;
+  // S3-compatible object versioning fields. versionId identifies an object
+  // version: allocated once when the version is written and then frozen,
+  // and increasing within a key so its versions can be ordered newest
+  // first. A delete marker is a record with isDeleteMarker set and no data
+  // blocks. isNullVersion marks the single overwritable "null version" slot
+  // per key (writes while versioning is suspended, or objects that predate
+  // enabling versioning).
+    optional uint64 versionId = 23;
+    optional bool isDeleteMarker = 24;
+    optional bool isNullVersion = 25;
 }
 
 // KeyInfoProtoLight is a lightweight subset of KeyInfo message containing

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1153,6 +1153,14 @@ message KeyArgs {
     // the given ETag for the operation to succeed. This is used for
     // S3 conditional writes with the If-Match header.
     optional string expectedETag = 24;
+
+    // S3-compatible object versioning: the versionId proposed for the version
+    // this request creates. It is generated in preExecute, on the OM that
+    // received the request, so every OM applies the same value; the applying
+    // OM raises it to come after the key's current version if the proposal does
+    // not already. Set on every request that can create a version, and ignored
+    // unless the bucket has versioning enabled when the request is applied.
+    optional uint64 proposedVersionId = 25;
 }
 
 message KeyLocation {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -818,12 +818,26 @@ message BucketInfo {
     optional uint64 snapshotUsedBytes = 21;
     optional uint64 snapshotUsedNamespace = 22;
     repeated hadoop.hdds.KeyValue tags = 23;
+    // S3-compatible object versioning status. When absent, derived from
+    // isVersionEnabled (true -> VERSIONING_ENABLED, false -> UNVERSIONED).
+    optional BucketVersioningStatusProto versioningStatus = 24;
 }
 
 enum BucketLayoutProto {
     LEGACY = 1;
     FILE_SYSTEM_OPTIMIZED = 2;
     OBJECT_STORE = 3;
+}
+
+/**
+ * S3-compatible bucket versioning state machine:
+ * UNVERSIONED -> VERSIONING_ENABLED <-> VERSIONING_SUSPENDED.
+ * Once enabled, a bucket can never return to UNVERSIONED.
+ */
+enum BucketVersioningStatusProto {
+    UNVERSIONED = 1;
+    VERSIONING_ENABLED = 2;
+    VERSIONING_SUSPENDED = 3;
 }
 
 /**
@@ -892,6 +906,9 @@ message BucketArgs {
     optional hadoop.hdds.DefaultReplicationConfig defaultReplicationConfig = 11;
     optional BucketEncryptionInfoProto bekInfo = 12;
     repeated hadoop.hdds.KeyValue tags = 13;
+    // S3-compatible object versioning status. Takes precedence over
+    // isVersionEnabled when both are set.
+    optional BucketVersioningStatusProto versioningStatus = 14;
 }
 
 message PrefixInfo {

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -173,6 +173,22 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
   String getOzoneKey(String volume, String bucket, String key);
 
   /**
+   * Given a volume, bucket, key and versionId, return the corresponding
+   * versionedKeyTable DB key: the versionId is appended as fixed-width hex of
+   * (Long.MAX_VALUE - versionId), so all versions of a key are adjacent and
+   * ordered newest first.
+   */
+  String getVersionedOzoneKey(String volume, String bucket, String key, long versionId);
+
+  /**
+   * Prefix under which all noncurrent versions of the given key are stored in
+   * the versionedKeyTable. Since key names may themselves contain the
+   * separator, iterating consumers must check that the remainder after this
+   * prefix is exactly one fixed-width versionId suffix.
+   */
+  String getVersionedOzoneKeyPrefix(String volume, String bucket, String key);
+
+  /**
    * Get DB key for a key or prefix in an FSO bucket given existing
    * volume and bucket names.
    */
@@ -404,6 +420,14 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
    */
 
   Table<String, OmKeyInfo> getKeyTable(BucketLayout bucketLayout);
+
+  /**
+   * Returns the versionedKeyTable holding noncurrent object versions
+   * (including noncurrent delete markers) of versioning-enabled buckets.
+   *
+   * @return versionedKeyTable.
+   */
+  Table<String, OmKeyInfo> getVersionedKeyTable();
 
   /**
    * Returns the FileTable.

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -182,9 +182,11 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
 
   /**
    * Prefix under which all noncurrent versions of the given key are stored in
-   * the versionedKeyTable. Since key names may themselves contain the
-   * separator, iterating consumers must check that the remainder after this
-   * prefix is exactly one fixed-width versionId suffix.
+   * the versionedKeyTable. The key name is separated from the versionId suffix
+   * by OM_VERSIONED_KEY_SEPARATOR rather than OM_KEY_PREFIX, so that a key's
+   * versions stay contiguous under this prefix and sort before any key nested
+   * under it: seeking this prefix yields exactly that key's versions, newest
+   * first.
    */
   String getVersionedOzoneKeyPrefix(String volume, String bucket, String key);
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -185,9 +185,11 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
 
   /**
    * Prefix under which all noncurrent versions of the given key are stored in
-   * the versionedKeyTable. Since key names may themselves contain the
-   * separator, iterating consumers must check that the remainder after this
-   * prefix is exactly one fixed-width versionId suffix.
+   * the versionedKeyTable. The key name is separated from the versionId suffix
+   * by OM_VERSIONED_KEY_SEPARATOR rather than OM_KEY_PREFIX, so that a key's
+   * versions stay contiguous under this prefix and sort before any key nested
+   * under it: seeking this prefix yields exactly that key's versions, newest
+   * first.
    */
   String getVersionedOzoneKeyPrefix(String volume, String bucket, String key);
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -176,6 +176,22 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
   String getOzoneKey(String volume, String bucket, String key);
 
   /**
+   * Given a volume, bucket, key and versionId, return the corresponding
+   * versionedKeyTable DB key: the versionId is appended as fixed-width hex of
+   * (Long.MAX_VALUE - versionId), so all versions of a key are adjacent and
+   * ordered newest first.
+   */
+  String getVersionedOzoneKey(String volume, String bucket, String key, long versionId);
+
+  /**
+   * Prefix under which all noncurrent versions of the given key are stored in
+   * the versionedKeyTable. Since key names may themselves contain the
+   * separator, iterating consumers must check that the remainder after this
+   * prefix is exactly one fixed-width versionId suffix.
+   */
+  String getVersionedOzoneKeyPrefix(String volume, String bucket, String key);
+
+  /**
    * Get DB key for a key or prefix in an FSO bucket given existing
    * volume and bucket names.
    */
@@ -407,6 +423,14 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
    */
 
   Table<String, OmKeyInfo> getKeyTable(BucketLayout bucketLayout);
+
+  /**
+   * Returns the versionedKeyTable holding noncurrent object versions
+   * (including noncurrent delete markers) of versioning-enabled buckets.
+   *
+   * @return versionedKeyTable.
+   */
+  Table<String, OmKeyInfo> getVersionedKeyTable();
 
   /**
    * Returns the FileTable.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -159,6 +159,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   private Table<String, OmVolumeArgs> volumeTable;
   private Table<String, OmBucketInfo> bucketTable;
   private Table<String, OmKeyInfo> keyTable;
+  private Table<String, OmKeyInfo> versionedKeyTable;
 
   private Table<String, OmKeyInfo> openKeyTable;
   private Table<String, OmMultipartKeyInfo> multipartInfoTable;
@@ -377,6 +378,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   @Override
+  public Table<String, OmKeyInfo> getVersionedKeyTable() {
+    return versionedKeyTable;
+  }
+
+  @Override
   public Table<String, OmKeyInfo> getFileTable() {
     return fileTable;
   }
@@ -494,6 +500,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     volumeTable = initializer.get(OMDBDefinition.VOLUME_TABLE_DEF, cacheType);
     bucketTable = initializer.get(OMDBDefinition.BUCKET_TABLE_DEF, cacheType);
     keyTable = initializer.get(OMDBDefinition.KEY_TABLE_DEF);
+    versionedKeyTable = initializer.get(OMDBDefinition.VERSIONED_KEY_TABLE_DEF);
 
     openKeyTable = initializer.get(OMDBDefinition.OPEN_KEY_TABLE_DEF);
     multipartInfoTable = initializer.get(OMDBDefinition.MULTIPART_INFO_TABLE_DEF);
@@ -647,6 +654,17 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       }
     }
     return builder.toString();
+  }
+
+  @Override
+  public String getVersionedOzoneKey(String volume, String bucket, String key, long versionId) {
+    return getVersionedOzoneKeyPrefix(volume, bucket, key)
+        + String.format("%016x", Long.MAX_VALUE - versionId);
+  }
+
+  @Override
+  public String getVersionedOzoneKeyPrefix(String volume, String bucket, String key) {
+    return getOzoneKey(volume, bucket, key) + OM_KEY_PREFIX;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_VERSIONED_KEY_SEPARATOR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES;
@@ -664,7 +665,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   @Override
   public String getVersionedOzoneKeyPrefix(String volume, String bucket, String key) {
-    return getOzoneKey(volume, bucket, key) + OM_KEY_PREFIX;
+    return getOzoneKey(volume, bucket, key) + OM_VERSIONED_KEY_SEPARATOR;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_VERSIONED_KEY_SEPARATOR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES;
@@ -672,7 +673,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   @Override
   public String getVersionedOzoneKeyPrefix(String volume, String bucket, String key) {
-    return getOzoneKey(volume, bucket, key) + OM_KEY_PREFIX;
+    return getOzoneKey(volume, bucket, key) + OM_VERSIONED_KEY_SEPARATOR;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -162,6 +162,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   private Table<String, OmVolumeArgs> volumeTable;
   private Table<String, OmBucketInfo> bucketTable;
   private Table<String, OmKeyInfo> keyTable;
+  private Table<String, OmKeyInfo> versionedKeyTable;
 
   private Table<String, OmKeyInfo> openKeyTable;
   private Table<String, OmMultipartKeyInfo> multipartInfoTable;
@@ -382,6 +383,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   @Override
+  public Table<String, OmKeyInfo> getVersionedKeyTable() {
+    return versionedKeyTable;
+  }
+
+  @Override
   public Table<String, OmKeyInfo> getFileTable() {
     return fileTable;
   }
@@ -499,6 +505,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     volumeTable = initializer.get(OMDBDefinition.VOLUME_TABLE_DEF, cacheType);
     bucketTable = initializer.get(OMDBDefinition.BUCKET_TABLE_DEF, cacheType);
     keyTable = initializer.get(OMDBDefinition.KEY_TABLE_DEF);
+    versionedKeyTable = initializer.get(OMDBDefinition.VERSIONED_KEY_TABLE_DEF);
 
     openKeyTable = initializer.get(OMDBDefinition.OPEN_KEY_TABLE_DEF);
     multipartInfoTable = initializer.get(OMDBDefinition.MULTIPART_INFO_TABLE_DEF);
@@ -655,6 +662,17 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       }
     }
     return builder.toString();
+  }
+
+  @Override
+  public String getVersionedOzoneKey(String volume, String bucket, String key, long versionId) {
+    return getVersionedOzoneKeyPrefix(volume, bucket, key)
+        + String.format("%016x", Long.MAX_VALUE - versionId);
+  }
+
+  @Override
+  public String getVersionedOzoneKeyPrefix(String volume, String bucket, String key) {
+    return getOzoneKey(volume, bucket, key) + OM_KEY_PREFIX;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -40,6 +40,7 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.SNAPSHOT_INFO_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.SNAPSHOT_RENAMED_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VERSIONED_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VOLUME_TABLE;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_NOT_FOUND;
@@ -2021,13 +2022,14 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   public TablePrefixInfo getTableBucketPrefix(String volume, String bucket) throws IOException {
     String keyPrefix = getBucketKeyPrefix(volume, bucket);
     String keyPrefixFso = getBucketKeyPrefixFSO(volume, bucket);
-    // Set value to 12 to avoid creating too big a HashTable unnecessarily.
-    Map<String, String> tablePrefixMap = new HashMap<>(12, 1.0f);
+    // Set value to 13 to avoid creating too big a HashTable unnecessarily.
+    Map<String, String> tablePrefixMap = new HashMap<>(13, 1.0f);
 
     tablePrefixMap.put(VOLUME_TABLE, getVolumeKey(volume));
     tablePrefixMap.put(BUCKET_TABLE, getBucketKey(volume, bucket));
 
     tablePrefixMap.put(KEY_TABLE, keyPrefix);
+    tablePrefixMap.put(VERSIONED_KEY_TABLE, keyPrefix);
     tablePrefixMap.put(DELETED_TABLE, keyPrefix);
     tablePrefixMap.put(SNAPSHOT_RENAMED_TABLE, keyPrefix);
     tablePrefixMap.put(OPEN_KEY_TABLE, keyPrefix);
@@ -2050,6 +2052,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     case BUCKET_TABLE:
       return getBucketKey(volume, bucket);
     case KEY_TABLE:
+    case VERSIONED_KEY_TABLE:
     case DELETED_TABLE:
     case SNAPSHOT_RENAMED_TABLE:
     case OPEN_KEY_TABLE:

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3060,6 +3060,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             .setDefaultReplicationConfig(
                 realBucket.getDefaultReplicationConfig())
             .setIsVersionEnabled(realBucket.getIsVersionEnabled())
+            .setVersioningStatus(realBucket.getVersioningStatus())
             .setStorageType(realBucket.getStorageType())
             .setQuotaInBytes(realBucket.getQuotaInBytes())
             .setQuotaInNamespace(realBucket.getQuotaInNamespace())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -424,6 +424,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private BucketManager bucketManager;
   private KeyManager keyManager;
   private PrefixManagerImpl prefixManager;
+  private final VersionIdAllocator versionIdAllocator;
   private final UpgradeFinalizer<OzoneManager> upgradeFinalizer;
   private ExecutorService edekCacheLoader = null;
 
@@ -576,6 +577,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     versionManager = new OMLayoutVersionManager(omStorage.getLayoutVersion());
     upgradeFinalizer = new OMUpgradeFinalizer(versionManager);
+    versionIdAllocator = new VersionIdAllocator(conf);
     replicationConfigValidator =
         conf.getObject(ReplicationConfigValidator.class);
 
@@ -2404,6 +2406,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public long getObjectIdFromTxId(long trxnId) {
     return OmUtils.getObjectIdFromTxId(metadataManager.getOmEpoch(),
         trxnId);
+  }
+
+  /**
+   * Assigns the versionId of a version being committed, using the
+   * {@link org.apache.hadoop.ozone.om.helpers.VersionIdGenerator} configured
+   * for this cluster.
+   */
+  public VersionIdAllocator getVersionIdAllocator() {
+    return versionIdAllocator;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3060,7 +3060,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             .setDefaultReplicationConfig(
                 realBucket.getDefaultReplicationConfig())
             .setIsVersionEnabled(realBucket.getIsVersionEnabled())
-            .setVersioningStatus(realBucket.getVersioningStatus())
+            // Only when the real bucket actually carries a status: copying the
+            // value getVersioningStatus() derives for a legacy bucket would give
+            // the link an explicit status the real bucket does not have.
+            .setVersioningStatus(realBucket.hasVersioningStatus()
+                ? realBucket.getVersioningStatus() : null)
             .setStorageType(realBucket.getStorageType())
             .setQuotaInBytes(realBucket.getQuotaInBytes())
             .setQuotaInNamespace(realBucket.getQuotaInNamespace())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -416,6 +416,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private BucketManager bucketManager;
   private KeyManager keyManager;
   private PrefixManagerImpl prefixManager;
+  private final VersionIdAllocator versionIdAllocator;
   private final UpgradeFinalizer<OzoneManager> upgradeFinalizer;
   private ExecutorService edekCacheLoader = null;
 
@@ -565,6 +566,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     versionManager = new OMLayoutVersionManager(omStorage.getLayoutVersion());
     upgradeFinalizer = new OMUpgradeFinalizer(versionManager);
+    versionIdAllocator = new VersionIdAllocator(conf);
     replicationConfigValidator =
         conf.getObject(ReplicationConfigValidator.class);
 
@@ -2385,6 +2387,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public long getObjectIdFromTxId(long trxnId) {
     return OmUtils.getObjectIdFromTxId(metadataManager.getOmEpoch(),
         trxnId);
+  }
+
+  /**
+   * Assigns the versionId of a version being committed, using the
+   * {@link org.apache.hadoop.ozone.om.helpers.VersionIdGenerator} configured
+   * for this cluster.
+   */
+  public VersionIdAllocator getVersionIdAllocator() {
+    return versionIdAllocator;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VersionIdAllocator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VersionIdAllocator.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import java.io.IOException;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
+
+/**
+ * Assigns the versionId of a version being committed, using the generator
+ * configured for this cluster.
+ *
+ * <p>The generator is cluster-wide and can be changed by reconfiguring the OMs,
+ * so ids generated before and after a change are not guaranteed to be distinct.
+ * Rather than constrain the change, a commit whose versionId already exists on
+ * the key is rejected: the operator or the client deletes the existing version
+ * first, and the write can then be retried.
+ */
+public class VersionIdAllocator {
+
+  private final VersionIdGenerator generator;
+
+  public VersionIdAllocator(ConfigurationSource conf) {
+    this(VersionIdGenerator.fromConfiguration(conf));
+  }
+
+  public VersionIdAllocator(VersionIdGenerator generator) {
+    this.generator = generator;
+  }
+
+  public VersionIdGenerator getGenerator() {
+    return generator;
+  }
+
+  /**
+   * Returns the versionId to freeze on the version being committed.
+   *
+   * <p>The id must be greater than the one on the key's current version: a
+   * generator has to hand out increasing ids for a key, and the versionedKeyTable
+   * ordering and version promotion depend on it. An id that is not greater is
+   * refused rather than written, because it would either overwrite an existing
+   * version or sort into the wrong place. In practice this only happens after the
+   * cluster's generator is changed, or if the Ratis log index went backwards.
+   *
+   * @param currentVersion the key's current version, or null if the key has
+   *     none. The write path holds it already, so no extra read is needed here.
+   * @throws OMException INVALID_REQUEST if the generated id does not exceed the
+   *     current version's id, KEY_ALREADY_EXISTS if it is already taken
+   */
+  public long allocate(OMMetadataManager metadataManager, String volumeName,
+      String bucketName, String keyName, long transactionLogIndex,
+      OmKeyInfo currentVersion) throws IOException {
+
+    long versionId =
+        generator.generateVersionId(transactionLogIndex, currentVersion != null);
+
+    if (currentVersion == null) {
+      // No current version means the key has no versions at all, so nothing can
+      // be taken and nothing constrains the id.
+      return versionId;
+    }
+
+    Long currentVersionId = currentVersion.getVersionId();
+    if (currentVersionId == null) {
+      // A current version written before versioning was enabled carries no id,
+      // so there is nothing to order against; fall back to looking the id up.
+      if (isTaken(metadataManager, volumeName, bucketName, keyName, versionId)) {
+        throw alreadyExists(volumeName, bucketName, keyName, versionId);
+      }
+      return versionId;
+    }
+
+    if (versionId <= currentVersionId) {
+      throw new OMException("Version " + versionId + " of key /" + volumeName + "/"
+          + bucketName + "/" + keyName + " does not come after the current version "
+          + currentVersionId + ". " + generator.getClass().getName()
+          + " must generate increasing versionIds for a key; an id that goes backwards can "
+          + "happen after the cluster's " + OMConfigKeys.OZONE_OM_VERSIONING_VERSION_ID_GENERATOR
+          + " is changed. Delete the key's versions before writing with the new generator.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    // Strictly greater than the largest id on the key, so no lookup is needed:
+    // every noncurrent version of the key has a smaller id than the current one.
+    return versionId;
+  }
+
+  private static OMException alreadyExists(String volumeName, String bucketName,
+      String keyName, long versionId) {
+    return new OMException("Version " + versionId + " of key /" + volumeName + "/"
+        + bucketName + "/" + keyName + " already exists. Delete that version before "
+        + "writing this one.", OMException.ResultCodes.KEY_ALREADY_EXISTS);
+  }
+
+  private boolean isTaken(OMMetadataManager metadataManager, String volumeName,
+      String bucketName, String keyName, long versionId) throws IOException {
+    return metadataManager.getVersionedKeyTable().isExist(
+        metadataManager.getVersionedOzoneKey(volumeName, bucketName, keyName, versionId));
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VersionIdAllocator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VersionIdAllocator.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
+
+/**
+ * Settles the versionId of a version as it is applied, from the id proposed for
+ * it before the request was replicated.
+ *
+ * <p>The versionedKeyTable orders a key's versions by
+ * {@code Long.MAX_VALUE - versionId}, so the ids of one key have to increase in
+ * the order the versions were written. A proposal is a clock reading and cannot
+ * promise that: ids proposed inside one millisecond can exhaust the counter
+ * separating them, and a leader change onto a lagging clock proposes a lower
+ * value.
+ *
+ * <p>So a proposal is a floor. The applied id is the later of it and the id
+ * after the key's current version, which the write path already holds — no read
+ * of its own, no global state, and identical on every OM. Under a clock
+ * regression an affected key's ids climb by one until proposals overtake them
+ * again: the versions stay ordered and only the id's reading as a time
+ * degrades.
+ */
+public class VersionIdAllocator {
+
+  private final VersionIdGenerator generator;
+
+  public VersionIdAllocator(ConfigurationSource conf) {
+    this(VersionIdGenerator.fromConfiguration(conf));
+  }
+
+  public VersionIdAllocator(VersionIdGenerator generator) {
+    this.generator = generator;
+  }
+
+  public VersionIdGenerator getGenerator() {
+    return generator;
+  }
+
+  /** Proposes an id, on the OM that received the request. */
+  public long propose() {
+    final long versionId = generator.generateVersionId();
+    Preconditions.checkState(versionId > VersionIdGenerator.UNSET_VERSION_ID,
+        "%s proposed the reserved versionId %s",
+        generator.getClass().getName(), versionId);
+    return versionId;
+  }
+
+  /**
+   * @param proposedVersionId the id the request carried, which must be set:
+   *     an unset field would otherwise be applied as the reserved unset value
+   * @param currentVersion the key's current version, or null when it has none.
+   *     The write path holds it already, so no extra read is needed here.
+   * @return the versionId to freeze on the version being applied
+   */
+  public long allocate(long proposedVersionId, OmKeyInfo currentVersion) {
+    Preconditions.checkArgument(
+        proposedVersionId > VersionIdGenerator.UNSET_VERSION_ID,
+        "no versionId was proposed for this version; every request that can "
+            + "create one has to propose it in preExecute");
+
+    final long versionId =
+        generator.versionIdFor(proposedVersionId, currentVersion != null);
+
+    if (currentVersion == null) {
+      return versionId;
+    }
+
+    final Long currentVersionId = currentVersion.getVersionId();
+    if (currentVersionId == null) {
+      // Written before versioning was enabled, so it carries no id and the key
+      // has no other versions to order against.
+      return versionId;
+    }
+
+    return Math.max(versionId, currentVersionId + 1);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -86,6 +86,7 @@ import org.apache.ozone.compaction.log.CompactionLogEntry;
  * |        Column Family |                           Mapping                         |
  * |----------------------------------------------------------------------------------|
  * |             keyTable | /volume/bucket/key                     :- KeyInfo         |
+ * |    versionedKeyTable | /volume/bucket/key/revVersionId        :- KeyInfo         |
  * |         deletedTable | /volume/bucket/key                     :- RepeatedKeyInfo |
  * |         openKeyTable | /volume/bucket/key/id                  :- KeyInfo         |
  * |   multipartInfoTable | /volume/bucket/key/uploadId            :- parts           |
@@ -207,6 +208,19 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
   /** keyTable: /volume/bucket/key :- KeyInfo (excludes fields only used in openKeyTable). */
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> KEY_TABLE_DEF
       = new DBColumnFamilyDefinition<>(KEY_TABLE,
+          StringCodec.get(),
+          OmKeyInfo.getKeyTableCodec());
+
+  public static final String VERSIONED_KEY_TABLE = "versionedKeyTable";
+  /**
+   * versionedKeyTable: /volume/bucket/key/revVersionId :- KeyInfo.
+   * Noncurrent object versions (including noncurrent delete markers) of
+   * versioning-enabled buckets; the current version stays in keyTable.
+   * revVersionId is the fixed-width hex of (Long.MAX_VALUE - versionId), so
+   * versions of a key are adjacent and ordered newest first.
+   */
+  public static final DBColumnFamilyDefinition<String, OmKeyInfo> VERSIONED_KEY_TABLE_DEF
+      = new DBColumnFamilyDefinition<>(VERSIONED_KEY_TABLE,
           StringCodec.get(),
           OmKeyInfo.getKeyTableCodec());
 
@@ -353,6 +367,7 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
           TENANT_STATE_TABLE_DEF,
           TRANSACTION_INFO_TABLE_DEF,
           USER_TABLE_DEF,
+          VERSIONED_KEY_TABLE_DEF,
           VOLUME_TABLE_DEF);
 
   private static final OMDBDefinition INSTANCE = new OMDBDefinition();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -89,7 +89,7 @@ import org.apache.ozone.compaction.log.CompactionLogEntry;
  * |        Column Family |                           Mapping                         |
  * |----------------------------------------------------------------------------------|
  * |             keyTable | /volume/bucket/key                     :- KeyInfo         |
- * |    versionedKeyTable | /volume/bucket/key/revVersionId        :- KeyInfo         |
+ * |    versionedKeyTable | /volume/bucket/key\0revVersionId       :- KeyInfo         |
  * |         deletedTable | /volume/bucket/key                     :- RepeatedKeyInfo |
  * |         openKeyTable | /volume/bucket/key/id                  :- KeyInfo         |
  * |   multipartInfoTable | /volume/bucket/key/uploadId            :- parts           |
@@ -216,11 +216,13 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
 
   public static final String VERSIONED_KEY_TABLE = "versionedKeyTable";
   /**
-   * versionedKeyTable: /volume/bucket/key/revVersionId :- KeyInfo.
+   * versionedKeyTable: /volume/bucket/key\0revVersionId :- KeyInfo.
    * Noncurrent object versions (including noncurrent delete markers) of
    * versioning-enabled buckets; the current version stays in keyTable.
    * revVersionId is the fixed-width hex of (Long.MAX_VALUE - versionId), so
-   * versions of a key are adjacent and ordered newest first.
+   * versions of a key are adjacent and ordered newest first. The separator is
+   * OM_VERSIONED_KEY_SEPARATOR (0x00), not '/', because OBJECT_STORE key names
+   * contain '/' verbatim.
    */
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> VERSIONED_KEY_TABLE_DEF
       = new DBColumnFamilyDefinition<>(VERSIONED_KEY_TABLE,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -86,7 +86,7 @@ import org.apache.ozone.compaction.log.CompactionLogEntry;
  * |        Column Family |                           Mapping                         |
  * |----------------------------------------------------------------------------------|
  * |             keyTable | /volume/bucket/key                     :- KeyInfo         |
- * |    versionedKeyTable | /volume/bucket/key/revVersionId        :- KeyInfo         |
+ * |    versionedKeyTable | /volume/bucket/key\0revVersionId       :- KeyInfo         |
  * |         deletedTable | /volume/bucket/key                     :- RepeatedKeyInfo |
  * |         openKeyTable | /volume/bucket/key/id                  :- KeyInfo         |
  * |   multipartInfoTable | /volume/bucket/key/uploadId            :- parts           |
@@ -213,11 +213,13 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
 
   public static final String VERSIONED_KEY_TABLE = "versionedKeyTable";
   /**
-   * versionedKeyTable: /volume/bucket/key/revVersionId :- KeyInfo.
+   * versionedKeyTable: /volume/bucket/key\0revVersionId :- KeyInfo.
    * Noncurrent object versions (including noncurrent delete markers) of
    * versioning-enabled buckets; the current version stays in keyTable.
    * revVersionId is the fixed-width hex of (Long.MAX_VALUE - versionId), so
-   * versions of a key are adjacent and ordered newest first.
+   * versions of a key are adjacent and ordered newest first. The separator is
+   * OM_VERSIONED_KEY_SEPARATOR (0x00), not '/', because OBJECT_STORE key names
+   * contain '/' verbatim.
    */
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> VERSIONED_KEY_TABLE_DEF
       = new DBColumnFamilyDefinition<>(VERSIONED_KEY_TABLE,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -89,6 +89,7 @@ import org.apache.ozone.compaction.log.CompactionLogEntry;
  * |        Column Family |                           Mapping                         |
  * |----------------------------------------------------------------------------------|
  * |             keyTable | /volume/bucket/key                     :- KeyInfo         |
+ * |    versionedKeyTable | /volume/bucket/key/revVersionId        :- KeyInfo         |
  * |         deletedTable | /volume/bucket/key                     :- RepeatedKeyInfo |
  * |         openKeyTable | /volume/bucket/key/id                  :- KeyInfo         |
  * |   multipartInfoTable | /volume/bucket/key/uploadId            :- parts           |
@@ -210,6 +211,19 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
   /** keyTable: /volume/bucket/key :- KeyInfo (excludes fields only used in openKeyTable). */
   public static final DBColumnFamilyDefinition<String, OmKeyInfo> KEY_TABLE_DEF
       = new DBColumnFamilyDefinition<>(KEY_TABLE,
+          StringCodec.get(),
+          OmKeyInfo.getKeyTableCodec());
+
+  public static final String VERSIONED_KEY_TABLE = "versionedKeyTable";
+  /**
+   * versionedKeyTable: /volume/bucket/key/revVersionId :- KeyInfo.
+   * Noncurrent object versions (including noncurrent delete markers) of
+   * versioning-enabled buckets; the current version stays in keyTable.
+   * revVersionId is the fixed-width hex of (Long.MAX_VALUE - versionId), so
+   * versions of a key are adjacent and ordered newest first.
+   */
+  public static final DBColumnFamilyDefinition<String, OmKeyInfo> VERSIONED_KEY_TABLE_DEF
+      = new DBColumnFamilyDefinition<>(VERSIONED_KEY_TABLE,
           StringCodec.get(),
           OmKeyInfo.getKeyTableCodec());
 
@@ -370,6 +384,7 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
           TENANT_STATE_TABLE_DEF,
           TRANSACTION_INFO_TABLE_DEF,
           USER_TABLE_DEF,
+          VERSIONED_KEY_TABLE_DEF,
           VOLUME_TABLE_DEF,
           LIFECYCLE_CONFIGURATION_TABLE_DEF,
           LIFECYCLE_SCAN_STATE_TABLE_DEF);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -101,6 +101,17 @@ public class OMBucketCreateRequest extends OMClientRequest {
     // FSO and LEGACY buckets are not strictly bound to S3 naming semantics.
     OmUtils.validateBucketName(bucketInfo.getBucketName(), strict);
 
+    // S3 has no way to create a bucket that is already in a versioning
+    // state; the state is set afterwards, through the transition checks in
+    // OMBucketSetPropertyRequest. versioningStatus is on BucketInfo because
+    // that message is also the bucket's on-disk record and the shape
+    // InfoBucket and ListBuckets return, not because a create needs it.
+    if (bucketInfo.hasVersioningStatus()) {
+      throw new OMException("Bucket versioning cannot be set while the bucket"
+          + " is being created; create the bucket first and then set its"
+          + " versioning status.", ResultCodes.INVALID_REQUEST);
+    }
+
     // ACL check during preExecute
     if (ozoneManager.getAclsEnabled()) {
       try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -396,4 +396,27 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
     }
     return req;
   }
+
+  @RequestFeatureValidator(
+      conditions = ValidationCondition.CLUSTER_NEEDS_FINALIZATION,
+      processingPhase = RequestProcessingPhase.PRE_PROCESS,
+      requestType = Type.SetBucketProperty
+  )
+  public static OMRequest disallowSetBucketPropertyWithVersioningStatus(
+      OMRequest req, ValidationContext ctx) throws OMException {
+    if (!ctx.versionManager()
+        .isAllowed(OMLayoutFeature.OBJECT_VERSIONING)) {
+      SetBucketPropertyRequest propReq =
+          req.getSetBucketPropertyRequest();
+      if (propReq.hasBucketArgs()
+          && propReq.getBucketArgs().hasVersioningStatus()) {
+        throw new OMException("Cluster does not have the object versioning"
+            + " feature finalized yet, but the request contains a bucket"
+            + " versioning status. Rejecting the request, please finalize the"
+            + " cluster upgrade and then try again.",
+            OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
+      }
+    }
+    return req;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.BucketVersioningStatus;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -174,10 +175,29 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
 
       //Check Versioning to update
       Boolean versioning = omBucketArgs.getIsVersionEnabled();
-      if (versioning != null) {
-        bucketInfoBuilder.setIsVersionEnabled(versioning);
-        LOG.debug("Updating bucket versioning for bucket: {} in volume: {}",
-            bucketName, volumeName);
+      BucketVersioningStatus newVersioningStatus = omBucketArgs.getVersioningStatus();
+      if (newVersioningStatus == null && versioning != null) {
+        // Legacy flag from older clients: enabling always maps to ENABLED;
+        // disabling maps to SUSPENDED once versioning has ever been enabled
+        // (the S3 state machine forbids returning to UNVERSIONED).
+        if (versioning) {
+          newVersioningStatus = BucketVersioningStatus.ENABLED;
+        } else {
+          newVersioningStatus =
+              dbBucketInfo.getVersioningStatus() == BucketVersioningStatus.UNVERSIONED
+                  ? BucketVersioningStatus.UNVERSIONED : BucketVersioningStatus.SUSPENDED;
+        }
+      }
+      if (newVersioningStatus != null) {
+        if (!dbBucketInfo.getVersioningStatus().canTransitionTo(newVersioningStatus)) {
+          throw new OMException("Bucket versioning cannot be changed from "
+              + dbBucketInfo.getVersioningStatus() + " to " + newVersioningStatus
+              + "; once enabled, versioning can only be suspended.",
+              OMException.ResultCodes.INVALID_REQUEST);
+        }
+        bucketInfoBuilder.setVersioningStatus(newVersioningStatus);
+        LOG.debug("Updating bucket versioning to {} for bucket: {} in volume: {}",
+            newVersioningStatus, bucketName, volumeName);
       }
 
       //Check quotaInBytes and quotaInNamespace to update

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -176,17 +176,23 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       //Check Versioning to update
       Boolean versioning = omBucketArgs.getIsVersionEnabled();
       BucketVersioningStatus newVersioningStatus = omBucketArgs.getVersioningStatus();
-      if (newVersioningStatus == null && versioning != null) {
-        // Legacy flag from older clients: enabling always maps to ENABLED;
-        // disabling maps to SUSPENDED once versioning has ever been enabled
-        // (the S3 state machine forbids returning to UNVERSIONED).
-        if (versioning) {
-          newVersioningStatus = BucketVersioningStatus.ENABLED;
-        } else {
-          newVersioningStatus =
-              dbBucketInfo.getVersioningStatus() == BucketVersioningStatus.UNVERSIONED
-                  ? BucketVersioningStatus.UNVERSIONED : BucketVersioningStatus.SUSPENDED;
-        }
+      if (versioning != null) {
+        // Apply the legacy flag on its own; setVersioningStatus below overrides
+        // it when a status is also being set.
+        bucketInfoBuilder.setIsVersionEnabled(versioning);
+      }
+      if (newVersioningStatus == null && versioning != null
+          && dbBucketInfo.hasVersioningStatus()) {
+        // Legacy flag from an older client against a bucket that already has an
+        // S3 versioning status: keep the two consistent. Disabling maps to
+        // SUSPENDED, since the S3 state machine forbids returning to
+        // UNVERSIONED once versioning has been enabled.
+        //
+        // On a bucket without a status the flag is left alone: it selects the
+        // legacy in-record block version list, and an old client must not be
+        // able to opt a bucket into S3 versioning semantics.
+        newVersioningStatus = versioning
+            ? BucketVersioningStatus.ENABLED : BucketVersioningStatus.SUSPENDED;
       }
       if (newVersioningStatus != null) {
         if (!dbBucketInfo.getVersioningStatus().canTransitionTo(newVersioningStatus)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/DeleteMarkerInsertion.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/DeleteMarkerInsertion.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.key;
+
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+
+/**
+ * What inserting a delete marker changed, for the response to write out.
+ *
+ * <p>Produced by {@link OMKeyRequest#insertDeleteMarker}, which has already
+ * applied all of it to the table cache and to the bucket's quota. A response
+ * only has to put the same records into its WriteBatch.
+ */
+public final class DeleteMarkerInsertion {
+
+  private final OmKeyInfo deleteMarker;
+  private final String objectKey;
+  private final String demotedVersionKey;
+  private final OmKeyInfo demotedVersion;
+
+  DeleteMarkerInsertion(OmKeyInfo deleteMarker, String objectKey,
+      String demotedVersionKey, OmKeyInfo demotedVersion) {
+    this.deleteMarker = deleteMarker;
+    this.objectKey = objectKey;
+    this.demotedVersionKey = demotedVersionKey;
+    this.demotedVersion = demotedVersion;
+  }
+
+  /** The marker that becomes the key's current version. */
+  public OmKeyInfo getDeleteMarker() {
+    return deleteMarker;
+  }
+
+  /** keyTable dbKey the marker takes. */
+  public String getObjectKey() {
+    return objectKey;
+  }
+
+  /**
+   * versionedKeyTable dbKey the superseded version moves to, or null when the
+   * key had no current version.
+   */
+  public String getDemotedVersionKey() {
+    return demotedVersionKey;
+  }
+
+  public OmKeyInfo getDemotedVersion() {
+    return demotedVersion;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/DeleteMarkerInsertion.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/DeleteMarkerInsertion.java
@@ -23,8 +23,11 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
  * What inserting a delete marker changed, for the response to write out.
  *
  * <p>Produced by {@link OMKeyRequest#insertDeleteMarker}, which has already
- * applied all of it to the table cache and to the bucket's quota. A response
- * only has to put the same records into its WriteBatch.
+ * applied the records to the table cache. The namespace it adds is left to
+ * the caller to apply to the bucket, once every marker of the request is in:
+ * the bucket is the cached instance, so counting a marker of a batch that
+ * then fails would persist with the next write to it. A response only has to
+ * put the same records into its WriteBatch.
  */
 public final class DeleteMarkerInsertion {
 
@@ -32,13 +35,21 @@ public final class DeleteMarkerInsertion {
   private final String objectKey;
   private final String demotedVersionKey;
   private final OmKeyInfo demotedVersion;
+  private final long addedNamespace;
 
   DeleteMarkerInsertion(OmKeyInfo deleteMarker, String objectKey,
-      String demotedVersionKey, OmKeyInfo demotedVersion) {
+      String demotedVersionKey, OmKeyInfo demotedVersion,
+      long addedNamespace) {
     this.deleteMarker = deleteMarker;
     this.objectKey = objectKey;
     this.demotedVersionKey = demotedVersionKey;
     this.demotedVersion = demotedVersion;
+    this.addedNamespace = addedNamespace;
+  }
+
+  /** Namespace the marker takes, not yet applied to the bucket. */
+  public long getAddedNamespace() {
+    return addedNamespace;
   }
 
   /** The marker that becomes the key's current version. */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.helpers.WithMetadata;
 import org.apache.hadoop.ozone.om.request.util.OmKeyHSyncUtil;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -124,7 +125,12 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
     KeyArgs.Builder newKeyArgs =
         keyArgs.toBuilder().setModificationTime(Time.now())
-            .setKeyName(keyPath);
+            .setKeyName(keyPath)
+            // Proposed here so every OM applies the same id. The call is local
+            // and cheap, so it is made for every commit and simply goes unused
+            // when the bucket turns out not to be versioned.
+            .setProposedVersionId(
+                ozoneManager.getVersionIdAllocator().propose());
 
     KeyArgs resolvedKeyArgs =
         resolveBucketAndCheckOpenKeyAcls(newKeyArgs.build(), ozoneManager,
@@ -303,14 +309,23 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       }
 
       validateAtomicRewrite(keyToDelete, omKeyInfo, auditMap);
+      final boolean s3Versioning = omBucketInfo.isS3VersioningEnabled();
       // Set the UpdateID to current transactionLogIndex
-      omKeyInfo = omKeyInfo.toBuilder()
+      OmKeyInfo.Builder committedKeyBuilder = omKeyInfo.toBuilder()
           .setExpectedDataGeneration(null)
           .addAllMetadata(KeyValueUtil.getFromProtobuf(
                 commitKeyArgs.getMetadataList()))
           .setUpdateID(trxnLogIndex)
-          .setDataSize(commitKeyArgs.getDataSize())
-          .build();
+          .setDataSize(commitKeyArgs.getDataSize());
+      if (s3Versioning) {
+        // The version identity is frozen when the version is created: an hsync
+        // re-commit keeps updating the same version, so it keeps its versionId.
+        committedKeyBuilder.setVersionId(isSameHsyncKey
+            ? keyToDelete.getVersionId()
+            : ozoneManager.getVersionIdAllocator().allocate(
+                commitKeyArgs.getProposedVersionId(), keyToDelete));
+      }
+      omKeyInfo = committedKeyBuilder.build();
 
       // Update the block length for each block, return the allocated but
       // uncommitted blocks
@@ -325,7 +340,10 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         correctedSpace -= keyToDelete.getReplicatedSize();
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
-      } else if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
+      } else if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()
+          && !s3Versioning) {
+        // Under S3 versioning the overwritten version is kept in the
+        // versionedKeyTable, so its blocks must not be reclaimed here.
         RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(
             keyToDelete, omBucketInfo.getObjectID(), trxnLogIndex);
         // using pseudoObjId as objectId can be same in case of overwrite key
@@ -401,6 +419,24 @@ public class OMKeyCommitRequest extends OMKeyRequest {
             dbOpenKey, newOpenKeyInfo, trxnLogIndex);
       }
 
+      // With S3-compatible versioning the overwritten current version is kept
+      // as a noncurrent version instead of being reclaimed. A record written
+      // before versioning was enabled carries no versionId and becomes the
+      // key's null version.
+      String dbVersionedKey = null;
+      OmKeyInfo versionedKeyInfo = null;
+      if (s3Versioning && keyToDelete != null && !isSameHsyncKey) {
+        versionedKeyInfo = keyToDelete.getVersionId() != null ? keyToDelete
+            : keyToDelete.toBuilder()
+                .setVersionId(VersionIdGenerator.UNSET_VERSION_ID)
+                .setNullVersion(true)
+                .build();
+        dbVersionedKey = omMetadataManager.getVersionedOzoneKey(
+            volumeName, bucketName, keyName, versionedKeyInfo.getVersionId());
+        omMetadataManager.getVersionedKeyTable().addCacheEntry(
+            dbVersionedKey, versionedKeyInfo, trxnLogIndex);
+      }
+
       omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
           dbOzoneKey, omKeyInfo, trxnLogIndex);
 
@@ -408,7 +444,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       omClientResponse = new OMKeyCommitResponse(omResponse.build(),
           omKeyInfo, dbOzoneKey, dbOpenKey, omBucketInfo.copyObject(),
-          oldKeyVersionsToDeleteMap, isHSync, newOpenKeyInfo, dbOpenKeyToDeleteKey, openKeyToDelete);
+          oldKeyVersionsToDeleteMap, isHSync, newOpenKeyInfo, dbOpenKeyToDeleteKey, openKeyToDelete)
+          .withVersionedKey(dbVersionedKey, versionedKeyInfo);
 
       result = Result.SUCCESS;
     } catch (IOException | InvalidPathException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -335,7 +335,10 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         correctedSpace -= keyToDelete.getReplicatedSize();
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
-      } else if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
+      } else if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()
+          && !s3Versioning) {
+        // Under S3 versioning the overwritten version is kept in the
+        // versionedKeyTable, so its blocks must not be reclaimed here.
         RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(
             keyToDelete, omBucketInfo.getObjectID(), trxnLogIndex);
         // using pseudoObjId as objectId can be same in case of overwrite key

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.helpers.WithMetadata;
 import org.apache.hadoop.ozone.om.request.util.OmKeyHSyncUtil;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -303,14 +304,23 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       }
 
       validateAtomicRewrite(keyToDelete, omKeyInfo, auditMap);
+      final boolean s3Versioning = omBucketInfo.isS3VersioningEnabled();
       // Set the UpdateID to current transactionLogIndex
-      omKeyInfo = omKeyInfo.toBuilder()
+      OmKeyInfo.Builder committedKeyBuilder = omKeyInfo.toBuilder()
           .setExpectedDataGeneration(null)
           .addAllMetadata(KeyValueUtil.getFromProtobuf(
                 commitKeyArgs.getMetadataList()))
           .setUpdateID(trxnLogIndex)
-          .setDataSize(commitKeyArgs.getDataSize())
-          .build();
+          .setDataSize(commitKeyArgs.getDataSize());
+      if (s3Versioning) {
+        // The version identity is frozen when the version is created: an hsync
+        // re-commit keeps updating the same version, so it keeps its versionId.
+        committedKeyBuilder.setVersionId(isSameHsyncKey
+            ? keyToDelete.getVersionId()
+            : ozoneManager.getVersionIdAllocator().allocate(omMetadataManager,
+                volumeName, bucketName, keyName, trxnLogIndex, keyToDelete));
+      }
+      omKeyInfo = committedKeyBuilder.build();
 
       // Update the block length for each block, return the allocated but
       // uncommitted blocks
@@ -401,6 +411,24 @@ public class OMKeyCommitRequest extends OMKeyRequest {
             dbOpenKey, newOpenKeyInfo, trxnLogIndex);
       }
 
+      // With S3-compatible versioning the overwritten current version is kept
+      // as a noncurrent version instead of being reclaimed. A record written
+      // before versioning was enabled carries no versionId and becomes the
+      // key's null version.
+      String dbVersionedKey = null;
+      OmKeyInfo versionedKeyInfo = null;
+      if (s3Versioning && keyToDelete != null && !isSameHsyncKey) {
+        versionedKeyInfo = keyToDelete.getVersionId() != null ? keyToDelete
+            : keyToDelete.toBuilder()
+                .setVersionId(VersionIdGenerator.UNSET_VERSION_ID)
+                .setNullVersion(true)
+                .build();
+        dbVersionedKey = omMetadataManager.getVersionedOzoneKey(
+            volumeName, bucketName, keyName, versionedKeyInfo.getVersionId());
+        omMetadataManager.getVersionedKeyTable().addCacheEntry(
+            dbVersionedKey, versionedKeyInfo, trxnLogIndex);
+      }
+
       omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
           dbOzoneKey, omKeyInfo, trxnLogIndex);
 
@@ -408,7 +436,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       omClientResponse = new OMKeyCommitResponse(omResponse.build(),
           omKeyInfo, dbOzoneKey, dbOpenKey, omBucketInfo.copyObject(),
-          oldKeyVersionsToDeleteMap, isHSync, newOpenKeyInfo, dbOpenKeyToDeleteKey, openKeyToDelete);
+          oldKeyVersionsToDeleteMap, isHSync, newOpenKeyInfo, dbOpenKeyToDeleteKey, openKeyToDelete)
+          .withVersionedKey(dbVersionedKey, versionedKeyInfo);
 
       result = Result.SUCCESS;
     } catch (IOException | InvalidPathException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -326,6 +326,12 @@ public class OMKeyCommitRequest extends OMKeyRequest {
                 commitKeyArgs.getProposedVersionId(), keyToDelete));
       }
       omKeyInfo = committedKeyBuilder.build();
+      if (omKeyInfo.getVersionId() != null) {
+        // The id as applied, which the floor can raise above the proposal
+        // that the key args carry.
+        auditMap.put(OzoneConsts.VERSION_ID,
+            String.valueOf(omKeyInfo.getVersionId()));
+      }
 
       // Update the block length for each block, return the allocated but
       // uncommitted blocks
@@ -435,6 +441,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
             volumeName, bucketName, keyName, versionedKeyInfo.getVersionId());
         omMetadataManager.getVersionedKeyTable().addCacheEntry(
             dbVersionedKey, versionedKeyInfo, trxnLogIndex);
+        auditMap.put(OzoneConsts.SUPERSEDED_VERSION_ID,
+            String.valueOf(versionedKeyInfo.getVersionId()));
       }
 
       omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -24,13 +24,8 @@ import static org.apache.hadoop.ozone.util.MetricUtil.captureLatencyNs;
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.hadoop.hdds.client.RatisReplicationConfig;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -47,8 +42,6 @@ import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
 import org.apache.hadoop.ozone.om.request.validation.ValidationCondition;
@@ -282,15 +275,6 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     return omClientResponse;
   }
 
-  /**
-   * Supersedes the key's current version with a delete marker: a record with
-   * no data blocks that makes plain reads of the key return KEY_NOT_FOUND
-   * while every existing version stays readable by versionId. The superseded
-   * current version becomes a noncurrent version; a record written before
-   * versioning was enabled carries no versionId and becomes the key's null
-   * version. When the key does not exist the marker is still inserted, as S3
-   * does.
-   */
   @SuppressWarnings("checkstyle:ParameterNumber")
   private OMClientResponse insertDeleteMarker(OzoneManager ozoneManager,
       OMMetadataManager omMetadataManager, OmBucketInfo omBucketInfo,
@@ -298,74 +282,15 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
       OzoneManagerProtocolProtos.KeyArgs keyArgs, long trxnLogIndex,
       OMResponse.Builder omResponse) throws IOException {
 
-    String volumeName = omBucketInfo.getVolumeName();
-    String bucketName = omBucketInfo.getBucketName();
-    String keyName = keyArgs.getKeyName();
-
-    long markerVersionId = ozoneManager.getVersionIdAllocator().allocate(
-        keyArgs.getProposedVersionId(), currentVersion);
-
-    // Everything that can fail runs before the first cache entry is added: a
-    // request that throws here is answered with an OMKeyDeleteResponse, whose
-    // cleanup does not cover the versionedKeyTable, so a cache entry left
-    // behind would never be removed and would outlive the failed request.
-    // The marker is a record of its own; it holds no blocks, so it consumes
-    // namespace but no space.
-    checkBucketQuotaInNamespace(omBucketInfo, 1L);
-
-    OmKeyInfo.Builder markerBuilder;
-    if (currentVersion != null) {
-      markerBuilder = currentVersion.toBuilder()
-          .setMetadata(new HashMap<>())
-          .setTags(new HashMap<>())
-          .setFileChecksum(null);
-    } else {
-      markerBuilder = new OmKeyInfo.Builder()
-          .setVolumeName(volumeName)
-          .setBucketName(bucketName)
-          .setKeyName(keyName)
-          .setReplicationConfig(RatisReplicationConfig.getInstance(
-              ReplicationFactor.ONE))
-          .setObjectID(ozoneManager.getObjectIdFromTxId(trxnLogIndex))
-          .setOwnerName(omBucketInfo.getOwner())
-          .setFile(true);
-    }
-    OmKeyInfo deleteMarker = markerBuilder
-        .setOmKeyLocationInfos(Collections.singletonList(
-            new OmKeyLocationInfoGroup(0, new ArrayList<>())))
-        .setDataSize(0L)
-        .setCreationTime(keyArgs.getModificationTime())
-        .setModificationTime(keyArgs.getModificationTime())
-        .setUpdateID(trxnLogIndex)
-        .setVersionId(markerVersionId)
-        .setDeleteMarker(true)
-        .setNullVersion(false)
-        .build();
-
-    String movedVersionedKeyName = null;
-    OmKeyInfo movedVersionedKeyInfo = null;
-    if (currentVersion != null) {
-      movedVersionedKeyInfo = currentVersion.getVersionId() != null
-          ? currentVersion
-          : currentVersion.toBuilder()
-              .setVersionId(VersionIdGenerator.UNSET_VERSION_ID)
-              .setNullVersion(true)
-              .build();
-      movedVersionedKeyName = omMetadataManager.getVersionedOzoneKey(
-          volumeName, bucketName, keyName,
-          movedVersionedKeyInfo.getVersionId());
-      omMetadataManager.getVersionedKeyTable().addCacheEntry(
-          movedVersionedKeyName, movedVersionedKeyInfo, trxnLogIndex);
-    }
-
-    omBucketInfo.incrUsedNamespace(1L);
-
-    omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
-        objectKey, deleteMarker, trxnLogIndex);
+    DeleteMarkerInsertion inserted = insertDeleteMarker(ozoneManager,
+        omMetadataManager, omBucketInfo, currentVersion, objectKey,
+        keyArgs.getKeyName(), keyArgs.getProposedVersionId(),
+        keyArgs.getModificationTime(), trxnLogIndex);
 
     return new OMKeyDeleteMarkerResponse(
         omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder()).build(),
-        deleteMarker, objectKey, movedVersionedKeyName, movedVersionedKeyInfo,
+        inserted.getDeleteMarker(), inserted.getObjectKey(),
+        inserted.getDemotedVersionKey(), inserted.getDemotedVersion(),
         omBucketInfo.copyObject());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -24,8 +24,13 @@ import static org.apache.hadoop.ozone.util.MetricUtil.captureLatencyNs;
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -42,11 +47,14 @@ import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
 import org.apache.hadoop.ozone.om.request.validation.ValidationCondition;
 import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyDeleteMarkerResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyDeleteResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
@@ -128,6 +136,12 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     boolean acquiredLock = false;
     OMClientResponse omClientResponse = null;
     Result result = null;
+    // whether the request removed a key that was visible to plain reads; a
+    // delete marker supersedes the current version without removing anything
+    boolean visibleKeyRemoved = false;
+    // whether the request took the delete marker path, and so may have left
+    // versionedKeyTable entries in the table cache for this transaction
+    boolean insertingDeleteMarker = false;
     long startNanos = Time.monotonicNowNanos();
     try {
       String objectKey =
@@ -142,57 +156,73 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
       OmKeyInfo omKeyInfo =
           omMetadataManager.getKeyTable(getBucketLayout()).get(objectKey);
-      if (omKeyInfo == null) {
-        throw new OMException("Key not found", KEY_NOT_FOUND);
-      }
-
-      validateIfMatchETag(keyArgs, omKeyInfo);
-
-      // Set the UpdateID to current transactionLogIndex
-      omKeyInfo = omKeyInfo.toBuilder()
-          .setUpdateID(trxnLogIndex)
-          .build();
-
-      // Update table cache. Put a tombstone entry
-      omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
-          new CacheKey<>(
-              omMetadataManager.getOzoneKey(volumeName, bucketName, keyName)),
-          CacheValue.get(trxnLogIndex));
 
       OmBucketInfo omBucketInfo =
           getBucketInfo(omMetadataManager, volumeName, bucketName);
 
-      long quotaReleased = sumBlockLengths(omKeyInfo);
-      // Empty entries won't be added to deleted table so this key shouldn't get added to snapshotUsed space.
-      boolean isKeyNonEmpty = !OmKeyInfo.isKeyEmpty(omKeyInfo);
-      omBucketInfo.decrUsedBytes(quotaReleased, isKeyNonEmpty);
-      omBucketInfo.decrUsedNamespace(1L, isKeyNonEmpty);
-      OmKeyInfo deletedOpenKeyInfo = null;
-
-      // If omKeyInfo has hsync metadata, delete its corresponding open key as well
-      String dbOpenKey = null;
-      String hsyncClientId = omKeyInfo.getMetadata().get(OzoneConsts.HSYNC_CLIENT_ID);
-      if (hsyncClientId != null) {
-        Table<String, OmKeyInfo> openKeyTable = omMetadataManager.getOpenKeyTable(getBucketLayout());
-        dbOpenKey = omMetadataManager.getOpenKey(volumeName, bucketName, keyName, hsyncClientId);
-        OmKeyInfo openKeyInfo = openKeyTable.get(dbOpenKey);
-        if (openKeyInfo != null) {
-          openKeyInfo = openKeyInfo.withMetadataMutations(
-              metadata -> metadata.put(DELETED_HSYNC_KEY, "true"));
-          openKeyTable.addCacheEntry(dbOpenKey, openKeyInfo, trxnLogIndex);
-          deletedOpenKeyInfo = openKeyInfo;
-        } else {
-          LOG.warn("Potentially inconsistent DB state: open key not found with dbOpenKey '{}'", dbOpenKey);
+      if (omBucketInfo.isS3VersioningEnabled()) {
+        // A delete without a versionId removes no data: a delete marker
+        // becomes the current version and the version it supersedes moves to
+        // the versionedKeyTable. Like S3, the marker is inserted even when the
+        // key does not exist.
+        insertingDeleteMarker = true;
+        omClientResponse = insertDeleteMarker(ozoneManager, omMetadataManager,
+            omBucketInfo, omKeyInfo, objectKey, keyArgs, trxnLogIndex,
+            omResponse);
+        // The key stays in the keyTable as a marker, so nothing is released;
+        // only superseding a visible object is one fewer visible key.
+        visibleKeyRemoved = omKeyInfo != null && !omKeyInfo.isDeleteMarker();
+      } else {
+        if (omKeyInfo == null) {
+          throw new OMException("Key not found", KEY_NOT_FOUND);
         }
-      }
 
-      omClientResponse = new OMKeyDeleteResponse(
-          omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder())
-              .build(), omKeyInfo,
-          omBucketInfo.copyObject(), deletedOpenKeyInfo);
-      if (omKeyInfo.isFile()) {
-        auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(omKeyInfo.getDataSize()));
-        auditMap.put(OzoneConsts.REPLICATION_CONFIG, omKeyInfo.getReplicationConfig().toString());
+        validateIfMatchETag(keyArgs, omKeyInfo);
+
+        // Set the UpdateID to current transactionLogIndex
+        omKeyInfo = omKeyInfo.toBuilder()
+            .setUpdateID(trxnLogIndex)
+            .build();
+
+        // Update table cache. Put a tombstone entry
+        omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+            new CacheKey<>(
+                omMetadataManager.getOzoneKey(volumeName, bucketName, keyName)),
+            CacheValue.get(trxnLogIndex));
+
+        long quotaReleased = sumBlockLengths(omKeyInfo);
+        // Empty entries won't be added to deleted table so this key shouldn't get added to snapshotUsed space.
+        boolean isKeyNonEmpty = !OmKeyInfo.isKeyEmpty(omKeyInfo);
+        omBucketInfo.decrUsedBytes(quotaReleased, isKeyNonEmpty);
+        omBucketInfo.decrUsedNamespace(1L, isKeyNonEmpty);
+        OmKeyInfo deletedOpenKeyInfo = null;
+
+        // If omKeyInfo has hsync metadata, delete its corresponding open key as well
+        String dbOpenKey = null;
+        String hsyncClientId = omKeyInfo.getMetadata().get(OzoneConsts.HSYNC_CLIENT_ID);
+        if (hsyncClientId != null) {
+          Table<String, OmKeyInfo> openKeyTable = omMetadataManager.getOpenKeyTable(getBucketLayout());
+          dbOpenKey = omMetadataManager.getOpenKey(volumeName, bucketName, keyName, hsyncClientId);
+          OmKeyInfo openKeyInfo = openKeyTable.get(dbOpenKey);
+          if (openKeyInfo != null) {
+            openKeyInfo = openKeyInfo.withMetadataMutations(
+                metadata -> metadata.put(DELETED_HSYNC_KEY, "true"));
+            openKeyTable.addCacheEntry(dbOpenKey, openKeyInfo, trxnLogIndex);
+            deletedOpenKeyInfo = openKeyInfo;
+          } else {
+            LOG.warn("Potentially inconsistent DB state: open key not found with dbOpenKey '{}'", dbOpenKey);
+          }
+        }
+
+        omClientResponse = new OMKeyDeleteResponse(
+            omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder())
+                .build(), omKeyInfo,
+            omBucketInfo.copyObject(), deletedOpenKeyInfo);
+        if (omKeyInfo.isFile()) {
+          auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(omKeyInfo.getDataSize()));
+          auditMap.put(OzoneConsts.REPLICATION_CONFIG, omKeyInfo.getReplicationConfig().toString());
+        }
+        visibleKeyRemoved = true;
       }
 
       result = Result.SUCCESS;
@@ -201,9 +231,15 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     } catch (IOException | InvalidPathException ex) {
       result = Result.FAILURE;
       exception = ex;
-      omClientResponse =
-          new OMKeyDeleteResponse(createErrorOMResponse(omResponse, exception),
-              getBucketLayout());
+      // The failure response has to declare the same tables as the successful
+      // one: the double buffer cleans up the table cache from the response's
+      // CleanupTableInfo, so a delete marker request that failed after
+      // touching the versionedKeyTable cache would otherwise leave an entry
+      // behind that is in no DB and is never cleaned up.
+      OMResponse errorResponse = createErrorOMResponse(omResponse, exception);
+      omClientResponse = insertingDeleteMarker
+          ? new OMKeyDeleteMarkerResponse(errorResponse, getBucketLayout())
+          : new OMKeyDeleteResponse(errorResponse, getBucketLayout());
       long endNanosDeleteKeyFailureLatencyNs = Time.monotonicNowNanos();
       perfMetrics.setDeleteKeyFailureLatencyNs(endNanosDeleteKeyFailureLatencyNs - startNanos);
     } finally {
@@ -222,7 +258,9 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
-      omMetrics.decNumKeys();
+      if (visibleKeyRemoved) {
+        omMetrics.decNumKeys();
+      }
       LOG.debug("Key deleted. Volume:{}, Bucket:{}, Key:{}", volumeName,
           bucketName, keyName);
       break;
@@ -237,6 +275,93 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     }
 
     return omClientResponse;
+  }
+
+  /**
+   * Supersedes the key's current version with a delete marker: a record with
+   * no data blocks that makes plain reads of the key return KEY_NOT_FOUND
+   * while every existing version stays readable by versionId. The superseded
+   * current version becomes a noncurrent version; a record written before
+   * versioning was enabled carries no versionId and becomes the key's null
+   * version. When the key does not exist the marker is still inserted, as S3
+   * does.
+   */
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  private OMClientResponse insertDeleteMarker(OzoneManager ozoneManager,
+      OMMetadataManager omMetadataManager, OmBucketInfo omBucketInfo,
+      OmKeyInfo currentVersion, String objectKey,
+      OzoneManagerProtocolProtos.KeyArgs keyArgs, long trxnLogIndex,
+      OMResponse.Builder omResponse) throws IOException {
+
+    String volumeName = omBucketInfo.getVolumeName();
+    String bucketName = omBucketInfo.getBucketName();
+    String keyName = keyArgs.getKeyName();
+
+    // Everything that can fail runs before the first cache entry is added: a
+    // request that throws here is answered with an OMKeyDeleteResponse, whose
+    // cleanup does not cover the versionedKeyTable, so a cache entry left
+    // behind would never be removed and would outlive the failed request.
+    long markerVersionId = ozoneManager.getVersionIdAllocator().allocate(
+        omMetadataManager, volumeName, bucketName, keyName, trxnLogIndex,
+        currentVersion);
+    // the marker is a record of its own; it holds no blocks, so it consumes
+    // namespace but no space
+    checkBucketQuotaInNamespace(omBucketInfo, 1L);
+
+    OmKeyInfo.Builder markerBuilder;
+    if (currentVersion != null) {
+      markerBuilder = currentVersion.toBuilder()
+          .setMetadata(new HashMap<>())
+          .setTags(new HashMap<>())
+          .setFileChecksum(null);
+    } else {
+      markerBuilder = new OmKeyInfo.Builder()
+          .setVolumeName(volumeName)
+          .setBucketName(bucketName)
+          .setKeyName(keyName)
+          .setReplicationConfig(RatisReplicationConfig.getInstance(
+              ReplicationFactor.ONE))
+          .setObjectID(ozoneManager.getObjectIdFromTxId(trxnLogIndex))
+          .setOwnerName(omBucketInfo.getOwner())
+          .setFile(true);
+    }
+    OmKeyInfo deleteMarker = markerBuilder
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, new ArrayList<>())))
+        .setDataSize(0L)
+        .setCreationTime(keyArgs.getModificationTime())
+        .setModificationTime(keyArgs.getModificationTime())
+        .setUpdateID(trxnLogIndex)
+        .setVersionId(markerVersionId)
+        .setDeleteMarker(true)
+        .setNullVersion(false)
+        .build();
+
+    String movedVersionedKeyName = null;
+    OmKeyInfo movedVersionedKeyInfo = null;
+    if (currentVersion != null) {
+      movedVersionedKeyInfo = currentVersion.getVersionId() != null
+          ? currentVersion
+          : currentVersion.toBuilder()
+              .setVersionId(VersionIdGenerator.UNSET_VERSION_ID)
+              .setNullVersion(true)
+              .build();
+      movedVersionedKeyName = omMetadataManager.getVersionedOzoneKey(
+          volumeName, bucketName, keyName,
+          movedVersionedKeyInfo.getVersionId());
+      omMetadataManager.getVersionedKeyTable().addCacheEntry(
+          movedVersionedKeyName, movedVersionedKeyInfo, trxnLogIndex);
+    }
+
+    omBucketInfo.incrUsedNamespace(1L);
+
+    omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+        objectKey, deleteMarker, trxnLogIndex);
+
+    return new OMKeyDeleteMarkerResponse(
+        omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder()).build(),
+        deleteMarker, objectKey, movedVersionedKeyName, movedVersionedKeyInfo,
+        omBucketInfo.copyObject());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -24,8 +24,13 @@ import static org.apache.hadoop.ozone.util.MetricUtil.captureLatencyNs;
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -42,11 +47,14 @@ import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
 import org.apache.hadoop.ozone.om.request.validation.ValidationCondition;
 import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyDeleteMarkerResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyDeleteResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
@@ -86,7 +94,12 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     keyPath = normalizeKeyPath(ozoneManager.getEnableFileSystemPaths(), keyPath, getBucketLayout());
 
     OzoneManagerProtocolProtos.KeyArgs.Builder newKeyArgs =
-        keyArgs.toBuilder().setModificationTime(Time.now()).setKeyName(keyPath);
+        keyArgs.toBuilder().setModificationTime(Time.now()).setKeyName(keyPath)
+            // A delete on a versioned bucket creates a delete marker, and a
+            // marker is a version, so it needs an id proposed here on the OM
+            // that received the request. Unused on an unversioned bucket.
+            .setProposedVersionId(
+                ozoneManager.getVersionIdAllocator().propose());
 
     KeyArgs resolvedArgs = resolveBucketAndCheckAcls(ozoneManager, newKeyArgs);
     return getOmRequest().toBuilder()
@@ -128,6 +141,12 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     boolean acquiredLock = false;
     OMClientResponse omClientResponse = null;
     Result result = null;
+    // whether the request removed a key that was visible to plain reads; a
+    // delete marker supersedes the current version without removing anything
+    boolean visibleKeyRemoved = false;
+    // whether the request took the delete marker path, and so may have left
+    // versionedKeyTable entries in the table cache for this transaction
+    boolean insertingDeleteMarker = false;
     long startNanos = Time.monotonicNowNanos();
     try {
       String objectKey =
@@ -142,57 +161,73 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
       OmKeyInfo omKeyInfo =
           omMetadataManager.getKeyTable(getBucketLayout()).get(objectKey);
-      if (omKeyInfo == null) {
-        throw new OMException("Key not found", KEY_NOT_FOUND);
-      }
-
-      validateIfMatchETag(keyArgs, omKeyInfo);
-
-      // Set the UpdateID to current transactionLogIndex
-      omKeyInfo = omKeyInfo.toBuilder()
-          .setUpdateID(trxnLogIndex)
-          .build();
-
-      // Update table cache. Put a tombstone entry
-      omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
-          new CacheKey<>(
-              omMetadataManager.getOzoneKey(volumeName, bucketName, keyName)),
-          CacheValue.get(trxnLogIndex));
 
       OmBucketInfo omBucketInfo =
           getBucketInfo(omMetadataManager, volumeName, bucketName);
 
-      long quotaReleased = sumBlockLengths(omKeyInfo);
-      // Empty entries won't be added to deleted table so this key shouldn't get added to snapshotUsed space.
-      boolean isKeyNonEmpty = !OmKeyInfo.isKeyEmpty(omKeyInfo);
-      omBucketInfo.decrUsedBytes(quotaReleased, isKeyNonEmpty);
-      omBucketInfo.decrUsedNamespace(1L, isKeyNonEmpty);
-      OmKeyInfo deletedOpenKeyInfo = null;
-
-      // If omKeyInfo has hsync metadata, delete its corresponding open key as well
-      String dbOpenKey = null;
-      String hsyncClientId = omKeyInfo.getMetadata().get(OzoneConsts.HSYNC_CLIENT_ID);
-      if (hsyncClientId != null) {
-        Table<String, OmKeyInfo> openKeyTable = omMetadataManager.getOpenKeyTable(getBucketLayout());
-        dbOpenKey = omMetadataManager.getOpenKey(volumeName, bucketName, keyName, hsyncClientId);
-        OmKeyInfo openKeyInfo = openKeyTable.get(dbOpenKey);
-        if (openKeyInfo != null) {
-          openKeyInfo = openKeyInfo.withMetadataMutations(
-              metadata -> metadata.put(DELETED_HSYNC_KEY, "true"));
-          openKeyTable.addCacheEntry(dbOpenKey, openKeyInfo, trxnLogIndex);
-          deletedOpenKeyInfo = openKeyInfo;
-        } else {
-          LOG.warn("Potentially inconsistent DB state: open key not found with dbOpenKey '{}'", dbOpenKey);
+      if (omBucketInfo.isS3VersioningEnabled()) {
+        // A delete without a versionId removes no data: a delete marker
+        // becomes the current version and the version it supersedes moves to
+        // the versionedKeyTable. Like S3, the marker is inserted even when the
+        // key does not exist.
+        insertingDeleteMarker = true;
+        omClientResponse = insertDeleteMarker(ozoneManager, omMetadataManager,
+            omBucketInfo, omKeyInfo, objectKey, keyArgs, trxnLogIndex,
+            omResponse);
+        // The key stays in the keyTable as a marker, so nothing is released;
+        // only superseding a visible object is one fewer visible key.
+        visibleKeyRemoved = omKeyInfo != null && !omKeyInfo.isDeleteMarker();
+      } else {
+        if (omKeyInfo == null) {
+          throw new OMException("Key not found", KEY_NOT_FOUND);
         }
-      }
 
-      omClientResponse = new OMKeyDeleteResponse(
-          omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder())
-              .build(), omKeyInfo,
-          omBucketInfo.copyObject(), deletedOpenKeyInfo);
-      if (omKeyInfo.isFile()) {
-        auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(omKeyInfo.getDataSize()));
-        auditMap.put(OzoneConsts.REPLICATION_CONFIG, omKeyInfo.getReplicationConfig().toString());
+        validateIfMatchETag(keyArgs, omKeyInfo);
+
+        // Set the UpdateID to current transactionLogIndex
+        omKeyInfo = omKeyInfo.toBuilder()
+            .setUpdateID(trxnLogIndex)
+            .build();
+
+        // Update table cache. Put a tombstone entry
+        omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+            new CacheKey<>(
+                omMetadataManager.getOzoneKey(volumeName, bucketName, keyName)),
+            CacheValue.get(trxnLogIndex));
+
+        long quotaReleased = sumBlockLengths(omKeyInfo);
+        // Empty entries won't be added to deleted table so this key shouldn't get added to snapshotUsed space.
+        boolean isKeyNonEmpty = !OmKeyInfo.isKeyEmpty(omKeyInfo);
+        omBucketInfo.decrUsedBytes(quotaReleased, isKeyNonEmpty);
+        omBucketInfo.decrUsedNamespace(1L, isKeyNonEmpty);
+        OmKeyInfo deletedOpenKeyInfo = null;
+
+        // If omKeyInfo has hsync metadata, delete its corresponding open key as well
+        String dbOpenKey = null;
+        String hsyncClientId = omKeyInfo.getMetadata().get(OzoneConsts.HSYNC_CLIENT_ID);
+        if (hsyncClientId != null) {
+          Table<String, OmKeyInfo> openKeyTable = omMetadataManager.getOpenKeyTable(getBucketLayout());
+          dbOpenKey = omMetadataManager.getOpenKey(volumeName, bucketName, keyName, hsyncClientId);
+          OmKeyInfo openKeyInfo = openKeyTable.get(dbOpenKey);
+          if (openKeyInfo != null) {
+            openKeyInfo = openKeyInfo.withMetadataMutations(
+                metadata -> metadata.put(DELETED_HSYNC_KEY, "true"));
+            openKeyTable.addCacheEntry(dbOpenKey, openKeyInfo, trxnLogIndex);
+            deletedOpenKeyInfo = openKeyInfo;
+          } else {
+            LOG.warn("Potentially inconsistent DB state: open key not found with dbOpenKey '{}'", dbOpenKey);
+          }
+        }
+
+        omClientResponse = new OMKeyDeleteResponse(
+            omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder())
+                .build(), omKeyInfo,
+            omBucketInfo.copyObject(), deletedOpenKeyInfo);
+        if (omKeyInfo.isFile()) {
+          auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(omKeyInfo.getDataSize()));
+          auditMap.put(OzoneConsts.REPLICATION_CONFIG, omKeyInfo.getReplicationConfig().toString());
+        }
+        visibleKeyRemoved = true;
       }
 
       result = Result.SUCCESS;
@@ -201,9 +236,15 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     } catch (IOException | InvalidPathException ex) {
       result = Result.FAILURE;
       exception = ex;
-      omClientResponse =
-          new OMKeyDeleteResponse(createErrorOMResponse(omResponse, exception),
-              getBucketLayout());
+      // The failure response has to declare the same tables as the successful
+      // one: the double buffer cleans up the table cache from the response's
+      // CleanupTableInfo, so a delete marker request that failed after
+      // touching the versionedKeyTable cache would otherwise leave an entry
+      // behind that is in no DB and is never cleaned up.
+      OMResponse errorResponse = createErrorOMResponse(omResponse, exception);
+      omClientResponse = insertingDeleteMarker
+          ? new OMKeyDeleteMarkerResponse(errorResponse, getBucketLayout())
+          : new OMKeyDeleteResponse(errorResponse, getBucketLayout());
       long endNanosDeleteKeyFailureLatencyNs = Time.monotonicNowNanos();
       perfMetrics.setDeleteKeyFailureLatencyNs(endNanosDeleteKeyFailureLatencyNs - startNanos);
     } finally {
@@ -222,7 +263,9 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
-      omMetrics.decNumKeys();
+      if (visibleKeyRemoved) {
+        omMetrics.decNumKeys();
+      }
       LOG.debug("Key deleted. Volume:{}, Bucket:{}, Key:{}", volumeName,
           bucketName, keyName);
       break;
@@ -237,6 +280,93 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     }
 
     return omClientResponse;
+  }
+
+  /**
+   * Supersedes the key's current version with a delete marker: a record with
+   * no data blocks that makes plain reads of the key return KEY_NOT_FOUND
+   * while every existing version stays readable by versionId. The superseded
+   * current version becomes a noncurrent version; a record written before
+   * versioning was enabled carries no versionId and becomes the key's null
+   * version. When the key does not exist the marker is still inserted, as S3
+   * does.
+   */
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  private OMClientResponse insertDeleteMarker(OzoneManager ozoneManager,
+      OMMetadataManager omMetadataManager, OmBucketInfo omBucketInfo,
+      OmKeyInfo currentVersion, String objectKey,
+      OzoneManagerProtocolProtos.KeyArgs keyArgs, long trxnLogIndex,
+      OMResponse.Builder omResponse) throws IOException {
+
+    String volumeName = omBucketInfo.getVolumeName();
+    String bucketName = omBucketInfo.getBucketName();
+    String keyName = keyArgs.getKeyName();
+
+    long markerVersionId = ozoneManager.getVersionIdAllocator().allocate(
+        keyArgs.getProposedVersionId(), currentVersion);
+
+    // Everything that can fail runs before the first cache entry is added: a
+    // request that throws here is answered with an OMKeyDeleteResponse, whose
+    // cleanup does not cover the versionedKeyTable, so a cache entry left
+    // behind would never be removed and would outlive the failed request.
+    // The marker is a record of its own; it holds no blocks, so it consumes
+    // namespace but no space.
+    checkBucketQuotaInNamespace(omBucketInfo, 1L);
+
+    OmKeyInfo.Builder markerBuilder;
+    if (currentVersion != null) {
+      markerBuilder = currentVersion.toBuilder()
+          .setMetadata(new HashMap<>())
+          .setTags(new HashMap<>())
+          .setFileChecksum(null);
+    } else {
+      markerBuilder = new OmKeyInfo.Builder()
+          .setVolumeName(volumeName)
+          .setBucketName(bucketName)
+          .setKeyName(keyName)
+          .setReplicationConfig(RatisReplicationConfig.getInstance(
+              ReplicationFactor.ONE))
+          .setObjectID(ozoneManager.getObjectIdFromTxId(trxnLogIndex))
+          .setOwnerName(omBucketInfo.getOwner())
+          .setFile(true);
+    }
+    OmKeyInfo deleteMarker = markerBuilder
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, new ArrayList<>())))
+        .setDataSize(0L)
+        .setCreationTime(keyArgs.getModificationTime())
+        .setModificationTime(keyArgs.getModificationTime())
+        .setUpdateID(trxnLogIndex)
+        .setVersionId(markerVersionId)
+        .setDeleteMarker(true)
+        .setNullVersion(false)
+        .build();
+
+    String movedVersionedKeyName = null;
+    OmKeyInfo movedVersionedKeyInfo = null;
+    if (currentVersion != null) {
+      movedVersionedKeyInfo = currentVersion.getVersionId() != null
+          ? currentVersion
+          : currentVersion.toBuilder()
+              .setVersionId(VersionIdGenerator.UNSET_VERSION_ID)
+              .setNullVersion(true)
+              .build();
+      movedVersionedKeyName = omMetadataManager.getVersionedOzoneKey(
+          volumeName, bucketName, keyName,
+          movedVersionedKeyInfo.getVersionId());
+      omMetadataManager.getVersionedKeyTable().addCacheEntry(
+          movedVersionedKeyName, movedVersionedKeyInfo, trxnLogIndex);
+    }
+
+    omBucketInfo.incrUsedNamespace(1L);
+
+    omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+        objectKey, deleteMarker, trxnLogIndex);
+
+    return new OMKeyDeleteMarkerResponse(
+        omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder()).build(),
+        deleteMarker, objectKey, movedVersionedKeyName, movedVersionedKeyInfo,
+        omBucketInfo.copyObject());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -166,7 +166,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
         insertingDeleteMarker = true;
         omClientResponse = insertDeleteMarker(ozoneManager, omMetadataManager,
             omBucketInfo, omKeyInfo, objectKey, keyArgs, trxnLogIndex,
-            omResponse);
+            omResponse, auditMap);
         // The key stays in the keyTable as a marker, so nothing is released;
         // only superseding a visible object is one fewer visible key.
         visibleKeyRemoved = omKeyInfo != null && !omKeyInfo.isDeleteMarker();
@@ -280,12 +280,20 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
       OMMetadataManager omMetadataManager, OmBucketInfo omBucketInfo,
       OmKeyInfo currentVersion, String objectKey,
       OzoneManagerProtocolProtos.KeyArgs keyArgs, long trxnLogIndex,
-      OMResponse.Builder omResponse) throws IOException {
+      OMResponse.Builder omResponse, Map<String, String> auditMap)
+      throws IOException {
 
     DeleteMarkerInsertion inserted = insertDeleteMarker(ozoneManager,
         omMetadataManager, omBucketInfo, currentVersion, objectKey,
         keyArgs.getKeyName(), keyArgs.getProposedVersionId(),
-        keyArgs.getModificationTime(), trxnLogIndex);
+        keyArgs.getModificationTime(), trxnLogIndex, 0L);
+    omBucketInfo.incrUsedNamespace(inserted.getAddedNamespace());
+    auditMap.put(OzoneConsts.VERSION_ID,
+        String.valueOf(inserted.getDeleteMarker().getVersionId()));
+    if (inserted.getDemotedVersion() != null) {
+      auditMap.put(OzoneConsts.SUPERSEDED_VERSION_ID,
+          String.valueOf(inserted.getDemotedVersion().getVersionId()));
+    }
 
     return new OMKeyDeleteMarkerResponse(
         omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder()).build(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -959,11 +959,15 @@ public abstract class OMKeyRequest extends OMClientRequest {
     if (dbKeyInfo != null) {
       // The key already exist, the new blocks will replace old ones
       // as new versions unless the bucket does not have versioning
-      // turned on.
-      dbKeyInfo.addNewVersion(locations, false,
-              omBucketInfo.getIsVersionEnabled());
+      // turned on. With S3-compatible versioning the previous current version
+      // is kept as its own record in the versionedKeyTable at commit time, so
+      // the in-record block version list is not used to accumulate object
+      // versions and always holds a single version.
+      boolean keepInRecordVersions = omBucketInfo.getIsVersionEnabled()
+          && !omBucketInfo.isS3VersioningEnabled();
+      dbKeyInfo.addNewVersion(locations, false, keepInRecordVersions);
       long newSize = size;
-      if (omBucketInfo.getIsVersionEnabled()) {
+      if (keepInRecordVersions) {
         newSize += dbKeyInfo.getDataSize();
       }
       // The modification time is set in preExecute. Use the same

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1013,11 +1013,15 @@ public abstract class OMKeyRequest extends OMClientRequest {
     if (dbKeyInfo != null) {
       // The key already exist, the new blocks will replace old ones
       // as new versions unless the bucket does not have versioning
-      // turned on.
-      dbKeyInfo.addNewVersion(locations, false,
-              omBucketInfo.getIsVersionEnabled());
+      // turned on. With S3-compatible versioning the previous current version
+      // is kept as its own record in the versionedKeyTable at commit time, so
+      // the in-record block version list is not used to accumulate object
+      // versions and always holds a single version.
+      boolean keepInRecordVersions = omBucketInfo.getIsVersionEnabled()
+          && !omBucketInfo.isS3VersioningEnabled();
+      dbKeyInfo.addNewVersion(locations, false, keepInRecordVersions);
       long newSize = size;
-      if (omBucketInfo.getIsVersionEnabled()) {
+      if (keepInRecordVersions) {
         newSize += dbKeyInfo.getDataSize();
       }
       // The modification time is set in preExecute. Use the same

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -56,10 +56,12 @@ import org.apache.hadoop.fs.FileEncryptionInfo;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -93,6 +95,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.lock.OzoneLockStrategy;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.OMClientRequestUtils;
@@ -1447,4 +1450,97 @@ public abstract class OMKeyRequest extends OMClientRequest {
         .clearExpectedETag()
         .build();
   }
+
+  /**
+   * Supersedes the key's current version with a delete marker: a record with
+   * no data blocks that makes plain reads of the key return KEY_NOT_FOUND
+   * while every existing version stays readable by versionId. The superseded
+   * current version becomes a noncurrent version; a record written before
+   * versioning was enabled carries no versionId and becomes the key's null
+   * version. When the key does not exist the marker is still inserted, as S3
+   * does.
+   *
+   * <p>Applies everything to the table cache and to the bucket's quota, and
+   * returns what a response has to put into its WriteBatch. Shared so that a
+   * single delete and a batch delete insert the same marker.
+   *
+   * @param currentVersion the key's current version, or null if it has none
+   * @param proposedVersionId the id the request proposed for the marker
+   * @param modificationTime the time to stamp the marker with
+   */
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  protected DeleteMarkerInsertion insertDeleteMarker(OzoneManager ozoneManager,
+      OMMetadataManager omMetadataManager, OmBucketInfo omBucketInfo,
+      OmKeyInfo currentVersion, String objectKey, String keyName,
+      long proposedVersionId, long modificationTime, long trxnLogIndex)
+      throws IOException {
+
+    String volumeName = omBucketInfo.getVolumeName();
+    String bucketName = omBucketInfo.getBucketName();
+
+    long markerVersionId = ozoneManager.getVersionIdAllocator().allocate(
+        proposedVersionId, currentVersion);
+
+    // Everything that can fail runs before the first cache entry is added: a
+    // request that throws here is answered with an OMKeyDeleteResponse, whose
+    // cleanup does not cover the versionedKeyTable, so a cache entry left
+    // behind would never be removed and would outlive the failed request.
+    // The marker is a record of its own; it holds no blocks, so it consumes
+    // namespace but no space.
+    checkBucketQuotaInNamespace(omBucketInfo, 1L);
+
+    OmKeyInfo.Builder markerBuilder;
+    if (currentVersion != null) {
+      markerBuilder = currentVersion.toBuilder()
+          .setMetadata(new HashMap<>())
+          .setTags(new HashMap<>())
+          .setFileChecksum(null);
+    } else {
+      markerBuilder = new OmKeyInfo.Builder()
+          .setVolumeName(volumeName)
+          .setBucketName(bucketName)
+          .setKeyName(keyName)
+          .setReplicationConfig(RatisReplicationConfig.getInstance(
+              ReplicationFactor.ONE))
+          .setObjectID(ozoneManager.getObjectIdFromTxId(trxnLogIndex))
+          .setOwnerName(omBucketInfo.getOwner())
+          .setFile(true);
+    }
+    OmKeyInfo deleteMarker = markerBuilder
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, new ArrayList<>())))
+        .setDataSize(0L)
+        .setCreationTime(modificationTime)
+        .setModificationTime(modificationTime)
+        .setUpdateID(trxnLogIndex)
+        .setVersionId(markerVersionId)
+        .setDeleteMarker(true)
+        .setNullVersion(false)
+        .build();
+
+    String movedVersionedKeyName = null;
+    OmKeyInfo movedVersionedKeyInfo = null;
+    if (currentVersion != null) {
+      movedVersionedKeyInfo = currentVersion.getVersionId() != null
+          ? currentVersion
+          : currentVersion.toBuilder()
+              .setVersionId(VersionIdGenerator.UNSET_VERSION_ID)
+              .setNullVersion(true)
+              .build();
+      movedVersionedKeyName = omMetadataManager.getVersionedOzoneKey(
+          volumeName, bucketName, keyName,
+          movedVersionedKeyInfo.getVersionId());
+      omMetadataManager.getVersionedKeyTable().addCacheEntry(
+          movedVersionedKeyName, movedVersionedKeyInfo, trxnLogIndex);
+    }
+
+    omBucketInfo.incrUsedNamespace(1L);
+
+    omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+        objectKey, deleteMarker, trxnLogIndex);
+
+    return new DeleteMarkerInsertion(deleteMarker, objectKey,
+        movedVersionedKeyName, movedVersionedKeyInfo);
+  }
+
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1472,7 +1472,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
   protected DeleteMarkerInsertion insertDeleteMarker(OzoneManager ozoneManager,
       OMMetadataManager omMetadataManager, OmBucketInfo omBucketInfo,
       OmKeyInfo currentVersion, String objectKey, String keyName,
-      long proposedVersionId, long modificationTime, long trxnLogIndex)
+      long proposedVersionId, long modificationTime, long trxnLogIndex,
+      long pendingNamespace)
       throws IOException {
 
     String volumeName = omBucketInfo.getVolumeName();
@@ -1486,8 +1487,9 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // cleanup does not cover the versionedKeyTable, so a cache entry left
     // behind would never be removed and would outlive the failed request.
     // The marker is a record of its own; it holds no blocks, so it consumes
-    // namespace but no space.
-    checkBucketQuotaInNamespace(omBucketInfo, 1L);
+    // namespace but no space. The check counts what earlier markers of the
+    // same request have claimed, which the bucket does not show yet.
+    checkBucketQuotaInNamespace(omBucketInfo, pendingNamespace + 1L);
 
     OmKeyInfo.Builder markerBuilder;
     if (currentVersion != null) {
@@ -1534,13 +1536,13 @@ public abstract class OMKeyRequest extends OMClientRequest {
           movedVersionedKeyName, movedVersionedKeyInfo, trxnLogIndex);
     }
 
-    omBucketInfo.incrUsedNamespace(1L);
-
     omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
         objectKey, deleteMarker, trxnLogIndex);
 
+    // The namespace is left to the caller: the bucket is the cached instance,
+    // and a batch that fails on a later key must not have counted this one.
     return new DeleteMarkerInsertion(deleteMarker, objectKey,
-        movedVersionedKeyName, movedVersionedKeyInfo);
+        movedVersionedKeyName, movedVersionedKeyInfo, 1L);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -159,6 +159,9 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
 
     boolean acquiredLock = false;
+    // Whether the request may have put an entry into the versionedKeyTable
+    // cache, which decides the failure response below.
+    boolean insertingDeleteMarkers = false;
 
     int indexFailed = 0;
     int length = deleteKeys.size();
@@ -167,6 +170,10 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
             .setVolumeName(volumeName).setBucketName(bucketName);
 
     boolean deleteStatus = true;
+    // Keys that stopped being visible to a plain read. A marker written
+    // over a key that was already a marker, or over one the bucket held no
+    // record of, hides nothing that was not hidden already.
+    int visibleKeysRemoved = 0;
     long startNanos = Time.monotonicNowNanos();
     try {
       long startNanosDeleteKeysResolveBucketLatency = Time.monotonicNowNanos();
@@ -193,15 +200,48 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
       String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
+      OmBucketInfo omBucketInfo =
+          getBucketInfo(omMetadataManager, volumeName, bucketName);
+      // Keys the bucket holds no record of. On a versioned bucket they still
+      // get a delete marker, so they are named rather than skipped.
+      List<String> markerOnlyKeys = new ArrayList<>();
 
       for (indexFailed = 0; indexFailed < length; indexFailed++) {
         String keyName = deleteKeyArgs.getKeys(indexFailed);
         String objectKey =
             omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
+        // Evaluate key ACL before existence, so that a missing key without
+        // DELETE permission is refused rather than being recorded as deleted.
+        try {
+          long startNanosDeleteKeysAclCheckLatency = Time.monotonicNowNanos();
+          checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
+              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
+              volumeOwner);
+          perfMetrics.setDeleteKeysAclCheckLatencyNs(
+              Time.monotonicNowNanos() - startNanosDeleteKeysAclCheckLatency);
+        } catch (Exception ex) {
+          deleteStatus = false;
+          LOG.error("Acl check failed for Key: {}", objectKey, ex);
+          deleteKeys.remove(keyName);
+          unDeletedKeys.addKeys(keyName);
+          keyToError.put(keyName, new ErrorInfo(OMException.ResultCodes.ACCESS_DENIED.name(), "ACL check failed"));
+          continue;
+        }
+
         OmKeyInfo omKeyInfo = getOmKeyInfo(ozoneManager, omMetadataManager,
             volumeName, bucketName, keyName);
 
         if (omKeyInfo == null) {
+          // S3 records the delete whether or not the key was there, so a key
+          // with no record takes a delete marker of its own rather than
+          // failing the batch. The single-key delete does the same. A request
+          // that asserts an updateID is excluded: a key with no record has no
+          // updateID that could match.
+          if (omBucketInfo.isS3VersioningEnabled()
+              && deleteKeyUpdateIDs == null) {
+            markerOnlyKeys.add(keyName);
+            continue;
+          }
           deleteStatus = false;
           LOG.error("Received a request to delete a Key does not exist {}",
               objectKey);
@@ -225,12 +265,6 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
         }
 
         try {
-          // check Acl
-          long startNanosDeleteKeysAclCheckLatency = Time.monotonicNowNanos();
-          checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
-              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
-              volumeOwner);
-          perfMetrics.setDeleteKeysAclCheckLatencyNs(Time.monotonicNowNanos() - startNanosDeleteKeysAclCheckLatency);
           OzoneFileStatus fileStatus = getOzoneKeyStatus(
               ozoneManager, omMetadataManager, volumeName, bucketName, keyName);
           addKeyToAppropriateList(omKeyInfoList, omKeyInfo, dirList,
@@ -238,24 +272,25 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           deleteKeysInfo.add(omKeyInfo);
         } catch (Exception ex) {
           deleteStatus = false;
-          LOG.error("Acl check failed for Key: {}", objectKey, ex);
+          LOG.error("Failed to prepare Key for deletion: {}", objectKey, ex);
           deleteKeys.remove(keyName);
           unDeletedKeys.addKeys(keyName);
-          keyToError.put(keyName, new ErrorInfo(OMException.ResultCodes.ACCESS_DENIED.name(), "ACL check failed"));
+          keyToError.put(keyName, new ErrorInfo(
+              OMException.ResultCodes.INTERNAL_ERROR.name(), ex.getMessage()));
         }
       }
-
-      OmBucketInfo omBucketInfo =
-          getBucketInfo(omMetadataManager, volumeName, bucketName);
 
       Map<String, OmKeyInfo> openKeyInfoMap = new HashMap<>();
       // On a versioned bucket a delete removes no data: each key gets a delete
       // marker as its current version, exactly as a single-key delete does.
       List<DeleteMarkerInsertion> markerInsertions = null;
       if (omBucketInfo.isS3VersioningEnabled()) {
+        insertingDeleteMarkers = true;
         markerInsertions = insertDeleteMarkers(ozoneManager, omMetadataManager,
-            omBucketInfo, omKeyInfoList,
+            omBucketInfo, omKeyInfoList, markerOnlyKeys,
             deleteKeyArgs.getProposedVersionId(), trxnLogIndex);
+        visibleKeysRemoved = (int) omKeyInfoList.stream()
+            .filter(keyInfo -> !keyInfo.isDeleteMarker()).count();
       } else {
         // Mark all keys which can be deleted, in cache as deleted.
         Pair<Long, Integer> quotaReleasedEmptyKeys =
@@ -266,6 +301,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
         omBucketInfo.decrUsedNamespace(omKeyInfoList.size() + dirList.size() -
                 quotaReleasedEmptyKeys.getValue(), true);
         omBucketInfo.decrUsedNamespace(quotaReleasedEmptyKeys.getValue(), false);
+        visibleKeysRemoved = deleteKeys.size();
       }
 
       OmLifecycleScanState state = null;
@@ -311,8 +347,15 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       omResponse.setDeleteKeysResponse(
           DeleteKeysResponse.newBuilder().setStatus(false)
               .setUnDeletedKeys(unDeletedKeys).build()).build();
-      omClientResponse =
-          new OMKeysDeleteResponse(omResponse.build(), getBucketLayout());
+      // The failure response has to declare the same tables as the successful
+      // one: the double buffer cleans up the table cache from the response's
+      // CleanupTableInfo, so a marker insertion that failed part way through
+      // the batch would otherwise leave a versionedKeyTable entry behind that
+      // is in no DB and is never cleaned up.
+      omClientResponse = insertingDeleteMarkers
+          ? new OMKeysDeleteMarkerResponse(omResponse.build(),
+              getBucketLayout())
+          : new OMKeysDeleteResponse(omResponse.build(), getBucketLayout());
       long endNanosDeleteKeyFailureLatencyNs = Time.monotonicNowNanos();
       perfMetrics.setDeleteKeyFailureLatencyNs(endNanosDeleteKeyFailureLatencyNs - startNanos);
     } finally {
@@ -346,7 +389,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       }
       omMetrics.incNumKeyDeletes(deleteKeys.size());
       omMetrics.incNumKeyDeleteFails(unDeletedKeys.getKeysList().size());
-      omMetrics.decNumKeys(deleteKeys.size());
+      omMetrics.decNumKeys(visibleKeysRemoved);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Keys delete success. Volume:{}, Bucket:{}, Keys:{}, sourceType:{}",
             volumeName, bucketName, auditMap.get(DELETED_KEYS_LIST), sourceType);
@@ -420,7 +463,8 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
   private List<DeleteMarkerInsertion> insertDeleteMarkers(
       OzoneManager ozoneManager, OMMetadataManager omMetadataManager,
       OmBucketInfo omBucketInfo, List<OmKeyInfo> omKeyInfoList,
-      long proposedVersionId, long trxnLogIndex) throws IOException {
+      List<String> markerOnlyKeys, long proposedVersionId, long trxnLogIndex)
+      throws IOException {
 
     List<DeleteMarkerInsertion> insertions = new ArrayList<>();
     for (OmKeyInfo currentVersion : omKeyInfoList) {
@@ -430,6 +474,15 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       insertions.add(insertDeleteMarker(ozoneManager, omMetadataManager,
           omBucketInfo, currentVersion, objectKey,
           currentVersion.getKeyName(), proposedVersionId,
+          Time.now(), trxnLogIndex));
+    }
+    // A key the bucket holds no record of supersedes nothing, so the marker
+    // is built without a current version to inherit from.
+    for (String keyName : markerOnlyKeys) {
+      String objectKey = omMetadataManager.getOzoneKey(
+          omBucketInfo.getVolumeName(), omBucketInfo.getBucketName(), keyName);
+      insertions.add(insertDeleteMarker(ozoneManager, omMetadataManager,
+          omBucketInfo, null, objectKey, keyName, proposedVersionId,
           Time.now(), trxnLogIndex));
     }
     return insertions;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
 import org.apache.hadoop.ozone.om.request.validation.ValidationCondition;
 import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeysDeleteMarkerResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeysDeleteResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyArgs;
@@ -110,7 +111,16 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       }
     }
 
-    return getOmRequest();
+    // A delete on a versioned bucket creates a marker per key, and a marker is
+    // a version, so it needs an id proposed here on the OM that received the
+    // request. One covers the batch: versionIds only have to increase within a
+    // key, and each key's own current version raises it if needed.
+    return getOmRequest().toBuilder()
+        .setDeleteKeysRequest(deleteKeysRequest.toBuilder()
+            .setDeleteKeys(deleteKeysRequest.getDeleteKeys().toBuilder()
+                .setProposedVersionId(
+                    ozoneManager.getVersionIdAllocator().propose())))
+        .build();
   }
 
   @Override @SuppressWarnings("methodlength")
@@ -239,15 +249,24 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           getBucketInfo(omMetadataManager, volumeName, bucketName);
 
       Map<String, OmKeyInfo> openKeyInfoMap = new HashMap<>();
-      // Mark all keys which can be deleted, in cache as deleted.
-      Pair<Long, Integer> quotaReleasedEmptyKeys =
-          markKeysAsDeletedInCache(ozoneManager, trxnLogIndex, omKeyInfoList,
-              dirList, omMetadataManager, openKeyInfoMap);
-      omBucketInfo.decrUsedBytes(quotaReleasedEmptyKeys.getKey(), true);
-      // For empty keyInfos the quota should be released and not added to namespace.
-      omBucketInfo.decrUsedNamespace(omKeyInfoList.size() + dirList.size() -
-              quotaReleasedEmptyKeys.getValue(), true);
-      omBucketInfo.decrUsedNamespace(quotaReleasedEmptyKeys.getValue(), false);
+      // On a versioned bucket a delete removes no data: each key gets a delete
+      // marker as its current version, exactly as a single-key delete does.
+      List<DeleteMarkerInsertion> markerInsertions = null;
+      if (omBucketInfo.isS3VersioningEnabled()) {
+        markerInsertions = insertDeleteMarkers(ozoneManager, omMetadataManager,
+            omBucketInfo, omKeyInfoList,
+            deleteKeyArgs.getProposedVersionId(), trxnLogIndex);
+      } else {
+        // Mark all keys which can be deleted, in cache as deleted.
+        Pair<Long, Integer> quotaReleasedEmptyKeys =
+            markKeysAsDeletedInCache(ozoneManager, trxnLogIndex, omKeyInfoList,
+                dirList, omMetadataManager, openKeyInfoMap);
+        omBucketInfo.decrUsedBytes(quotaReleasedEmptyKeys.getKey(), true);
+        // For empty keyInfos the quota should be released and not added to namespace.
+        omBucketInfo.decrUsedNamespace(omKeyInfoList.size() + dirList.size() -
+                quotaReleasedEmptyKeys.getValue(), true);
+        omBucketInfo.decrUsedNamespace(quotaReleasedEmptyKeys.getValue(), false);
+      }
 
       OmLifecycleScanState state = null;
       if (sourceType == RequestSource.LIFECYCLE && deleteKeyRequest.hasScanState()) {
@@ -259,9 +278,17 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       }
 
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
-      omClientResponse =
-          getOmClientResponse(ozoneManager, omKeyInfoList, dirList, omResponse,
-              unDeletedKeys, keyToError, deleteStatus, omBucketInfo, volumeId, openKeyInfoMap, state);
+      if (markerInsertions != null) {
+        omResponse.setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
+            .setStatus(deleteStatus).setUnDeletedKeys(unDeletedKeys))
+            .setStatus(deleteStatus ? OK : PARTIAL_DELETE).setSuccess(deleteStatus);
+        omClientResponse = new OMKeysDeleteMarkerResponse(omResponse.build(),
+            markerInsertions, omBucketInfo.copyObject(), state);
+      } else {
+        omClientResponse =
+            getOmClientResponse(ozoneManager, omKeyInfoList, dirList, omResponse,
+                unDeletedKeys, keyToError, deleteStatus, omBucketInfo, volumeId, openKeyInfoMap, state);
+      }
 
       result = Result.SUCCESS;
       long endNanosDeleteKeySuccessLatencyNs = Time.monotonicNowNanos();
@@ -382,6 +409,30 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
         .build(), omKeyInfoList,
         omBucketInfo.copyObject(), openKeyInfoMap, scanState);
     return omClientResponse;
+  }
+
+  /**
+   * Inserts a delete marker for every key that survived validation, reusing
+   * the implementation a single-key delete uses so the two cannot drift.
+   *
+   * @return what each insertion changed, for the response to write out
+   */
+  private List<DeleteMarkerInsertion> insertDeleteMarkers(
+      OzoneManager ozoneManager, OMMetadataManager omMetadataManager,
+      OmBucketInfo omBucketInfo, List<OmKeyInfo> omKeyInfoList,
+      long proposedVersionId, long trxnLogIndex) throws IOException {
+
+    List<DeleteMarkerInsertion> insertions = new ArrayList<>();
+    for (OmKeyInfo currentVersion : omKeyInfoList) {
+      String objectKey = omMetadataManager.getOzoneKey(
+          currentVersion.getVolumeName(), currentVersion.getBucketName(),
+          currentVersion.getKeyName());
+      insertions.add(insertDeleteMarker(ozoneManager, omMetadataManager,
+          omBucketInfo, currentVersion, objectKey,
+          currentVersion.getKeyName(), proposedVersionId,
+          Time.now(), trxnLogIndex));
+    }
+    return insertions;
   }
 
   protected Pair<Long, Integer> markKeysAsDeletedInCache(OzoneManager ozoneManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -467,24 +467,32 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       throws IOException {
 
     List<DeleteMarkerInsertion> insertions = new ArrayList<>();
+    // Applied to the bucket only once every marker is in, so that a batch
+    // failing on a later key leaves the cached bucket as it found it.
+    long pendingNamespace = 0;
     for (OmKeyInfo currentVersion : omKeyInfoList) {
       String objectKey = omMetadataManager.getOzoneKey(
           currentVersion.getVolumeName(), currentVersion.getBucketName(),
           currentVersion.getKeyName());
-      insertions.add(insertDeleteMarker(ozoneManager, omMetadataManager,
-          omBucketInfo, currentVersion, objectKey,
+      DeleteMarkerInsertion insertion = insertDeleteMarker(ozoneManager,
+          omMetadataManager, omBucketInfo, currentVersion, objectKey,
           currentVersion.getKeyName(), proposedVersionId,
-          Time.now(), trxnLogIndex));
+          Time.now(), trxnLogIndex, pendingNamespace);
+      pendingNamespace += insertion.getAddedNamespace();
+      insertions.add(insertion);
     }
     // A key the bucket holds no record of supersedes nothing, so the marker
     // is built without a current version to inherit from.
     for (String keyName : markerOnlyKeys) {
       String objectKey = omMetadataManager.getOzoneKey(
           omBucketInfo.getVolumeName(), omBucketInfo.getBucketName(), keyName);
-      insertions.add(insertDeleteMarker(ozoneManager, omMetadataManager,
-          omBucketInfo, null, objectKey, keyName, proposedVersionId,
-          Time.now(), trxnLogIndex));
+      DeleteMarkerInsertion insertion = insertDeleteMarker(ozoneManager,
+          omMetadataManager, omBucketInfo, null, objectKey, keyName,
+          proposedVersionId, Time.now(), trxnLogIndex, pendingNamespace);
+      pendingNamespace += insertion.getAddedNamespace();
+      insertions.add(insertion);
     }
+    omBucketInfo.incrUsedNamespace(pendingNamespace);
     return insertions;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -331,7 +331,12 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         OmKeyInfo keyToDelete =
             omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
         boolean isNamespaceUpdate = false;
-        if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
+        // The S3 versioning check is redundant while the legacy flag is kept in
+        // sync with an ENABLED status, but the reclaim must depend on the
+        // status rather than on that sync: dropping the previous version's
+        // blocks would strand the version record kept for it.
+        if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()
+            && !omBucketInfo.isS3VersioningEnabled()) {
           RepeatedOmKeyInfo oldKeyVersionsToDelete = getOldVersionsToCleanUp(
               keyToDelete, omBucketInfo.getObjectID(), trxnLogIndex);
           allKeyInfoToRemove.addAll(oldKeyVersionsToDelete.getOmKeyInfoList());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -338,7 +338,12 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         OmKeyInfo keyToDelete =
             omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
         boolean isNamespaceUpdate = false;
-        if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
+        // The S3 versioning check is redundant while the legacy flag is kept in
+        // sync with an ENABLED status, but the reclaim must depend on the
+        // status rather than on that sync: dropping the previous version's
+        // blocks would strand the version record kept for it.
+        if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()
+            && !omBucketInfo.isS3VersioningEnabled()) {
           RepeatedOmKeyInfo oldKeyVersionsToDelete = getOldVersionsToCleanUp(
               keyToDelete, omBucketInfo.getObjectID(), trxnLogIndex);
           allKeyInfoToRemove.addAll(oldKeyVersionsToDelete.getOmKeyInfoList());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VERSIONED_KEY_TABLE;
 
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nonnull;
@@ -39,7 +40,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * Response for CommitKey request.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, KEY_TABLE, DELETED_TABLE,
-    BUCKET_TABLE})
+    BUCKET_TABLE, VERSIONED_KEY_TABLE})
 public class OMKeyCommitResponse extends OmKeyResponse {
 
   private OmKeyInfo omKeyInfo;
@@ -51,6 +52,8 @@ public class OMKeyCommitResponse extends OmKeyResponse {
   private OmKeyInfo newOpenKeyInfo;
   private OmKeyInfo openKeyToUpdate;
   private String openKeyNameToUpdate;
+  private String versionedKeyName;
+  private OmKeyInfo versionedKeyInfo;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public OMKeyCommitResponse(
@@ -82,6 +85,17 @@ public class OMKeyCommitResponse extends OmKeyResponse {
     checkStatusNotOK();
   }
 
+  /**
+   * The version this commit overwrote, to be kept in the versionedKeyTable as
+   * a noncurrent version. Null for buckets without S3-compatible versioning.
+   */
+  public OMKeyCommitResponse withVersionedKey(String dbVersionedKey,
+      OmKeyInfo keyInfo) {
+    this.versionedKeyName = dbVersionedKey;
+    this.versionedKeyInfo = keyInfo;
+    return this;
+  }
+
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
@@ -97,6 +111,11 @@ public class OMKeyCommitResponse extends OmKeyResponse {
 
     omMetadataManager.getKeyTable(getBucketLayout())
         .putWithBatch(batchOperation, ozoneKeyName, omKeyInfo);
+
+    if (versionedKeyInfo != null) {
+      omMetadataManager.getVersionedKeyTable()
+          .putWithBatch(batchOperation, versionedKeyName, versionedKeyInfo);
+    }
 
     updateDeletedTable(omMetadataManager, batchOperation);
     handleOpenKeyToUpdate(omMetadataManager, batchOperation);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteMarkerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteMarkerResponse.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.key;
+
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VERSIONED_KEY_TABLE;
+
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+/**
+ * Response for a DeleteKey request on a bucket with S3-compatible versioning
+ * enabled: no data is removed. A delete marker becomes the current version in
+ * the keyTable, and the version it supersedes (if the key existed) moves to
+ * the versionedKeyTable.
+ */
+@CleanupTableInfo(cleanupTables = {KEY_TABLE, VERSIONED_KEY_TABLE, BUCKET_TABLE})
+public class OMKeyDeleteMarkerResponse extends OmKeyResponse {
+
+  private OmKeyInfo deleteMarker;
+  private String ozoneKeyName;
+  private String movedVersionedKeyName;
+  private OmKeyInfo movedVersionedKeyInfo;
+  private OmBucketInfo omBucketInfo;
+
+  public OMKeyDeleteMarkerResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmKeyInfo deleteMarker, @Nonnull String ozoneKeyName,
+      String movedVersionedKeyName, OmKeyInfo movedVersionedKeyInfo,
+      @Nonnull OmBucketInfo omBucketInfo) {
+    super(omResponse, omBucketInfo.getBucketLayout());
+    this.deleteMarker = deleteMarker;
+    this.ozoneKeyName = ozoneKeyName;
+    this.movedVersionedKeyName = movedVersionedKeyName;
+    this.movedVersionedKeyInfo = movedVersionedKeyInfo;
+    this.omBucketInfo = omBucketInfo;
+  }
+
+  /**
+   * For when the request is not successful.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMKeyDeleteMarkerResponse(@Nonnull OMResponse omResponse,
+      @Nonnull BucketLayout bucketLayout) {
+    super(omResponse, bucketLayout);
+    checkStatusNotOK();
+  }
+
+  @Override
+  public void addToDBBatch(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+    omMetadataManager.getKeyTable(getBucketLayout())
+        .putWithBatch(batchOperation, ozoneKeyName, deleteMarker);
+
+    if (movedVersionedKeyInfo != null) {
+      omMetadataManager.getVersionedKeyTable().putWithBatch(batchOperation,
+          movedVersionedKeyName, movedVersionedKeyInfo);
+    }
+
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),
+            omBucketInfo.getBucketName()), omBucketInfo);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteMarkerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteMarkerResponse.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.key;
+
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.LIFECYCLE_SCAN_STATE_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VERSIONED_KEY_TABLE;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.PARTIAL_DELETE;
+
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmLifecycleScanState;
+import org.apache.hadoop.ozone.om.request.key.DeleteMarkerInsertion;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+/**
+ * Response for a batch DeleteKeys request on a bucket with S3-compatible
+ * versioning enabled: no data is removed. Each key gets a delete marker as its
+ * current version, and the version each marker supersedes moves to the
+ * versionedKeyTable.
+ *
+ * <p>The single-key counterpart is {@link OMKeyDeleteMarkerResponse}; both
+ * write out what {@code OMKeyRequest.insertDeleteMarker} produced.
+ */
+@CleanupTableInfo(cleanupTables = {KEY_TABLE, VERSIONED_KEY_TABLE, BUCKET_TABLE,
+    LIFECYCLE_SCAN_STATE_TABLE})
+public class OMKeysDeleteMarkerResponse extends OmKeyResponse {
+
+  private List<DeleteMarkerInsertion> insertions;
+  private OmBucketInfo omBucketInfo;
+  private OmLifecycleScanState scanState;
+
+  public OMKeysDeleteMarkerResponse(@Nonnull OMResponse omResponse,
+      @Nonnull List<DeleteMarkerInsertion> insertions,
+      @Nonnull OmBucketInfo omBucketInfo, OmLifecycleScanState scanState) {
+    super(omResponse, BucketLayout.OBJECT_STORE);
+    this.insertions = insertions;
+    this.omBucketInfo = omBucketInfo;
+    this.scanState = scanState;
+  }
+
+  /**
+   * For when the request is not successful.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMKeysDeleteMarkerResponse(@Nonnull OMResponse omResponse,
+      @Nonnull BucketLayout bucketLayout) {
+    super(omResponse, bucketLayout);
+    checkStatusNotOK();
+  }
+
+  @Override
+  public void checkAndUpdateDB(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+    if (getOMResponse().getStatus() == OK
+        || getOMResponse().getStatus() == PARTIAL_DELETE) {
+      addToDBBatch(omMetadataManager, batchOperation);
+    }
+  }
+
+  @Override
+  public void addToDBBatch(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+
+    for (DeleteMarkerInsertion inserted : insertions) {
+      // The version the marker supersedes and the marker itself go in one
+      // batch, so a reader never sees the key without either.
+      if (inserted.getDemotedVersion() != null) {
+        omMetadataManager.getVersionedKeyTable().putWithBatch(batchOperation,
+            inserted.getDemotedVersionKey(), inserted.getDemotedVersion());
+      }
+      omMetadataManager.getKeyTable(getBucketLayout()).putWithBatch(
+          batchOperation, inserted.getObjectKey(), inserted.getDeleteMarker());
+    }
+
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),
+            omBucketInfo.getBucketName()), omBucketInfo);
+
+    if (scanState != null) {
+      omMetadataManager.getLifecycleScanStateTable().putWithBatch(
+          batchOperation, scanState.getBucketKey(), scanState);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
@@ -44,7 +44,10 @@ public enum OMLayoutFeature implements LayoutFeature {
   QUOTA(6, "Ozone quota re-calculate"),
   HBASE_SUPPORT(7, "Full support of hsync, lease recovery and listOpenFiles APIs for HBase"),
   DELEGATION_TOKEN_SYMMETRIC_SIGN(8, "Delegation token signed by symmetric key"),
-  SNAPSHOT_DEFRAG(9, "Supporting defragmentation of snapshot");
+  SNAPSHOT_DEFRAG(9, "Supporting defragmentation of snapshot"),
+
+  OBJECT_VERSIONING(10, "S3-compatible object versioning: bucket versioning"
+      + " state machine and the versionedKeyTable for noncurrent versions");
 
   ///////////////////////////////  /////////////////////////////
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
@@ -46,7 +46,10 @@ public enum OMLayoutFeature implements LayoutFeature {
   DELEGATION_TOKEN_SYMMETRIC_SIGN(8, "Delegation token signed by symmetric key"),
   SNAPSHOT_DEFRAG(9, "Supporting defragmentation of snapshot"),
   S3_LIFECYCLE_SUPPORT(10, "S3 bucket lifecycle configuration support"),
-  MPU_PARTS_TABLE_SPLIT(11, "Split multipart table into separate table for parts and key");
+  MPU_PARTS_TABLE_SPLIT(11, "Split multipart table into separate table for parts and key"),
+
+  OBJECT_VERSIONING(12, "S3-compatible object versioning: bucket versioning"
+      + " state machine and the versionedKeyTable for noncurrent versions");
 
   ///////////////////////////////  /////////////////////////////
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -46,6 +46,7 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.TENANT_ACCESS_ID_T
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.TENANT_STATE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.TRANSACTION_INFO_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.USER_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VERSIONED_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VOLUME_TABLE;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
@@ -120,6 +121,7 @@ public class TestOmMetadataManager {
       VOLUME_TABLE,
       BUCKET_TABLE,
       KEY_TABLE,
+      VERSIONED_KEY_TABLE,
       DELETED_TABLE,
       OPEN_KEY_TABLE,
       MULTIPART_INFO_TABLE,
@@ -170,6 +172,23 @@ public class TestOmMetadataManager {
 
     assertEquals(3, transactionInfo.getTerm());
     assertEquals(250, transactionInfo.getTransactionIndex());
+  }
+
+  @Test
+  public void testVersionedOzoneKeyOrdering() {
+    String prefix = omMetadataManager.getVersionedOzoneKeyPrefix("vol", "buck", "key");
+    assertEquals("/vol/buck/key/", prefix);
+
+    // newer versions (larger versionId) must sort before older ones, and all
+    // versioned keys must sort under the key's prefix
+    String v1 = omMetadataManager.getVersionedOzoneKey("vol", "buck", "key", 1L);
+    String v2 = omMetadataManager.getVersionedOzoneKey("vol", "buck", "key", 42L);
+    String v3 = omMetadataManager.getVersionedOzoneKey("vol", "buck", "key", Long.MAX_VALUE - 1);
+    assertThat(v3).startsWith(prefix).isLessThan(v2);
+    assertThat(v2).startsWith(prefix).isLessThan(v1);
+
+    // fixed-width suffix: identical length regardless of versionId magnitude
+    assertEquals(v1.length(), v3.length());
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -186,7 +186,7 @@ public class TestOmMetadataManager {
   @Test
   public void testVersionedOzoneKeyOrdering() {
     String prefix = omMetadataManager.getVersionedOzoneKeyPrefix("vol", "buck", "key");
-    assertEquals("/vol/buck/key/", prefix);
+    assertEquals("/vol/buck/key\0", prefix);
 
     // newer versions (larger versionId) must sort before older ones, and all
     // versioned keys must sort under the key's prefix
@@ -198,6 +198,25 @@ public class TestOmMetadataManager {
 
     // fixed-width suffix: identical length regardless of versionId magnitude
     assertEquals(v1.length(), v3.length());
+  }
+
+  @Test
+  public void testVersionedOzoneKeyIsolatedFromNestedKeys() {
+    // OBJECT_STORE key names contain '/' verbatim, so "key" and "key/001" are two
+    // unrelated keys. Every version of "key" must sort under "key"'s prefix and
+    // ahead of anything belonging to "key/001", otherwise a prefix seek for the
+    // newest noncurrent version of "key" would land on a version of "key/001".
+    String prefix = omMetadataManager.getVersionedOzoneKeyPrefix("vol", "buck", "key");
+    String nestedPrefix = omMetadataManager.getVersionedOzoneKeyPrefix("vol", "buck", "key/001");
+    assertThat(nestedPrefix).doesNotStartWith(prefix);
+
+    String oldest = omMetadataManager.getVersionedOzoneKey("vol", "buck", "key", 1L);
+    String nestedNewest =
+        omMetadataManager.getVersionedOzoneKey("vol", "buck", "key/001", Long.MAX_VALUE - 1);
+    assertThat(oldest).isLessThan(nestedNewest);
+
+    // the nested key's own current entry in keyTable also sorts after all of them
+    assertThat(oldest).isLessThan(omMetadataManager.getOzoneKey("vol", "buck", "key/001"));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -177,7 +177,7 @@ public class TestOmMetadataManager {
   @Test
   public void testVersionedOzoneKeyOrdering() {
     String prefix = omMetadataManager.getVersionedOzoneKeyPrefix("vol", "buck", "key");
-    assertEquals("/vol/buck/key/", prefix);
+    assertEquals("/vol/buck/key\0", prefix);
 
     // newer versions (larger versionId) must sort before older ones, and all
     // versioned keys must sort under the key's prefix
@@ -189,6 +189,25 @@ public class TestOmMetadataManager {
 
     // fixed-width suffix: identical length regardless of versionId magnitude
     assertEquals(v1.length(), v3.length());
+  }
+
+  @Test
+  public void testVersionedOzoneKeyIsolatedFromNestedKeys() {
+    // OBJECT_STORE key names contain '/' verbatim, so "key" and "key/001" are two
+    // unrelated keys. Every version of "key" must sort under "key"'s prefix and
+    // ahead of anything belonging to "key/001", otherwise a prefix seek for the
+    // newest noncurrent version of "key" would land on a version of "key/001".
+    String prefix = omMetadataManager.getVersionedOzoneKeyPrefix("vol", "buck", "key");
+    String nestedPrefix = omMetadataManager.getVersionedOzoneKeyPrefix("vol", "buck", "key/001");
+    assertThat(nestedPrefix).doesNotStartWith(prefix);
+
+    String oldest = omMetadataManager.getVersionedOzoneKey("vol", "buck", "key", 1L);
+    String nestedNewest =
+        omMetadataManager.getVersionedOzoneKey("vol", "buck", "key/001", Long.MAX_VALUE - 1);
+    assertThat(oldest).isLessThan(nestedNewest);
+
+    // the nested key's own current entry in keyTable also sorts after all of them
+    assertThat(oldest).isLessThan(omMetadataManager.getOzoneKey("vol", "buck", "key/001"));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -48,6 +48,7 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.TENANT_ACCESS_ID_T
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.TENANT_STATE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.TRANSACTION_INFO_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.USER_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VERSIONED_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VOLUME_TABLE;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
@@ -127,6 +128,7 @@ public class TestOmMetadataManager {
       VOLUME_TABLE,
       BUCKET_TABLE,
       KEY_TABLE,
+      VERSIONED_KEY_TABLE,
       DELETED_TABLE,
       OPEN_KEY_TABLE,
       MULTIPART_INFO_TABLE,
@@ -179,6 +181,23 @@ public class TestOmMetadataManager {
 
     assertEquals(3, transactionInfo.getTerm());
     assertEquals(250, transactionInfo.getTransactionIndex());
+  }
+
+  @Test
+  public void testVersionedOzoneKeyOrdering() {
+    String prefix = omMetadataManager.getVersionedOzoneKeyPrefix("vol", "buck", "key");
+    assertEquals("/vol/buck/key/", prefix);
+
+    // newer versions (larger versionId) must sort before older ones, and all
+    // versioned keys must sort under the key's prefix
+    String v1 = omMetadataManager.getVersionedOzoneKey("vol", "buck", "key", 1L);
+    String v2 = omMetadataManager.getVersionedOzoneKey("vol", "buck", "key", 42L);
+    String v3 = omMetadataManager.getVersionedOzoneKey("vol", "buck", "key", Long.MAX_VALUE - 1);
+    assertThat(v3).startsWith(prefix).isLessThan(v2);
+    assertThat(v2).startsWith(prefix).isLessThan(v1);
+
+    // fixed-width suffix: identical length regardless of versionId magnitude
+    assertEquals(v1.length(), v3.length());
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -1619,4 +1619,19 @@ public class TestOmMetadataManager {
         .collect(Collectors.toList());
     assertEquals(Collections.singletonList(newlinePrefixed), newlinePrefixMatches);
   }
+
+  /**
+   * The SST filter trims a snapshot's versionedKeyTable to its bucket, by the same prefix as the keyTable, which its
+   * keys share.
+   */
+  @Test
+  public void testVersionedKeyTableHasTheBucketKeyPrefix() throws Exception {
+    OMRequestTestUtils.addVolumeAndBucketToDB("vol1", "bucket1", omMetadataManager);
+    String bucketPrefix = omMetadataManager.getBucketKeyPrefix("vol1", "bucket1");
+
+    assertEquals(bucketPrefix,
+        omMetadataManager.getTableBucketPrefix("vol1", "bucket1").getTablePrefix(VERSIONED_KEY_TABLE));
+    assertEquals(bucketPrefix, omMetadataManager.getTableBucketPrefix(VERSIONED_KEY_TABLE, "vol1", "bucket1"));
+    assertTrue(omMetadataManager.getVersionedOzoneKey("vol1", "bucket1", "key", 1L).startsWith(bucketPrefix));
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVersionIdAllocator.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVersionIdAllocator.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.TransactionIndexVersionIdGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link VersionIdAllocator}: which versionId a commit gets, and the
+ * rejection of ids that are already taken on the key.
+ */
+public class TestVersionIdAllocator {
+
+  private static final String VOLUME = "vol1";
+  private static final String BUCKET = "bucket1";
+  private static final String KEY = "key1";
+
+  private OMMetadataManager metadataManager;
+  private Set<String> versionedKeys;
+  private int lookups;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    versionedKeys = new HashSet<>();
+    lookups = 0;
+
+    Table<String, OmKeyInfo> versionedKeyTable = mock(Table.class);
+    when(versionedKeyTable.isExist(anyString())).thenAnswer(invocation -> {
+      lookups++;
+      return versionedKeys.contains(invocation.getArgument(0));
+    });
+
+    metadataManager = mock(OMMetadataManager.class);
+    when(metadataManager.getVersionedKeyTable()).thenReturn(versionedKeyTable);
+    when(metadataManager.getVersionedOzoneKey(eq(VOLUME), eq(BUCKET), eq(KEY), anyLong()))
+        .thenAnswer(invocation -> dbKey(invocation.getArgument(3)));
+  }
+
+  private static String dbKey(long versionId) {
+    return "/" + VOLUME + "/" + BUCKET + "/" + KEY + "/" + versionId;
+  }
+
+  private VersionIdAllocator allocator() {
+    return new VersionIdAllocator(new TransactionIndexVersionIdGenerator());
+  }
+
+  private static OmKeyInfo keyWithVersionId(Long versionId) {
+    return new OmKeyInfo.Builder()
+        .setVolumeName(VOLUME)
+        .setBucketName(BUCKET)
+        .setKeyName(KEY)
+        .setVersionId(versionId)
+        .build();
+  }
+
+  @Test
+  void allocatesTheTransactionIndexForTheFirstVersion() throws Exception {
+    assertEquals(7, allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 7, null));
+  }
+
+  @Test
+  void allocatesTheTransactionIndexForALaterVersion() throws Exception {
+    assertEquals(9, allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 9,
+        keyWithVersionId(7L)));
+  }
+
+  @Test
+  void rejectsAnIdEqualToTheCurrentVersion() {
+    OMException e = assertThrows(OMException.class,
+        () -> allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 7,
+            keyWithVersionId(7L)));
+
+    assertEquals(OMException.ResultCodes.INVALID_REQUEST, e.getResult());
+  }
+
+  @Test
+  void rejectsAnIdOlderThanTheCurrentVersion() {
+    // Refused even though no version holds this id: writing it would sort the
+    // new version before versions that predate it.
+    OMException e = assertThrows(OMException.class,
+        () -> allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 5,
+            keyWithVersionId(9L)));
+
+    assertEquals(OMException.ResultCodes.INVALID_REQUEST, e.getResult());
+  }
+
+  @Test
+  void skipsTheLookupWhenTheKeyHasNoCurrentVersion() throws Exception {
+    assertEquals(7, allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 7, null));
+    assertEquals(0, lookups);
+  }
+
+  @Test
+  void skipsTheLookupWhenTheGeneratedIdIsNewerThanTheCurrentVersion() throws Exception {
+    // The steady-state path: the current version holds the key's largest id, so
+    // an id above it cannot be taken and costs no read.
+    assertEquals(9, allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 9,
+        keyWithVersionId(7L)));
+    assertEquals(0, lookups);
+  }
+
+  @Test
+  void skipsTheLookupWhenTheIdIsRefusedForGoingBackwards() {
+    assertThrows(OMException.class,
+        () -> allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 5,
+            keyWithVersionId(9L)));
+
+    assertEquals(0, lookups);
+  }
+
+  @Test
+  void looksUpTheTableForACurrentVersionPredatingVersioning() throws Exception {
+    // Keys written before versioning was enabled carry no versionId, so there
+    // is nothing to order against and the id has to be looked up.
+    assertEquals(7, allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 7,
+        keyWithVersionId(null)));
+
+    assertEquals(1, lookups);
+  }
+
+  @Test
+  void rejectsATakenIdForACurrentVersionPredatingVersioning() {
+    versionedKeys.add(dbKey(7));
+
+    OMException e = assertThrows(OMException.class,
+        () -> allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 7,
+            keyWithVersionId(null)));
+
+    assertEquals(OMException.ResultCodes.KEY_ALREADY_EXISTS, e.getResult());
+  }
+
+  @Test
+  void allowsAnIdHeldByAnotherKeysVersion() throws Exception {
+    // Ids are only unique within a key, so another key holding it is fine.
+    versionedKeys.add("/" + VOLUME + "/" + BUCKET + "/otherKey/7");
+
+    assertEquals(7, allocator().allocate(metadataManager, VOLUME, BUCKET, KEY, 7,
+        keyWithVersionId(null)));
+  }
+
+  @Test
+  void usesTheGeneratorConfiguredForTheCluster() {
+    assertInstanceOf(TransactionIndexVersionIdGenerator.class,
+        new VersionIdAllocator(new OzoneConfiguration()).getGenerator());
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVersionIdAllocator.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVersionIdAllocator.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om;
 
+import static org.apache.hadoop.ozone.om.helpers.PinnedFirstVersionIdGenerator.FIRST_VERSION_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.PinnedFirstVersionIdGenerator;
 import org.apache.hadoop.ozone.om.helpers.UniqueIdVersionIdGenerator;
 import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.junit.jupiter.api.Test;
@@ -156,6 +158,32 @@ public class TestVersionIdAllocator {
           "the allocator should hold nothing but its generator, but holds "
               + field.getType().getName() + " " + field.getName());
     }
+  }
+
+  /**
+   * Whether the key has a current version is settled under the write's lock, so
+   * a generator that numbers the first one specially decides it here.
+   */
+  @Test
+  void thePinnedGeneratorGivesTheFirstVersionTheSentinel() {
+    VersionIdAllocator allocator =
+        new VersionIdAllocator(new PinnedFirstVersionIdGenerator());
+
+    assertEquals(FIRST_VERSION_ID, allocator.allocate(5000L, null));
+  }
+
+  @Test
+  void thePinnedGeneratorLeavesLaterVersionsAlone() {
+    VersionIdAllocator allocator =
+        new VersionIdAllocator(new PinnedFirstVersionIdGenerator());
+
+    assertEquals(5000L,
+        allocator.allocate(5000L, versionWithId(FIRST_VERSION_ID)));
+  }
+
+  @Test
+  void theDefaultGeneratorDoesNotPinTheFirstVersion() {
+    assertEquals(5000L, allocator().allocate(5000L, null));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVersionIdAllocator.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVersionIdAllocator.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.UniqueIdVersionIdGenerator;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link VersionIdAllocator}: a proposal is a floor, and the id a version
+ * is applied with always comes after the key's current version, however the
+ * clock behaved.
+ */
+public class TestVersionIdAllocator {
+
+  private static final String VOLUME = "vol1";
+  private static final String BUCKET = "bucket1";
+  private static final String KEY = "key1";
+
+  /** Hands out the readings it was given, standing in for a wall clock. */
+  private static VersionIdGenerator clockReading(long... readings) {
+    final Deque<Long> queue = new ArrayDeque<>();
+    Arrays.stream(readings).forEach(queue::add);
+    return () -> queue.size() > 1 ? queue.poll() : queue.peek();
+  }
+
+  private static VersionIdAllocator allocator() {
+    return new VersionIdAllocator(new UniqueIdVersionIdGenerator());
+  }
+
+  private static OmKeyInfo versionWithId(Long versionId) {
+    OmKeyInfo.Builder builder = new OmKeyInfo.Builder()
+        .setVolumeName(VOLUME)
+        .setBucketName(BUCKET)
+        .setKeyName(KEY)
+        .setReplicationConfig(
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+    if (versionId != null) {
+      builder.setVersionId(versionId);
+    }
+    return builder.build();
+  }
+
+  @Test
+  void theProposalComesFromTheGenerator() {
+    VersionIdAllocator allocator =
+        new VersionIdAllocator(clockReading(1234L, 5678L));
+
+    assertEquals(1234L, allocator.propose());
+    assertEquals(5678L, allocator.propose());
+  }
+
+  @Test
+  void theFirstVersionOfAKeyTakesTheProposedId() {
+    assertEquals(5000L, allocator().allocate(5000L, null));
+  }
+
+  @Test
+  void aLaterVersionTakesTheProposedIdWhenTheClockMovedOn() {
+    assertEquals(5000L, allocator().allocate(5000L, versionWithId(4000L)));
+  }
+
+  /**
+   * Two versions of one key proposed inside the same millisecond can exhaust
+   * the counter that separates them; the second still has to come after the
+   * first.
+   */
+  @Test
+  void aRepeatedProposalStillMovesTheKeyForward() {
+    assertEquals(4001L, allocator().allocate(4000L, versionWithId(4000L)));
+  }
+
+  /**
+   * The case no wall clock handles on its own: a leader change onto a node
+   * whose clock lags, which would otherwise sort the new version before the one
+   * it supersedes.
+   */
+  @Test
+  void aClockThatWentBackwardsDoesNotReorderTheKey() {
+    assertEquals(9001L, allocator().allocate(3000L, versionWithId(9000L)));
+  }
+
+  @Test
+  void everyAllocationComesAfterTheCurrentVersion() {
+    VersionIdAllocator allocator = allocator();
+    long currentId = 1_000_000L;
+
+    for (long proposed : new long[] {2_000_000L, 1L, 1_000_000L, 2_000_001L}) {
+      long allocated = allocator.allocate(proposed, versionWithId(currentId));
+      assertTrue(allocated > currentId,
+          "allocated " + allocated + " does not come after " + currentId);
+      currentId = allocated;
+    }
+  }
+
+  /**
+   * A current version written before versioning was enabled carries no id, and
+   * a key in that state has no other versions to order against.
+   */
+  @Test
+  void aVersionPredatingVersioningDoesNotConstrainTheId() {
+    assertEquals(7000L, allocator().allocate(7000L, versionWithId(null)));
+  }
+
+  /**
+   * A request that reaches apply without a proposal would otherwise take the
+   * reserved unset value as its id, and read back as a version that predates
+   * versioning.
+   */
+  @Test
+  void aVersionCannotBeAppliedWithoutAProposal() {
+    assertThrows(IllegalArgumentException.class,
+        () -> allocator().allocate(VersionIdGenerator.UNSET_VERSION_ID, null));
+  }
+
+  /**
+   * The floor comes from the current version the write path already holds, so
+   * the allocator reads nothing of its own - versionedKeyTable included. It
+   * holds no table to read one from.
+   */
+  @Test
+  void theAllocatorReadsNoTable() {
+    for (Field field : VersionIdAllocator.class.getDeclaredFields()) {
+      if (field.isSynthetic()) {
+        continue;
+      }
+      assertEquals(VersionIdGenerator.class, field.getType(),
+          "the allocator should hold nothing but its generator, but holds "
+              + field.getType().getName() + " " + field.getName());
+    }
+  }
+
+  @Test
+  void theAllocatorTakesItsGeneratorFromConfiguration() {
+    assertInstanceOf(UniqueIdVersionIdGenerator.class,
+        new VersionIdAllocator(new OzoneConfiguration()).getGenerator());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -413,6 +413,29 @@ public class TestOMBucketCreateRequest extends BucketRequestTests {
     }
   }
 
+  @Test
+  public void testVersioningStatusRejectedAtCreation() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    addCreateVolumeToTable(volumeName, omMetadataManager);
+
+    OMRequest request = newCreateBucketRequest(
+        newBucketInfoBuilder(bucketName, volumeName)
+            .setVersioningStatus(OzoneManagerProtocolProtos
+                .BucketVersioningStatusProto.VERSIONING_ENABLED)).build();
+
+    OMException omException = assertThrows(OMException.class,
+        () -> new OMBucketCreateRequest(request).preExecute(ozoneManager));
+    assertEquals(OMException.ResultCodes.INVALID_REQUEST,
+        omException.getResult());
+
+    // the same request without a status is accepted
+    OMRequest withoutStatus = newCreateBucketRequest(
+        newBucketInfoBuilder(bucketName, volumeName)).build();
+    assertNotNull(
+        new OMBucketCreateRequest(withoutStatus).preExecute(ozoneManager));
+  }
+
   private void acceptBucketCreationHelper(String volumeName, String bucketName)
         throws Exception {
     OMBucketCreateRequest omBucketCreateRequest = 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.BucketVersioningStatus;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -420,6 +421,112 @@ public class TestOMBucketSetPropertyRequest extends BucketRequestTests {
     assertThat(omClientResponse.getOMResponse().getMessage()).
         contains("Cannot update bucket quota. NamespaceQuota requested " +
             "is less than used namespaceQuota");
+  }
+
+  @Test
+  public void testVersioningStatusTransitions() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
+        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+
+    // UNVERSIONED -> ENABLED
+    OMClientResponse response = new OMBucketSetPropertyRequest(
+        createSetVersioningStatusRequest(volumeName, bucketName,
+            BucketVersioningStatus.ENABLED)).validateAndUpdateCache(ozoneManager, 1);
+    assertTrue(response.getOMResponse().getSuccess());
+    OmBucketInfo dbBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    assertEquals(BucketVersioningStatus.ENABLED, dbBucketInfo.getVersioningStatus());
+    assertTrue(dbBucketInfo.getIsVersionEnabled());
+
+    // ENABLED -> SUSPENDED
+    response = new OMBucketSetPropertyRequest(
+        createSetVersioningStatusRequest(volumeName, bucketName,
+            BucketVersioningStatus.SUSPENDED)).validateAndUpdateCache(ozoneManager, 2);
+    assertTrue(response.getOMResponse().getSuccess());
+    dbBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    assertEquals(BucketVersioningStatus.SUSPENDED, dbBucketInfo.getVersioningStatus());
+    assertFalse(dbBucketInfo.getIsVersionEnabled());
+
+    // SUSPENDED -> UNVERSIONED is rejected
+    response = new OMBucketSetPropertyRequest(
+        createSetVersioningStatusRequest(volumeName, bucketName,
+            BucketVersioningStatus.UNVERSIONED)).validateAndUpdateCache(ozoneManager, 3);
+    assertFalse(response.getOMResponse().getSuccess());
+    assertEquals(OzoneManagerProtocolProtos.Status.INVALID_REQUEST,
+        response.getOMResponse().getStatus());
+    assertThat(response.getOMResponse().getMessage())
+        .contains("once enabled, versioning can only be suspended");
+    assertEquals(BucketVersioningStatus.SUSPENDED,
+        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+
+    // SUSPENDED -> ENABLED
+    response = new OMBucketSetPropertyRequest(
+        createSetVersioningStatusRequest(volumeName, bucketName,
+            BucketVersioningStatus.ENABLED)).validateAndUpdateCache(ozoneManager, 4);
+    assertTrue(response.getOMResponse().getSuccess());
+    assertEquals(BucketVersioningStatus.ENABLED,
+        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+  }
+
+  @Test
+  public void testLegacyVersioningFlagMapsToStateMachine() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+    // legacy false on a never-enabled bucket stays UNVERSIONED
+    OMClientResponse response = new OMBucketSetPropertyRequest(
+        createSetVersioningFlagRequest(volumeName, bucketName, false))
+        .validateAndUpdateCache(ozoneManager, 1);
+    assertTrue(response.getOMResponse().getSuccess());
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
+        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+
+    // legacy true -> ENABLED
+    response = new OMBucketSetPropertyRequest(
+        createSetVersioningFlagRequest(volumeName, bucketName, true))
+        .validateAndUpdateCache(ozoneManager, 2);
+    assertTrue(response.getOMResponse().getSuccess());
+    assertEquals(BucketVersioningStatus.ENABLED,
+        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+
+    // legacy false after enabling -> SUSPENDED, not UNVERSIONED
+    response = new OMBucketSetPropertyRequest(
+        createSetVersioningFlagRequest(volumeName, bucketName, false))
+        .validateAndUpdateCache(ozoneManager, 3);
+    assertTrue(response.getOMResponse().getSuccess());
+    OmBucketInfo dbBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    assertEquals(BucketVersioningStatus.SUSPENDED, dbBucketInfo.getVersioningStatus());
+    assertFalse(dbBucketInfo.getIsVersionEnabled());
+  }
+
+  private OMRequest createSetVersioningStatusRequest(String volumeName,
+      String bucketName, BucketVersioningStatus status) {
+    return OMRequest.newBuilder().setSetBucketPropertyRequest(
+        SetBucketPropertyRequest.newBuilder().setBucketArgs(
+            BucketArgs.newBuilder().setBucketName(bucketName)
+                .setVolumeName(volumeName)
+                .setVersioningStatus(status.toProto()).build()))
+        .setCmdType(OzoneManagerProtocolProtos.Type.SetBucketProperty)
+        .setClientId(UUID.randomUUID().toString()).build();
+  }
+
+  private OMRequest createSetVersioningFlagRequest(String volumeName,
+      String bucketName, boolean isVersionEnabled) {
+    return OMRequest.newBuilder().setSetBucketPropertyRequest(
+        SetBucketPropertyRequest.newBuilder().setBucketArgs(
+            BucketArgs.newBuilder().setBucketName(bucketName)
+                .setVolumeName(volumeName)
+                .setIsVersionEnabled(isVersionEnabled).build()))
+        .setCmdType(OzoneManagerProtocolProtos.Type.SetBucketProperty)
+        .setClientId(UUID.randomUUID().toString()).build();
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -24,20 +24,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.BucketVersioningStatus;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -505,6 +513,47 @@ public class TestOMBucketSetPropertyRequest extends BucketRequestTests {
     OmBucketInfo dbBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
     assertEquals(BucketVersioningStatus.SUSPENDED, dbBucketInfo.getVersioningStatus());
     assertFalse(dbBucketInfo.getIsVersionEnabled());
+  }
+
+  @Test
+  public void testVersioningStatusRejectedBeforeFinalization()
+      throws Exception {
+    OMRequest request = createSetVersioningStatusRequest(
+        UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+        BucketVersioningStatus.ENABLED);
+
+    OMLayoutVersionManager preFinalizedVersionManager =
+        mock(OMLayoutVersionManager.class);
+    when(preFinalizedVersionManager
+        .isAllowed(OMLayoutFeature.OBJECT_VERSIONING)).thenReturn(false);
+    ValidationContext preFinalizedContext = ValidationContext.of(
+        preFinalizedVersionManager, omMetadataManager);
+
+    OMException omException = assertThrows(OMException.class,
+        () -> OMBucketSetPropertyRequest
+            .disallowSetBucketPropertyWithVersioningStatus(
+                request, preFinalizedContext));
+    assertEquals(OMException.ResultCodes
+            .NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION,
+        omException.getResult());
+
+    // requests without a versioningStatus pass through untouched
+    OMRequest legacyRequest = createSetVersioningFlagRequest(
+        UUID.randomUUID().toString(), UUID.randomUUID().toString(), true);
+    assertSame(legacyRequest, OMBucketSetPropertyRequest
+        .disallowSetBucketPropertyWithVersioningStatus(
+            legacyRequest, preFinalizedContext));
+
+    // after finalization the request passes through untouched
+    OMLayoutVersionManager finalizedVersionManager =
+        mock(OMLayoutVersionManager.class);
+    when(finalizedVersionManager
+        .isAllowed(OMLayoutFeature.OBJECT_VERSIONING)).thenReturn(true);
+    ValidationContext finalizedContext = ValidationContext.of(
+        finalizedVersionManager, omMetadataManager);
+    assertSame(request, OMBucketSetPropertyRequest
+        .disallowSetBucketPropertyWithVersioningStatus(
+            request, finalizedContext));
   }
 
   private OMRequest createSetVersioningStatusRequest(String volumeName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -497,20 +497,31 @@ public class TestOMBucketSetPropertyRequest extends BucketRequestTests {
     assertEquals(BucketVersioningStatus.UNVERSIONED,
         omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
 
-    // legacy true -> ENABLED
+    // legacy true does NOT opt the bucket into S3 versioning: it only sets the
+    // legacy flag, which selects the in-record block version list
     response = new OMBucketSetPropertyRequest(
         createSetVersioningFlagRequest(volumeName, bucketName, true))
         .validateAndUpdateCache(ozoneManager, 2);
     assertTrue(response.getOMResponse().getSuccess());
-    assertEquals(BucketVersioningStatus.ENABLED,
-        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+    OmBucketInfo dbBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    assertFalse(dbBucketInfo.hasVersioningStatus());
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
+        dbBucketInfo.getVersioningStatus());
+    assertTrue(dbBucketInfo.getIsVersionEnabled());
 
-    // legacy false after enabling -> SUSPENDED, not UNVERSIONED
+    // once a status exists, an old client's flag is kept consistent with it:
+    // disabling maps to SUSPENDED rather than back to UNVERSIONED
     response = new OMBucketSetPropertyRequest(
-        createSetVersioningFlagRequest(volumeName, bucketName, false))
+        createSetVersioningStatusRequest(volumeName, bucketName,
+            BucketVersioningStatus.ENABLED))
         .validateAndUpdateCache(ozoneManager, 3);
     assertTrue(response.getOMResponse().getSuccess());
-    OmBucketInfo dbBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+
+    response = new OMBucketSetPropertyRequest(
+        createSetVersioningFlagRequest(volumeName, bucketName, false))
+        .validateAndUpdateCache(ozoneManager, 4);
+    assertTrue(response.getOMResponse().getSuccess());
+    dbBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
     assertEquals(BucketVersioningStatus.SUSPENDED, dbBucketInfo.getVersioningStatus());
     assertFalse(dbBucketInfo.getIsVersionEnabled());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -27,6 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,6 +53,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetBucketPropertyRequest;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 
@@ -481,6 +487,61 @@ public class TestOMBucketSetPropertyRequest extends BucketRequestTests {
         omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
   }
 
+  /**
+   * Changing the versioning status is a bucket property change, so it takes
+   * that request's permission: under native ACLs, the bucket owner or an
+   * administrator.
+   */
+  @Test
+  public void testOnlyOwnerOrAdminMayChangeVersioningStatus()
+      throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, BucketLayout.OBJECT_STORE);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+    when(ozoneManager.getAclsEnabled()).thenReturn(true);
+    IAccessAuthorizer authorizer = mock(IAccessAuthorizer.class);
+    when(authorizer.isNative()).thenReturn(true);
+    when(ozoneManager.getAccessAuthorizer()).thenReturn(authorizer);
+    when(ozoneManager.getBucketOwner(eq(volumeName), eq(bucketName),
+        any(IAccessAuthorizer.ACLType.class), any(OzoneObj.ResourceType.class)))
+        .thenReturn("bucketOwner");
+
+    // neither the owner nor an administrator
+    when(ozoneManager.isAdmin(any(UserGroupInformation.class)))
+        .thenReturn(false);
+    when(ozoneManager.isOwner(any(UserGroupInformation.class), anyString()))
+        .thenReturn(false);
+    OMClientResponse response = setVersioningStatusAs("regularUser",
+        volumeName, bucketName, BucketVersioningStatus.ENABLED, 1);
+    assertEquals(OzoneManagerProtocolProtos.Status.PERMISSION_DENIED,
+        response.getOMResponse().getStatus());
+    assertEquals(BucketVersioningStatus.UNVERSIONED,
+        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+
+    // the bucket owner
+    when(ozoneManager.isOwner(any(UserGroupInformation.class),
+        eq("bucketOwner"))).thenReturn(true);
+    response = setVersioningStatusAs("bucketOwner",
+        volumeName, bucketName, BucketVersioningStatus.ENABLED, 2);
+    assertTrue(response.getOMResponse().getSuccess());
+    assertEquals(BucketVersioningStatus.ENABLED,
+        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+
+    // an administrator who does not own the bucket
+    when(ozoneManager.isOwner(any(UserGroupInformation.class), anyString()))
+        .thenReturn(false);
+    when(ozoneManager.isAdmin(any(UserGroupInformation.class)))
+        .thenReturn(true);
+    response = setVersioningStatusAs("adminUser",
+        volumeName, bucketName, BucketVersioningStatus.SUSPENDED, 3);
+    assertTrue(response.getOMResponse().getSuccess());
+    assertEquals(BucketVersioningStatus.SUSPENDED,
+        omMetadataManager.getBucketTable().get(bucketKey).getVersioningStatus());
+  }
+
   @Test
   public void testLegacyVersioningFlagMapsToStateMachine() throws Exception {
     String volumeName = UUID.randomUUID().toString();
@@ -565,6 +626,15 @@ public class TestOMBucketSetPropertyRequest extends BucketRequestTests {
     assertSame(request, OMBucketSetPropertyRequest
         .disallowSetBucketPropertyWithVersioningStatus(
             request, finalizedContext));
+  }
+
+  private OMClientResponse setVersioningStatusAs(String user,
+      String volumeName, String bucketName, BucketVersioningStatus status,
+      long trxnLogIndex) throws Exception {
+    OMBucketSetPropertyRequest request = new OMBucketSetPropertyRequest(
+        createSetVersioningStatusRequest(volumeName, bucketName, status));
+    request.setUGI(UserGroupInformation.createRemoteUser(user));
+    return request.validateAndUpdateCache(ozoneManager, trxnLogIndex);
   }
 
   private OMRequest createSetVersioningStatusRequest(String volumeName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequestTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequestTests.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.ScmClient;
+import org.apache.hadoop.ozone.om.VersionIdAllocator;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -154,6 +155,8 @@ public class OMKeyRequestTests {
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     when(ozoneManager.getConfiguration()).thenReturn(ozoneConfiguration);
     when(ozoneManager.getConfig()).thenReturn(ozoneConfiguration.getObject(OmConfig.class));
+    when(ozoneManager.getVersionIdAllocator())
+        .thenReturn(new VersionIdAllocator(ozoneConfiguration));
     OMLayoutVersionManager lvm = mock(OMLayoutVersionManager.class);
     when(lvm.isAllowed(anyString())).thenReturn(true);
     when(ozoneManager.getVersionManager()).thenReturn(lvm);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.request.key;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -27,13 +28,16 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.BucketVersioningStatus;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyDeleteMarkerResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
@@ -63,12 +67,25 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
   }
 
   private void setupVersionedBucket() throws Exception {
+    setupVersionedBucket(OzoneConsts.QUOTA_RESET, OzoneConsts.QUOTA_RESET);
+  }
+
+  private void setupVersionedBucket(long quotaInBytes, long quotaInNamespace)
+      throws Exception {
+    setupVersionedBucket(quotaInBytes, quotaInNamespace, 0L);
+  }
+
+  private void setupVersionedBucket(long quotaInBytes, long quotaInNamespace,
+      long usedNamespace) throws Exception {
     OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setBucketLayout(BucketLayout.OBJECT_STORE)
         .setVersioningStatus(BucketVersioningStatus.ENABLED)
+        .setQuotaInBytes(quotaInBytes)
+        .setQuotaInNamespace(quotaInNamespace)
+        .setUsedNamespace(usedNamespace)
         .setCreationTime(Time.now())
         .build();
     omMetadataManager.getBucketTable().addCacheEntry(
@@ -124,19 +141,20 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
         omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
   }
 
-  private OMRequest commitRequest(boolean isHsync, long proposedVersionId) {
+  private OMRequest commitRequest(boolean isHsync, long proposedVersionId,
+      long dataSize, long writerClientId) {
     KeyArgs keyArgs = KeyArgs.newBuilder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setModificationTime(Time.now())
-        .setDataSize(0)
+        .setDataSize(dataSize)
         .setProposedVersionId(proposedVersionId)
         .build();
     return OMRequest.newBuilder()
         .setCommitKeyRequest(CommitKeyRequest.newBuilder()
             .setKeyArgs(keyArgs)
-            .setClientID(clientID)
+            .setClientID(writerClientId)
             .setHsync(isHsync))
         .setCmdType(OzoneManagerProtocolProtos.Type.CommitKey)
         .setClientId(UUID.randomUUID().toString()).build();
@@ -149,14 +167,25 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
 
   private OMClientResponse commitAt(long trxnLogIndex, long proposedVersionId,
       boolean isHsync) throws Exception {
-    OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
-        clientID, replicationConfig, omMetadataManager);
-    OMClientResponse response = new OMKeyCommitRequest(
-        commitRequest(isHsync, proposedVersionId),
-        getBucketLayout()).validateAndUpdateCache(ozoneManager, trxnLogIndex);
+    OMClientResponse response =
+        commitAt(trxnLogIndex, proposedVersionId, isHsync, 0L, clientID);
     assertEquals(OzoneManagerProtocolProtos.Status.OK,
         response.getOMResponse().getStatus());
     return response;
+  }
+
+  /**
+   * Commits the key as the writer identified by {@code writerClientId}. A
+   * non-hsync commit tombstones its own open key, so a second write of the
+   * same key comes from a different client, as it would in practice.
+   */
+  private OMClientResponse commitAt(long trxnLogIndex, long proposedVersionId,
+      boolean isHsync, long dataSize, long writerClientId) throws Exception {
+    OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
+        writerClientId, replicationConfig, omMetadataManager);
+    return new OMKeyCommitRequest(
+        commitRequest(isHsync, proposedVersionId, dataSize, writerClientId),
+        getBucketLayout()).validateAndUpdateCache(ozoneManager, trxnLogIndex);
   }
 
   private OmKeyInfo noncurrentVersion(long versionId) throws Exception {
@@ -190,7 +219,8 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
     setupVersionedBucket();
 
     OMRequest processed = new OMKeyCommitRequest(
-        commitRequest(false, VersionIdGenerator.UNSET_VERSION_ID),
+        commitRequest(false, VersionIdGenerator.UNSET_VERSION_ID, 0L,
+            clientID),
         getBucketLayout()).preExecute(ozoneManager);
 
     assertTrue(processed.getCommitKeyRequest().getKeyArgs()
@@ -396,6 +426,85 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
     assertNotNull(noncurrent);
     assertTrue(noncurrent.isNullVersion());
     assertFalse(noncurrent.isDeleteMarker());
+  }
+
+  /**
+   * Every version counts against the bucket's space quota: an overwrite adds
+   * the new version's usage without releasing the version it supersedes.
+   */
+  @Test
+  public void testEachVersionCountsAgainstUsedBytes() throws Exception {
+    setupVersionedBucket();
+    String bucketKey =
+        omMetadataManager.getBucketKey(volumeName, bucketName);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitAt(500L, PROPOSED, false, 100L, clientID).getOMResponse().getStatus());
+    long afterFirst = omMetadataManager.getBucketTable().get(bucketKey)
+        .getUsedBytes();
+    assertEquals(QuotaUtil.getReplicatedSize(100L, replicationConfig),
+        afterFirst);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitAt(600L, LATER_PROPOSED, false, 300L, clientID + 1).getOMResponse().getStatus());
+    long afterSecond = omMetadataManager.getBucketTable().get(bucketKey)
+        .getUsedBytes();
+    assertEquals(afterFirst
+            + QuotaUtil.getReplicatedSize(300L, replicationConfig),
+        afterSecond);
+    assertEquals(2, omMetadataManager.getBucketTable().get(bucketKey)
+        .getUsedNamespace());
+  }
+
+  @Test
+  public void testVersionedWriteRejectedWhenSpaceQuotaExceeded()
+      throws Exception {
+    long quota = QuotaUtil.getReplicatedSize(150L, replicationConfig);
+    setupVersionedBucket(quota, OzoneConsts.QUOTA_RESET);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitAt(500L, PROPOSED, false, 100L, clientID).getOMResponse().getStatus());
+    // the first version is not released, so the second one no longer fits
+    assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
+        commitAt(600L, LATER_PROPOSED, false, 100L, clientID + 1)
+            .getOMResponse().getStatus());
+
+    OmKeyInfo current = currentVersion();
+    assertEquals(PROPOSED, current.getVersionId());
+    assertNull(noncurrentVersion(PROPOSED));
+  }
+
+  @Test
+  public void testVersionedWriteRejectedWhenNamespaceQuotaExceeded()
+      throws Exception {
+    setupVersionedBucket(OzoneConsts.QUOTA_RESET, 1L);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitAt(500L, PROPOSED, false, 0L, clientID).getOMResponse().getStatus());
+    // each version is a record of its own, so the second one needs namespace
+    assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
+        commitAt(600L, LATER_PROPOSED, false, 0L, clientID + 1).getOMResponse().getStatus());
+  }
+
+  /** A delete marker is a record too, so it needs namespace quota. */
+  @Test
+  public void testDeleteMarkerRejectedWhenNamespaceQuotaExceeded()
+      throws Exception {
+    // the bucket already holds the one key its namespace quota allows
+    setupVersionedBucket(OzoneConsts.QUOTA_RESET, 1L, 1L);
+    seedCurrentVersion(100L);
+
+    OMClientResponse response =
+        new OMKeyDeleteRequest(deleteRequest(PROPOSED), getBucketLayout())
+            .validateAndUpdateCache(ozoneManager, 200L);
+    assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
+        response.getOMResponse().getStatus());
+    assertFalse(currentVersion().isDeleteMarker());
+    // a rejected request must not leave the superseded version behind in the
+    // versionedKeyTable cache, and its response has to declare that table so
+    // that the double buffer cleans up whatever the request did touch
+    assertNull(noncurrentVersion(100L));
+    assertInstanceOf(OMKeyDeleteMarkerResponse.class, response);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.key;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.BucketVersioningStatus;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the S3-compatible versioning behaviour of key writes on a
+ * versioning-enabled OBJECT_STORE bucket: a commit freezes a versionId on the
+ * new current version and keeps the version it overwrote as a noncurrent
+ * version in the versionedKeyTable instead of reclaiming it.
+ */
+public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
+
+  /**
+   * versionIds a request proposes, deliberately unrelated to the transaction
+   * index it is applied at: the id no longer comes from the replication log.
+   */
+  private static final long PROPOSED = 4_000_000L;
+  private static final long LATER_PROPOSED = 5_000_000L;
+
+  @Override
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.OBJECT_STORE;
+  }
+
+  private void setupVersionedBucket() throws Exception {
+    OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
+    OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setBucketLayout(BucketLayout.OBJECT_STORE)
+        .setVersioningStatus(BucketVersioningStatus.ENABLED)
+        .setCreationTime(Time.now())
+        .build();
+    omMetadataManager.getBucketTable().addCacheEntry(
+        new CacheKey<>(omMetadataManager.getBucketKey(volumeName, bucketName)),
+        CacheValue.get(1L, bucketInfo));
+  }
+
+  /** Puts a current version into keyTable, as an earlier write would have. */
+  private String seedCurrentVersion(Long versionId) throws Exception {
+    OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(
+            volumeName, bucketName, keyName, replicationConfig)
+        .setVersionId(versionId)
+        .build();
+    String ozoneKey = omMetadataManager.getOzoneKey(
+        volumeName, bucketName, keyName);
+    omMetadataManager.getKeyTable(getBucketLayout()).put(ozoneKey, keyInfo);
+    return ozoneKey;
+  }
+
+  private OMRequest commitRequest(boolean isHsync, long proposedVersionId) {
+    KeyArgs keyArgs = KeyArgs.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setModificationTime(Time.now())
+        .setDataSize(0)
+        .setProposedVersionId(proposedVersionId)
+        .build();
+    return OMRequest.newBuilder()
+        .setCommitKeyRequest(CommitKeyRequest.newBuilder()
+            .setKeyArgs(keyArgs)
+            .setClientID(clientID)
+            .setHsync(isHsync))
+        .setCmdType(OzoneManagerProtocolProtos.Type.CommitKey)
+        .setClientId(UUID.randomUUID().toString()).build();
+  }
+
+  private OMClientResponse commitAt(long trxnLogIndex, long proposedVersionId)
+      throws Exception {
+    return commitAt(trxnLogIndex, proposedVersionId, false);
+  }
+
+  private OMClientResponse commitAt(long trxnLogIndex, long proposedVersionId,
+      boolean isHsync) throws Exception {
+    OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
+        clientID, replicationConfig, omMetadataManager);
+    OMClientResponse response = new OMKeyCommitRequest(
+        commitRequest(isHsync, proposedVersionId),
+        getBucketLayout()).validateAndUpdateCache(ozoneManager, trxnLogIndex);
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        response.getOMResponse().getStatus());
+    return response;
+  }
+
+  private OmKeyInfo noncurrentVersion(long versionId) throws Exception {
+    return omMetadataManager.getVersionedKeyTable().get(
+        omMetadataManager.getVersionedOzoneKey(
+            volumeName, bucketName, keyName, versionId));
+  }
+
+  @Test
+  public void testCommitOfNewKeyAssignsVersionIdAndHasNoNoncurrentVersion()
+      throws Exception {
+    setupVersionedBucket();
+
+    commitAt(500L, PROPOSED);
+
+    OmKeyInfo current = omMetadataManager.getKeyTable(getBucketLayout()).get(
+        omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
+    assertNotNull(current);
+    assertEquals(PROPOSED, current.getVersionId());
+    assertFalse(current.isDeleteMarker());
+    assertFalse(current.isNullVersion());
+    assertNull(noncurrentVersion(PROPOSED));
+  }
+
+  /**
+   * The id is proposed on the OM that received the request, so it travels in
+   * the replicated request rather than being generated during apply.
+   */
+  @Test
+  public void testPreExecuteProposesAVersionId() throws Exception {
+    setupVersionedBucket();
+
+    OMRequest processed = new OMKeyCommitRequest(
+        commitRequest(false, VersionIdGenerator.UNSET_VERSION_ID),
+        getBucketLayout()).preExecute(ozoneManager);
+
+    assertTrue(processed.getCommitKeyRequest().getKeyArgs()
+        .getProposedVersionId() > VersionIdGenerator.UNSET_VERSION_ID);
+  }
+
+  /**
+   * A proposal is only a floor. A current version numbered above it - which a
+   * clock regression or a change of generator can produce - still has to be
+   * superseded by a larger id, or the versionedKeyTable would order the key's
+   * versions wrongly.
+   */
+  @Test
+  public void testCommitRaisesAProposalBelowTheCurrentVersion()
+      throws Exception {
+    setupVersionedBucket();
+    String ozoneKey = seedCurrentVersion(PROPOSED + 10);
+
+    commitAt(500L, PROPOSED);
+
+    assertEquals(PROPOSED + 11,
+        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey)
+            .getVersionId());
+  }
+
+  @Test
+  public void testOverwriteKeepsPreviousVersionAsNoncurrent()
+      throws Exception {
+    setupVersionedBucket();
+    String ozoneKey = seedCurrentVersion(100L);
+
+    commitAt(500L, PROPOSED);
+
+    OmKeyInfo current =
+        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    assertEquals(PROPOSED, current.getVersionId());
+
+    OmKeyInfo noncurrent = noncurrentVersion(100L);
+    assertNotNull(noncurrent);
+    assertEquals(100L, noncurrent.getVersionId());
+    assertFalse(noncurrent.isNullVersion());
+  }
+
+  /**
+   * Both tables are updated in one WriteBatch, so what the table cache shows
+   * during apply is what the DB holds once the batch is committed: a reader
+   * that missed the cache finds the new current version and the version it
+   * superseded, never one without the other.
+   */
+  @Test
+  public void testBothTablesAreWrittenInOneBatch() throws Exception {
+    setupVersionedBucket();
+    String ozoneKey = seedCurrentVersion(100L);
+
+    OMClientResponse response = commitAt(500L, PROPOSED);
+    try (BatchOperation batch =
+             omMetadataManager.getStore().initBatchOperation()) {
+      response.checkAndUpdateDB(omMetadataManager, batch);
+      omMetadataManager.getStore().commitBatchOperation(batch);
+    }
+
+    assertEquals(PROPOSED, omMetadataManager.getKeyTable(getBucketLayout())
+        .getSkipCache(ozoneKey).getVersionId());
+    assertNotNull(omMetadataManager.getVersionedKeyTable().getSkipCache(
+        omMetadataManager.getVersionedOzoneKey(
+            volumeName, bucketName, keyName, 100L)));
+  }
+
+  /**
+   * A record written before versioning was enabled carries no versionId, so on
+   * the first overwrite it becomes the key's single null version.
+   */
+  @Test
+  public void testPreVersioningRecordBecomesNullVersion() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(null);
+
+    commitAt(500L, PROPOSED);
+
+    OmKeyInfo noncurrent =
+        noncurrentVersion(VersionIdGenerator.UNSET_VERSION_ID);
+    assertNotNull(noncurrent);
+    assertTrue(noncurrent.isNullVersion());
+    assertEquals(VersionIdGenerator.UNSET_VERSION_ID,
+        noncurrent.getVersionId());
+  }
+
+  /**
+   * The overwritten version keeps its blocks in the versionedKeyTable: they
+   * must not be queued for reclamation, and they must not be carried into the
+   * new current version's in-record block version list either.
+   */
+  @Test
+  public void testOverwriteDoesNotReclaimOrInheritPreviousBlocks()
+      throws Exception {
+    setupVersionedBucket();
+    String ozoneKey = seedCurrentVersion(100L);
+
+    commitAt(500L, PROPOSED);
+
+    assertNull(omMetadataManager.getDeletedTable().get(ozoneKey));
+    OmKeyInfo current =
+        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    assertEquals(1, current.getKeyLocationVersions().size());
+    assertNotNull(noncurrentVersion(100L));
+  }
+
+  /**
+   * An hsync re-commit keeps updating the version it opened rather than
+   * creating a new one, so its versionId stays frozen and nothing moves to the
+   * versionedKeyTable.
+   */
+  @Test
+  public void testHsyncRecommitKeepsVersionIdFrozen() throws Exception {
+    setupVersionedBucket();
+
+    commitAt(500L, PROPOSED, true);
+    OmKeyInfo firstCommit = omMetadataManager.getKeyTable(getBucketLayout())
+        .get(omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
+    assertEquals(PROPOSED, firstCommit.getVersionId());
+
+    commitAt(600L, LATER_PROPOSED, true);
+    OmKeyInfo recommitted = omMetadataManager.getKeyTable(getBucketLayout())
+        .get(omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
+    assertEquals(PROPOSED, recommitted.getVersionId());
+    assertNull(noncurrentVersion(PROPOSED));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -38,9 +38,12 @@ import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyDeleteMarkerResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeysDeleteMarkerResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
@@ -96,6 +99,18 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
   /** Puts a current version into keyTable, as an earlier write would have. */
   private String seedCurrentVersion(Long versionId) throws Exception {
     return seedCurrentVersion(versionId, false);
+  }
+
+  /** Puts a current version of another key, to batch alongside the first. */
+  private void seedCurrentVersion(String otherKey, Long versionId)
+      throws Exception {
+    OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(
+            volumeName, bucketName, otherKey, replicationConfig)
+        .setVersionId(versionId)
+        .build();
+    omMetadataManager.getKeyTable(getBucketLayout()).put(
+        omMetadataManager.getOzoneKey(volumeName, bucketName, otherKey),
+        keyInfo);
   }
 
   private String seedCurrentVersion(Long versionId, boolean deleteMarker)
@@ -380,6 +395,83 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
 
     assertTrue(processed.getDeleteKeyRequest().getKeyArgs()
         .getProposedVersionId() > VersionIdGenerator.UNSET_VERSION_ID);
+  }
+
+  /**
+   * A batch delete is the same operation over more keys, so it has to leave
+   * the bucket in the same shape a single delete would: a marker per key, the
+   * version each one superseded kept. Hard-deleting instead would destroy the
+   * current version and strand the versions under it.
+   */
+  @Test
+  public void testBatchDeleteInsertsAMarkerPerKey() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L);
+    String otherKey = keyName + "-other";
+    seedCurrentVersion(otherKey, 150L);
+
+    OMClientResponse response = new OMKeysDeleteRequest(
+        batchDeleteRequest(PROPOSED, keyName, otherKey), getBucketLayout())
+        .validateAndUpdateCache(ozoneManager, 200L);
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        response.getOMResponse().getStatus());
+
+    // both keys are now markers, and neither superseded version was reclaimed
+    assertTrue(currentVersion().isDeleteMarker());
+    assertEquals(PROPOSED, currentVersion().getVersionId());
+    assertNotNull(noncurrentVersion(100L));
+
+    OmKeyInfo otherCurrent = omMetadataManager.getKeyTable(getBucketLayout())
+        .get(omMetadataManager.getOzoneKey(volumeName, bucketName, otherKey));
+    assertTrue(otherCurrent.isDeleteMarker());
+    // one proposal covers the batch: ids only have to increase within a key
+    assertEquals(PROPOSED, otherCurrent.getVersionId());
+    assertNotNull(omMetadataManager.getVersionedKeyTable().get(
+        omMetadataManager.getVersionedOzoneKey(volumeName, bucketName,
+            otherKey, 150L)));
+
+    assertInstanceOf(OMKeysDeleteMarkerResponse.class, response);
+  }
+
+  /** The proposal is a floor for each key independently. */
+  @Test
+  public void testBatchDeleteRaisesTheProposalPerKey() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(PROPOSED + 10);
+
+    new OMKeysDeleteRequest(batchDeleteRequest(PROPOSED, keyName),
+        getBucketLayout()).validateAndUpdateCache(ozoneManager, 200L);
+
+    assertEquals(PROPOSED + 11, currentVersion().getVersionId());
+  }
+
+  /** A bucket without versioning keeps the old hard-delete behaviour. */
+  @Test
+  public void testBatchDeleteOnAnUnversionedBucketStillDeletes()
+      throws Exception {
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+    seedCurrentVersion(null);
+
+    OMClientResponse response = new OMKeysDeleteRequest(
+        batchDeleteRequest(PROPOSED, keyName), getBucketLayout())
+        .validateAndUpdateCache(ozoneManager, 200L);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        response.getOMResponse().getStatus());
+    assertNull(currentVersion());
+  }
+
+  private OMRequest batchDeleteRequest(long proposedVersionId, String... keys) {
+    return OMRequest.newBuilder()
+        .setDeleteKeysRequest(DeleteKeysRequest.newBuilder()
+            .setDeleteKeys(DeleteKeyArgs.newBuilder()
+                .setVolumeName(volumeName)
+                .setBucketName(bucketName)
+                .addAllKeys(java.util.Arrays.asList(keys))
+                .setProposedVersionId(proposedVersionId)))
+        .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKeys)
+        .setClientId(UUID.randomUUID().toString()).build();
   }
 
   /** S3 inserts a delete marker even for a key that does not exist. */

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.key;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.BucketVersioningStatus;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the S3-compatible versioning behaviour of key writes on a
+ * versioning-enabled OBJECT_STORE bucket: a commit freezes a versionId on the
+ * new current version and keeps the version it overwrote as a noncurrent
+ * version in the versionedKeyTable instead of reclaiming it.
+ */
+public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
+
+  @Override
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.OBJECT_STORE;
+  }
+
+  private void setupVersionedBucket() throws Exception {
+    OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
+    OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setBucketLayout(BucketLayout.OBJECT_STORE)
+        .setVersioningStatus(BucketVersioningStatus.ENABLED)
+        .setCreationTime(Time.now())
+        .build();
+    omMetadataManager.getBucketTable().addCacheEntry(
+        new CacheKey<>(omMetadataManager.getBucketKey(volumeName, bucketName)),
+        CacheValue.get(1L, bucketInfo));
+  }
+
+  /** Puts a current version into keyTable, as an earlier write would have. */
+  private String seedCurrentVersion(Long versionId) throws Exception {
+    OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(
+            volumeName, bucketName, keyName, replicationConfig)
+        .setVersionId(versionId)
+        .build();
+    String ozoneKey = omMetadataManager.getOzoneKey(
+        volumeName, bucketName, keyName);
+    omMetadataManager.getKeyTable(getBucketLayout()).put(ozoneKey, keyInfo);
+    return ozoneKey;
+  }
+
+  private OMRequest commitRequest(boolean isHsync) {
+    KeyArgs keyArgs = KeyArgs.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setModificationTime(Time.now())
+        .setDataSize(0)
+        .build();
+    return OMRequest.newBuilder()
+        .setCommitKeyRequest(CommitKeyRequest.newBuilder()
+            .setKeyArgs(keyArgs)
+            .setClientID(clientID)
+            .setHsync(isHsync))
+        .setCmdType(OzoneManagerProtocolProtos.Type.CommitKey)
+        .setClientId(UUID.randomUUID().toString()).build();
+  }
+
+  private OMClientResponse commitAt(long trxnLogIndex) throws Exception {
+    return commitAt(trxnLogIndex, false);
+  }
+
+  private OMClientResponse commitAt(long trxnLogIndex, boolean isHsync)
+      throws Exception {
+    OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
+        clientID, replicationConfig, omMetadataManager);
+    OMClientResponse response = new OMKeyCommitRequest(commitRequest(isHsync),
+        getBucketLayout()).validateAndUpdateCache(ozoneManager, trxnLogIndex);
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        response.getOMResponse().getStatus());
+    return response;
+  }
+
+  private OmKeyInfo noncurrentVersion(long versionId) throws Exception {
+    return omMetadataManager.getVersionedKeyTable().get(
+        omMetadataManager.getVersionedOzoneKey(
+            volumeName, bucketName, keyName, versionId));
+  }
+
+  @Test
+  public void testCommitOfNewKeyAssignsVersionIdAndHasNoNoncurrentVersion()
+      throws Exception {
+    setupVersionedBucket();
+
+    commitAt(500L);
+
+    OmKeyInfo current = omMetadataManager.getKeyTable(getBucketLayout()).get(
+        omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
+    assertNotNull(current);
+    assertEquals(500L, current.getVersionId());
+    assertFalse(current.isDeleteMarker());
+    assertFalse(current.isNullVersion());
+    assertNull(noncurrentVersion(500L));
+  }
+
+  @Test
+  public void testOverwriteKeepsPreviousVersionAsNoncurrent()
+      throws Exception {
+    setupVersionedBucket();
+    String ozoneKey = seedCurrentVersion(100L);
+
+    commitAt(500L);
+
+    OmKeyInfo current =
+        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    assertEquals(500L, current.getVersionId());
+
+    OmKeyInfo noncurrent = noncurrentVersion(100L);
+    assertNotNull(noncurrent);
+    assertEquals(100L, noncurrent.getVersionId());
+    assertFalse(noncurrent.isNullVersion());
+  }
+
+  /**
+   * A record written before versioning was enabled carries no versionId, so on
+   * the first overwrite it becomes the key's single null version.
+   */
+  @Test
+  public void testPreVersioningRecordBecomesNullVersion() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(null);
+
+    commitAt(500L);
+
+    OmKeyInfo noncurrent =
+        noncurrentVersion(VersionIdGenerator.UNSET_VERSION_ID);
+    assertNotNull(noncurrent);
+    assertTrue(noncurrent.isNullVersion());
+    assertEquals(VersionIdGenerator.UNSET_VERSION_ID,
+        noncurrent.getVersionId());
+  }
+
+  /**
+   * The overwritten version keeps its blocks in the versionedKeyTable: they
+   * must not be queued for reclamation, and they must not be carried into the
+   * new current version's in-record block version list either.
+   */
+  @Test
+  public void testOverwriteDoesNotReclaimOrInheritPreviousBlocks()
+      throws Exception {
+    setupVersionedBucket();
+    String ozoneKey = seedCurrentVersion(100L);
+
+    commitAt(500L);
+
+    assertNull(omMetadataManager.getDeletedTable().get(ozoneKey));
+    OmKeyInfo current =
+        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    assertEquals(1, current.getKeyLocationVersions().size());
+    assertNotNull(noncurrentVersion(100L));
+  }
+
+  /**
+   * An hsync re-commit keeps updating the version it opened rather than
+   * creating a new one, so its versionId stays frozen and nothing moves to the
+   * versionedKeyTable.
+   */
+  @Test
+  public void testHsyncRecommitKeepsVersionIdFrozen() throws Exception {
+    setupVersionedBucket();
+
+    commitAt(500L, true);
+    OmKeyInfo firstCommit = omMetadataManager.getKeyTable(getBucketLayout())
+        .get(omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
+    assertEquals(500L, firstCommit.getVersionId());
+
+    commitAt(600L, true);
+    OmKeyInfo recommitted = omMetadataManager.getKeyTable(getBucketLayout())
+        .get(omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
+    assertEquals(500L, recommitted.getVersionId());
+    assertNull(noncurrentVersion(500L));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
@@ -69,14 +70,46 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
 
   /** Puts a current version into keyTable, as an earlier write would have. */
   private String seedCurrentVersion(Long versionId) throws Exception {
+    return seedCurrentVersion(versionId, false);
+  }
+
+  private String seedCurrentVersion(Long versionId, boolean deleteMarker)
+      throws Exception {
     OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(
             volumeName, bucketName, keyName, replicationConfig)
         .setVersionId(versionId)
+        .setDeleteMarker(deleteMarker)
         .build();
     String ozoneKey = omMetadataManager.getOzoneKey(
         volumeName, bucketName, keyName);
     omMetadataManager.getKeyTable(getBucketLayout()).put(ozoneKey, keyInfo);
     return ozoneKey;
+  }
+
+  private OMRequest deleteRequest() {
+    KeyArgs keyArgs = KeyArgs.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setModificationTime(Time.now())
+        .build();
+    return OMRequest.newBuilder()
+        .setDeleteKeyRequest(DeleteKeyRequest.newBuilder().setKeyArgs(keyArgs))
+        .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey)
+        .setClientId(UUID.randomUUID().toString()).build();
+  }
+
+  private OMClientResponse deleteAt(long trxnLogIndex) throws Exception {
+    OMClientResponse response = new OMKeyDeleteRequest(deleteRequest(),
+        getBucketLayout()).validateAndUpdateCache(ozoneManager, trxnLogIndex);
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        response.getOMResponse().getStatus());
+    return response;
+  }
+
+  private OmKeyInfo currentVersion() throws Exception {
+    return omMetadataManager.getKeyTable(getBucketLayout()).get(
+        omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
   }
 
   private OMRequest commitRequest(boolean isHsync) {
@@ -209,5 +242,92 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
         .get(omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
     assertEquals(500L, recommitted.getVersionId());
     assertNull(noncurrentVersion(500L));
+  }
+
+  @Test
+  public void testDeleteInsertsMarkerAndKeepsPreviousVersion()
+      throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L);
+
+    deleteAt(200L);
+
+    OmKeyInfo current = currentVersion();
+    assertNotNull(current);
+    assertTrue(current.isDeleteMarker());
+    assertEquals(200L, current.getVersionId());
+    assertEquals(0L, current.getDataSize());
+    assertTrue(current.getLatestVersionLocations().getLocationList().isEmpty());
+
+    OmKeyInfo noncurrent = noncurrentVersion(100L);
+    assertNotNull(noncurrent);
+    assertFalse(noncurrent.isDeleteMarker());
+  }
+
+  /** S3 inserts a delete marker even for a key that does not exist. */
+  @Test
+  public void testDeleteOfMissingKeyStillInsertsMarker() throws Exception {
+    setupVersionedBucket();
+
+    deleteAt(200L);
+
+    OmKeyInfo current = currentVersion();
+    assertNotNull(current);
+    assertTrue(current.isDeleteMarker());
+    assertEquals(200L, current.getVersionId());
+    assertNull(noncurrentVersion(VersionIdGenerator.UNSET_VERSION_ID));
+  }
+
+  /** Deleting a key whose current version is already a marker stacks another. */
+  @Test
+  public void testDeleteStacksAnotherMarker() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L, true);
+
+    deleteAt(200L);
+
+    OmKeyInfo current = currentVersion();
+    assertTrue(current.isDeleteMarker());
+    assertEquals(200L, current.getVersionId());
+
+    OmKeyInfo stacked = noncurrentVersion(100L);
+    assertNotNull(stacked);
+    assertTrue(stacked.isDeleteMarker());
+  }
+
+  @Test
+  public void testDeleteOfPreVersioningRecordMovesItToNullVersion()
+      throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(null);
+
+    deleteAt(200L);
+
+    OmKeyInfo noncurrent =
+        noncurrentVersion(VersionIdGenerator.UNSET_VERSION_ID);
+    assertNotNull(noncurrent);
+    assertTrue(noncurrent.isNullVersion());
+    assertFalse(noncurrent.isDeleteMarker());
+  }
+
+  /**
+   * A delete marker holds no blocks, so it consumes namespace but no space,
+   * and the superseded version keeps its own usage.
+   */
+  @Test
+  public void testDeleteMarkerConsumesNamespaceButNoSpace() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L);
+    String bucketKey =
+        omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo before = omMetadataManager.getBucketTable().get(bucketKey);
+    long usedBytes = before.getUsedBytes();
+    long usedNamespace = before.getUsedNamespace();
+
+    deleteAt(200L);
+
+    OmBucketInfo after = omMetadataManager.getBucketTable().get(bucketKey);
+    assertEquals(usedBytes, after.getUsedBytes());
+    assertEquals(usedNamespace + 1, after.getUsedNamespace());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -104,9 +104,15 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
   /** Puts a current version of another key, to batch alongside the first. */
   private void seedCurrentVersion(String otherKey, Long versionId)
       throws Exception {
+    seedCurrentVersion(otherKey, versionId, false);
+  }
+
+  private void seedCurrentVersion(String otherKey, Long versionId,
+      boolean deleteMarker) throws Exception {
     OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(
             volumeName, bucketName, otherKey, replicationConfig)
         .setVersionId(versionId)
+        .setDeleteMarker(deleteMarker)
         .build();
     omMetadataManager.getKeyTable(getBucketLayout()).put(
         omMetadataManager.getOzoneKey(volumeName, bucketName, otherKey),
@@ -431,6 +437,81 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
             otherKey, 150L)));
 
     assertInstanceOf(OMKeysDeleteMarkerResponse.class, response);
+  }
+
+  /**
+   * A batch that fails part way through has already put entries into the
+   * versionedKeyTable cache. The double buffer cleans the table cache from the
+   * response's CleanupTableInfo, so the failure response has to declare the
+   * same tables as the successful one or those entries are in no DB and are
+   * never cleaned up.
+   */
+  @Test
+  public void testAFailedBatchDeleteStillCleansTheVersionedKeyTable()
+      throws Exception {
+    // namespace for one more record, so the second marker cannot be written
+    setupVersionedBucket(OzoneConsts.QUOTA_RESET, 3L, 2L);
+    seedCurrentVersion(100L);
+    String otherKey = keyName + "-other";
+    seedCurrentVersion(otherKey, 150L);
+
+    OMClientResponse response = new OMKeysDeleteRequest(
+        batchDeleteRequest(PROPOSED, keyName, otherKey), getBucketLayout())
+        .validateAndUpdateCache(ozoneManager, 200L);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
+        response.getOMResponse().getStatus());
+    assertInstanceOf(OMKeysDeleteMarkerResponse.class, response);
+  }
+
+  /**
+   * S3 records the delete whether or not the key was there, so a key the
+   * bucket holds no record of takes a delete marker of its own instead of
+   * failing the batch. The single-key delete already does this.
+   */
+  @Test
+  public void testBatchDeleteMarksAKeyThatDoesNotExist() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L);
+    String absentKey = keyName + "-absent";
+
+    OMClientResponse response = new OMKeysDeleteRequest(
+        batchDeleteRequest(PROPOSED, keyName, absentKey), getBucketLayout())
+        .validateAndUpdateCache(ozoneManager, 200L);
+
+    // the whole batch succeeds: a missing key is not a partial failure
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        response.getOMResponse().getStatus());
+
+    OmKeyInfo marker = omMetadataManager.getKeyTable(getBucketLayout())
+        .get(omMetadataManager.getOzoneKey(volumeName, bucketName, absentKey));
+    assertNotNull(marker);
+    assertTrue(marker.isDeleteMarker());
+    // nothing was superseded, so the marker stands alone
+    assertNull(omMetadataManager.getVersionedKeyTable().get(
+        omMetadataManager.getVersionedOzoneKey(volumeName, bucketName,
+            absentKey, PROPOSED)));
+  }
+
+  /**
+   * Only a key that stopped being visible to a plain read comes off the key
+   * count. A marker written over a key that was already a marker, or over one
+   * the bucket held no record of, hides nothing that was not hidden already.
+   */
+  @Test
+  public void testBatchDeleteCountsOnlyTheKeysItHides() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L);
+    String markedKey = keyName + "-marked";
+    seedCurrentVersion(markedKey, 150L, true);
+    String absentKey = keyName + "-absent";
+
+    long before = omMetrics.getNumKeys();
+    new OMKeysDeleteRequest(
+        batchDeleteRequest(PROPOSED, keyName, markedKey, absentKey),
+        getBucketLayout()).validateAndUpdateCache(ozoneManager, 200L);
+
+    assertEquals(before - 1, omMetrics.getNumKeys());
   }
 
   /** The proposal is a floor for each key independently. */

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
@@ -77,14 +78,50 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
 
   /** Puts a current version into keyTable, as an earlier write would have. */
   private String seedCurrentVersion(Long versionId) throws Exception {
+    return seedCurrentVersion(versionId, false);
+  }
+
+  private String seedCurrentVersion(Long versionId, boolean deleteMarker)
+      throws Exception {
     OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(
             volumeName, bucketName, keyName, replicationConfig)
         .setVersionId(versionId)
+        .setDeleteMarker(deleteMarker)
         .build();
     String ozoneKey = omMetadataManager.getOzoneKey(
         volumeName, bucketName, keyName);
     omMetadataManager.getKeyTable(getBucketLayout()).put(ozoneKey, keyInfo);
     return ozoneKey;
+  }
+
+  private OMRequest deleteRequest(long proposedVersionId) {
+    KeyArgs keyArgs = KeyArgs.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setModificationTime(Time.now())
+        .setProposedVersionId(proposedVersionId)
+        .build();
+    return OMRequest.newBuilder()
+        .setDeleteKeyRequest(DeleteKeyRequest.newBuilder().setKeyArgs(keyArgs))
+        .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey)
+        .setClientId(UUID.randomUUID().toString()).build();
+  }
+
+  private OMClientResponse deleteAt(long trxnLogIndex, long proposedVersionId)
+      throws Exception {
+    OMClientResponse response =
+        new OMKeyDeleteRequest(deleteRequest(proposedVersionId),
+            getBucketLayout()).validateAndUpdateCache(ozoneManager,
+                trxnLogIndex);
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        response.getOMResponse().getStatus());
+    return response;
+  }
+
+  private OmKeyInfo currentVersion() throws Exception {
+    return omMetadataManager.getKeyTable(getBucketLayout()).get(
+        omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
   }
 
   private OMRequest commitRequest(boolean isHsync, long proposedVersionId) {
@@ -280,5 +317,105 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
         .get(omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
     assertEquals(PROPOSED, recommitted.getVersionId());
     assertNull(noncurrentVersion(PROPOSED));
+  }
+
+  @Test
+  public void testDeleteInsertsMarkerAndKeepsPreviousVersion()
+      throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L);
+
+    deleteAt(200L, PROPOSED);
+
+    OmKeyInfo current = currentVersion();
+    assertNotNull(current);
+    assertTrue(current.isDeleteMarker());
+    assertEquals(PROPOSED, current.getVersionId());
+    assertEquals(0L, current.getDataSize());
+    assertTrue(current.getLatestVersionLocations().getLocationList().isEmpty());
+
+    OmKeyInfo noncurrent = noncurrentVersion(100L);
+    assertNotNull(noncurrent);
+    assertFalse(noncurrent.isDeleteMarker());
+  }
+
+  /** A marker is a version, so a delete proposes an id in preExecute too. */
+  @Test
+  public void testDeletePreExecuteProposesAVersionId() throws Exception {
+    setupVersionedBucket();
+
+    OMRequest processed = new OMKeyDeleteRequest(
+        deleteRequest(VersionIdGenerator.UNSET_VERSION_ID), getBucketLayout())
+        .preExecute(ozoneManager);
+
+    assertTrue(processed.getDeleteKeyRequest().getKeyArgs()
+        .getProposedVersionId() > VersionIdGenerator.UNSET_VERSION_ID);
+  }
+
+  /** S3 inserts a delete marker even for a key that does not exist. */
+  @Test
+  public void testDeleteOfMissingKeyStillInsertsMarker() throws Exception {
+    setupVersionedBucket();
+
+    deleteAt(200L, PROPOSED);
+
+    OmKeyInfo current = currentVersion();
+    assertNotNull(current);
+    assertTrue(current.isDeleteMarker());
+    assertEquals(PROPOSED, current.getVersionId());
+    assertNull(noncurrentVersion(VersionIdGenerator.UNSET_VERSION_ID));
+  }
+
+  /** Deleting a key whose current version is already a marker stacks another. */
+  @Test
+  public void testDeleteStacksAnotherMarker() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L, true);
+
+    deleteAt(200L, PROPOSED);
+
+    OmKeyInfo current = currentVersion();
+    assertTrue(current.isDeleteMarker());
+    assertEquals(PROPOSED, current.getVersionId());
+
+    OmKeyInfo stacked = noncurrentVersion(100L);
+    assertNotNull(stacked);
+    assertTrue(stacked.isDeleteMarker());
+  }
+
+  @Test
+  public void testDeleteOfPreVersioningRecordMovesItToNullVersion()
+      throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(null);
+
+    deleteAt(200L, PROPOSED);
+
+    OmKeyInfo noncurrent =
+        noncurrentVersion(VersionIdGenerator.UNSET_VERSION_ID);
+    assertNotNull(noncurrent);
+    assertTrue(noncurrent.isNullVersion());
+    assertFalse(noncurrent.isDeleteMarker());
+  }
+
+  /**
+   * A delete marker holds no blocks, so it consumes namespace but no space,
+   * and the superseded version keeps its own usage.
+   */
+  @Test
+  public void testDeleteMarkerConsumesNamespaceButNoSpace() throws Exception {
+    setupVersionedBucket();
+    seedCurrentVersion(100L);
+    String bucketKey =
+        omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo before = omMetadataManager.getBucketTable().get(bucketKey);
+    long usedBytes = before.getUsedBytes();
+    long usedNamespace = before.getUsedNamespace();
+
+    deleteAt(200L, PROPOSED);
+
+    OmBucketInfo after = omMetadataManager.getBucketTable().get(bucketKey);
+    assertEquals(usedBytes, after.getUsedBytes());
+    assertEquals(usedNamespace + 1, after.getUsedNamespace());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.request.key;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,13 +27,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.UUID;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.BucketVersioningStatus;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.helpers.VersionIdGenerator;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyDeleteMarkerResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
@@ -55,12 +59,25 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
   }
 
   private void setupVersionedBucket() throws Exception {
+    setupVersionedBucket(OzoneConsts.QUOTA_RESET, OzoneConsts.QUOTA_RESET);
+  }
+
+  private void setupVersionedBucket(long quotaInBytes, long quotaInNamespace)
+      throws Exception {
+    setupVersionedBucket(quotaInBytes, quotaInNamespace, 0L);
+  }
+
+  private void setupVersionedBucket(long quotaInBytes, long quotaInNamespace,
+      long usedNamespace) throws Exception {
     OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setBucketLayout(BucketLayout.OBJECT_STORE)
         .setVersioningStatus(BucketVersioningStatus.ENABLED)
+        .setQuotaInBytes(quotaInBytes)
+        .setQuotaInNamespace(quotaInNamespace)
+        .setUsedNamespace(usedNamespace)
         .setCreationTime(Time.now())
         .build();
     omMetadataManager.getBucketTable().addCacheEntry(
@@ -112,18 +129,19 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
         omMetadataManager.getOzoneKey(volumeName, bucketName, keyName));
   }
 
-  private OMRequest commitRequest(boolean isHsync) {
+  private OMRequest commitRequest(boolean isHsync, long dataSize,
+      long writerClientId) {
     KeyArgs keyArgs = KeyArgs.newBuilder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setModificationTime(Time.now())
-        .setDataSize(0)
+        .setDataSize(dataSize)
         .build();
     return OMRequest.newBuilder()
         .setCommitKeyRequest(CommitKeyRequest.newBuilder()
             .setKeyArgs(keyArgs)
-            .setClientID(clientID)
+            .setClientID(writerClientId)
             .setHsync(isHsync))
         .setCmdType(OzoneManagerProtocolProtos.Type.CommitKey)
         .setClientId(UUID.randomUUID().toString()).build();
@@ -135,13 +153,25 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
 
   private OMClientResponse commitAt(long trxnLogIndex, boolean isHsync)
       throws Exception {
-    OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
-        clientID, replicationConfig, omMetadataManager);
-    OMClientResponse response = new OMKeyCommitRequest(commitRequest(isHsync),
-        getBucketLayout()).validateAndUpdateCache(ozoneManager, trxnLogIndex);
+    OMClientResponse response =
+        commitAt(trxnLogIndex, isHsync, 0L, clientID);
     assertEquals(OzoneManagerProtocolProtos.Status.OK,
         response.getOMResponse().getStatus());
     return response;
+  }
+
+  /**
+   * Commits the key as the writer identified by {@code writerClientId}. A
+   * non-hsync commit tombstones its own open key, so a second write of the
+   * same key comes from a different client, as it would in practice.
+   */
+  private OMClientResponse commitAt(long trxnLogIndex, boolean isHsync,
+      long dataSize, long writerClientId) throws Exception {
+    OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
+        writerClientId, replicationConfig, omMetadataManager);
+    return new OMKeyCommitRequest(
+        commitRequest(isHsync, dataSize, writerClientId),
+        getBucketLayout()).validateAndUpdateCache(ozoneManager, trxnLogIndex);
   }
 
   private OmKeyInfo noncurrentVersion(long versionId) throws Exception {
@@ -308,6 +338,83 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
     assertNotNull(noncurrent);
     assertTrue(noncurrent.isNullVersion());
     assertFalse(noncurrent.isDeleteMarker());
+  }
+
+  /**
+   * Every version counts against the bucket's space quota: an overwrite adds
+   * the new version's usage without releasing the version it supersedes.
+   */
+  @Test
+  public void testEachVersionCountsAgainstUsedBytes() throws Exception {
+    setupVersionedBucket();
+    String bucketKey =
+        omMetadataManager.getBucketKey(volumeName, bucketName);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitAt(500L, false, 100L, clientID).getOMResponse().getStatus());
+    long afterFirst = omMetadataManager.getBucketTable().get(bucketKey)
+        .getUsedBytes();
+    assertEquals(QuotaUtil.getReplicatedSize(100L, replicationConfig),
+        afterFirst);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitAt(600L, false, 300L, clientID + 1).getOMResponse().getStatus());
+    long afterSecond = omMetadataManager.getBucketTable().get(bucketKey)
+        .getUsedBytes();
+    assertEquals(afterFirst
+            + QuotaUtil.getReplicatedSize(300L, replicationConfig),
+        afterSecond);
+    assertEquals(2, omMetadataManager.getBucketTable().get(bucketKey)
+        .getUsedNamespace());
+  }
+
+  @Test
+  public void testVersionedWriteRejectedWhenSpaceQuotaExceeded()
+      throws Exception {
+    long quota = QuotaUtil.getReplicatedSize(150L, replicationConfig);
+    setupVersionedBucket(quota, OzoneConsts.QUOTA_RESET);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitAt(500L, false, 100L, clientID).getOMResponse().getStatus());
+    // the first version is not released, so the second one no longer fits
+    assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
+        commitAt(600L, false, 100L, clientID + 1).getOMResponse().getStatus());
+
+    OmKeyInfo current = currentVersion();
+    assertEquals(500L, current.getVersionId());
+    assertNull(noncurrentVersion(500L));
+  }
+
+  @Test
+  public void testVersionedWriteRejectedWhenNamespaceQuotaExceeded()
+      throws Exception {
+    setupVersionedBucket(OzoneConsts.QUOTA_RESET, 1L);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitAt(500L, false, 0L, clientID).getOMResponse().getStatus());
+    // each version is a record of its own, so the second one needs namespace
+    assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
+        commitAt(600L, false, 0L, clientID + 1).getOMResponse().getStatus());
+  }
+
+  /** A delete marker is a record too, so it needs namespace quota. */
+  @Test
+  public void testDeleteMarkerRejectedWhenNamespaceQuotaExceeded()
+      throws Exception {
+    // the bucket already holds the one key its namespace quota allows
+    setupVersionedBucket(OzoneConsts.QUOTA_RESET, 1L, 1L);
+    seedCurrentVersion(100L);
+
+    OMClientResponse response = new OMKeyDeleteRequest(deleteRequest(),
+        getBucketLayout()).validateAndUpdateCache(ozoneManager, 200L);
+    assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
+        response.getOMResponse().getStatus());
+    assertFalse(currentVersion().isDeleteMarker());
+    // a rejected request must not leave the superseded version behind in the
+    // versionedKeyTable cache, and its response has to declare that table so
+    // that the double buffer cleans up whatever the request did touch
+    assertNull(noncurrentVersion(100L));
+    assertInstanceOf(OMKeyDeleteMarkerResponse.class, response);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyVersioningRequests.java
@@ -454,6 +454,7 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
     seedCurrentVersion(100L);
     String otherKey = keyName + "-other";
     seedCurrentVersion(otherKey, 150L);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
 
     OMClientResponse response = new OMKeysDeleteRequest(
         batchDeleteRequest(PROPOSED, keyName, otherKey), getBucketLayout())
@@ -462,6 +463,10 @@ public class TestOMKeyVersioningRequests extends OMKeyRequestTests {
     assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
         response.getOMResponse().getStatus());
     assertInstanceOf(OMKeysDeleteMarkerResponse.class, response);
+    // The bucket is the cached instance, which the next write to it persists:
+    // the marker that did fit must not stay counted for a batch that failed.
+    assertEquals(2L, omMetadataManager.getBucketTable().get(bucketKey)
+        .getUsedNamespace());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
@@ -38,7 +38,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.VersionIdAllocator;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -172,6 +174,10 @@ public class TestOMKeysDeleteRequest extends OMKeyRequestTests {
     OMLayoutVersionManager versionManager = mock(OMLayoutVersionManager.class);
     when(versionManager.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
     when(ozoneManager.getVersionManager()).thenReturn(versionManager);
+    // preExecute proposes a versionId for the delete markers a versioned
+    // bucket would need, before it knows which bucket the request is for.
+    when(ozoneManager.getVersionIdAllocator())
+        .thenReturn(new VersionIdAllocator(new OzoneConfiguration()));
 
     when(ozoneManager.isAdminAuthorizationEnabled()).thenReturn(true);
     when(ozoneManager.isAdmin(any(UserGroupInformation.class))).thenReturn(false);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR only includes the commits with prefix of **[T3.x]**, please ignore the commits prefixed with "T1" and "T2".

This ticket is related to the write part of versioning feature.

Sub-task | Scope | Acceptance
-- | -- | --
T3.1 PUT commit two-table update | old current → versionedKeyTable, new current into keyTable, one WriteBatch | after overwrite both versions readable; two-table cache-consistency tests
T3.2 DELETE inserts marker | DELETE without versionId: current moves to versionedKeyTable, marker becomes current | GET returns KEY_NOT_FOUND; the old version survives; DELETE on a marker stacks another
T3.3 quota accounting | all versions (incl. marker namespace usage) count against bucket quota | over-quota versioned PUT rejected (unit test); deletions deduct correctly

</div></b>

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16014

## How was this patch tested?

unit test.