### PR TITLE
HDDS-16016. Adding unit test for datanodeUseHostname functionality in XceiverClientGrpc

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -1,19 +1,18 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.hadoop.hdds.scm;

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeID;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TestXceiverClientGrpc {
+
+  private static final int PORT = 9882;
+  private static final String HOSTNAME = "dn-host.example.com";
+  private static final String IP_ADDRESS = "192.168.1.100";
+
+  @ParameterizedTest(name = "useDatanodeHostname={0}")
+  @ValueSource(booleans = {false, true})
+  void createChannelUsesConfiguredAddress(boolean useHostname) throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(HddsConfigKeys.HDDS_DATANODE_USE_DN_HOSTNAME, useHostname);
+
+    DatanodeDetails dn = datanodeWithDistinctHostAndIp();
+    Pipeline pipeline = MockPipeline.createPipeline(Collections.singletonList(dn));
+
+    XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf);
+    ManagedChannel channel = client.createChannel(dn, PORT).build();
+    try {
+      String expectedHost = useHostname ? HOSTNAME : IP_ADDRESS;
+      assertThat(channel.authority()).isEqualTo(expectedHost + ":" + PORT);
+    } finally {
+      channel.shutdownNow();
+    }
+  }
+
+  private static DatanodeDetails datanodeWithDistinctHostAndIp() {
+    return MockDatanodeDetails.createDatanodeDetails(
+        DatanodeID.of(UUID.randomUUID()), HOSTNAME, IP_ADDRESS, "/rack");
+  }
+
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpcChannel.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpcChannel.java
@@ -17,11 +17,12 @@
 
 package org.apache.hadoop.hdds.scm;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -33,7 +34,7 @@ import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class TestXceiverClientGrpc {
+class TestXceiverClientGrpcChannel {
 
   private static final int PORT = 9882;
   private static final String HOSTNAME = "dn-host.example.com";
@@ -41,7 +42,7 @@ class TestXceiverClientGrpc {
 
   @ParameterizedTest(name = "useDatanodeHostname={0}")
   @ValueSource(booleans = {false, true})
-  void createChannelUsesConfiguredAddress(boolean useHostname) throws IOException {
+  void createChannelUsesConfiguredAddress(boolean useHostname) throws IOException, InterruptedException {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(HddsConfigKeys.HDDS_DATANODE_USE_DN_HOSTNAME, useHostname);
 
@@ -55,6 +56,7 @@ class TestXceiverClientGrpc {
       assertThat(channel.authority()).isEqualTo(expectedHost + ":" + PORT);
     } finally {
       channel.shutdownNow();
+      channel.awaitTermination(10, TimeUnit.SECONDS);
     }
   }
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpcChannel.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpcChannel.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -49,20 +48,21 @@ class TestXceiverClientGrpcChannel {
     DatanodeDetails dn = datanodeWithDistinctHostAndIp();
     Pipeline pipeline = MockPipeline.createPipeline(Collections.singletonList(dn));
 
-    XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf);
-    ManagedChannel channel = client.createChannel(dn, PORT).build();
-    try {
-      String expectedHost = useHostname ? HOSTNAME : IP_ADDRESS;
-      assertThat(channel.authority()).isEqualTo(expectedHost + ":" + PORT);
-    } finally {
-      channel.shutdownNow();
-      channel.awaitTermination(5, TimeUnit.SECONDS);
+    try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf)) {
+      ManagedChannel channel = client.createChannel(dn, PORT).build();
+      try {
+        String expectedHost = useHostname ? HOSTNAME : IP_ADDRESS;
+        assertThat(channel.authority()).isEqualTo(expectedHost + ":" + PORT);
+      } finally {
+        channel.shutdownNow();
+        channel.awaitTermination(5, TimeUnit.SECONDS);
+      }
     }
   }
 
   private static DatanodeDetails datanodeWithDistinctHostAndIp() {
     return MockDatanodeDetails.createDatanodeDetails(
-        DatanodeID.of(UUID.randomUUID()), HOSTNAME, IP_ADDRESS, "/rack");
+        DatanodeID.randomID(), HOSTNAME, IP_ADDRESS, "/rack");
   }
 
 }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpcChannel.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpcChannel.java
@@ -56,7 +56,7 @@ class TestXceiverClientGrpcChannel {
       assertThat(channel.authority()).isEqualTo(expectedHost + ":" + PORT);
     } finally {
       channel.shutdownNow();
-      channel.awaitTermination(10, TimeUnit.SECONDS);
+      channel.awaitTermination(5, TimeUnit.SECONDS);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding a unit test for the datanodeUseHostname functionality

Please describe your PR in detail:
* Creating a new TestXceiverClientGrpc class with a unit test to verify the addresses used when datanodeUseHostname is enabled / disabled

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16016

## How was this patch tested?
Unit tests
