### PR TITLE
HDDS-15645. ListObjectsV2 returns Owner when FetchOwner is not requested

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -1668,6 +1668,30 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
   }
 
   @Test
+  public void testListObjectsV2FetchOwner() {
+    final String bucketName = getBucketName("fetch-owner");
+    final String keyName = getKeyName("obj");
+    s3Client.createBucket(bucketName);
+    s3Client.putObject(bucketName, keyName, RandomStringUtils.secure().nextAlphanumeric(5));
+
+    ListObjectsV2Result defaultResponse = s3Client.listObjectsV2(
+        new ListObjectsV2Request().withBucketName(bucketName));
+    assertThat(defaultResponse.getObjectSummaries()).isNotEmpty();
+    assertNull(defaultResponse.getObjectSummaries().get(0).getOwner());
+
+    ListObjectsV2Result falseResponse = s3Client.listObjectsV2(
+        new ListObjectsV2Request().withBucketName(bucketName).withFetchOwner(false));
+    assertNull(falseResponse.getObjectSummaries().get(0).getOwner());
+
+    ListObjectsV2Result trueResponse = s3Client.listObjectsV2(
+        new ListObjectsV2Request().withBucketName(bucketName).withFetchOwner(true));
+    Owner owner = trueResponse.getObjectSummaries().get(0).getOwner();
+    assertNotNull(owner);
+    assertNotNull(owner.getDisplayName());
+    assertEquals(S3Owner.DEFAULT_S3OWNER_ID, owner.getId());
+  }
+
+  @Test
   public void testHighLevelMultipartUpload(@TempDir Path tempDir) throws Exception {
     TransferManager tm = TransferManagerBuilder.standard()
         .withS3Client(s3Client)

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -1109,6 +1109,30 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     assertEquals(S3SDKTestUtils.S3_SPECIAL_KEY_NAMES, listedKeys);
   }
 
+  @Test
+  public void testListObjectsV2FetchOwner() {
+    final String bucketName = getBucketName("fetch-owner");
+    final String keyName = getKeyName("obj");
+    s3Client.createBucket(b -> b.bucket(bucketName));
+    s3Client.putObject(b -> b.bucket(bucketName).key(keyName),
+        RequestBody.fromString("x"));
+
+    ListObjectsV2Response defaultResponse = s3Client.listObjectsV2(
+        ListObjectsV2Request.builder().bucket(bucketName).build());
+    assertThat(defaultResponse.contents()).isNotEmpty();
+    assertNull(defaultResponse.contents().get(0).owner());
+
+    ListObjectsV2Response falseResponse = s3Client.listObjectsV2(
+        ListObjectsV2Request.builder().bucket(bucketName).fetchOwner(false).build());
+    assertNull(falseResponse.contents().get(0).owner());
+
+    ListObjectsV2Response trueResponse = s3Client.listObjectsV2(
+        ListObjectsV2Request.builder().bucket(bucketName).fetchOwner(true).build());
+    assertNotNull(trueResponse.contents().get(0).owner());
+    assertNotNull(trueResponse.contents().get(0).owner().displayName());
+    assertEquals(S3Owner.DEFAULT_S3OWNER_ID, trueResponse.contents().get(0).owner().id());
+  }
+
   private void testListObjectsMany(boolean isListV2) throws Exception {
     final String bucketName = getBucketName();
     s3Client.createBucket(b -> b.bucket(bucketName));

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/RequestParameters.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/RequestParameters.java
@@ -65,6 +65,20 @@ public interface RequestParameters {
     }
   }
 
+  default boolean getBoolean(String key, boolean defaultValue) {
+    final String value = get(key);
+    if (value == null) {
+      return defaultValue;
+    }
+    if ("true".equalsIgnoreCase(value)) {
+      return true;
+    }
+    if ("false".equalsIgnoreCase(value)) {
+      return false;
+    }
+    throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, key);
+  }
+
   /** Mutable implementation based on {@link MultivaluedMap}. */
   final class MultivaluedMapImpl implements Mutable {
     private final MultivaluedMap<String, String> params;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -113,7 +113,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     int maxKeys = queryParams().getInt(QueryParams.MAX_KEYS, 1000);
     String prefix = queryParams().get(QueryParams.PREFIX, "");
     String startAfter = queryParams().get(QueryParams.START_AFTER);
-
+    boolean includeOwner = shouldIncludeOwnerInListResponse();
     Iterator<? extends OzoneKey> ozoneKeyIterator = null;
     // AWS S3 treats an empty continuation-token as no token: list from the
     // start and echo the empty token back (see setContinueToken below).
@@ -217,11 +217,11 @@ public class BucketEndpoint extends BucketOperationHandler {
           } else {
             // means our key is matched with prefix if prefix is given and it
             // does not have any common prefix.
-            addKey(response, next);
+            addKey(response, next, includeOwner);
             count++;
           }
         } else {
-          addKey(response, next);
+          addKey(response, next, includeOwner);
           count++;
         }
 
@@ -402,7 +402,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     return result;
   }
 
-  private void addKey(ListObjectResponse response, OzoneKey next) {
+  private void addKey(ListObjectResponse response, OzoneKey next, boolean includeOwner) {
     KeyMetadata keyMetadata = new KeyMetadata();
     keyMetadata.setKey(EncodingTypeObject.createNullable(next.getName(),
         response.getEncodingType()));
@@ -414,8 +414,9 @@ public class BucketEndpoint extends BucketOperationHandler {
     keyMetadata.setStorageClass(S3StorageType.fromReplicationConfig(
         next.getReplicationConfig()).toString());
     keyMetadata.setLastModified(next.getModificationTime());
-    String displayName = next.getOwner();
-    keyMetadata.setOwner(S3Owner.of(displayName));
+    if (includeOwner) {
+      keyMetadata.setOwner(S3Owner.of(next.getOwner()));
+    }
     response.addKey(keyMetadata);
   }
 
@@ -438,5 +439,11 @@ public class BucketEndpoint extends BucketOperationHandler {
         .add(this)
         .build();
     handler = new AuditingBucketOperationHandler(chain);
+  }
+
+  private boolean shouldIncludeOwnerInListResponse() {
+    int listType = queryParams().getInt(QueryParams.LIST_TYPE, 1);
+    boolean fetchOwner = queryParams().getBoolean(QueryParams.FETCH_OWNER, false);
+    return listType != 2 || fetchOwner;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
@@ -144,6 +144,8 @@ public final class S3Consts {
     public static final String DELIMITER = "delimiter";
     public static final String ENCODING_TYPE = "encoding-type";
     public static final String KEY_MARKER = "key-marker";
+    public static final String FETCH_OWNER = "fetch-owner";
+    public static final String LIST_TYPE = "list-type";
     // GetBucketLocation is not implemented
     public static final String LOCATION = "location";
     public static final String MARKER = "marker";

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -700,6 +700,43 @@ public class TestBucketList {
         "response must not use the non-AWS <continueToken> element");
   }
 
+  @Test
+  public void listObjectOwnerOmittedForListV2ByDefault() throws OS3Exception, IOException {
+    OzoneClient client = createClientWithKeys("key1", "key2");
+    BucketEndpoint endpoint = newBucketEndpointBuilder().setClient(client).build();
+
+    endpoint.queryParamsForTest().setInt(QueryParams.LIST_TYPE, 2);
+    ListObjectResponse response = (ListObjectResponse) endpoint.get("b1").getEntity();
+
+    assertEquals(2, response.getContents().size());
+    assertNull(response.getContents().get(0).getOwner());
+    assertNull(response.getContents().get(1).getOwner());
+  }
+
+  @Test
+  public void listObjectOwnerOmittedForListV2WhenFetchOwnerFalse() throws OS3Exception, IOException {
+    OzoneClient client = createClientWithKeys("key1");
+    BucketEndpoint endpoint = newBucketEndpointBuilder().setClient(client).build();
+
+    endpoint.queryParamsForTest().setInt(QueryParams.LIST_TYPE, 2);
+    endpoint.queryParamsForTest().set(QueryParams.FETCH_OWNER, "false");
+    ListObjectResponse response = (ListObjectResponse) endpoint.get("b1").getEntity();
+
+    assertNull(response.getContents().get(0).getOwner());
+  }
+
+  @Test
+  public void listObjectOwnerIncludedForListV2WhenFetchOwnerTrue() throws OS3Exception, IOException {
+    OzoneClient client = createClientWithKeys("key1");
+    BucketEndpoint endpoint = newBucketEndpointBuilder().setClient(client).build();
+
+    endpoint.queryParamsForTest().setInt(QueryParams.LIST_TYPE, 2);
+    endpoint.queryParamsForTest().set(QueryParams.FETCH_OWNER, "true");
+    ListObjectResponse response = (ListObjectResponse) endpoint.get("b1").getEntity();
+
+    assertNotNull(response.getContents().get(0).getOwner());
+  }
+
   private OzoneClient createClientWithKeys(String... keys) throws IOException {
     OzoneClient client = new OzoneClientStub();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The S3 compatibility tests test_bucket_listv2_fetchowner_defaultempty and test_bucket_listv2_fetchowner_empty are failing because in the S3 ListObjectsV2 response, the Owner field is currently included for each object even when the fetch-owner parameter is not set or is false. According to S3 behavior, owner information should only be returned when fetch-owner=true is requested. Update the response generation logic to omit the Owner field unless the fetch-owner flag is enabled.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15645

## How was this patch tested?

Written unit tests.
