### PR TITLE
HDDS-16024. Make OM and SCM proto finalization status an enum

### DIFF
--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -434,8 +434,7 @@ message UpgradeFinalizationStatus {
 enum FinalizationStatus {
     UNFINALIZED = 1;
     FINALIZED = 2;
-    PENDING = 3;
-    IN_PROGRESS = 4;
+    IN_PROGRESS = 3;
 }
 
 message UpgradeStatus {

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -430,9 +430,17 @@ message UpgradeFinalizationStatus {
     repeated string messages = 2;
 }
 
+// Finalization status of a component or group of components.
+enum FinalizationStatus {
+    UNFINALIZED = 1;
+    FINALIZED = 2;
+    PENDING = 3;
+    IN_PROGRESS = 4;
+}
+
 message UpgradeStatus {
-  optional bool hddsFinalized = 1;
-  optional bool scmFinalized = 2;
+  optional FinalizationStatus hddsFinalizationStatus = 1;
+  optional FinalizationStatus scmFinalizationStatus = 2;
   optional int32 numDatanodesFinalized = 3;
   optional int32 numDatanodesTotal = 4;
   optional uint32 scmApparentVersion = 5;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1224,13 +1224,23 @@ public class SCMClientProtocolServer implements
           scm.getScmNodeManager().getDatanodeFinalizationCounts();
       int finalizedDatanodes = datanodeFinalizationCounts.getNumFinalizedDatanodes();
       int healthyDatanodes = datanodeFinalizationCounts.getTotalHealthyDatanodes();
-      boolean hddsFinalized = scmFinalized && datanodeFinalizationCounts.allNodesFinalized();
+
+      HddsProtos.FinalizationStatus scmFinalizationStatus =
+          scmFinalized ? HddsProtos.FinalizationStatus.FINALIZED : HddsProtos.FinalizationStatus.UNFINALIZED;
+      HddsProtos.FinalizationStatus hddsFinalizationStatus;
+      if (!scmFinalized) {
+        hddsFinalizationStatus = HddsProtos.FinalizationStatus.UNFINALIZED;
+      } else if (datanodeFinalizationCounts.allNodesFinalized()) {
+        hddsFinalizationStatus = HddsProtos.FinalizationStatus.FINALIZED;
+      } else {
+        hddsFinalizationStatus = HddsProtos.FinalizationStatus.IN_PROGRESS;
+      }
 
       HddsProtos.UpgradeStatus result = HddsProtos.UpgradeStatus.newBuilder()
-          .setScmFinalized(scmFinalized)
+          .setScmFinalizationStatus(scmFinalizationStatus)
           .setNumDatanodesFinalized(finalizedDatanodes)
           .setNumDatanodesTotal(healthyDatanodes)
-          .setHddsFinalized(hddsFinalized)
+          .setHddsFinalizationStatus(hddsFinalizationStatus)
           .setScmApparentVersion(scm.getVersionManager().getApparentVersion().serialize())
           .setMinDatanodeApparentVersion(datanodeFinalizationCounts.getMinApparentVersion())
           .setMaxDatanodeApparentVersion(datanodeFinalizationCounts.getMaxApparentVersion())

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1219,16 +1219,21 @@ public class SCMClientProtocolServer implements
             + "safe mode and try again.", ResultCodes.SAFE_MODE_EXCEPTION);
       }
 
+      // Set SCM finalization status to return to the client.
+      // Since SCM finalization goes through Ratis, it moves from unfinalized to finalized immediately with no
+      // in-progress state.
       boolean scmFinalized = !scm.getVersionManager().needsFinalization();
+      HddsProtos.FinalizationStatus scmFinalizationStatus =
+          scmFinalized ? HddsProtos.FinalizationStatus.FINALIZED : HddsProtos.FinalizationStatus.UNFINALIZED;
+
+      // Set overall HDDS finalization status (SCM and Datanodes) to return to the client.
       NodeManager.DatanodeFinalizationCounts datanodeFinalizationCounts =
           scm.getScmNodeManager().getDatanodeFinalizationCounts();
       int finalizedDatanodes = datanodeFinalizationCounts.getNumFinalizedDatanodes();
       int healthyDatanodes = datanodeFinalizationCounts.getTotalHealthyDatanodes();
-
-      HddsProtos.FinalizationStatus scmFinalizationStatus =
-          scmFinalized ? HddsProtos.FinalizationStatus.FINALIZED : HddsProtos.FinalizationStatus.UNFINALIZED;
       HddsProtos.FinalizationStatus hddsFinalizationStatus;
       if (!scmFinalized) {
+        // SCM must finish finalizing before Datanodes can start finalizing.
         hddsFinalizationStatus = HddsProtos.FinalizationStatus.UNFINALIZED;
       } else if (datanodeFinalizationCounts.allNodesFinalized()) {
         hddsFinalizationStatus = HddsProtos.FinalizationStatus.FINALIZED;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -293,7 +293,7 @@ public class TestSCMClientProtocolServer {
 
   @Test
   public void testQueryUpgradeStatusHddsInProgress() throws Exception {
-    // SCM is finalized but not all datanodes are, so HDDS is only partially finalized.
+    // SCM is finalized but not all datanodes are, so HDDS finalization is still in progress.
     ScmVersionManager mockVersionManager = mock(ScmVersionManager.class);
     when(mockVersionManager.needsFinalization()).thenReturn(false);
     ComponentVersion apparentVersion = mock(ComponentVersion.class);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import org.apache.hadoop.hdds.ComponentVersion;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
@@ -49,10 +50,12 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
+import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocolServerSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
@@ -281,11 +284,48 @@ public class TestSCMClientProtocolServer {
     HddsProtos.UpgradeStatus status = server.queryUpgradeStatus();
 
     // SCM starts already finalized in tests
-    assertTrue(status.getScmFinalized());
+    assertEquals(HddsProtos.FinalizationStatus.FINALIZED, status.getScmFinalizationStatus());
     // No datanodes registered
     assertEquals(0, status.getNumDatanodesFinalized());
     assertEquals(0, status.getNumDatanodesTotal());
-    assertTrue(status.getHddsFinalized());
+    assertEquals(HddsProtos.FinalizationStatus.FINALIZED, status.getHddsFinalizationStatus());
+  }
+
+  @Test
+  public void testQueryUpgradeStatusHddsInProgress() throws Exception {
+    // SCM is finalized but not all datanodes are, so HDDS is only partially finalized.
+    ScmVersionManager mockVersionManager = mock(ScmVersionManager.class);
+    when(mockVersionManager.needsFinalization()).thenReturn(false);
+    ComponentVersion apparentVersion = mock(ComponentVersion.class);
+    when(apparentVersion.serialize()).thenReturn(0);
+    when(mockVersionManager.getApparentVersion()).thenReturn(apparentVersion);
+
+    NodeManager mockNodeManager = new MockNodeManager(false, 0) {
+      @Override
+      public DatanodeFinalizationCounts getDatanodeFinalizationCounts() {
+        return DatanodeFinalizationCounts.newBuilder()
+            .setNumFinalizedDatanodes(1)
+            .setTotalHealthyDatanodes(3)
+            .build();
+      }
+    };
+
+    StorageContainerManager mockScm = mockStorageContainerManager();
+    when(mockScm.getVersionManager()).thenReturn(mockVersionManager);
+    when(mockScm.getScmNodeManager()).thenReturn(mockNodeManager);
+    when(mockScm.getScmContext()).thenReturn(SCMContext.emptyContext());
+
+    SCMClientProtocolServer testServer = new SCMClientProtocolServer(
+        new OzoneConfiguration(), mockScm, mock(ReconfigurationHandler.class));
+    try {
+      HddsProtos.UpgradeStatus status = testServer.queryUpgradeStatus();
+      assertEquals(HddsProtos.FinalizationStatus.FINALIZED, status.getScmFinalizationStatus());
+      assertEquals(HddsProtos.FinalizationStatus.IN_PROGRESS, status.getHddsFinalizationStatus());
+      assertEquals(1, status.getNumDatanodesFinalized());
+      assertEquals(3, status.getNumDatanodesTotal());
+    } finally {
+      testServer.stop();
+    }
   }
 
   @Test

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/FinalizeSubCommand.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.FinalizationStatus;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.admin.om.OmAddressOptions;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
@@ -91,7 +92,7 @@ public class FinalizeSubCommand extends AbstractSubcommand implements Callable<I
 
       if (status != null) {
         // Finalization checks before sleeping, so an already-finalized cluster returns without waiting.
-        if (status.getClusterFinalized()) {
+        if (status.getClusterFinalizationStatus() == FinalizationStatus.FINALIZED) {
           out().println("Finalization complete.");
           return 0;
         }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/StatusSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/ozone/admin/upgrade/StatusSubCommand.java
@@ -75,9 +75,10 @@ public class StatusSubCommand extends AbstractSubcommand implements Callable<Int
 
   /** Basic, non-verbose human-readable status. */
   static void printBasic(QueryUpgradeStatusResponse status, PrintWriter out) {
-    out.println("Upgrade status:");
-    out.println("    OM Finalized? " + status.getOmFinalized());
-    out.println("    SCM Finalized? " + status.getHddsStatus().getScmFinalized());
+    out.println("Upgrade finalization status:");
+    out.println("    Cluster: " + status.getClusterFinalizationStatus().name());
+    out.println("    OM: " + status.getOmFinalizationStatus().name());
+    out.println("    SCM: " + status.getHddsStatus().getScmFinalizationStatus().name());
     out.println("    Datanodes finalized: " + status.getHddsStatus().getNumDatanodesFinalized()
         + "/" + status.getHddsStatus().getNumDatanodesTotal());
   }
@@ -88,11 +89,12 @@ public class StatusSubCommand extends AbstractSubcommand implements Callable<Int
    */
   static void printVerbose(QueryUpgradeStatusResponse status, PrintWriter out) {
     HddsProtos.UpgradeStatus hdds = status.getHddsStatus();
-    out.println("Upgrade status:");
-    out.println("    OM Finalized?            " + status.getOmFinalized());
+    out.println("Upgrade finalization status:");
+    out.println("    Cluster:                 " + status.getClusterFinalizationStatus().name());
+    out.println("    OM:                      " + status.getOmFinalizationStatus().name());
     out.println("    OM Apparent Version:     "
         + OzoneManagerVersion.deserialize(status.getOmApparentVersion()).toString());
-    out.println("    SCM Finalized?           " + hdds.getScmFinalized());
+    out.println("    SCM:                     " + hdds.getScmFinalizationStatus().name());
     out.println("    SCM Apparent Version:    " + HDDSVersion.deserialize(hdds.getScmApparentVersion()).toString());
     out.println("    Datanodes finalized:     " + hdds.getNumDatanodesFinalized() + "/" + hdds.getNumDatanodesTotal());
     out.println("    Min Datanode Apparent Version: "
@@ -109,9 +111,10 @@ public class StatusSubCommand extends AbstractSubcommand implements Callable<Int
    * JSON-friendly DTO mirroring {@link QueryUpgradeStatusResponse}.
    */
   public static final class UpgradeStatusDto {
-    private boolean omFinalized;
+    private String clusterFinalizationStatus;
+    private String omFinalizationStatus;
     private String omApparentVersion;
-    private boolean scmFinalized;
+    private String scmFinalizationStatus;
     private String scmApparentVersion;
     private int datanodesFinalized;
     private int datanodesTotal;
@@ -121,8 +124,9 @@ public class StatusSubCommand extends AbstractSubcommand implements Callable<Int
     public static UpgradeStatusDto from(QueryUpgradeStatusResponse status) {
       HddsProtos.UpgradeStatus hdds = status.getHddsStatus();
       UpgradeStatusDto dto = new UpgradeStatusDto();
-      dto.omFinalized = status.getOmFinalized();
-      dto.scmFinalized = hdds.getScmFinalized();
+      dto.clusterFinalizationStatus = status.getClusterFinalizationStatus().name();
+      dto.omFinalizationStatus = status.getOmFinalizationStatus().name();
+      dto.scmFinalizationStatus = hdds.getScmFinalizationStatus().name();
       dto.datanodesFinalized = hdds.getNumDatanodesFinalized();
       dto.datanodesTotal = hdds.getNumDatanodesTotal();
       dto.omApparentVersion = OzoneManagerVersion.deserialize(status.getOmApparentVersion()).toString();
@@ -132,16 +136,20 @@ public class StatusSubCommand extends AbstractSubcommand implements Callable<Int
       return dto;
     }
 
-    public boolean isOmFinalized() {
-      return omFinalized;
+    public String getClusterFinalizationStatus() {
+      return clusterFinalizationStatus;
+    }
+
+    public String getOmFinalizationStatus() {
+      return omFinalizationStatus;
     }
 
     public String getOmApparentVersion() {
       return omApparentVersion;
     }
 
-    public boolean isScmFinalized() {
-      return scmFinalized;
+    public String getScmFinalizationStatus() {
+      return scmFinalizationStatus;
     }
 
     public String getScmApparentVersion() {

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
@@ -286,8 +286,8 @@ public class TestFinalizeSubCommand {
     assertEquals(0, cmd.call());
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertTrue(output.contains("OM Finalized?"));
-    assertTrue(output.contains("SCM Finalized?"));
+    assertTrue(output.contains("OM:"));
+    assertTrue(output.contains("SCM:"));
     assertTrue(output.contains("OM Apparent Version:"));
     assertTrue(output.contains("SCM Apparent Version:"));
     assertTrue(output.contains("Min Datanode Apparent Version:"));
@@ -297,10 +297,10 @@ public class TestFinalizeSubCommand {
 
   private static QueryUpgradeStatusResponse inProgressStatus(int dnFinalized, int dnTotal) {
     return QueryUpgradeStatusResponse.newBuilder()
-        .setOmFinalized(false)
-        .setClusterFinalized(false)
+        .setOmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
+        .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
         .setHddsStatus(HddsProtos.UpgradeStatus.newBuilder()
-            .setScmFinalized(false)
+            .setScmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
             .setNumDatanodesFinalized(dnFinalized)
             .setNumDatanodesTotal(dnTotal)
             .build())
@@ -309,10 +309,10 @@ public class TestFinalizeSubCommand {
 
   private static QueryUpgradeStatusResponse finalizedStatus(int dnFinalized, int dnTotal) {
     return QueryUpgradeStatusResponse.newBuilder()
-        .setOmFinalized(true)
-        .setClusterFinalized(true)
+        .setOmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+        .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
         .setHddsStatus(HddsProtos.UpgradeStatus.newBuilder()
-            .setScmFinalized(true)
+            .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
             .setNumDatanodesFinalized(dnFinalized)
             .setNumDatanodesTotal(dnTotal)
             .build())

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
@@ -144,7 +144,7 @@ public class TestFinalizeSubCommand {
 
   @Test
   public void testStatusCalledOnceWhenAlreadyFinalized() throws Exception {
-    when(omClient.queryUpgradeStatus()).thenReturn(finalizedStatus(3, 3));
+    when(omClient.queryUpgradeStatus()).thenReturn(finalizedStatus());
 
     new CommandLine(cmd).parseArgs("--wait");
     assertEquals(0, cmd.call());
@@ -158,9 +158,9 @@ public class TestFinalizeSubCommand {
   @Test
   public void testWaitFlagPollsUntilFinalized() throws Exception {
     when(omClient.queryUpgradeStatus())
-        .thenReturn(inProgressStatus(0, 3))
-        .thenReturn(inProgressStatus(2, 3))
-        .thenReturn(finalizedStatus(3, 3));
+        .thenReturn(inProgressStatus())
+        .thenReturn(inProgressStatus())
+        .thenReturn(finalizedStatus());
 
     new CommandLine(cmd).parseArgs("--wait");
     assertEquals(0, cmd.call());
@@ -177,7 +177,7 @@ public class TestFinalizeSubCommand {
     // A transient query failure is reported to stderr and retried on the next poll, not fatal.
     when(omClient.queryUpgradeStatus())
         .thenThrow(new IOException("RPC timeout"))
-        .thenReturn(finalizedStatus(3, 3));
+        .thenReturn(finalizedStatus());
 
     new CommandLine(cmd).parseArgs("--wait");
     assertEquals(0, cmd.call());
@@ -192,8 +192,9 @@ public class TestFinalizeSubCommand {
   @Test
   public void testWaitFlagInterruptIsHandledCleanly() throws Exception {
     // Make the poll interval long enough that the interrupt lands during the sleep (after the first poll).
+    // The test will exit well before this interval elapses.
     cmd.setPollIntervalMillis(60_000);
-    when(omClient.queryUpgradeStatus()).thenReturn(inProgressStatus(0, 3));
+    when(omClient.queryUpgradeStatus()).thenReturn(inProgressStatus());
 
     new CommandLine(cmd).parseArgs("--wait");
 
@@ -228,8 +229,8 @@ public class TestFinalizeSubCommand {
     cmd.setPollIntervalMillis(60_000);
     // First invocation's poll: in progress (so it sleeps); second invocation's poll: finalized.
     when(omClient.queryUpgradeStatus())
-        .thenReturn(inProgressStatus(0, 3))
-        .thenReturn(finalizedStatus(3, 3));
+        .thenReturn(inProgressStatus())
+        .thenReturn(finalizedStatus());
 
     new CommandLine(cmd).parseArgs("--wait");
 
@@ -279,8 +280,8 @@ public class TestFinalizeSubCommand {
     verbose = true;
     // Return one in-progress poll first so the verbose status is printed.
     when(omClient.queryUpgradeStatus())
-        .thenReturn(inProgressStatus(1, 2))
-        .thenReturn(finalizedStatus(2, 2));
+        .thenReturn(inProgressStatus())
+        .thenReturn(finalizedStatus());
 
     new CommandLine(cmd).parseArgs("--wait");
     assertEquals(0, cmd.call());
@@ -295,26 +296,34 @@ public class TestFinalizeSubCommand {
     assertTrue(output.contains("Finalization complete."));
   }
 
-  private static QueryUpgradeStatusResponse inProgressStatus(int dnFinalized, int dnTotal) {
+  /**
+   * @return An upgrade status with the whole cluster finalization status set to IN_PROGRESS. All other status fields
+   * are placeholders and not intended to be checked for exact values.
+   */
+  private static QueryUpgradeStatusResponse inProgressStatus() {
     return QueryUpgradeStatusResponse.newBuilder()
         .setOmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
         .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
         .setHddsStatus(HddsProtos.UpgradeStatus.newBuilder()
             .setScmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
-            .setNumDatanodesFinalized(dnFinalized)
-            .setNumDatanodesTotal(dnTotal)
+            .setNumDatanodesFinalized(1)
+            .setNumDatanodesTotal(3)
             .build())
         .build();
   }
 
-  private static QueryUpgradeStatusResponse finalizedStatus(int dnFinalized, int dnTotal) {
+  /**
+   * @return An upgrade status with the whole cluster finalization status set to FINALIZED. All other status fields
+   * are placeholders and not intended to be checked for exact values.
+   */
+  private static QueryUpgradeStatusResponse finalizedStatus() {
     return QueryUpgradeStatusResponse.newBuilder()
         .setOmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
         .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
         .setHddsStatus(HddsProtos.UpgradeStatus.newBuilder()
             .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
-            .setNumDatanodesFinalized(dnFinalized)
-            .setNumDatanodesTotal(dnTotal)
+            .setNumDatanodesFinalized(3)
+            .setNumDatanodesTotal(3)
             .build())
         .build();
   }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestFinalizeSubCommand.java
@@ -167,7 +167,7 @@ public class TestFinalizeSubCommand {
 
     String output = outContent.toString(DEFAULT_ENCODING);
     // While polling, the shared basic status output is printed on each in-progress poll.
-    assertTrue(output.contains("Upgrade status:"));
+    assertTrue(output.contains("Upgrade finalization status:"));
     assertTrue(output.contains("Finalization complete."));
     verify(omClient, times(3)).queryUpgradeStatus();
   }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestStatusSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestStatusSubCommand.java
@@ -91,15 +91,16 @@ public class TestStatusSubCommand {
   @Test
   public void testStatusCommandPrintsUpgradeStatus() throws Exception {
     HddsProtos.UpgradeStatus hddsStatus = HddsProtos.UpgradeStatus.newBuilder()
-        .setScmFinalized(false)
+        .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
         .setNumDatanodesFinalized(1)
         .setNumDatanodesTotal(3)
-        .setHddsFinalized(true)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
         .build();
 
     OzoneManagerProtocolProtos.QueryUpgradeStatusResponse response =
         OzoneManagerProtocolProtos.QueryUpgradeStatusResponse.newBuilder()
-            .setOmFinalized(false)
+            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
+            .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
             .setHddsStatus(hddsStatus)
             .build();
 
@@ -109,11 +110,40 @@ public class TestStatusSubCommand {
 
     String output = outContent.toString(DEFAULT_ENCODING);
     assertTrue(output.contains("Upgrade status"));
-    assertTrue(output.contains("OM Finalized? false"));
-    assertTrue(output.contains("SCM Finalized? false"));
+    assertTrue(output.contains("Cluster: IN_PROGRESS"));
+    assertTrue(output.contains("OM: UNFINALIZED"));
+    assertTrue(output.contains("SCM: FINALIZED"));
     assertTrue(output.contains("Datanodes finalized: 1/3"));
     // Without --verbose the apparent versions are not shown.
     assertFalse(output.contains("Apparent Version"));
+    verify(omClient).queryUpgradeStatus();
+  }
+
+  @Test
+  public void testStatusCommandPrintsPendingOm() throws Exception {
+    // OM has begun polling SCM (marker present) but is not finalized yet.
+    HddsProtos.UpgradeStatus hddsStatus = HddsProtos.UpgradeStatus.newBuilder()
+        .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+        .setNumDatanodesFinalized(3)
+        .setNumDatanodesTotal(3)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+        .build();
+
+    OzoneManagerProtocolProtos.QueryUpgradeStatusResponse response =
+        OzoneManagerProtocolProtos.QueryUpgradeStatusResponse.newBuilder()
+            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.PENDING)
+            .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
+            .setHddsStatus(hddsStatus)
+            .build();
+
+    when(omClient.queryUpgradeStatus()).thenReturn(response);
+    new CommandLine(cmd).parseArgs();
+    cmd.call();
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertTrue(output.contains("OM: PENDING"));
+    assertTrue(output.contains("Cluster: IN_PROGRESS"));
+    assertTrue(output.contains("SCM: FINALIZED"));
     verify(omClient).queryUpgradeStatus();
   }
 
@@ -142,10 +172,11 @@ public class TestStatusSubCommand {
     int hddsVersion = HDDSVersion.SOFTWARE_VERSION.serialize();
     OzoneManagerProtocolProtos.QueryUpgradeStatusResponse response =
         OzoneManagerProtocolProtos.QueryUpgradeStatusResponse.newBuilder()
-            .setOmFinalized(true)
+            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+            .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
             .setOmApparentVersion(omVersion)
             .setHddsStatus(HddsProtos.UpgradeStatus.newBuilder()
-                .setScmFinalized(true)
+                .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
                 .setNumDatanodesFinalized(2)
                 .setNumDatanodesTotal(3)
                 .setScmApparentVersion(hddsVersion)
@@ -161,8 +192,9 @@ public class TestStatusSubCommand {
     String jsonOutput = outContent.toString(DEFAULT_ENCODING);
 
     JsonNode root = JSON.readTree(jsonOutput);
-    assertTrue(root.path("omFinalized").asBoolean());
-    assertTrue(root.path("scmFinalized").asBoolean());
+    assertEquals("FINALIZED", root.path("clusterFinalizationStatus").asText());
+    assertEquals("FINALIZED", root.path("omFinalizationStatus").asText());
+    assertEquals("FINALIZED", root.path("scmFinalizationStatus").asText());
     assertEquals(2, root.path("datanodesFinalized").asInt());
     assertEquals(3, root.path("datanodesTotal").asInt());
     assertEquals(OzoneManagerVersion.ZDU.toString(), root.path("omApparentVersion").asText());
@@ -185,10 +217,11 @@ public class TestStatusSubCommand {
     int hddsVersion = HDDSVersion.SOFTWARE_VERSION.serialize();
     OzoneManagerProtocolProtos.QueryUpgradeStatusResponse response =
         OzoneManagerProtocolProtos.QueryUpgradeStatusResponse.newBuilder()
-            .setOmFinalized(true)
+            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+            .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
             .setOmApparentVersion(omVersion)
             .setHddsStatus(HddsProtos.UpgradeStatus.newBuilder()
-                .setScmFinalized(true)
+                .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
                 .setNumDatanodesFinalized(3)
                 .setNumDatanodesTotal(3)
                 .setScmApparentVersion(hddsVersion)
@@ -202,9 +235,9 @@ public class TestStatusSubCommand {
     assertEquals(0, cmd.call());
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertTrue(output.contains("OM Finalized?"));
+    assertTrue(output.contains("OM:"));
     assertTrue(output.contains("OM Apparent Version:"));
-    assertTrue(output.contains("SCM Finalized?"));
+    assertTrue(output.contains("SCM:"));
     assertTrue(output.contains("SCM Apparent Version:"));
     assertTrue(output.contains("Min Datanode Apparent Version:"));
     assertTrue(output.contains("Max Datanode Apparent Version:"));

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestStatusSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestStatusSubCommand.java
@@ -109,7 +109,7 @@ public class TestStatusSubCommand {
     cmd.call();
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertTrue(output.contains("Upgrade status"));
+    assertTrue(output.contains("Upgrade finalization status"));
     assertTrue(output.contains("Cluster: IN_PROGRESS"));
     assertTrue(output.contains("OM: UNFINALIZED"));
     assertTrue(output.contains("SCM: FINALIZED"));
@@ -120,7 +120,7 @@ public class TestStatusSubCommand {
   }
 
   @Test
-  public void testStatusCommandPrintsPendingOm() throws Exception {
+  public void testStatusCommandPrintsInProgressOm() throws Exception {
     // OM has begun polling SCM (marker present) but is not finalized yet.
     HddsProtos.UpgradeStatus hddsStatus = HddsProtos.UpgradeStatus.newBuilder()
         .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
@@ -131,7 +131,7 @@ public class TestStatusSubCommand {
 
     OzoneManagerProtocolProtos.QueryUpgradeStatusResponse response =
         OzoneManagerProtocolProtos.QueryUpgradeStatusResponse.newBuilder()
-            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.PENDING)
+            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
             .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
             .setHddsStatus(hddsStatus)
             .build();
@@ -141,7 +141,7 @@ public class TestStatusSubCommand {
     cmd.call();
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertTrue(output.contains("OM: PENDING"));
+    assertTrue(output.contains("OM: IN_PROGRESS"));
     assertTrue(output.contains("Cluster: IN_PROGRESS"));
     assertTrue(output.contains("SCM: FINALIZED"));
     verify(omClient).queryUpgradeStatus();

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestStatusSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/ozone/admin/upgrade/TestStatusSubCommand.java
@@ -89,18 +89,19 @@ public class TestStatusSubCommand {
   }
 
   @Test
-  public void testStatusCommandPrintsUpgradeStatus() throws Exception {
+  public void testStatusCommandPrintsFinalized() throws Exception {
+    // Every component has finished finalizing and all datanodes are finalized.
     HddsProtos.UpgradeStatus hddsStatus = HddsProtos.UpgradeStatus.newBuilder()
         .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
-        .setNumDatanodesFinalized(1)
+        .setNumDatanodesFinalized(3)
         .setNumDatanodesTotal(3)
-        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
         .build();
 
     OzoneManagerProtocolProtos.QueryUpgradeStatusResponse response =
         OzoneManagerProtocolProtos.QueryUpgradeStatusResponse.newBuilder()
-            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
-            .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
+            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+            .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
             .setHddsStatus(hddsStatus)
             .build();
 
@@ -110,23 +111,23 @@ public class TestStatusSubCommand {
 
     String output = outContent.toString(DEFAULT_ENCODING);
     assertTrue(output.contains("Upgrade finalization status"));
-    assertTrue(output.contains("Cluster: IN_PROGRESS"));
-    assertTrue(output.contains("OM: UNFINALIZED"));
+    assertTrue(output.contains("Cluster: FINALIZED"));
+    assertTrue(output.contains("OM: FINALIZED"));
     assertTrue(output.contains("SCM: FINALIZED"));
-    assertTrue(output.contains("Datanodes finalized: 1/3"));
-    // Without --verbose the apparent versions are not shown.
-    assertFalse(output.contains("Apparent Version"));
+    assertTrue(output.contains("Datanodes finalized: 3/3"));
+    // Without --verbose internal server versions are not shown.
+    assertFalse(output.toLowerCase().contains("version"));
     verify(omClient).queryUpgradeStatus();
   }
 
   @Test
-  public void testStatusCommandPrintsInProgressOm() throws Exception {
-    // OM has begun polling SCM (marker present) but is not finalized yet.
+  public void testStatusCommandPrintsInProgress() throws Exception {
+    // SCM is finalized and datanodes are partway through, but OM has not finalized yet.
     HddsProtos.UpgradeStatus hddsStatus = HddsProtos.UpgradeStatus.newBuilder()
         .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
-        .setNumDatanodesFinalized(3)
+        .setNumDatanodesFinalized(1)
         .setNumDatanodesTotal(3)
-        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
         .build();
 
     OzoneManagerProtocolProtos.QueryUpgradeStatusResponse response =
@@ -141,9 +142,41 @@ public class TestStatusSubCommand {
     cmd.call();
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertTrue(output.contains("OM: IN_PROGRESS"));
+    assertTrue(output.contains("Upgrade finalization status"));
     assertTrue(output.contains("Cluster: IN_PROGRESS"));
+    assertTrue(output.contains("OM: IN_PROGRESS"));
     assertTrue(output.contains("SCM: FINALIZED"));
+    assertTrue(output.contains("Datanodes finalized: 1/3"));
+    verify(omClient).queryUpgradeStatus();
+  }
+
+  @Test
+  public void testStatusCommandPrintsUnfinalized() throws Exception {
+    // Nothing has been finalized yet.
+    HddsProtos.UpgradeStatus hddsStatus = HddsProtos.UpgradeStatus.newBuilder()
+        .setScmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
+        .setNumDatanodesFinalized(0)
+        .setNumDatanodesTotal(3)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
+        .build();
+
+    OzoneManagerProtocolProtos.QueryUpgradeStatusResponse response =
+        OzoneManagerProtocolProtos.QueryUpgradeStatusResponse.newBuilder()
+            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
+            .setClusterFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
+            .setHddsStatus(hddsStatus)
+            .build();
+
+    when(omClient.queryUpgradeStatus()).thenReturn(response);
+    new CommandLine(cmd).parseArgs();
+    cmd.call();
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertTrue(output.contains("Upgrade finalization status"));
+    assertTrue(output.contains("Cluster: UNFINALIZED"));
+    assertTrue(output.contains("OM: UNFINALIZED"));
+    assertTrue(output.contains("SCM: UNFINALIZED"));
+    assertTrue(output.contains("Datanodes finalized: 0/3"));
     verify(omClient).queryUpgradeStatus();
   }
 
@@ -236,13 +269,12 @@ public class TestStatusSubCommand {
 
     String output = outContent.toString(DEFAULT_ENCODING);
     assertTrue(output.contains("OM:"));
-    assertTrue(output.contains("OM Apparent Version:"));
     assertTrue(output.contains("SCM:"));
-    assertTrue(output.contains("SCM Apparent Version:"));
-    assertTrue(output.contains("Min Datanode Apparent Version:"));
-    assertTrue(output.contains("Max Datanode Apparent Version:"));
-    assertTrue(output.contains(OzoneManagerVersion.ZDU.toString()));
-    assertTrue(output.contains(HDDSVersion.SOFTWARE_VERSION.toString()));
+    // Each apparent version label should be followed by the version number set on the response.
+    assertTrue(output.contains("OM Apparent Version:     " + OzoneManagerVersion.ZDU));
+    assertTrue(output.contains("SCM Apparent Version:    " + HDDSVersion.SOFTWARE_VERSION));
+    assertTrue(output.contains("Min Datanode Apparent Version: " + HDDSVersion.SOFTWARE_VERSION));
+    assertTrue(output.contains("Max Datanode Apparent Version: " + HDDSVersion.SOFTWARE_VERSION));
   }
 
   private ServiceInfoEx serviceInfoWithVersion(OzoneManagerVersion version) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/HddsUpgradeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/HddsUpgradeTestUtils.java
@@ -51,7 +51,7 @@ public final class HddsUpgradeTestUtils {
     LambdaTestUtils.await(60_000, 1_000, () -> {
       HddsProtos.UpgradeStatus status = scmClient.queryUpgradeStatus();
       LOG.info("Waiting for upgrade finalization to complete from client. Current status is:\n{}", status);
-      return status.getHddsFinalized();
+      return status.getHddsFinalizationStatus() == HddsProtos.FinalizationStatus.FINALIZED;
     });
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OMUpgradeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OMUpgradeTestUtils.java
@@ -45,12 +45,10 @@ public final class OMUpgradeTestUtils {
       try {
         QueryUpgradeStatusResponse status = omClient.queryUpgradeStatus();
         HddsProtos.UpgradeStatus hdds = status.getHddsStatus();
-        LOG.info("Finalization status: omFinalized={}, scmFinalized={}, datanodes={}/{}",
-            status.getOmFinalized(), hdds.getScmFinalized(),
+        LOG.info("Finalization status: om={}, scm={}, datanodes={}/{}",
+            status.getOmFinalizationStatus(), hdds.getScmFinalizationStatus(),
             hdds.getNumDatanodesFinalized(), hdds.getNumDatanodesTotal());
-        return status.getOmFinalized()
-            && hdds.getScmFinalized()
-            && hdds.getNumDatanodesFinalized() == hdds.getNumDatanodesTotal();
+        return status.getClusterFinalizationStatus() == HddsProtos.FinalizationStatus.FINALIZED;
       } catch (IOException e) {
         fail(e.getMessage());
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
@@ -166,7 +166,7 @@ class TestOMUpgradeFinalization {
   }
 
   /**
-   * OM's reported finalization status should move UNFINALIZED -> PENDING (once the in-progress
+   * OM's reported finalization status should move UNFINALIZED -> IN_PROGRESS (once the in-progress
    * marker is present) -> FINALIZED.
    */
   @Test
@@ -189,9 +189,9 @@ class TestOMUpgradeFinalization {
         assertEquals(HddsProtos.FinalizationStatus.UNFINALIZED,
             omClient.queryUpgradeStatus().getOmFinalizationStatus());
 
-        // With the in-progress marker present but the OM not yet finalized, OM reports PENDING.
+        // With the in-progress marker present but the OM not yet finalized, OM reports IN_PROGRESS.
         om.getMetadataManager().getMetaTable().put(FINALIZATION_IN_PROGRESS_KEY, "ignored");
-        assertEquals(HddsProtos.FinalizationStatus.PENDING,
+        assertEquals(HddsProtos.FinalizationStatus.IN_PROGRESS,
             omClient.queryUpgradeStatus().getOmFinalizationStatus());
         om.getMetadataManager().getMetaTable().delete(FINALIZATION_IN_PROGRESS_KEY);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om;
 
 import static org.apache.hadoop.ozone.OzoneConsts.APPARENT_VERSION_KEY;
+import static org.apache.hadoop.ozone.OzoneConsts.FINALIZATION_IN_PROGRESS_KEY;
 import static org.apache.hadoop.ozone.om.TestOzoneManagerHAWithStoppedNodes.createKey;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.INITIAL_VERSION;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
@@ -31,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
@@ -159,6 +161,45 @@ class TestOMUpgradeFinalization {
         // Confirm finalization happened via snapshot install, not log replay.
         assertThat(versionManagerLogCapture.getOutput()).contains("New snapshot received with higher apparent version");
         versionManagerLogCapture.stopCapturing();
+      }
+    }
+  }
+
+  /**
+   * OM's reported finalization status should move UNFINALIZED -> PENDING (once the in-progress
+   * marker is present) -> FINALIZED.
+   */
+  @Test
+  void testOmFinalizationStatusTransitions() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_UPGRADE_FINALIZATION_CHECK_INTERVAL, "10ms");
+    conf.setInt(OMStorage.TESTING_INIT_APPARENT_VERSION_KEY, INITIAL_VERSION.serialize());
+
+    try (MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(1)
+        .build()) {
+      cluster.waitForClusterToBeReady();
+      OzoneManager om = cluster.getOzoneManager();
+
+      try (OzoneClient client = cluster.newClient()) {
+        OzoneManagerProtocol omClient = client.getObjectStore().getClientProxy().getOzoneManagerClient();
+
+        // Before finalization: no in-progress marker, OM reports UNFINALIZED.
+        assertNull(om.getMetadataManager().getMetaTable().get(FINALIZATION_IN_PROGRESS_KEY));
+        assertEquals(HddsProtos.FinalizationStatus.UNFINALIZED,
+            omClient.queryUpgradeStatus().getOmFinalizationStatus());
+
+        // With the in-progress marker present but the OM not yet finalized, OM reports PENDING.
+        om.getMetadataManager().getMetaTable().put(FINALIZATION_IN_PROGRESS_KEY, "ignored");
+        assertEquals(HddsProtos.FinalizationStatus.PENDING,
+            omClient.queryUpgradeStatus().getOmFinalizationStatus());
+        om.getMetadataManager().getMetaTable().delete(FINALIZATION_IN_PROGRESS_KEY);
+
+        // After finalization completes, OM reports FINALIZED.
+        omClient.finalizeUpgrade();
+        OMUpgradeTestUtils.waitForFinalization(omClient);
+        assertEquals(HddsProtos.FinalizationStatus.FINALIZED,
+            omClient.queryUpgradeStatus().getOmFinalizationStatus());
       }
     }
   }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1666,10 +1666,10 @@ message QueryUpgradeStatusRequest {
 }
 
 message QueryUpgradeStatusResponse {
-    // True when OM, SCM and all healthy datanodes are finalized
-    optional bool clusterFinalized = 1;
+    // Aggregate status of OM, SCM and all healthy datanodes
+    optional hadoop.hdds.FinalizationStatus clusterFinalizationStatus = 1;
     optional hadoop.hdds.UpgradeStatus hddsStatus = 2;
-    optional bool omFinalized = 3;
+    optional hadoop.hdds.FinalizationStatus omFinalizationStatus = 3;
     optional uint32 omApparentVersion = 4;
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3676,15 +3676,32 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throw e;
     }
 
-    boolean omFinalized = !versionManager.needsFinalization();
-    boolean hddsFinalized = scmStatus.getHddsFinalized();
-    boolean clusterFinalized = omFinalized && hddsFinalized;
+    HddsProtos.FinalizationStatus omFinalizationStatus;
+    if (!versionManager.needsFinalization()) {
+      omFinalizationStatus = HddsProtos.FinalizationStatus.FINALIZED;
+    } else if (metadataManager.getMetaTable().get(FINALIZATION_IN_PROGRESS_KEY) != null) {
+      omFinalizationStatus = HddsProtos.FinalizationStatus.PENDING;
+    } else {
+      omFinalizationStatus = HddsProtos.FinalizationStatus.UNFINALIZED;
+    }
+    HddsProtos.FinalizationStatus hddsFinalizationStatus = scmStatus.getHddsFinalizationStatus();
+
+    HddsProtos.FinalizationStatus clusterFinalizationStatus;
+    if (omFinalizationStatus == HddsProtos.FinalizationStatus.FINALIZED
+        && hddsFinalizationStatus == HddsProtos.FinalizationStatus.FINALIZED) {
+      clusterFinalizationStatus = HddsProtos.FinalizationStatus.FINALIZED;
+    } else if (omFinalizationStatus == HddsProtos.FinalizationStatus.UNFINALIZED
+        && hddsFinalizationStatus == HddsProtos.FinalizationStatus.UNFINALIZED) {
+      clusterFinalizationStatus = HddsProtos.FinalizationStatus.UNFINALIZED;
+    } else {
+      clusterFinalizationStatus = HddsProtos.FinalizationStatus.IN_PROGRESS;
+    }
 
     return QueryUpgradeStatusResponse.newBuilder()
-        .setOmFinalized(omFinalized)
+        .setOmFinalizationStatus(omFinalizationStatus)
         .setHddsStatus(scmStatus)
         .setOmApparentVersion(versionManager.getApparentVersion().serialize())
-        .setClusterFinalized(clusterFinalized)
+        .setClusterFinalizationStatus(clusterFinalizationStatus)
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3680,7 +3680,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (!versionManager.needsFinalization()) {
       omFinalizationStatus = HddsProtos.FinalizationStatus.FINALIZED;
     } else if (metadataManager.getMetaTable().get(FINALIZATION_IN_PROGRESS_KEY) != null) {
-      omFinalizationStatus = HddsProtos.FinalizationStatus.PENDING;
+      omFinalizationStatus = HddsProtos.FinalizationStatus.IN_PROGRESS;
     } else {
       omFinalizationStatus = HddsProtos.FinalizationStatus.UNFINALIZED;
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMUpgradeFinalizeService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMUpgradeFinalizeService.java
@@ -117,7 +117,7 @@ public class OMUpgradeFinalizeService extends BackgroundService {
           }
 
           HddsProtos.UpgradeStatus upgradeStatus = scmClient.getContainerClient().queryUpgradeStatus();
-          if (upgradeStatus.getHddsFinalized()) {
+          if (upgradeStatus.getHddsFinalizationStatus() == HddsProtos.FinalizationStatus.FINALIZED) {
             LOG.info("The SCM Upgrade has been finalized. OM will now finalize. Run count {}", run);
 
             OzoneManagerProtocolProtos.OMRequest omRequest = OzoneManagerProtocolProtos.OMRequest.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMUpgradeFinalizeService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMUpgradeFinalizeService.java
@@ -125,7 +125,7 @@ public class TestOMUpgradeFinalizeService {
 
   /**
    * When the OM is the leader, finalization is needed, the finalization command is given and SCM reports
-   * hddsFinalized=true, a FinalizeUpgrade request should be submitted via Ratis.
+   * hddsFinalizationStatus=FINALIZED, a FinalizeUpgrade request should be submitted via Ratis.
    */
   @Test
   void testFinalizationTriggeredWhenScmIsFinalizedAndFinalizationInProgress() throws Exception {
@@ -133,8 +133,8 @@ public class TestOMUpgradeFinalizeService {
     when(versionManager.needsFinalization()).thenReturn(true);
 
     HddsProtos.UpgradeStatus scmStatus = HddsProtos.UpgradeStatus.newBuilder()
-        .setScmFinalized(true)
-        .setHddsFinalized(true)
+        .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
         .setNumDatanodesFinalized(3)
         .setNumDatanodesTotal(3)
         .build();
@@ -156,7 +156,7 @@ public class TestOMUpgradeFinalizeService {
   }
 
   /**
-   * When SCM reports hddsFinalized=false (SCM is not yet finalized),
+   * When SCM reports hddsFinalizationStatus=UNFINALIZED (SCM is not yet finalized),
    * no Ratis request should be submitted.
    */
   @Test
@@ -165,8 +165,8 @@ public class TestOMUpgradeFinalizeService {
     when(versionManager.needsFinalization()).thenReturn(true);
 
     HddsProtos.UpgradeStatus scmStatus = HddsProtos.UpgradeStatus.newBuilder()
-        .setScmFinalized(false)
-        .setHddsFinalized(false)
+        .setScmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
         .setNumDatanodesFinalized(0)
         .setNumDatanodesTotal(3)
         .build();
@@ -247,8 +247,8 @@ public class TestOMUpgradeFinalizeService {
     when(versionManager.needsFinalization()).thenReturn(true);
 
     HddsProtos.UpgradeStatus scmStatus = HddsProtos.UpgradeStatus.newBuilder()
-        .setScmFinalized(true)
-        .setHddsFinalized(true)
+        .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
         .setNumDatanodesFinalized(3)
         .setNumDatanodesTotal(3)
         .build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMUpgradeFinalizeService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMUpgradeFinalizeService.java
@@ -45,6 +45,8 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.ratis.protocol.ClientId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * Unit tests for {@link OMUpgradeFinalizeService}.
@@ -156,17 +158,18 @@ public class TestOMUpgradeFinalizeService {
   }
 
   /**
-   * When SCM reports hddsFinalizationStatus=UNFINALIZED (SCM is not yet finalized),
-   * no Ratis request should be submitted.
+   * When SCM reports an hddsFinalizationStatus other than FINALIZED (HDDS is unfinalized or still
+   * in progress), no Ratis request should be submitted.
    */
-  @Test
-  void testFinalizationSkippedWhenScmNotYetFinalized() throws Exception {
+  @ParameterizedTest
+  @EnumSource(value = HddsProtos.FinalizationStatus.class, names = {"UNFINALIZED", "IN_PROGRESS"})
+  void testFinalizationSkippedWhenScmNotYetFinalized(HddsProtos.FinalizationStatus hddsStatus) throws Exception {
     when(ozoneManager.isLeaderReady()).thenReturn(true);
     when(versionManager.needsFinalization()).thenReturn(true);
 
     HddsProtos.UpgradeStatus scmStatus = HddsProtos.UpgradeStatus.newBuilder()
-        .setScmFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
-        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.UNFINALIZED)
+        .setScmFinalizationStatus(hddsStatus)
+        .setHddsFinalizationStatus(hddsStatus)
         .setNumDatanodesFinalized(0)
         .setNumDatanodesTotal(3)
         .build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
@@ -475,14 +475,14 @@ public class TestOzoneManagerRequestHandler {
     OzoneManager ozoneManager = handler.getOzoneManager();
 
     HddsProtos.UpgradeStatus hddsStatus = HddsProtos.UpgradeStatus.newBuilder()
-        .setScmFinalized(true)
-        .setHddsFinalized(false)
+        .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
         .setNumDatanodesFinalized(3)
         .setNumDatanodesTotal(3)
         .build();
     OzoneManagerProtocolProtos.QueryUpgradeStatusResponse expected =
         OzoneManagerProtocolProtos.QueryUpgradeStatusResponse.newBuilder()
-            .setOmFinalized(true)
+            .setOmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
             .setHddsStatus(hddsStatus)
             .build();
     Mockito.when(ozoneManager.queryUpgradeStatus()).thenReturn(expected);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
@@ -474,9 +474,10 @@ public class TestOzoneManagerRequestHandler {
     OzoneManagerRequestHandler handler = getRequestHandler(10);
     OzoneManager ozoneManager = handler.getOzoneManager();
 
+    // Test verifies that the same upgrade status is passed through the response regardless of its values.
     HddsProtos.UpgradeStatus hddsStatus = HddsProtos.UpgradeStatus.newBuilder()
         .setScmFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
-        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.IN_PROGRESS)
+        .setHddsFinalizationStatus(HddsProtos.FinalizationStatus.FINALIZED)
         .setNumDatanodesFinalized(3)
         .setNumDatanodesTotal(3)
         .build();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use enum instead of boolean to indicate finalization status from SCM and OM to Clients. This allows us to use a more descriptive "in progress" state when only some datanodes are finalized and OM is waiting. It also allows more states to be added in the future if needed.

## What is the link to the Apache JIRA

HDDS-16024

## How was this patch tested?

- Existing unit and integration tests updated
- New tests added for intermediate in-progress enum state
