### PR TITLE
HDDS-16030. Allow plain hostnames for certificate

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/profile/DefaultProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/profile/DefaultProfile.java
@@ -233,7 +233,7 @@ public class DefaultProfile implements PKIProfile {
         return false;
       }
     case GeneralName.dNSName:
-      return DomainValidator.getInstance().isValid(value);
+      return DomainValidator.getInstance(true).isValid(value);
     case GeneralName.otherName:
       // for other name it's a general string, nothing to validate
       return true;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateSignRequest.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateSignRequest.java
@@ -292,7 +292,7 @@ public final class CertificateSignRequest {
     public CertificateSignRequest.Builder addInetAddresses()
         throws CertificateException {
       try {
-        DomainValidator validator = DomainValidator.getInstance();
+        DomainValidator validator = DomainValidator.getInstance(true);
         // Add all valid ips.
         List<InetAddress> inetAddresses = getValidInetsForCurrentHost();
         this.addInetAddresses(inetAddresses, validator);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/SelfSignedCertificate.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/SelfSignedCertificate.java
@@ -219,7 +219,7 @@ public final class SelfSignedCertificate {
 
     public Builder addInetAddresses() throws CertificateException {
       try {
-        DomainValidator validator = DomainValidator.getInstance();
+        DomainValidator validator = DomainValidator.getInstance(true);
         // Add all valid ips.
         List<InetAddress> inetAddresses = getValidInetsForCurrentHost();
         this.addInetAddresses(inetAddresses, validator);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Certificate sign requests should include hostname even if it does not have proper TLD (e.g. `scm` in Docker Compose environment).  Otherwise certificate host name validation will fail:

```
Caused by: javax.net.ssl.SSLHandshakeException: General OpenSslEngine problem
...
Caused by: java.security.cert.CertificateException: No name matching scm found for SNIHostName=null and peerHost=scm in the chain of 2 certificate(s): 1. subjectAlternativeNames=[IP:172.18.0.18], CN=scm-sub@scm. 2. subjectAlternativeNames=[IP:172.18.0.18], CN=scm@scm.
...
Caused by: java.security.cert.CertificateException: No name matching scm found
```

after upgrade to Netty 4.1.135 (https://github.com/netty/netty/security/advisories/GHSA-c653-97m9-rcg9).

https://issues.apache.org/jira/browse/HDDS-16030

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/30532333980
