### PR TITLE
HDDS-16032. cd: lib/native: No such file or directory

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1327,6 +1327,23 @@ function ozone_add_to_classpath_userpath
   fi
 }
 
+function ozone_update_native_symlink
+{
+  if [ -z "$TARGET_FILE" ]; then
+    echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2
+    return 1
+  elif pushd "${OZONE_HOME}/lib/native" > /dev/null 2>&1; then
+    # Check if it already exists but points to the wrong target
+    if [ -L "$LINK_FILE" ] && [ "$(readlink "$LINK_FILE")" != "$TARGET_FILE" ]; then
+      # Forcefully recreate it so it points to the correct target file
+      ln -sf "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
+    fi
+    popd > /dev/null
+  else
+    return 1
+  fi
+}
+
 ## @description  Routine to configure any OS-specific settings.
 ## @audience     public
 ## @stability    stable
@@ -1352,20 +1369,10 @@ function ozone_os_tricks
         TARGET_FILE="libhadoop_osx_aarch_64.dylib"
       fi
 
-      pushd lib/native > /dev/null
-      # If no matching file variant was found for the current environment
-      if [ -z "$TARGET_FILE" ]; then
-        echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2
-      else
-        LINK_FILE="libhadoop.dylib"
-        # Check if it already exists but points to the wrong target
-        if [ -L "$LINK_FILE" ] && [ "$(readlink "$LINK_FILE")" != "$TARGET_FILE" ]; then
-          # Forcefully recreate it so it points to the correct target file
-          ln -sf "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
-        fi
-        export DYLD_LIBRARY_PATH=$OZONE_HOME/lib/native:$DYLD_LIBRARY_PATH
+      LINK_FILE="libhadoop.dylib"
+      if ozone_update_native_symlink; then
+        export DYLD_LIBRARY_PATH="${OZONE_HOME}/lib/native":$DYLD_LIBRARY_PATH
       fi
-      popd > /dev/null
     ;;
     Linux)
 
@@ -1381,21 +1388,10 @@ function ozone_os_tricks
         TARGET_FILE="libhadoop_linux_x86_64.so"
       fi
 
-      pushd . > /dev/null && cd lib/native
-      # If no matching file variant was found for the current environment
-      if [ -z "$TARGET_FILE" ]; then
-        echo "Error: libhadoop doesn't support platform combination ($OS_TYPE / $ARCH_TYPE)." >&2
-      else
-        LINK_FILE="libhadoop.so"
-
-        # Check if it already exists but points to the wrong target
-        if [ -L "$LINK_FILE" ] && [ "$(readlink "$LINK_FILE")" != "$TARGET_FILE" ]; then
-          # Forcefully recreate it so it points to the correct target file
-          ln -sf "$TARGET_FILE" "$LINK_FILE" > /dev/null 2>&1
-        fi
-        export LD_LIBRARY_PATH=$OZONE_HOME/lib/native:$LD_LIBRARY_PATH
+      LINK_FILE="libhadoop.so"
+      if ozone_update_native_symlink; then
+        export LD_LIBRARY_PATH="${OZONE_HOME}/lib/native":$LD_LIBRARY_PATH
       fi
-      popd > /dev/null
     ;;
     CYGWIN*)
       # Flag that we're running on Cygwin to trigger path translation later.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the error message emitted by `ozone` when built without `-Pdist`:

```bash
$ cd hadoop-ozone/dist/target/ozone-2.3.0-SNAPSHOT

$ bin/ozone debug checknative    
bin/../libexec/ozone-functions.sh: line 1384: cd: lib/native: No such file or directory
Native library checking:
     hadoop:  false  
...

$ ls lib/native
ls: cannot access 'lib/native': No such file or directory
```

Also when built with `-Pdist`, but not executed from `OZONE_HOME` directory:

```
$ cd hadoop-ozone/dist/target/ozone-2.3.0-SNAPSHOT/bin
$ ./ozone debug checknative
bin/../libexec/ozone-functions.sh: line 1384: cd: lib/native: No such file or directory
Native library checking:
     hadoop:  true   lib/native/libhadoop_linux_x86_64.so
```

Reduce code duplication between Linux and Mac-specific branches.

https://issues.apache.org/jira/browse/HDDS-16032

## How was this patch tested?

Without `-Pdist`:

```bash
$ mvn -DskipRecon -DskipShade -DskipTests clean verify
...
$ cd hadoop-ozone/dist/target/ozone-2.3.0-SNAPSHOT
$ ls lib/native
ls: cannot access 'lib/native': No such file or directory

$ bin/ozone debug checknative
Native library checking:
     hadoop:  false
...
```

With `-Pdist`:

```
$ mvn -DskipRecon -DskipShade -DskipTests clean verify -Pdist
...
$ cd hadoop-ozone/dist/target/ozone-2.3.0-SNAPSHOT
$ bin/ozone debug checknative
Native library checking:
     hadoop:  true   lib/native/libhadoop_linux_x86_64.so
...

$ ls -1 --file-type lib/native
libhadoop.dylib@
libhadoop_linux_aarch_64.so
libhadoop_linux_x86_64.so
libhadoop_osx_aarch_64.dylib
libhadoop.so@

$ cd bin
$ ./ozone debug checknative
Native library checking:
     hadoop:  true   lib/native/libhadoop_linux_x86_64.so
...
```

https://github.com/adoroszlai/ozone/actions/runs/30548924292
