### PR TITLE
HDDS-16018. Use configured DNS-to-switch mapping directly in SCM and OM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -181,7 +181,6 @@ import org.apache.hadoop.hdds.utils.NettyMetrics;
 import org.apache.hadoop.ipc_.RPC;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.util.MBeans;
-import org.apache.hadoop.net.CachedDNSToSwitchMapping;
 import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.ScriptBasedMapping;
@@ -755,15 +754,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           .build();
     }
 
-    Class<? extends DNSToSwitchMapping> dnsToSwitchMappingClass =
-        conf.getClass(
-            ScmConfigKeys.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
-            ScriptBasedMapping.class, DNSToSwitchMapping.class);
-    DNSToSwitchMapping newInstance = ReflectionUtils.newInstance(
-        dnsToSwitchMappingClass, conf);
-    dnsToSwitchMapping =
-        ((newInstance instanceof CachedDNSToSwitchMapping) ? newInstance
-            : new CachedDNSToSwitchMapping(newInstance));
+    dnsToSwitchMapping = createDNSToSwitchMapping(conf);
 
     if (configurator.getScmNodeManager() != null) {
       scmNodeManager = configurator.getScmNodeManager();
@@ -2373,6 +2364,14 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       LOG.debug("Node resolution did not yield any result for {}", hostname);
       return null;
     }
+  }
+
+  static DNSToSwitchMapping createDNSToSwitchMapping(OzoneConfiguration conf) {
+    Class<? extends DNSToSwitchMapping> mappingClass =
+        conf.getClass(
+            ScmConfigKeys.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
+            ScriptBasedMapping.class, DNSToSwitchMapping.class);
+    return ReflectionUtils.newInstance(mappingClass, conf);
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManager.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.net.CachedDNSToSwitchMapping;
+import org.apache.hadoop.net.DNSToSwitchMapping;
+import org.apache.hadoop.net.ScriptBasedMapping;
+import org.apache.hadoop.net.StaticMapping;
+import org.junit.jupiter.api.Test;
+
+class TestStorageContainerManager {
+
+  @Test
+  void defaultMappingKeepsCachedBehavior() {
+    DNSToSwitchMapping mapping =
+        StorageContainerManager.createDNSToSwitchMapping(
+            new OzoneConfiguration());
+
+    assertInstanceOf(ScriptBasedMapping.class, mapping);
+    assertInstanceOf(CachedDNSToSwitchMapping.class, mapping);
+  }
+
+  @Test
+  void configuredMappingIsUsedDirectly() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setClass(ScmConfigKeys.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
+        StaticMapping.class, DNSToSwitchMapping.class);
+
+    DNSToSwitchMapping mapping =
+        StorageContainerManager.createDNSToSwitchMapping(conf);
+
+    assertInstanceOf(StaticMapping.class, mapping);
+    assertFalse(mapping instanceof CachedDNSToSwitchMapping,
+        "Configured mapping should not be wrapped in CachedDNSToSwitchMapping");
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -144,7 +144,6 @@ import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
-import org.apache.hadoop.net.CachedDNSToSwitchMapping;
 import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.ScriptBasedMapping;
 import org.apache.hadoop.ozone.OmUtils;
@@ -379,15 +378,15 @@ public class KeyManagerImpl implements KeyManager {
       keyLifecycleService.start();
     }
 
-    Class<? extends DNSToSwitchMapping> dnsToSwitchMappingClass =
-        configuration.getClass(
+    dnsToSwitchMapping = createDNSToSwitchMapping(configuration);
+  }
+
+  static DNSToSwitchMapping createDNSToSwitchMapping(OzoneConfiguration conf) {
+    Class<? extends DNSToSwitchMapping> mappingClass =
+        conf.getClass(
             ScmConfigKeys.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
             ScriptBasedMapping.class, DNSToSwitchMapping.class);
-    DNSToSwitchMapping newInstance = ReflectionUtils.newInstance(
-        dnsToSwitchMappingClass, configuration);
-    dnsToSwitchMapping =
-        ((newInstance instanceof CachedDNSToSwitchMapping) ? newInstance
-            : new CachedDNSToSwitchMapping(newInstance));
+    return ReflectionUtils.newInstance(mappingClass, conf);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -21,6 +21,8 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_DIR_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.SNAPSHOT_RENAMED_TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,11 +37,17 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.MapBackedTableIterator;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.net.CachedDNSToSwitchMapping;
+import org.apache.hadoop.net.DNSToSwitchMapping;
+import org.apache.hadoop.net.ScriptBasedMapping;
+import org.apache.hadoop.net.StaticMapping;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.ratis.util.function.CheckedFunction;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -47,6 +55,31 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Test class for unit tests KeyManagerImpl.
  */
 public class TestKeyManagerImpl {
+
+  @Test
+  void defaultMappingKeepsCachedBehavior() {
+    DNSToSwitchMapping mapping =
+        KeyManagerImpl.createDNSToSwitchMapping(
+            new OzoneConfiguration());
+
+    assertInstanceOf(ScriptBasedMapping.class, mapping);
+    assertInstanceOf(CachedDNSToSwitchMapping.class, mapping);
+  }
+
+  @Test
+  void configuredMappingIsUsedDirectly() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setClass(ScmConfigKeys.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
+        StaticMapping.class, DNSToSwitchMapping.class);
+
+    DNSToSwitchMapping mapping =
+        KeyManagerImpl.createDNSToSwitchMapping(conf);
+
+    assertInstanceOf(StaticMapping.class, mapping);
+    assertFalse(mapping instanceof CachedDNSToSwitchMapping,
+        "Configured mapping should not be wrapped in CachedDNSToSwitchMapping");
+  }
+
   private static Stream<TestCase> getSuccessfulTableIteratorParameters() {
     return Stream.of(
         TestCase.newBuilder("Fetch first 50 entries for volume 0, bucket 0")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change updates SCM to instantiate the configured `DNSToSwitchMapping` directly instead of wrapping every non-cached mapping in `CachedDNSToSwitchMapping`.

This follows up on the topology mapping behavior discussed in [apache/ozone#10598](https://github.com/apache/ozone/pull/10598), where static host-to-rack mappings should not be affected by an additional SCM-side cache wrapper.

The default mapping behavior remains cached because Hadoop `ScriptBasedMapping` already extends `CachedDNSToSwitchMapping`. Using configured mappings directly avoids changing their input through the cache wrapper hostname normalization step, which is important for mappings such as `StaticMapping`.

The patch also adds focused SCM coverage for the default cached mapping and direct configured mapping usage.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16018

## How was this patch tested?

```
mvn -B --no-transfer-progress -pl :hdds-server-scm -am -Dtest=TestStorageContainerManager,TestSCMBlockProtocolServer test -DskipShade -DskipRecon -DskipDocs
git diff --check
```

CI: https://github.com/F64116045/ozone/actions/runs/30590053420
