### PR TITLE
HDDS-16050. Fix aspectj profile activation upper bounds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2750,7 +2750,7 @@
     <profile>
       <id>aspectj-java8-10</id>
       <activation>
-        <jdk>[1.8,10]</jdk>
+        <jdk>[1.8,11)</jdk>
       </activation>
       <properties>
         <aspectj.version>${aspectj.java8.version}</aspectj.version>
@@ -2759,7 +2759,7 @@
     <profile>
       <id>aspectj-java11-20</id>
       <activation>
-        <jdk>[11,20]</jdk>
+        <jdk>[11,21)</jdk>
       </activation>
       <properties>
         <aspectj.version>${aspectj.java11.version}</aspectj.version>
@@ -2768,7 +2768,7 @@
     <profile>
       <id>aspectj-java21-24</id>
       <activation>
-        <jdk>[21,24]</jdk>
+        <jdk>[21,25)</jdk>
       </activation>
       <properties>
         <aspectj.version>${aspectj.java21.version}</aspectj.version>


### PR DESCRIPTION
Please describe your PR in detail:
* When using Java 24.0.2 as Maven version, an error similar to the following occurs when building Ozone:

```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'build.plugins.plugin[dev.aspectj:aspectj-maven-plugin].dependencies.dependency.version' for org.aspectj:aspectjtools:jar must be a valid version but is '${aspectj.version}'. @ line 1775, column 24
 @ 
[INFO] 0 goals, 0 executed
[WARNING] Adding build scan buildFinished actions is not allowed once their invocation has started. Newly added action will be ignored.
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.apache.ozone:ozone-main:2.3.0-SNAPSHOT (/<OZONE_PATH>/pom.xml) has 1 error
[ERROR]     'build.plugins.plugin[dev.aspectj:aspectj-maven-plugin].dependencies.dependency.version' for org.aspectj:aspectjtools:jar must be a valid version but is '${aspectj.version}'. @ line 1775, column 24
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
```

The reason is that the `aspectj.version` is never set when run on Java 24.0.2 (there could be similar issues on other versions such as Java 10, etc). This ticket makes the fix.
This is related to [HDDS-15699](https://issues.apache.org/jira/browse/HDDS-15699).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16050

## How was this patch tested?
locally build Ozone after update
