### PR TITLE
HDDS-16056. non-varargs call of varargs method with inexact argument type

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSLayoutVersionManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSLayoutVersionManager.java
@@ -41,15 +41,15 @@ import org.junit.jupiter.api.Test;
  */
 public class TestHDDSLayoutVersionManager {
 
-  private static final String[] UPGRADE_ACTIONS_TEST_PACKAGES = new String[] {
-      "org.apache.hadoop.hdds.upgrade.test"};
+  private static final String UPGRADE_ACTIONS_TEST_PACKAGE =
+      "org.apache.hadoop.hdds.upgrade.test";
 
   @Test
   public void testUpgradeActionsRegistered() throws Exception {
 
     HDDSLayoutVersionManager lvm =
         new HDDSLayoutVersionManager(maxLayoutVersion());
-    lvm.registerUpgradeActions(UPGRADE_ACTIONS_TEST_PACKAGES);
+    lvm.registerUpgradeActions(UPGRADE_ACTIONS_TEST_PACKAGE);
 
     //Cluster is finalized, hence should not register.
     Optional<HDDSUpgradeAction> action = INITIAL_VERSION.scmAction();
@@ -62,7 +62,7 @@ public class TestHDDSLayoutVersionManager {
     when(lvm.getMetadataLayoutVersion()).thenReturn(-1);
 
     doCallRealMethod().when(lvm).registerUpgradeActions(any());
-    lvm.registerUpgradeActions(UPGRADE_ACTIONS_TEST_PACKAGES);
+    lvm.registerUpgradeActions(UPGRADE_ACTIONS_TEST_PACKAGE);
 
     action = INITIAL_VERSION.scmAction();
     assertTrue(action.isPresent());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
@@ -320,7 +320,7 @@ public class SCMHANodeDetails {
     return builder.build();
   }
 
-  private static void throwConfException(String message, String... arguments)
+  private static void throwConfException(String message, Object... arguments)
       throws IllegalArgumentException {
     String exceptionMsg = String.format(message, arguments);
     LOG.error(exceptionMsg);

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
@@ -193,7 +193,7 @@ public class DiskBalancerReportSubcommand extends AbstractDiskBalancerSubCommand
         .append("  - move delta: source volume space to be reclaimed after move completion;" +
             " this value is reflected only when diskBalancer is running else it is 0.%n");
 
-    return String.format(formatBuilder.toString(), contentList.toArray(new String[0]));
+    return String.format(formatBuilder.toString(), contentList.toArray(new Object[0]));
   }
 
   @Override

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -154,7 +154,7 @@ public class DiskBalancerStatusSubcommand extends AbstractDiskBalancerSubCommand
             " by default, CLOSED and QUASI_CLOSED are allowed.");
 
     return String.format(formatBuilder.toString(),
-        contentList.toArray(new String[0]));
+        contentList.toArray(new Object[0]));
   }
 
   @Override

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServer.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServer.java
@@ -830,7 +830,7 @@ public class HttpFSServer {
         uploadOperation)
         .queryParam(DataParam.NAME, Boolean.TRUE)
         .replaceQueryParam(NoRedirectParam.NAME, (Object[]) null);
-    return uriBuilder.build(null);
+    return uriBuilder.build();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -324,7 +324,7 @@ public class OMHANodeDetails {
         .build();
   }
 
-  private static void throwConfException(String message, String... arguments)
+  private static void throwConfException(String message, Object... arguments)
       throws IllegalArgumentException {
     String exceptionMsg = String.format(message, arguments);
     LOG.error(exceptionMsg);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMetadataReader.java
@@ -47,7 +47,7 @@ public class TestOMMetadataReader {
       String expectedClientAddressInCaseOfGrpcCall = "172.45.23.4";
       Context.Key<String> clientIpAddressKey = mock(Context.Key.class);
       when(clientIpAddressKey.get())
-          .thenReturn(expectedClientAddressInCaseOfGrpcCall, null);
+          .thenReturn(expectedClientAddressInCaseOfGrpcCall, null, null);
 
       grpcRequestContextStaticMock.when(() -> Context.key("CLIENT_IP_ADDRESS"))
           .thenReturn(clientIpAddressKey);

--- a/hadoop-ozone/recon-codegen/src/main/java/org/apache/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/apache/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -17,6 +17,8 @@
 
 package org.apache.ozone.recon.schema;
 
+import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
 import static org.apache.ozone.recon.schema.SqlDbUtils.TABLE_EXISTS_CHECK;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.name;
@@ -25,6 +27,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
 import javax.sql.DataSource;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
@@ -78,7 +82,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
             .primaryKey(CONTAINER_ID, CONTAINER_STATE))
         .constraint(DSL.constraint(UNHEALTHY_CONTAINERS_TABLE_NAME + "ck1")
             .check(field(name(CONTAINER_STATE))
-                .in(UnHealthyContainerStates.values())))
+                .in(UnHealthyContainerStates.NAMES)))
         .execute();
     // Composite index (container_state, container_id) serves two query patterns:
     //
@@ -121,6 +125,10 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     MIS_REPLICATED,
     ALL_REPLICAS_BAD,
     NEGATIVE_SIZE, // Added new state to track containers with negative sizes
-    REPLICA_MISMATCH
+    REPLICA_MISMATCH;
+
+    public static final List<String> NAMES = unmodifiableList(Arrays.stream(values())
+        .map(Enum::toString)
+        .collect(toList()));
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/InitialConstraintUpgradeAction.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/InitialConstraintUpgradeAction.java
@@ -26,7 +26,6 @@ import static org.jooq.impl.DSL.name;
 import com.google.common.annotations.VisibleForTesting;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
 import javax.sql.DataSource;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
 import org.jooq.DSLContext;
@@ -75,19 +74,14 @@ public class InitialConstraintUpgradeAction implements ReconUpgradeAction {
    * Adds the updated constraint directly within this class.
    */
   private void addUpdatedConstraint() {
-    String[] enumStates = Arrays
-        .stream(ContainerSchemaDefinition.UnHealthyContainerStates.values())
-        .map(Enum::name)
-        .toArray(String[]::new);
-
     dslContext.alterTable(ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME)
         .add(DSL.constraint(ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME + "ck1")
         .check(field(name("container_state"))
-        .in(enumStates)))
+        .in(ContainerSchemaDefinition.UnHealthyContainerStates.NAMES)))
         .execute();
 
     LOG.info("Added the updated constraint to the UNHEALTHY_CONTAINERS table for enum state values: {}",
-        Arrays.toString(enumStates));
+        ContainerSchemaDefinition.UnHealthyContainerStates.NAMES);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/UnhealthyContainerReplicaMismatchAction.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/UnhealthyContainerReplicaMismatchAction.java
@@ -25,7 +25,6 @@ import static org.jooq.impl.DSL.name;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
 import javax.sql.DataSource;
 import org.apache.ozone.recon.schema.ContainerSchemaDefinition;
 import org.jooq.DSLContext;
@@ -73,18 +72,13 @@ public class UnhealthyContainerReplicaMismatchAction implements ReconUpgradeActi
    * Adds the updated constraint directly within this class.
    */
   private void addUpdatedConstraint() {
-    String[] enumStates = Arrays
-        .stream(ContainerSchemaDefinition.UnHealthyContainerStates.values())
-        .map(Enum::name)
-        .toArray(String[]::new);
-
     dslContext.alterTable(ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME)
         .add(DSL.constraint(ContainerSchemaDefinition.UNHEALTHY_CONTAINERS_TABLE_NAME + "ck1")
             .check(field(name("container_state"))
-                .in(enumStates)))
+                .in(ContainerSchemaDefinition.UnHealthyContainerStates.NAMES)))
         .execute();
 
     LOG.info("Added the updated constraint to the UNHEALTHY_CONTAINERS table for enum state values: {}",
-        Arrays.toString(enumStates));
+        ContainerSchemaDefinition.UnHealthyContainerStates.NAMES);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix warnings about `non-varargs call of varargs method with inexact argument type for last parameter`.

Example:

```
[WARNING] hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSLayoutVersionManager.java:[52,32] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.Object for a varargs call
  cast to java.lang.Object[] for a non-varargs call and to suppress this warning
```

https://issues.apache.org/jira/browse/HDDS-16056

## How was this patch tested?

Build, grep log for the warning.

Compare list of `Annotations` in CI summary.

Before:
https://github.com/apache/ozone/actions/runs/30622461584

After:
https://github.com/adoroszlai/ozone/actions/runs/30630408587
