### PR TITLE
HDDS-16047. Certificate renewal stops permanently after an unexpected failure

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -1395,6 +1395,17 @@ public abstract class DefaultCertificateClient implements CertificateClient {
 
     @Override
     public void run() {
+      try {
+        renewCertificateIfNeeded();
+      } catch (RuntimeException e) {
+        // This task is scheduled at a fixed rate: an exception escaping it cancels every future
+        // execution, and the component stops renewing its certificate without any further notice.
+        getLogger().error("Certificate renewal for {} failed unexpectedly, keeping the renewal "
+            + "schedule.", component, e);
+      }
+    }
+
+    private void renewCertificateIfNeeded() {
       // Lock to protect the certificate renew process, to make sure there is
       // only one renew process is ongoing at one time.
       // Certificate renew steps:

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -49,6 +50,7 @@ import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -585,5 +587,53 @@ public class TestDefaultCertificateClient {
         .filter(monitorFilterPredicate)
         .count();
     assertThat(monitorThreadCount).isEqualTo(0L);
+  }
+
+  /**
+   * A renewal that fails with an unchecked exception must not let it escape the renewer task.
+   * The task is scheduled at a fixed rate, so an escaping exception cancels every further
+   * execution and the component stops renewing its certificate until it is restarted.
+   */
+  @Test
+  public void testRenewerContainsUnexpectedFailure(@TempDir File metaDir)
+      throws Exception {
+    OzoneConfiguration ozoneConf = new OzoneConfiguration();
+    ozoneConf.set(HDDS_METADATA_DIR_NAME, metaDir.getPath());
+    SecurityConfig conf = new SecurityConfig(ozoneConf);
+    String compName = "test-unexpected-failure";
+
+    CertificateCodec certCodec = new CertificateCodec(conf, compName);
+    X509Certificate cert = generateX509Cert(null);
+    certCodec.writeCertificate(cert);
+    String certId = cert.getSerialNumber().toString();
+
+    AtomicInteger attempts = new AtomicInteger();
+    DefaultCertificateClient client = new DefaultCertificateClient(
+        conf, null, mock(Logger.class), certId, compName, "", null, null) {
+
+      @Override
+      protected SCMGetCertResponseProto sign(CertificateSignRequest request) {
+        return null;
+      }
+
+      @Override
+      protected String signAndStoreCertificate(CertificateSignRequest request, Path certificatePath, boolean renew) {
+        return null;
+      }
+
+      @Override
+      public String renewAndStoreKeyAndCertificate(boolean force) {
+        attempts.incrementAndGet();
+        throw new IllegalStateException("renewal failed unexpectedly");
+      }
+    };
+
+    try {
+      // Runs exactly what the scheduled task runs.
+      assertDoesNotThrow(client.new CertificateRenewerService(true, () -> { })::run);
+      assertThat(attempts.get()).isPositive();
+    } finally {
+      client.close();
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-16047. Certificate renewal stops permanently after an unexpected failure
CertificateRenewerService is submitted with scheduleAtFixedRate. If the task throws an unchecked exception, the executor cancels every further execution, and the exception is only stored in a Future that nobody inspects, so nothing is logged. The component then never renews its certificate again.  Recovery needs a restart, and by then there is no evidence of what stopped the renewal.
    
The renewal body is now wrapped so an unchecked failure is logged and the schedule is kept. Failures raised by the renewal itself are already reported as CertificateException and handled; the paths that can still throw unchecked sit outside that catch block: the certificate id save callback supplied by the service, the certificate reload, the backup directory cleanup, and the notification receivers.
    
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16047

## How was this patch tested?
Adds a unit test that drives the renewer task with a renewal that throws an unchecked exception, and asserts the task contains it. The test invokes the task directly rather than waiting on the scheduler, so it stays deterministic