### PR TITLE
HDDS-16065. Fix flaky testCloseNonStreamablePipelineThenStream

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemDataStreamEnablement.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemDataStreamEnablement.java
@@ -214,6 +214,11 @@ public class TestOzoneFileSystemDataStreamEnablement {
             Pipeline.PipelineState.OPEN);
   }
 
+  private static boolean noNodesHaveDatastreamPort(Pipeline pipeline) {
+    return pipeline.getNodes().stream()
+        .noneMatch(n -> n.hasPort(RATIS_DATASTREAM));
+  }
+
   private static boolean allNodesHaveDatastreamPort(Pipeline pipeline) {
     return pipeline.getNodes().stream()
         .allMatch(n -> n.hasPort(RATIS_DATASTREAM));
@@ -336,7 +341,7 @@ public class TestOzoneFileSystemDataStreamEnablement {
       }
       final List<Pipeline> before = openRatisThreePipelines();
       assertFalse(before.isEmpty());
-      before.forEach(p -> assertFalse(allNodesHaveDatastreamPort(p),
+      before.forEach(p -> assertTrue(noNodesHaveDatastreamPort(p),
           "pipeline should be portless before enabling datastream"));
 
       rollingRestartEnablingDataStream();
@@ -350,8 +355,8 @@ public class TestOzoneFileSystemDataStreamEnablement {
       final PipelineManagerImpl pipelineManager =
           (PipelineManagerImpl) cluster.getStorageContainerManager().getPipelineManager();
       final List<Pipeline> reloaded = openRatisThreePipelines();
-      assertFalse(reloaded.isEmpty());
-      reloaded.forEach(p -> assertFalse(allNodesHaveDatastreamPort(p),
+      reloaded.retainAll(before);
+      reloaded.forEach(p -> assertTrue(noNodesHaveDatastreamPort(p),
           "reloaded pipeline should still be portless"));
 
       // Close the pipeline(s) exposing the new datastream port; a fresh


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix flaky `testCloseNonStreamablePipelineThenStream`: "reloaded pipeline should still be portless" check should ignore any new pipelines created after datastream was enabled.

On the other hand, instead of `!allNodesHaveDatastreamPort` we can assert even `noNodesHaveDatastreamPort`.

https://issues.apache.org/jira/browse/HDDS-16065

## How was this patch tested?

Before: 27/50 [failures](https://github.com/adoroszlai/ozone/actions/runs/30707726694).

After: 100/100 [passed](https://github.com/adoroszlai/ozone/actions/runs/30708690528).
