### PR TITLE
HDDS-16045. Make PendingContainerTracker StorageType aware

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -35,11 +35,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.hadoop.fs.StorageType;
-import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -49,7 +47,6 @@ import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.apache.hadoop.ozone.container.common.volume.VolumeUsage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -284,7 +281,7 @@ public abstract class SCMCommonPlacementPolicy implements
       StorageType storageType)
       throws SCMException {
     List<DatanodeDetails> nodesWithSpace = nodes.stream().filter(d ->
-        hasEnoughSpace(d, metadataSizeRequired, dataSizeRequired, storageType, nodeManager))
+        hasEnoughSpace(d, metadataSizeRequired, storageType, nodeManager))
         .collect(Collectors.toList());
 
     if (nodesWithSpace.size() < nodesRequired) {
@@ -326,7 +323,7 @@ public abstract class SCMCommonPlacementPolicy implements
    *
    * <p>Data-space is checked via {@link NodeManager#hasAvailableSpace}, which
    * delegates to {@link org.apache.hadoop.hdds.scm.node.PendingContainerTracker}
-   * and accounts for both current disk usage and in-flight allocations.
+   * and accounts for current disk usage, storage type and in-flight allocations.
    * The check always uses {@code maxContainerSize} as the unit of allocation,
    * regardless of the actual container's used bytes.
    *
@@ -338,16 +335,23 @@ public abstract class SCMCommonPlacementPolicy implements
   public static boolean hasEnoughSpace(DatanodeDetails datanodeDetails,
                                        long metadataSizeRequired,
                                        NodeManager nodeManager) {
+    return hasEnoughSpace(datanodeDetails, metadataSizeRequired, null,
+        nodeManager);
+  }
+
+  public static boolean hasEnoughSpace(DatanodeDetails datanodeDetails,
+      long metadataSizeRequired, StorageType storageType,
+      NodeManager nodeManager) {
     Preconditions.checkArgument(datanodeDetails instanceof DatanodeInfo);
 
     boolean enoughForMeta = false;
 
     DatanodeInfo datanodeInfo = (DatanodeInfo) datanodeDetails;
 
-    // Data-space check: use PendingContainerTracker slot availability.
-    // This accounts for both current disk usage and in-flight allocations.
+    // Data-space check: use PendingContainerTracker availability.
+    // This accounts for current disk usage, storage type and in-flight allocations.
     // Always slot-based (maxContainerSize unit).
-    if (!nodeManager.hasAvailableSpace(datanodeInfo)) {
+    if (!nodeManager.hasAvailableSpace(datanodeInfo, storageType)) {
       LOG.debug("Datanode {} has no available container slots.", datanodeDetails);
       return false;
     }
@@ -368,30 +372,6 @@ public abstract class SCMCommonPlacementPolicy implements
               "bytes for metadata.", datanodeDetails, metadataSizeRequired);
     }
     return enoughForMeta;
-  }
-
-  public static boolean hasEnoughSpace(DatanodeDetails datanodeDetails,
-      long metadataSizeRequired, long dataSizeRequired, StorageType storageType,
-      NodeManager nodeManager) {
-    if (!hasEnoughSpace(datanodeDetails, metadataSizeRequired, nodeManager)) {
-      return false;
-    }
-    if (storageType == null || dataSizeRequired <= 0) {
-      return true;
-    }
-
-    Preconditions.checkArgument(datanodeDetails instanceof DatanodeInfo);
-    DatanodeInfo datanodeInfo = (DatanodeInfo) datanodeDetails;
-    for (StorageReportProto reportProto : datanodeInfo.getStorageReports()) {
-      boolean matchesTier = StorageTypeUtils.getFromProtobuf(
-          reportProto.getStorageType()).equals(storageType);
-      if (matchesTier && VolumeUsage.getUsableSpace(reportProto) > dataSizeRequired) {
-        return true;
-      }
-    }
-    LOG.debug("Datanode {} has no {} volumes with enough space to allocate {} bytes for data.",
-        datanodeDetails, storageType, dataSizeRequired);
-    return false;
   }
 
   /**
@@ -593,7 +573,7 @@ public abstract class SCMCommonPlacementPolicy implements
     }
     NodeStatus nodeStatus = datanodeInfo.getNodeStatus();
     if (nodeStatus.isNodeWritable() &&
-        hasEnoughSpace(datanodeInfo, metadataSizeRequired, dataSizeRequired, storageType, nodeManager)) {
+        hasEnoughSpace(datanodeInfo, metadataSizeRequired, storageType, nodeManager)) {
       LOG.debug("Datanode {} is chosen. Required metadata size is {} and " +
               "required data size is {} and NodeStatus is {}",
           datanodeDetails, metadataSizeRequired, dataSizeRequired, nodeStatus);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -271,6 +271,7 @@ public class ContainerManagerImpl implements ContainerManager {
     }
 
     containerStateManager.addContainer(containerInfoBuilder.build());
+    pipelineManager.recordPendingAllocation(pipeline, containerID);
     scmContainerManagerMetrics.incNumSuccessfulCreateContainers();
     return containerStateManager.getContainer(containerID);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaOp.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaOp.java
@@ -17,13 +17,13 @@
 
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
 /**
  * ContainerReplicaOp wraps the information needed to track a pending
  * replication operation (ADD or DELETE) against a specific datanode.
- * It uses a single constructor so all call sites follow the same code path.
  */
 public class ContainerReplicaOp {
 
@@ -33,6 +33,7 @@ public class ContainerReplicaOp {
   private final SCMCommand<?> command;
   private final long deadlineEpochMillis;
   private final long containerSize;
+  private final StorageType storageType;
 
   /**
    * Create a ContainerReplicaOp with all parameters.
@@ -43,16 +44,18 @@ public class ContainerReplicaOp {
    * @param command SCM command associated with the op (nullable)
    * @param deadlineEpochMillis deadline in epoch milliseconds
    * @param containerSize size of the container in bytes
+   * @param storageType storage type for ADD operations (nullable)
    */
   public ContainerReplicaOp(PendingOpType opType,
       DatanodeDetails target, int replicaIndex, SCMCommand<?> command,
-      long deadlineEpochMillis, long containerSize) {
+      long deadlineEpochMillis, long containerSize, StorageType storageType) {
     this.opType = opType;
     this.target = target;
     this.replicaIndex = replicaIndex;
     this.command = command;
     this.deadlineEpochMillis = deadlineEpochMillis;
     this.containerSize = containerSize;
+    this.storageType = storageType;
   }
 
   public PendingOpType getOpType() {
@@ -77,6 +80,10 @@ public class ContainerReplicaOp {
 
   public long getContainerSize() {
     return containerSize;
+  }
+
+  public StorageType getStorageType() {
+    return storageType;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaPendingOps.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
@@ -163,12 +164,17 @@ public class ContainerReplicaPendingOps {
    * @param deadlineEpochMillis The time by which the replica should have been
    *                            added and reported by the datanode, or it will
    *                            be discarded.
+   * @param containerSize The size of the container in bytes
+   * @param storageType The storage type used for pending allocation accounting
+   * @param scheduledEpochMillis The time the operation was scheduled
    */
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public void scheduleAddReplica(ContainerID containerID,
-      DatanodeDetails target, int replicaIndex, SCMCommand<?> command, long deadlineEpochMillis, long containerSize,
+      DatanodeDetails target, int replicaIndex, SCMCommand<?> command,
+      long deadlineEpochMillis, long containerSize, StorageType storageType,
       long scheduledEpochMillis) {
-    addReplica(ADD, containerID, target, replicaIndex, command, deadlineEpochMillis, containerSize,
-        scheduledEpochMillis);
+    addReplica(ADD, containerID, target, replicaIndex, command,
+        deadlineEpochMillis, containerSize, storageType, scheduledEpochMillis);
   }
 
   /**
@@ -183,7 +189,8 @@ public class ContainerReplicaPendingOps {
    */
   public void scheduleDeleteReplica(ContainerID containerID,
       DatanodeDetails target, int replicaIndex, SCMCommand<?> command, long deadlineEpochMillis) {
-    addReplica(DELETE, containerID, target, replicaIndex, command, deadlineEpochMillis, 0L, clock.millis());
+    addReplica(DELETE, containerID, target, replicaIndex, command,
+        deadlineEpochMillis, 0L, null, clock.millis());
   }
 
   /**
@@ -328,9 +335,11 @@ public class ContainerReplicaPendingOps {
   @SuppressWarnings("checkstyle:ParameterNumber")
   private void addReplica(ContainerReplicaOp.PendingOpType opType,
       ContainerID containerID, DatanodeDetails target, int replicaIndex, SCMCommand<?> command,
-      long deadlineEpochMillis, long containerSize, long scheduledEpochMillis) {
+      long deadlineEpochMillis, long containerSize, StorageType storageType,
+      long scheduledEpochMillis) {
     ContainerReplicaOp op = new ContainerReplicaOp(opType,
-        target, replicaIndex, command, deadlineEpochMillis, containerSize);
+        target, replicaIndex, command, deadlineEpochMillis, containerSize,
+        storageType);
     Lock lock = writeLock(containerID);
     lock(lock);
     boolean found;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -608,7 +608,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
                                 DatanodeDetails target, int replicaIndex) {
     replicaCount.addPendingOp(new ContainerReplicaOp(
         ContainerReplicaOp.PendingOpType.ADD, target, replicaIndex, null,
-        Long.MAX_VALUE, 0));
+        Long.MAX_VALUE, 0, null));
   }
 
   static ByteString integers2ByteString(List<Integer> src) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/QuasiClosedStuckUnderReplicationHandler.java
@@ -125,7 +125,7 @@ public class QuasiClosedStuckUnderReplicationHandler implements UnhealthyReplica
           // Add the pending op, so we exclude the node for subsequent origins
           mutablePendingOps.add(new ContainerReplicaOp(
               ContainerReplicaOp.PendingOpType.ADD, target, 0,
-              null, System.currentTimeMillis(), 0));
+              null, System.currentTimeMillis(), 0, null));
           totalCommandsSent++;
         } catch (CommandTargetOverloadedException e) {
           LOG.warn("Cannot replicate container {} because all sources are overloaded.", containerInfo);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -41,8 +41,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
@@ -692,17 +694,21 @@ public class ReplicationManager implements SCMService, ContainerReplicaPendingOp
       List<DatanodeDetails> targets = rcc.getTargetDatanodes();
       final ByteString targetIndexes = rcc.getMissingContainerIndexes();
       long requiredSize = HddsServerUtil.requiredReplicationSpace(containerInfo.getUsedBytes());
+      StorageType storageType = getStorageType(containerInfo);
       for (int i = 0; i < targetIndexes.size(); i++) {
         containerReplicaPendingOps.scheduleAddReplica(containerInfo.containerID(), targets.get(i),
-            targetIndexes.byteAt(i), cmd, scmDeadlineEpochMs, requiredSize, clock.millis());
+            targetIndexes.byteAt(i), cmd, scmDeadlineEpochMs, requiredSize,
+            storageType, clock.millis());
       }
       getMetrics().incrEcReconstructionCmdsSentTotal();
     } else if (cmd.getType() == Type.replicateContainerCommand) {
       ReplicateContainerCommand rcc = (ReplicateContainerCommand) cmd;
       long requiredSize = HddsServerUtil.requiredReplicationSpace(containerInfo.getUsedBytes());
+      StorageType storageType = getStorageType(containerInfo);
 
       containerReplicaPendingOps.scheduleAddReplica(containerInfo.containerID(), rcc.getTargetDatanode(),
-          rcc.getReplicaIndex(), cmd, scmDeadlineEpochMs, requiredSize, clock.millis());
+          rcc.getReplicaIndex(), cmd, scmDeadlineEpochMs, requiredSize,
+          storageType, clock.millis());
 
       if (rcc.getReplicaIndex() > 0) {
         getMetrics().incrEcReplicationCmdsSentTotal();
@@ -710,6 +716,12 @@ public class ReplicationManager implements SCMService, ContainerReplicaPendingOp
         getMetrics().incrReplicationCmdsSentTotal();
       }
     }
+  }
+
+  private StorageType getStorageType(ContainerInfo containerInfo) {
+    StorageTier storageTier = containerInfo.getStorageTier();
+    return storageTier == null || storageTier == StorageTier.EMPTY
+        ? null : storageTier.getUniformStorageType();
   }
 
   /**
@@ -1591,4 +1603,3 @@ public class ReplicationManager implements SCMService, ContainerReplicaPendingOp
     }
   }
 }
-

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
-import org.apache.hadoop.hdds.scm.node.PendingContainerTracker.TwoWindowBucket;
+import org.apache.hadoop.hdds.scm.node.PendingContainerTracker.PendingContainerAllocations;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,9 +52,9 @@ public class DatanodeInfo extends DatanodeDetails {
   private int failedVolumeCount;
 
   /**
-   * Two-window tumbling bucket for tracking pending container allocations on this datanode.
+   * Pending container allocations tracked on this datanode.
    */
-  private final TwoWindowBucket pendingContainerAllocations;
+  private final PendingContainerAllocations pendingContainerAllocations;
 
   private List<StorageReportProto> storageReports;
   private List<MetadataStorageReportProto> metadataStorageReports;
@@ -81,7 +81,8 @@ public class DatanodeInfo extends DatanodeDetails {
     this.nodeStatus = nodeStatus;
     this.metadataStorageReports = Collections.emptyList();
     this.commandCounts = new HashMap<>();
-    this.pendingContainerAllocations = new TwoWindowBucket(this.getID(), containerRollIntervalMs);
+    this.pendingContainerAllocations =
+        new PendingContainerAllocations(this.getID(), containerRollIntervalMs);
   }
 
   /**
@@ -361,9 +362,9 @@ public class DatanodeInfo extends DatanodeDetails {
   }
 
   /**
-   * Returns the {@link TwoWindowBucket} for this datanode.
+   * Returns the pending container allocations for this datanode.
    */
-  public TwoWindowBucket getPendingContainerAllocations() {
+  public PendingContainerAllocations getPendingContainerAllocations() {
     pendingContainerAllocations.rollIfNeeded();
     return pendingContainerAllocations;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
@@ -190,12 +191,32 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   boolean hasSpaceForNewContainerAllocation(DatanodeID datanodeID);
 
   /**
+   * True if the node can accept another container of the given storage type.
+   */
+  default boolean hasSpaceForNewContainerAllocation(
+      DatanodeID datanodeID, StorageType storageType) {
+    return hasSpaceForNewContainerAllocation(datanodeID);
+  }
+
+  /**
    * Records a pending container allocation for a single DataNode identified by its ID.
    *
    * @param datanodeID  the ID of the DataNode receiving the allocation
    * @param containerID the container being allocated
    */
   void recordPendingAllocationForDatanode(DatanodeID datanodeID, ContainerID containerID);
+
+  /**
+   * Records a pending container allocation for a single DataNode identified by its ID.
+   *
+   * @param datanodeID  the ID of the DataNode receiving the allocation
+   * @param containerID the container being allocated
+   * @param storageType the storage type selected for the allocation
+   */
+  default void recordPendingAllocationForDatanode(
+      DatanodeID datanodeID, ContainerID containerID, StorageType storageType) {
+    recordPendingAllocationForDatanode(datanodeID, containerID);
+  }
 
   /**
    * Return the node stat of the specified datanode.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
@@ -180,26 +181,30 @@ public interface NodeManager extends StorageContainerNodeProtocol,
    *
    * @param datanodeInfo node info of the receiving the allocation
    * @param containerID the container being allocated
+   * @param storageType the storage type selected for the allocation
    * @return true if space was available and allocation was recorded, false otherwise
    */
-  boolean checkSpaceAndRecordAllocation(DatanodeInfo datanodeInfo, ContainerID containerID);
+  boolean checkSpaceAndRecordAllocation(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType);
 
   /**
    * Records a container allocation on the given datanode.
    * Unlike {@link #checkSpaceAndRecordAllocation}, this does not check for
-   * available space — it is called after the placement policy has already
+   * available space; it is called after the placement policy has already
    * validated space and a replication command has been committed.
    */
-  void recordAllocationForDatanode(DatanodeInfo datanodeInfo, ContainerID containerID);
+  void recordAllocationForDatanode(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType);
 
   /**
    * Returns true if the datanode has at least one available container slot considering
    * in-flight allocations tracked by PendingContainerTracker.
    *
    * @param datanodeInfo the datanode to check
+   * @param storageType storage type to check
    * @return true if at least one slot is free
    */
-  boolean hasAvailableSpace(DatanodeInfo datanodeInfo);
+  boolean hasAvailableSpace(DatanodeInfo datanodeInfo, StorageType storageType);
 
   /**
    * Removes a pending container allocation from a datanode.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -18,10 +18,14 @@
 package org.apache.hadoop.hdds.scm.node;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -34,10 +38,11 @@ import org.slf4j.LoggerFactory;
  * Tracks per-datanode pending container allocations at SCM using a Two Window Tumbling Bucket
  * pattern (similar to HDFS HADOOP-3707).
  *
- * Two Window Tumbling Bucket for automatic aging and cleanup.
+ * Pending allocations are grouped by storage type. Each group uses a two-window
+ * tumbling bucket for automatic aging and cleanup.
  *
  * How It Works:
- *   <li>Each DataNode has two sets: <b>currentWindow</b> and <b>previousWindow</b></li>
+ *   <li>Each bucket has two sets: <b>currentWindow</b> and <b>previousWindow</b></li>
  *   <li>New allocations go into <b>currentWindow</b></li>
  *   <li>Every <b>ROLL_INTERVAL</b> (default 5 minutes):
  *     <ul>
@@ -125,6 +130,17 @@ public class PendingContainerTracker {
       return currentWindow.contains(containerID) || previousWindow.contains(containerID);
     }
 
+    synchronized boolean containsInCurrentWindow(ContainerID containerID) {
+      return currentWindow.contains(containerID);
+    }
+
+    /**
+     * Add container to current window.
+     */
+    synchronized boolean add(ContainerID containerID) {
+      return currentWindow.add(containerID);
+    }
+
     /**
      * Remove container from both windows.
      */
@@ -132,8 +148,6 @@ public class PendingContainerTracker {
       boolean removedFromCurrent = currentWindow.remove(containerID);
       boolean removedFromPrevious = previousWindow.remove(containerID);
       boolean removed = removedFromCurrent || removedFromPrevious;
-      LOG.debug("Removed pending container {} from DataNode {}. Removed={}, Remaining={}",
-          containerID, datanodeID, removed, getCount());
       return removed;
     }
 
@@ -143,14 +157,98 @@ public class PendingContainerTracker {
     synchronized int getCount() {
       return currentWindow.size() + previousWindow.size();
     }
+  }
+
+  /**
+   * Pending container allocations for one datanode, grouped by storage type.
+   */
+  public static class PendingContainerAllocations {
+    private final Map<StorageType, TwoWindowBucket> typedBuckets =
+        new EnumMap<>(StorageType.class);
+    private final TwoWindowBucket unknownBucket;
+    private final long rollIntervalMs;
+    private final DatanodeID datanodeID;
+
+    PendingContainerAllocations(DatanodeID id, long rollIntervalMs) {
+      this.datanodeID = id;
+      this.rollIntervalMs = rollIntervalMs;
+      this.unknownBucket = new TwoWindowBucket(id, rollIntervalMs);
+    }
+
+    synchronized void rollIfNeeded() {
+      unknownBucket.rollIfNeeded();
+      typedBuckets.values().forEach(TwoWindowBucket::rollIfNeeded);
+    }
+
+    synchronized boolean contains(ContainerID containerID) {
+      return unknownBucket.contains(containerID)
+          || typedBuckets.values().stream()
+          .anyMatch(bucket -> bucket.contains(containerID));
+    }
+
+    /**
+     * Count pending containers of the given storage type.
+     * Unknown storage type entries are counted for typed checks because they
+     * may occupy the requested storage type.
+     */
+    synchronized int getCount(StorageType storageType) {
+      if (checksAllStorageTypes(storageType)) {
+        return getCount();
+      }
+      TwoWindowBucket bucket = typedBuckets.get(storageType);
+      return unknownBucket.getCount() + (bucket != null ? bucket.getCount() : 0);
+    }
+
+    /**
+     * Count of pending containers in all buckets.
+     */
+    synchronized int getCount() {
+      return unknownBucket.getCount()
+          + typedBuckets.values().stream()
+          .mapToInt(TwoWindowBucket::getCount)
+          .sum();
+    }
 
     /**
      * Records a container allocation in the current window,
      * without checking available space. Use this when the space check has
      * already been performed by the placement policy.
      */
-    synchronized void add(ContainerID containerID) {
-      currentWindow.add(containerID);
+    synchronized boolean record(ContainerID containerID, StorageType storageType) {
+      return add(containerID, storageType);
+    }
+
+    synchronized boolean add(ContainerID containerID, StorageType storageType) {
+      if (containsInCurrentWindow(containerID)) {
+        LOG.debug("Recorded pending container {} on DataNode {} with storageType {}. "
+            + "Added=false, Total pending={}",
+            containerID, datanodeID, storageType, getCount());
+        return false;
+      }
+      boolean added = bucketFor(storageType).add(containerID);
+      LOG.debug("Recorded pending container {} on DataNode {} with storageType {}. "
+          + "Added={}, Total pending={}",
+          containerID, datanodeID, storageType, added, getCount());
+      return added;
+    }
+
+    private boolean containsInCurrentWindow(ContainerID containerID) {
+      return unknownBucket.containsInCurrentWindow(containerID)
+          || typedBuckets.values().stream()
+          .anyMatch(bucket -> bucket.containsInCurrentWindow(containerID));
+    }
+
+    /**
+     * Remove container from all buckets.
+     */
+    synchronized boolean remove(ContainerID containerID) {
+      boolean removed = unknownBucket.remove(containerID);
+      for (TwoWindowBucket bucket : typedBuckets.values()) {
+        removed |= bucket.remove(containerID);
+      }
+      LOG.debug("Removed pending container {} from DataNode {}. Removed={}, Remaining={}",
+          containerID, datanodeID, removed, getCount());
+      return removed;
     }
 
     /**
@@ -161,28 +259,39 @@ public class PendingContainerTracker {
      * @param storageReports storage reports for the datanode
      * @param maxContainerSize maximum size of a single container in bytes
      * @param containerID the container being allocated
+     * @param storageType the storage type selected for the allocation
      * @return true if space was available and the container was recorded, false otherwise
      */
-
     synchronized boolean checkSpaceAndAdd(
-        List<StorageReportProto> storageReports, long maxContainerSize, ContainerID containerID) {
-      final int pendingAllocationCount = getCount();
+        List<StorageReportProto> storageReports, long maxContainerSize,
+        ContainerID containerID, StorageType storageType) {
+      rollIfNeeded();
+      final int pendingAllocationCount = getCount(storageType);
       long allocatableCount = 0;
       for (StorageReportProto report : storageReports) {
         if (report.hasFailed() && report.getFailed()) {
+          continue;
+        }
+        if (!matchesStorageType(report, storageType)) {
           continue;
         }
         final long allocatableCountOnThisDisk =
             Math.max(0L, VolumeUsage.getUsableSpace(report)) / maxContainerSize;
         allocatableCount += allocatableCountOnThisDisk;
         if (allocatableCount > pendingAllocationCount) {
-          final boolean added = currentWindow.add(containerID);
-          LOG.debug("Recorded pending container {} on DataNode {}. Added={}, Total pending={}",
-              containerID, datanodeID, added, getCount());
+          final boolean added = add(containerID, storageType);
           return added;
         }
       }
       return false;
+    }
+
+    private TwoWindowBucket bucketFor(StorageType storageType) {
+      if (checksAllStorageTypes(storageType)) {
+        return unknownBucket;
+      }
+      return typedBuckets.computeIfAbsent(storageType,
+          ignored -> new TwoWindowBucket(datanodeID, rollIntervalMs));
     }
   }
 
@@ -196,13 +305,14 @@ public class PendingContainerTracker {
   /**
    * Atomically checks if the datanode has space for a new container and records the allocation
    * if space is available. The check-and-add atomicity is enforced inside
-   * {@link TwoWindowBucket#checkSpaceAndAdd}.
+   * {@link PendingContainerAllocations#checkSpaceAndAdd}.
    *
-   * @param datanodeInfo datanode whose storage reports and pending bucket
+   * @param datanodeInfo datanode whose storage reports and pending allocations are checked
    * @param containerID the container being allocated
    * @return true if space was available and the allocation was recorded, false otherwise
    */
-  public boolean checkSpaceAndRecordAllocation(DatanodeInfo datanodeInfo, ContainerID containerID) {
+  public boolean checkSpaceAndRecordAllocation(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType) {
     Objects.requireNonNull(datanodeInfo, "datanodeInfo == null");
     Objects.requireNonNull(containerID, "containerID == null");
 
@@ -213,7 +323,7 @@ public class PendingContainerTracker {
     }
 
     boolean added = datanodeInfo.getPendingContainerAllocations()
-        .checkSpaceAndAdd(storageReports, maxContainerSize, containerID);
+        .checkSpaceAndAdd(storageReports, maxContainerSize, containerID, storageType);
     if (metrics != null) {
       if (added) {
         metrics.incNumPendingContainersAdded();
@@ -232,39 +342,48 @@ public class PendingContainerTracker {
    *
    * @param datanodeInfo the datanode receiving the container
    * @param containerID  the container being allocated
+   * @param storageType the storage type selected for the allocation
    */
-  public void recordAllocation(DatanodeInfo datanodeInfo, ContainerID containerID) {
+  public void recordAllocation(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType) {
     Objects.requireNonNull(datanodeInfo, "datanodeInfo == null");
     Objects.requireNonNull(containerID, "containerID == null");
-    datanodeInfo.getPendingContainerAllocations().add(containerID);
-    if (metrics != null) {
+    final boolean added =
+        datanodeInfo.getPendingContainerAllocations().record(containerID, storageType);
+    if (added && metrics != null) {
       metrics.incNumPendingContainersAdded();
     }
   }
 
   /**
-   * Returns true if the given datanode has at least one allocatable container slot
-   * available, accounting for pending in-flight allocations.
+   * Returns true if the given datanode has at least one allocatable container
+   * slot available, accounting for pending in-flight allocations.
    *
    * <p>Slot availability is based on {@code maxContainerSize}: a slot exists for each
    * {@code maxContainerSize}-worth of usable space on any volume. This check is intended for the placement policy.
    * This rolls expired-window entries but does not consume a slot.
    *
    * @param datanodeInfo the datanode to check
+   * @param storageType storage type to check
    * @return true if at least one container slot is available
    */
-  public boolean hasAvailableSpace(DatanodeInfo datanodeInfo) {
+  public boolean hasAvailableSpace(
+      DatanodeInfo datanodeInfo, StorageType storageType) {
     Objects.requireNonNull(datanodeInfo, "datanodeInfo == null");
     List<StorageReportProto> storageReports = datanodeInfo.getStorageReports();
     if (storageReports.isEmpty()) {
       return false;
     }
-    TwoWindowBucket bucket = datanodeInfo.getPendingContainerAllocations();
-    bucket.rollIfNeeded();
-    final int pendingCount = bucket.getCount();
+    PendingContainerAllocations pendingAllocations =
+        datanodeInfo.getPendingContainerAllocations();
+    pendingAllocations.rollIfNeeded();
+    final int pendingCount = pendingAllocations.getCount(storageType);
     long allocatableCount = 0;
     for (StorageReportProto report : storageReports) {
       if (report.hasFailed() && report.getFailed()) {
+        continue;
+      }
+      if (!matchesStorageType(report, storageType)) {
         continue;
       }
       allocatableCount += Math.max(0L, VolumeUsage.getUsableSpace(report)) / maxContainerSize;
@@ -278,19 +397,30 @@ public class PendingContainerTracker {
   }
 
   /**
-   * Remove pending allocation from the bucket for the given container.
+   * Remove pending allocation for the given container.
    *
-   * @param bucket TWO window bucket of the datanode
+   * @param pendingAllocations pending allocations of the datanode
    * @param containerID containerID
    */
-  public void removePendingAllocation(TwoWindowBucket bucket, ContainerID containerID) {
+  public void removePendingAllocation(
+      PendingContainerAllocations pendingAllocations, ContainerID containerID) {
     Objects.requireNonNull(containerID, "containerID == null");
 
-    boolean removed = bucket.remove(containerID);
+    boolean removed = pendingAllocations.remove(containerID);
 
     if (removed && metrics != null) {
       metrics.incNumPendingContainersRemoved();
     }
+  }
+
+  private static boolean matchesStorageType(
+      StorageReportProto report, StorageType storageType) {
+    return checksAllStorageTypes(storageType)
+        || StorageTypeUtils.getFromProtobuf(report.getStorageType()).equals(storageType);
+  }
+
+  private static boolean checksAllStorageTypes(StorageType storageType) {
+    return storageType == null;
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -165,6 +165,8 @@ public class PendingContainerTracker {
 
     /**
      * Count pending containers of the given storage type.
+     * Unknown storage type entries are counted for typed checks because they
+     * may occupy the requested storage type.
      */
     synchronized int getCount(StorageType storageType) {
       if (checksAllStorageTypes(storageType)) {
@@ -177,7 +179,8 @@ public class PendingContainerTracker {
     private static int countByStorageType(
         Map<ContainerID, StorageType> window, StorageType storageType) {
       return (int) window.values().stream()
-          .filter(storageType::equals)
+          .filter(recordedStorageType ->
+              recordedStorageType == null || storageType.equals(recordedStorageType))
           .count();
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/PendingContainerTracker.java
@@ -17,10 +17,12 @@
 
 package org.apache.hadoop.hdds.scm.node;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -78,11 +80,11 @@ public class PendingContainerTracker {
 
   /**
    * Two-window bucket for a single DataNode.
-   * Contains current and previous window sets, plus last roll timestamp.
+   * Contains current and previous window maps, plus last roll timestamp.
    */
   public static class TwoWindowBucket {
-    private Set<ContainerID> currentWindow = new HashSet<>();
-    private Set<ContainerID> previousWindow = new HashSet<>();
+    private Map<ContainerID, StorageType> currentWindow = new HashMap<>();
+    private Map<ContainerID, StorageType> previousWindow = new HashMap<>();
     private long lastRollTime = Time.monotonicNow();
     private final long rollIntervalMs;
     private final DatanodeID datanodeID;
@@ -107,7 +109,7 @@ public class PendingContainerTracker {
         LOG.debug("Double roll interval elapsed ({}ms): dropped {} pending containers", elapsed, dropped);
       } else if (elapsed >= rollIntervalMs) {
         previousWindow.clear();
-        final Set<ContainerID> tmp = previousWindow;
+        final Map<ContainerID, StorageType> tmp = previousWindow;
         previousWindow = currentWindow;
         currentWindow = tmp;
         lastRollTime = now;
@@ -117,16 +119,26 @@ public class PendingContainerTracker {
     }
 
     synchronized boolean contains(ContainerID containerID) {
-      return currentWindow.contains(containerID) || previousWindow.contains(containerID);
+      return currentWindow.containsKey(containerID) || previousWindow.containsKey(containerID);
     }
 
     /**
      * Add container to current window.
      */
     synchronized boolean add(ContainerID containerID) {
-      boolean added = currentWindow.add(containerID);
-      LOG.debug("Recorded pending container {} on DataNode {}. Added={}, Total pending={}",
-          containerID, datanodeID, added, getCount());
+      return add(containerID, null);
+    }
+
+    /**
+     * Add container with its storage type to current window.
+     */
+    synchronized boolean add(ContainerID containerID, StorageType storageType) {
+      boolean added = !currentWindow.containsKey(containerID);
+      if (added) {
+        currentWindow.put(containerID, storageType);
+      }
+      LOG.debug("Recorded pending container {} on DataNode {} with storageType {}. Added={}, Total pending={}",
+          containerID, datanodeID, storageType, added, getCount());
       return added;
     }
 
@@ -134,8 +146,10 @@ public class PendingContainerTracker {
      * Remove container from both windows.
      */
     synchronized boolean remove(ContainerID containerID) {
-      boolean removedFromCurrent = currentWindow.remove(containerID);
-      boolean removedFromPrevious = previousWindow.remove(containerID);
+      boolean removedFromCurrent = currentWindow.containsKey(containerID);
+      currentWindow.remove(containerID);
+      boolean removedFromPrevious = previousWindow.containsKey(containerID);
+      previousWindow.remove(containerID);
       boolean removed = removedFromCurrent || removedFromPrevious;
       LOG.debug("Removed pending container {} from DataNode {}. Removed={}, Remaining={}",
           containerID, datanodeID, removed, getCount());
@@ -147,6 +161,24 @@ public class PendingContainerTracker {
      */
     synchronized int getCount() {
       return currentWindow.size() + previousWindow.size();
+    }
+
+    /**
+     * Count pending containers of the given storage type.
+     */
+    synchronized int getCount(StorageType storageType) {
+      if (checksAllStorageTypes(storageType)) {
+        return getCount();
+      }
+      return countByStorageType(currentWindow, storageType)
+          + countByStorageType(previousWindow, storageType);
+    }
+
+    private static int countByStorageType(
+        Map<ContainerID, StorageType> window, StorageType storageType) {
+      return (int) window.values().stream()
+          .filter(storageType::equals)
+          .count();
     }
   }
 
@@ -166,9 +198,23 @@ public class PendingContainerTracker {
    * @param datanodeInfo storage reports for the datanode
    */
   public boolean hasEffectiveAllocatableSpaceForNewContainer(DatanodeInfo datanodeInfo) {
+    return hasEffectiveAllocatableSpaceForNewContainer(datanodeInfo, null);
+  }
+
+  /**
+   * Whether the datanode can fit another container of {@link #maxContainerSize}
+   * in the requested storage type after accounting for SCM pending allocations.
+   * A null storage type preserves the legacy behavior of checking all reports.
+   *
+   * @param datanodeInfo storage reports for the datanode
+   * @param storageType storage type for this allocation, or null for all reports
+   */
+  public boolean hasEffectiveAllocatableSpaceForNewContainer(
+      DatanodeInfo datanodeInfo, StorageType storageType) {
     Objects.requireNonNull(datanodeInfo, "datanodeInfo == null");
 
-    long pendingAllocationSize = datanodeInfo.getPendingContainerAllocations().getCount() * maxContainerSize;
+    long pendingAllocationSize =
+        datanodeInfo.getPendingContainerAllocations().getCount(storageType) * maxContainerSize;
     List<StorageReportProto> storageReports = datanodeInfo.getStorageReports();
     Objects.requireNonNull(storageReports, "storageReports == null");
     if (storageReports.isEmpty()) {
@@ -176,6 +222,9 @@ public class PendingContainerTracker {
     }
     long effectiveAllocatableSpace = 0L;
     for (StorageReportProto report : storageReports) {
+      if (!matchesStorageType(report, storageType)) {
+        continue;
+      }
       long usableSpace = VolumeUsage.getUsableSpace(report);
       long containersOnThisDisk = usableSpace / maxContainerSize;
       effectiveAllocatableSpace += containersOnThisDisk * maxContainerSize;
@@ -193,14 +242,29 @@ public class PendingContainerTracker {
    * Record a pending container allocation for a single DataNode.
    * Container is added to the current window.
    *
+   * @param datanodeInfo The DataNode receiving the allocation
    * @param containerID The container being allocated/replicated
    */
   public void recordPendingAllocationForDatanode(DatanodeInfo datanodeInfo, ContainerID containerID) {
+    recordPendingAllocationForDatanode(datanodeInfo, containerID, null);
+  }
+
+  /**
+   * Record a pending container allocation for a single DataNode.
+   * Container is added to the current window.
+   *
+   * @param datanodeInfo The DataNode receiving the allocation
+   * @param containerID The container being allocated/replicated
+   * @param storageType The storage type selected for the allocation
+   */
+  public void recordPendingAllocationForDatanode(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType) {
     Objects.requireNonNull(containerID, "containerID == null");
     if (datanodeInfo == null) {
       return;
     }
-    final boolean added = datanodeInfo.getPendingContainerAllocations().add(containerID);
+    final boolean added =
+        datanodeInfo.getPendingContainerAllocations().add(containerID, storageType);
     if (added && metrics != null) {
       metrics.incNumPendingContainersAdded();
     }
@@ -221,5 +285,15 @@ public class PendingContainerTracker {
     if (removed && metrics != null) {
       metrics.incNumPendingContainersRemoved();
     }
+  }
+
+  private static boolean matchesStorageType(
+      StorageReportProto report, StorageType storageType) {
+    return checksAllStorageTypes(storageType)
+        || StorageTypeUtils.getFromProtobuf(report.getStorageType()).equals(storageType);
+  }
+
+  private static boolean checksAllStorageTypes(StorageType storageType) {
+    return storageType == null;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1078,22 +1078,36 @@ public class SCMNodeManager implements NodeManager {
    */
   @Override
   public boolean hasSpaceForNewContainerAllocation(DatanodeID datanodeID) {
+    return hasSpaceForNewContainerAllocation(datanodeID, null);
+  }
+
+  @Override
+  public boolean hasSpaceForNewContainerAllocation(
+      DatanodeID datanodeID, StorageType storageType) {
     DatanodeInfo datanodeInfo = getNode(datanodeID);
     if (datanodeInfo == null) {
       LOG.warn("DatanodeInfo not found for node {}", datanodeID);
       return false;
     }
-    return pendingContainerTracker.hasEffectiveAllocatableSpaceForNewContainer(datanodeInfo);
+    return pendingContainerTracker.hasEffectiveAllocatableSpaceForNewContainer(
+        datanodeInfo, storageType);
   }
 
   @Override
   public void recordPendingAllocationForDatanode(DatanodeID datanodeID, ContainerID containerID) {
+    recordPendingAllocationForDatanode(datanodeID, containerID, null);
+  }
+
+  @Override
+  public void recordPendingAllocationForDatanode(
+      DatanodeID datanodeID, ContainerID containerID, StorageType storageType) {
     DatanodeInfo datanodeInfo = getNode(datanodeID);
     if (datanodeInfo == null) {
       LOG.warn("DatanodeInfo not found for node {}", datanodeID);
       return;
     }
-    pendingContainerTracker.recordPendingAllocationForDatanode(datanodeInfo, containerID);
+    pendingContainerTracker.recordPendingAllocationForDatanode(
+        datanodeInfo, containerID, storageType);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -49,6 +49,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.management.ObjectName;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -1065,22 +1066,28 @@ public class SCMNodeManager implements NodeManager, ContainerReplicaPendingOpsSu
   }
 
   @Override
-  public boolean checkSpaceAndRecordAllocation(DatanodeInfo datanodeInfo, ContainerID containerID) {
-    return pendingContainerTracker.checkSpaceAndRecordAllocation(datanodeInfo, containerID);
+  public boolean checkSpaceAndRecordAllocation(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType) {
+    return pendingContainerTracker.checkSpaceAndRecordAllocation(
+        datanodeInfo, containerID, storageType);
   }
 
   @Override
-  public void recordAllocationForDatanode(DatanodeInfo datanodeInfo, ContainerID containerID) {
-    pendingContainerTracker.recordAllocation(datanodeInfo, containerID);
+  public void recordAllocationForDatanode(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType) {
+    pendingContainerTracker.recordAllocation(
+        datanodeInfo, containerID, storageType);
   }
 
   @Override
-  public boolean hasAvailableSpace(DatanodeInfo datanodeInfo) {
-    return pendingContainerTracker.hasAvailableSpace(datanodeInfo);
+  public boolean hasAvailableSpace(
+      DatanodeInfo datanodeInfo, StorageType storageType) {
+    return pendingContainerTracker.hasAvailableSpace(datanodeInfo, storageType);
   }
 
   @Override
-  public void removePendingAllocationForDatanode(DatanodeInfo datanodeInfo, ContainerID containerID) {
+  public void removePendingAllocationForDatanode(
+      DatanodeInfo datanodeInfo, ContainerID containerID) {
     pendingContainerTracker.removePendingAllocation(
         datanodeInfo.getPendingContainerAllocations(), containerID);
   }
@@ -1090,7 +1097,7 @@ public class SCMNodeManager implements NodeManager, ContainerReplicaPendingOpsSu
     if (op.getOpType() == ContainerReplicaOp.PendingOpType.ADD) {
       DatanodeInfo dnInfo = getNode(op.getTarget().getID());
       if (dnInfo != null) {
-        recordAllocationForDatanode(dnInfo, containerID);
+        recordAllocationForDatanode(dnInfo, containerID, op.getStorageType());
       }
     }
   }
@@ -1510,7 +1517,7 @@ public class SCMNodeManager implements NodeManager, ContainerReplicaPendingOpsSu
      * {@link PendingContainerTracker}) and sufficient Ratis metadata volume space.
      */
     private boolean hasEnoughSpaceForNode(DatanodeInfo dn) {
-      if (!tracker.hasAvailableSpace(dn)) {
+      if (!tracker.hasAvailableSpace(dn, null)) {
         return false;
       }
       if (minRatisVolumeSizeBytes <= 0) {
@@ -1785,6 +1792,7 @@ public class SCMNodeManager implements NodeManager, ContainerReplicaPendingOpsSu
       final ContainerID containerId)
       throws NodeNotFoundException {
     nodeStateManager.addContainer(datanodeDetails.getID(), containerId);
+    removePendingAllocation(datanodeDetails, containerId);
   }
 
   @Override
@@ -1792,6 +1800,14 @@ public class SCMNodeManager implements NodeManager, ContainerReplicaPendingOpsSu
                            final ContainerID containerId)
       throws NodeNotFoundException {
     nodeStateManager.removeContainer(datanodeDetails.getID(), containerId);
+    removePendingAllocation(datanodeDetails, containerId);
+  }
+
+  private void removePendingAllocation(DatanodeDetails datanodeDetails,
+      ContainerID containerId) throws NodeNotFoundException {
+    DatanodeInfo datanodeInfo = nodeStateManager.getNode(datanodeDetails);
+    pendingContainerTracker.removePendingAllocation(
+        datanodeInfo.getPendingContainerAllocations(), containerId);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1772,6 +1772,7 @@ public class SCMNodeManager implements NodeManager {
       final ContainerID containerId)
       throws NodeNotFoundException {
     nodeStateManager.addContainer(datanodeDetails.getID(), containerId);
+    removePendingAllocation(datanodeDetails, containerId);
   }
 
   @Override
@@ -1779,6 +1780,14 @@ public class SCMNodeManager implements NodeManager {
                            final ContainerID containerId)
       throws NodeNotFoundException {
     nodeStateManager.removeContainer(datanodeDetails.getID(), containerId);
+    removePendingAllocation(datanodeDetails, containerId);
+  }
+
+  private void removePendingAllocation(DatanodeDetails datanodeDetails,
+      ContainerID containerId) throws NodeNotFoundException {
+    DatanodeInfo datanodeInfo = nodeStateManager.getNode(datanodeDetails);
+    pendingContainerTracker.removePendingAllocation(
+        datanodeInfo.getPendingContainerAllocations(), containerId);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import javax.management.ObjectName;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -703,6 +704,7 @@ public class PipelineManagerImpl implements PipelineManager {
 
   @Override
   public boolean checkSpaceAndRecordAllocation(Pipeline pipeline, ContainerID containerID) {
+    StorageType storageType = getStorageType(pipeline);
     final Set<DatanodeDetails> datanodeDetails = pipeline.getNodeSet();
     final List<DatanodeInfo> datanodeInfos = new ArrayList<>(datanodeDetails.size());
     for (DatanodeDetails dn : datanodeDetails) {
@@ -717,7 +719,7 @@ public class PipelineManagerImpl implements PipelineManager {
 
     final List<DatanodeInfo> successfulNodes = new ArrayList<>(datanodeInfos.size());
     for (DatanodeInfo dn : datanodeInfos) {
-      if (!nodeManager.checkSpaceAndRecordAllocation(dn, containerID)) {
+      if (!nodeManager.checkSpaceAndRecordAllocation(dn, containerID, storageType)) {
         for (DatanodeInfo rollbackNode : successfulNodes) {
           nodeManager.removePendingAllocationForDatanode(rollbackNode, containerID);
         }
@@ -726,6 +728,14 @@ public class PipelineManagerImpl implements PipelineManager {
       successfulNodes.add(dn);
     }
     return true;
+  }
+
+  private StorageType getStorageType(Pipeline pipeline) {
+    StorageTier storageTier = pipeline.getSupportedStorageTier();
+    if (storageTier == null || storageTier == StorageTier.EMPTY) {
+      return null;
+    }
+    return storageTier.getUniformStorageType();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import javax.management.ObjectName;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -649,8 +650,9 @@ public class PipelineManagerImpl implements PipelineManager {
 
   @Override
   public boolean hasEnoughSpace(Pipeline pipeline) {
+    StorageType storageType = getStorageTypeForPendingAllocation(pipeline);
     for (DatanodeDetails node : pipeline.getNodes()) {
-      if (!nodeManager.hasSpaceForNewContainerAllocation(node.getID())) {
+      if (!nodeManager.hasSpaceForNewContainerAllocation(node.getID(), storageType)) {
         return false;
       }
     }
@@ -659,9 +661,18 @@ public class PipelineManagerImpl implements PipelineManager {
 
   @Override
   public void recordPendingAllocation(Pipeline pipeline, ContainerID containerID) {
+    StorageType storageType = getStorageTypeForPendingAllocation(pipeline);
     for (DatanodeDetails dn : pipeline.getNodes()) {
-      nodeManager.recordPendingAllocationForDatanode(dn.getID(), containerID);
+      nodeManager.recordPendingAllocationForDatanode(dn.getID(), containerID, storageType);
     }
+  }
+
+  private StorageType getStorageTypeForPendingAllocation(Pipeline pipeline) {
+    StorageTier storageTier = pipeline.getSupportedStorageTier();
+    if (storageTier == null || storageTier == StorageTier.EMPTY) {
+      return null;
+    }
+    return storageTier.getUniformStorageType();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
@@ -109,7 +109,7 @@ public abstract class PipelineProvider<REPLICATION_CONFIG
     List<DatanodeDetails> healthyDNs = pickAllNodesNotUsed(replicationConfig);
     List<DatanodeDetails> healthyDNsWithSpace = healthyDNs.stream()
         .filter(dn -> SCMCommonPlacementPolicy.hasEnoughSpace(
-            dn, metadataSizeRequired, dataSizeRequired, storageType, nodeManager))
+            dn, metadataSizeRequired, storageType, nodeManager))
         .limit(nodesRequired)
         .collect(Collectors.toList());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -505,16 +505,16 @@ public class TestSCMCommonPlacementPolicy {
     when(datanodeInfo.getMetadataStorageReports())
         .thenReturn(Collections.singletonList(metaReport));
 
-    // Space check now uses PendingContainerTracker.hasAvailableSpace:
-    // slot available → isValidNode returns true
-    when(nodeMngr.hasAvailableSpace(datanodeInfo)).thenReturn(true);
-    assertTrue(placementPolicy.isValidNode(
-        datanodeDetails, 100, 4000, StorageType.DEFAULT));
+    // slot available -> isValidNode returns true.
+    // storageType == null checks all storage reports and relies on the slot check.
+    when(nodeMngr.hasAvailableSpace(datanodeInfo, null))
+        .thenReturn(true);
+    assertTrue(placementPolicy.isValidNode(datanodeDetails, 100, 4000, null));
 
-    // No slot available (all pending) → isValidNode returns false
-    when(nodeMngr.hasAvailableSpace(datanodeInfo)).thenReturn(false);
-    assertFalse(placementPolicy.isValidNode(
-        datanodeDetails, 100, 4000, StorageType.DEFAULT));
+    // No slot available (all pending) -> isValidNode returns false
+    when(nodeMngr.hasAvailableSpace(datanodeInfo, null))
+        .thenReturn(false);
+    assertFalse(placementPolicy.isValidNode(datanodeDetails, 100, 4000, null));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -485,13 +485,14 @@ public class MockNodeManager implements NodeManager {
 
   @Override
   public void recordPendingAllocationForDatanode(
-      DatanodeID datanodeID, ContainerID containerID, StorageType storageType) {
+      DatanodeID datanodeID, ContainerID containerID,
+      StorageType pendingStorageType) {
     DatanodeDetails dd = nodeMetricMap.keySet().stream()
         .filter(d -> d.getID().equals(datanodeID))
         .findFirst().orElse(null);
     DatanodeInfo info = getDatanodeInfo(dd);
     pendingContainerTracker.recordPendingAllocationForDatanode(
-        info, containerID, storageType);
+        info, containerID, pendingStorageType);
   }
 
   /**
@@ -995,7 +996,7 @@ public class MockNodeManager implements NodeManager {
 
   @Override
   public boolean hasSpaceForNewContainerAllocation(
-      DatanodeID datanodeID, StorageType storageType) {
+      DatanodeID datanodeID, StorageType pendingStorageType) {
     DatanodeDetails dd = nodeMetricMap.keySet().stream()
         .filter(d -> d.getID().equals(datanodeID))
         .findFirst().orElse(null);
@@ -1004,7 +1005,7 @@ public class MockNodeManager implements NodeManager {
       return false;
     }
     return pendingContainerTracker.hasEffectiveAllocatableSpaceForNewContainer(
-        info, storageType);
+        info, pendingStorageType);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -480,11 +480,18 @@ public class MockNodeManager implements NodeManager {
 
   @Override
   public void recordPendingAllocationForDatanode(DatanodeID datanodeID, ContainerID containerID) {
+    recordPendingAllocationForDatanode(datanodeID, containerID, null);
+  }
+
+  @Override
+  public void recordPendingAllocationForDatanode(
+      DatanodeID datanodeID, ContainerID containerID, StorageType storageType) {
     DatanodeDetails dd = nodeMetricMap.keySet().stream()
         .filter(d -> d.getID().equals(datanodeID))
         .findFirst().orElse(null);
     DatanodeInfo info = getDatanodeInfo(dd);
-    pendingContainerTracker.recordPendingAllocationForDatanode(info, containerID);
+    pendingContainerTracker.recordPendingAllocationForDatanode(
+        info, containerID, storageType);
   }
 
   /**
@@ -983,6 +990,12 @@ public class MockNodeManager implements NodeManager {
 
   @Override
   public boolean hasSpaceForNewContainerAllocation(DatanodeID datanodeID) {
+    return hasSpaceForNewContainerAllocation(datanodeID, null);
+  }
+
+  @Override
+  public boolean hasSpaceForNewContainerAllocation(
+      DatanodeID datanodeID, StorageType storageType) {
     DatanodeDetails dd = nodeMetricMap.keySet().stream()
         .filter(d -> d.getID().equals(datanodeID))
         .findFirst().orElse(null);
@@ -990,7 +1003,8 @@ public class MockNodeManager implements NodeManager {
     if (info == null) {
       return false;
     }
-    return pendingContainerTracker.hasEffectiveAllocatableSpaceForNewContainer(info);
+    return pendingContainerTracker.hasEffectiveAllocatableSpaceForNewContainer(
+        info, storageType);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -490,27 +490,36 @@ public class MockNodeManager implements NodeManager {
   }
 
   @Override
-  public boolean checkSpaceAndRecordAllocation(DatanodeInfo datanodeInfo, ContainerID containerID) {
+  public boolean checkSpaceAndRecordAllocation(
+      DatanodeInfo datanodeInfo, ContainerID containerID,
+      StorageType pendingStorageType) {
     if (datanodeInfo == null) {
       return false;
     }
-    return pendingContainerTracker.checkSpaceAndRecordAllocation(datanodeInfo, containerID);
+    return pendingContainerTracker.checkSpaceAndRecordAllocation(
+        datanodeInfo, containerID, pendingStorageType);
   }
 
   @Override
-  public void recordAllocationForDatanode(DatanodeInfo datanodeInfo, ContainerID containerID) {
+  public void recordAllocationForDatanode(
+      DatanodeInfo datanodeInfo, ContainerID containerID,
+      StorageType pendingStorageType) {
     if (datanodeInfo != null) {
-      pendingContainerTracker.recordAllocation(datanodeInfo, containerID);
+      pendingContainerTracker.recordAllocation(
+          datanodeInfo, containerID, pendingStorageType);
     }
   }
-    
-  @Override  
-  public boolean hasAvailableSpace(DatanodeInfo datanodeInfo) {
-    return pendingContainerTracker.hasAvailableSpace(datanodeInfo);
+
+  @Override
+  public boolean hasAvailableSpace(
+      DatanodeInfo datanodeInfo, StorageType pendingStorageType) {
+    return pendingContainerTracker.hasAvailableSpace(
+        datanodeInfo, pendingStorageType);
   }
 
   @Override
-  public void removePendingAllocationForDatanode(DatanodeInfo datanodeInfo, ContainerID containerID) {
+  public void removePendingAllocationForDatanode(
+      DatanodeInfo datanodeInfo, ContainerID containerID) {
     if (datanodeInfo != null) {
       pendingContainerTracker.removePendingAllocation(
           datanodeInfo.getPendingContainerAllocations(), containerID);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -245,16 +246,19 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
-  public boolean checkSpaceAndRecordAllocation(DatanodeInfo datanodeInfo, ContainerID containerID) {
+  public boolean checkSpaceAndRecordAllocation(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType) {
     return true;
   }
 
   @Override
-  public void recordAllocationForDatanode(DatanodeInfo datanodeInfo, ContainerID containerID) {
+  public void recordAllocationForDatanode(
+      DatanodeInfo datanodeInfo, ContainerID containerID, StorageType storageType) {
   }
   
   @Override
-  public boolean hasAvailableSpace(DatanodeInfo datanodeInfo) {
+  public boolean hasAvailableSpace(
+      DatanodeInfo datanodeInfo, StorageType storageType) {
     return true;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -133,6 +134,8 @@ public class TestContainerManagerImpl {
     assertEquals(1, containerManager.getContainers().size());
     assertNotNull(containerManager.getContainer(
         container.containerID()));
+    verify(pipelineManager).recordPendingAllocation(
+        any(Pipeline.class), eq(container.containerID()));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -135,6 +136,8 @@ public class TestContainerManagerImpl {
     assertEquals(1, containerManager.getContainers().size());
     assertNotNull(containerManager.getContainer(
         container.containerID()));
+    verify(pipelineManager).checkSpaceAndRecordAllocation(
+        any(Pipeline.class), eq(container.containerID()));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -204,13 +204,13 @@ public class TestMoveManager {
     nodes.put(src, NodeStatus.inServiceHealthy());
     nodes.put(tgt, NodeStatus.inServiceHealthy());
 
-    pendingOps.add(new ContainerReplicaOp(ADD, tgt, 0, null, clock.millis(), 0));
+    pendingOps.add(new ContainerReplicaOp(ADD, tgt, 0, null, clock.millis(), 0, null));
 
     assertMoveFailsWith(REPLICATION_FAIL_INFLIGHT_REPLICATION,
         containerInfo.containerID());
 
     pendingOps.clear();
-    pendingOps.add(new ContainerReplicaOp(DELETE, src, 0, null, clock.millis(), 0));
+    pendingOps.add(new ContainerReplicaOp(DELETE, src, 0, null, clock.millis(), 0, null));
     assertMoveFailsWith(REPLICATION_FAIL_INFLIGHT_DELETION,
         containerInfo.containerID());
   }
@@ -330,7 +330,7 @@ public class TestMoveManager {
         .when(containerManager).getContainer(any(ContainerID.class));
 
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, 0, null, clock.millis() + 1000, 0);
+        ADD, tgt, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     MoveManager.MoveResult moveResult = res.get();
@@ -342,14 +342,14 @@ public class TestMoveManager {
     CompletableFuture<MoveManager.MoveResult> res = setupSuccessfulMove();
 
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, 0, null, clock.millis() + 1000, 0);
+        ADD, tgt, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     verify(replicationManager).sendDeleteCommand(
         eq(containerInfo), eq(0), eq(src), eq(true), anyLong());
 
     op = new ContainerReplicaOp(
-        DELETE, src, 0, null, clock.millis() + 1000, 0);
+        DELETE, src, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     MoveManager.MoveResult finalResult = res.get();
@@ -379,7 +379,7 @@ public class TestMoveManager {
         anyLong());
 
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, srcReplica.getReplicaIndex(), null, clock.millis() + 1000, 0);
+        ADD, tgt, srcReplica.getReplicaIndex(), null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     verify(replicationManager).sendDeleteCommand(
@@ -387,7 +387,7 @@ public class TestMoveManager {
         eq(true), anyLong());
 
     op = new ContainerReplicaOp(
-        DELETE, src, srcReplica.getReplicaIndex(), null, clock.millis() + 1000, 0);
+        DELETE, src, srcReplica.getReplicaIndex(), null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     MoveManager.MoveResult finalResult = res.get();
@@ -399,7 +399,7 @@ public class TestMoveManager {
     CompletableFuture<MoveManager.MoveResult> res = setupSuccessfulMove();
 
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, 0, null, clock.millis() + 1000, 0);
+        ADD, tgt, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), true);
 
     MoveManager.MoveResult finalResult = res.get();
@@ -411,14 +411,14 @@ public class TestMoveManager {
     CompletableFuture<MoveManager.MoveResult> res = setupSuccessfulMove();
 
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, 0, null, clock.millis() + 1000, 0);
+        ADD, tgt, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     verify(replicationManager).sendDeleteCommand(
         eq(containerInfo), eq(0), eq(src), eq(true), anyLong());
 
     op = new ContainerReplicaOp(
-        DELETE, src, 0, null, clock.millis() + 1000, 0);
+        DELETE, src, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), true);
 
     MoveManager.MoveResult finalResult = res.get();
@@ -439,7 +439,7 @@ public class TestMoveManager {
       }
     }
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, 0, null, clock.millis() + 1000, 0);
+        ADD, tgt, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     MoveManager.MoveResult finalResult = res.get();
@@ -455,7 +455,7 @@ public class TestMoveManager {
 
     nodes.put(src, NodeStatus.inServiceStale());
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, 0, null, clock.millis() + 1000, 0);
+        ADD, tgt, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     MoveManager.MoveResult finalResult = res.get();
@@ -473,7 +473,7 @@ public class TestMoveManager {
         HddsProtos.NodeOperationalState.DECOMMISSIONING,
         HddsProtos.NodeState.HEALTHY));
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, 0, null, clock.millis() + 1000, 0);
+        ADD, tgt, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     MoveManager.MoveResult finalResult = res.get();
@@ -492,7 +492,7 @@ public class TestMoveManager {
             .MisReplicatedHealthResult(containerInfo, false, null));
 
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, 0, null, clock.millis() + 1000, 0);
+        ADD, tgt, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     MoveManager.MoveResult finalResult = res.get();
@@ -528,7 +528,7 @@ public class TestMoveManager {
         eq(tgt), longCaptorReplicate.capture());
 
     ContainerReplicaOp op = new ContainerReplicaOp(
-        ADD, tgt, srcReplica.getReplicaIndex(), null, clock.millis() + 1000, 0);
+        ADD, tgt, srcReplica.getReplicaIndex(), null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
     ArgumentCaptor<Long> longCaptorDelete = ArgumentCaptor.forClass(Long.class);
     verify(replicationManager).sendDeleteCommand(
@@ -544,7 +544,7 @@ public class TestMoveManager {
     assertTrue((longCaptorDelete.getValue() - Duration.ofMinutes(6).toMillis()) > clock.millis());
 
     op = new ContainerReplicaOp(
-        DELETE, src, srcReplica.getReplicaIndex(), null, clock.millis() + 1000, 0);
+        DELETE, src, srcReplica.getReplicaIndex(), null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(op, containerInfo.containerID(), false);
     MoveManager.MoveResult finalResult = res.get();
     assertEquals(COMPLETED, finalResult);
@@ -739,14 +739,14 @@ public class TestMoveManager {
   private void completeMove(ContainerInfo container, DatanodeDetails source,
       DatanodeDetails target, CompletableFuture<MoveManager.MoveResult> moveResult) throws Exception {
     ContainerReplicaOp addOp = new ContainerReplicaOp(
-        ADD, target, 0, null, clock.millis() + 1000, 0);
+        ADD, target, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(addOp, container.containerID(), false);
 
     verify(replicationManager).sendDeleteCommand(
         eq(container), eq(0), eq(source), eq(true), anyLong());
 
     ContainerReplicaOp deleteOp = new ContainerReplicaOp(
-        DELETE, source, 0, null, clock.millis() + 1000, 0);
+        DELETE, source, 0, null, clock.millis() + 1000, 0, null);
     moveManager.opCompleted(deleteOp, container.containerID(), false);
 
     assertEquals(COMPLETED, moveResult.get());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -148,7 +148,8 @@ public class TestContainerPlacementFactory {
       when(nodeManager.getNode(dn.getID()))
           .thenReturn(dn);
     }
-    when(nodeManager.hasAvailableSpace(any(DatanodeInfo.class))).thenReturn(true);
+    when(nodeManager.hasAvailableSpace(any(DatanodeInfo.class), any()))
+        .thenReturn(true);
 
     PlacementPolicy policy = ContainerPlacementPolicyFactory
         .getPolicy(conf, nodeManager, cluster, true,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -119,10 +119,13 @@ public class TestSCMContainerPlacementCapacity {
                 .filter(dn -> dn.getID().equals(invocation.getArgument(0)))
                 .findFirst()
                 .orElse(null));
-    when(mockNodeManager.hasAvailableSpace(any(DatanodeInfo.class))).thenAnswer(invocation -> {
-      DatanodeInfo di = invocation.getArgument(0);
-      return di.getStorageReports().stream().anyMatch(r -> r.getRemaining() >= 15L);
-    });
+    when(mockNodeManager.hasAvailableSpace(
+        any(DatanodeInfo.class), any()))
+        .thenAnswer(invocation -> {
+          DatanodeInfo di = invocation.getArgument(0);
+          return di.getStorageReports().stream()
+              .anyMatch(r -> r.getRemaining() >= 15L);
+        });
 
     SCMContainerPlacementCapacity scmContainerPlacementRandom =
         new SCMContainerPlacementCapacity(mockNodeManager, conf, null, true,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -183,7 +183,14 @@ public class TestSCMContainerPlacementRackAware {
     }
     when(nodeManager.getClusterNetworkTopologyMap())
         .thenReturn(cluster);
-    when(nodeManager.hasAvailableSpace(any(DatanodeInfo.class))).thenReturn(true);
+    when(nodeManager.hasAvailableSpace(
+        any(DatanodeInfo.class), any()))
+        .thenAnswer(invocation -> {
+          DatanodeInfo di = invocation.getArgument(0);
+          StorageType requestedStorageType = invocation.getArgument(1);
+          return di.getStorageReports().stream()
+              .anyMatch(report -> hasEnoughSpace(report, requestedStorageType));
+        });
 
     // create placement policy instances
     policy = new SCMContainerPlacementRackAware(
@@ -909,5 +916,12 @@ public class TestSCMContainerPlacementRackAware {
     assertThrows(SCMException.class,
             () -> policy.chooseDatanodes(usedNodes, null, null, 1, 0, 0, StorageType.DEFAULT),
             "No target datanode, this call should fail");
+  }
+
+  private static boolean hasEnoughSpace(
+      StorageReportProto report, StorageType storageType) {
+    return (storageType == null
+        || getStorageTypeProto(storageType).equals(report.getStorageType()))
+        && report.getRemaining() > 0;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -262,10 +262,14 @@ public class TestSCMContainerPlacementRackScatter {
     }
     when(nodeManager.getClusterNetworkTopologyMap())
         .thenReturn(cluster);
-    when(nodeManager.hasAvailableSpace(any(DatanodeInfo.class))).thenAnswer(invocation -> {
-      DatanodeInfo di = invocation.getArgument(0);
-      return di.getStorageReports().stream().anyMatch(r -> r.getRemaining() > 1L);
-    });
+    when(nodeManager.hasAvailableSpace(
+        any(DatanodeInfo.class), any()))
+        .thenAnswer(invocation -> {
+          DatanodeInfo di = invocation.getArgument(0);
+          StorageType requestedStorageType = invocation.getArgument(1);
+          return di.getStorageReports().stream()
+              .anyMatch(report -> hasEnoughSpace(report, requestedStorageType));
+        });
     when(nodeManager.getNodeStat(any(DatanodeDetails.class))).thenAnswer(invocation -> {
       DatanodeDetails dd = invocation.getArgument(0);
       DatanodeInfo di = dnInfos.stream()
@@ -973,5 +977,12 @@ public class TestSCMContainerPlacementRackScatter {
       }
     }
     return racks.size();
+  }
+
+  private static boolean hasEnoughSpace(
+      StorageReportProto report, StorageType storageType) {
+    return (storageType == null
+        || getStorageTypeProto(storageType).equals(report.getStorageType()))
+        && report.getRemaining() > 1L;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -91,10 +91,13 @@ public class TestSCMContainerPlacementRandom {
     NodeManager mockNodeManager = mock(NodeManager.class);
     when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
-    when(mockNodeManager.hasAvailableSpace(any(DatanodeInfo.class))).thenAnswer(invocation -> {
-      DatanodeInfo di = invocation.getArgument(0);
-      return di.getStorageReports().stream().anyMatch(r -> r.getRemaining() >= 15L);
-    });
+    when(mockNodeManager.hasAvailableSpace(
+        any(DatanodeInfo.class), any()))
+        .thenAnswer(invocation -> {
+          DatanodeInfo di = invocation.getArgument(0);
+          return di.getStorageReports().stream()
+              .anyMatch(r -> r.getRemaining() >= 15L);
+        });
 
     SCMContainerPlacementRandom scmContainerPlacementRandom =
         new SCMContainerPlacementRandom(mockNodeManager, conf, null, true,
@@ -215,10 +218,13 @@ public class TestSCMContainerPlacementRandom {
         .thenReturn(datanodes.get(1));
     when(mockNodeManager.getNode(datanodes.get(2).getID()))
         .thenReturn(datanodes.get(2));
-    when(mockNodeManager.hasAvailableSpace(any(DatanodeInfo.class))).thenAnswer(invocation -> {
-      DatanodeInfo di = invocation.getArgument(0);
-      return di.getStorageReports().stream().anyMatch(r -> r.getRemaining() >= 15L);
-    });
+    when(mockNodeManager.hasAvailableSpace(
+        any(DatanodeInfo.class), any()))
+        .thenAnswer(invocation -> {
+          DatanodeInfo di = invocation.getArgument(0);
+          return di.getStorageReports().stream()
+              .anyMatch(r -> r.getRemaining() >= 15L);
+        });
 
     SCMContainerPlacementRandom scmContainerPlacementRandom =
         new SCMContainerPlacementRandom(mockNodeManager, conf, null, true,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
@@ -105,7 +105,7 @@ public class TestContainerReplicaPendingOps {
   @Test
   public void testClear() {
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn1, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(2), dn1, 0, deleteCmd, deadline);
 
     assertEquals(1, pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
@@ -123,24 +123,24 @@ public class TestContainerReplicaPendingOps {
   @Test
   public void testCanAddReplicasForAdd() {
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn1, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn2, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn3, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     // Duplicate for DN2
     pendingOps.scheduleAddReplica(
         ContainerID.valueOf(1), dn2, 0, addCmd, deadline + 1,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     // Not a duplicate for DN2 as different index. Should not happen in practice as it is not valid to have 2 indexes
     // on the same node.
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn2, 1, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleAddReplica(ContainerID.valueOf(2), dn1, 1, addCmd, deadline,
-        THREE_GB_CONTAINER_SIZE, clock.millis());
+        THREE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleAddReplica(
         ContainerID.valueOf(2), dn1, 1, addCmd, deadline + 1,
-        THREE_GB_CONTAINER_SIZE, clock.millis());
+        THREE_GB_CONTAINER_SIZE, null, clock.millis());
 
     List<ContainerReplicaOp> ops =
         pendingOps.getPendingOps(ContainerID.valueOf(1));
@@ -201,10 +201,10 @@ public class TestContainerReplicaPendingOps {
   public void testCompletingOps() {
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(1), dn1, 0, deleteCmd, deadline);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn1, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(1), dn2, 0, deleteCmd, deadline);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn3, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(2), dn1, 1, deleteCmd, deadline);
 
     List<ContainerReplicaOp> ops =
@@ -236,10 +236,10 @@ public class TestContainerReplicaPendingOps {
   public void testRemoveSpecificOp() {
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(1), dn1, 0, deleteCmd, deadline);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn1, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(1), dn2, 0, deleteCmd, deadline);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn3, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(2), dn1, 1, deleteCmd, deadline);
 
     ContainerID cid = ContainerID.valueOf(1);
@@ -261,13 +261,13 @@ public class TestContainerReplicaPendingOps {
     long latestExpiry = clock.millis() + 3000;
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(1), dn1, 0, deleteCmd, expiry);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn1, 0, addCmd, expiry,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(1), dn2, 0, deleteCmd, laterExpiry);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn3, 0, addCmd, laterExpiry,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(2), dn1, 1, deleteCmd, latestExpiry);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(2), dn1, 1, addCmd, latestExpiry,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
 
     List<ContainerReplicaOp> ops =
         pendingOps.getPendingOps(ContainerID.valueOf(1));
@@ -325,12 +325,12 @@ public class TestContainerReplicaPendingOps {
     long expiry = clock.millis() + 1000;
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(1), dn1, 1, deleteCmd, expiry);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn1, 2, addCmd, expiry,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(2), dn2, 1, deleteCmd, expiry);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(2), dn3, 1, addCmd, expiry,
-        THREE_GB_CONTAINER_SIZE, clock.millis());
+        THREE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleAddReplica(ContainerID.valueOf(3), dn3, 0, addCmd, expiry,
-        THREE_GB_CONTAINER_SIZE, clock.millis());
+        THREE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(4), dn3, 0, deleteCmd, expiry);
 
     // InFlight Replication and Deletion
@@ -354,12 +354,12 @@ public class TestContainerReplicaPendingOps {
     expiry = clock.millis() + 1000;
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(3), dn1, 2, deleteCmd, expiry);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(3), dn1, 3, addCmd, expiry,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(4), dn2, 2, deleteCmd, expiry);
     pendingOps.scheduleAddReplica(ContainerID.valueOf(4), dn3, 4, addCmd, expiry,
-        THREE_GB_CONTAINER_SIZE, clock.millis());
+        THREE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleAddReplica(ContainerID.valueOf(5), dn3, 0, addCmd, expiry,
-        THREE_GB_CONTAINER_SIZE, clock.millis());
+        THREE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.scheduleDeleteReplica(ContainerID.valueOf(6), dn3, 0, deleteCmd, expiry);
 
     // InFlight Replication and Deletion. Previous Inflight should be
@@ -403,7 +403,7 @@ public class TestContainerReplicaPendingOps {
 
     // schedule an ADD and a DELETE
     ContainerID containerID = ContainerID.valueOf(1);
-    pendingOps.scheduleAddReplica(containerID, dn1, 0, addCmd, deadline, FIVE_GB_CONTAINER_SIZE, clock.millis());
+    pendingOps.scheduleAddReplica(containerID, dn1, 0, addCmd, deadline, FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     ContainerReplicaOp addOp = pendingOps.getPendingOps(containerID).get(0);
     pendingOps.scheduleDeleteReplica(containerID, dn1, 0, deleteCmd, deadline);
 
@@ -420,7 +420,7 @@ public class TestContainerReplicaPendingOps {
 
     // now, test notification on expiration
     pendingOps.scheduleDeleteReplica(containerID, dn1, 0, deleteCmd, deadline);
-    pendingOps.scheduleAddReplica(containerID, dn2, 0, addCmd, deadline, FIVE_GB_CONTAINER_SIZE, clock.millis());
+    pendingOps.scheduleAddReplica(containerID, dn2, 0, addCmd, deadline, FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     for (ContainerReplicaOp op : pendingOps.getPendingOps(containerID)) {
       if (op.getOpType() == ADD) {
         addOp = op;
@@ -443,7 +443,7 @@ public class TestContainerReplicaPendingOps {
 
     // schedule ops
     pendingOps.scheduleDeleteReplica(containerID, dn1, 0, deleteCmd, deadline);
-    pendingOps.scheduleAddReplica(containerID, dn2, 0, addCmd, deadline, FIVE_GB_CONTAINER_SIZE, clock.millis());
+    pendingOps.scheduleAddReplica(containerID, dn2, 0, addCmd, deadline, FIVE_GB_CONTAINER_SIZE, null, clock.millis());
 
     // register subscriber
     ContainerReplicaPendingOpsSubscriber subscriber1 = mock(
@@ -462,7 +462,7 @@ public class TestContainerReplicaPendingOps {
     ContainerID containerID = ContainerID.valueOf(1);
 
     // schedule ops
-    pendingOps.scheduleAddReplica(containerID, dn2, 0, addCmd, deadline, FIVE_GB_CONTAINER_SIZE, clock.millis());
+    pendingOps.scheduleAddReplica(containerID, dn2, 0, addCmd, deadline, FIVE_GB_CONTAINER_SIZE, null, clock.millis());
 
     // register subscriber
     ContainerReplicaPendingOpsSubscriber subscriber1 = mock(
@@ -471,7 +471,7 @@ public class TestContainerReplicaPendingOps {
 
     clock.fastForward(1000);
     pendingOps.scheduleAddReplica(containerID, dn2, 0, addCmd, deadline + 1,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     // no entries have expired, so there should be zero interactions with the
     // subscriber
     verifyNoMoreInteractions(subscriber1);
@@ -487,7 +487,7 @@ public class TestContainerReplicaPendingOps {
     final long eventTimeout = rmConf.getEventTimeout();
     long now = clock.millis();
     pendingOps.scheduleAddReplica(ContainerID.valueOf(1), dn1, 0, addCmd,
-        now + eventTimeout, FIVE_GB_CONTAINER_SIZE, clock.millis());
+        now + eventTimeout, FIVE_GB_CONTAINER_SIZE, null, clock.millis());
 
     // Assert that containerSizeScheduled has the correct size
     ConcurrentHashMap<DatanodeID, ContainerReplicaPendingOps.SizeAndTime> scheduled =
@@ -497,7 +497,7 @@ public class TestContainerReplicaPendingOps {
 
     // Schedule a second op for the same datanode
     pendingOps.scheduleAddReplica(ContainerID.valueOf(2), dn1, 0, addCmd,
-        now + eventTimeout, THREE_GB_CONTAINER_SIZE, clock.millis());
+        now + eventTimeout, THREE_GB_CONTAINER_SIZE, null, clock.millis());
     assertEquals(FIVE_GB_CONTAINER_SIZE + THREE_GB_CONTAINER_SIZE, scheduled.get(dn1.getID()).getSize());
 
     // Complete the first op
@@ -520,7 +520,7 @@ public class TestContainerReplicaPendingOps {
 
     long now = clock.millis();
     pendingOps.scheduleAddReplica(ContainerID.valueOf(3), dn2, 0, addCmd,
-        now + eventTimeout, FIVE_GB_CONTAINER_SIZE, clock.millis());
+        now + eventTimeout, FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     ConcurrentHashMap<DatanodeID, ContainerReplicaPendingOps.SizeAndTime>
         scheduled = pendingOps.getContainerSizeScheduled();
     assertEquals(FIVE_GB_CONTAINER_SIZE, scheduled.get(dn2.getID()).getSize());
@@ -544,11 +544,11 @@ public class TestContainerReplicaPendingOps {
     long now = clock.millis();
     // Schedule first op
     pendingOps.scheduleAddReplica(ContainerID.valueOf(4), dn2, 0, addCmd,
-        now + eventTimeout, FIVE_GB_CONTAINER_SIZE, clock.millis());
+        now + eventTimeout, FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     //  another replication scheduled for dn1 to receive a container - just testing that this entry isn't removed or
     //  modified when other entries expire or are modified
     pendingOps.scheduleAddReplica((ContainerID.valueOf(2)), dn1, 2, addCmd,
-        now + eventTimeout * 10, THREE_GB_CONTAINER_SIZE, clock.millis());
+        now + eventTimeout * 10, THREE_GB_CONTAINER_SIZE, null, clock.millis());
     ConcurrentHashMap<DatanodeID, ContainerReplicaPendingOps.SizeAndTime>
         scheduled = pendingOps.getContainerSizeScheduled();
     assertEquals(FIVE_GB_CONTAINER_SIZE, scheduled.get(dn2.getID()).getSize());
@@ -561,7 +561,7 @@ public class TestContainerReplicaPendingOps {
 
     // Schedule second op for dn2, which should update the lastUpdatedTime
     pendingOps.scheduleAddReplica(ContainerID.valueOf(5), dn2, 1, addCmd,
-        updateTime + eventTimeout, THREE_GB_CONTAINER_SIZE, clock.millis());
+        updateTime + eventTimeout, THREE_GB_CONTAINER_SIZE, null, clock.millis());
     assertEquals(FIVE_GB_CONTAINER_SIZE + THREE_GB_CONTAINER_SIZE, scheduled.get(dn2.getID()).getSize());
     assertEquals(THREE_GB_CONTAINER_SIZE, scheduled.get(dn1.getID()).getSize());
     assertEquals(updateTime, scheduled.get(dn2.getID()).getLastUpdatedTime());
@@ -594,7 +594,7 @@ public class TestContainerReplicaPendingOps {
 
     pendingOps.registerSubscriber(subscriber);
     pendingOps.scheduleAddReplica(containerID, dn1, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
 
     verify(subscriber, times(1)).opAdded(
         org.mockito.ArgumentMatchers.argThat(op ->
@@ -628,7 +628,7 @@ public class TestContainerReplicaPendingOps {
 
     pendingOps.registerSubscriber(subscriber);
     pendingOps.scheduleAddReplica(containerID, dn1, 0, addCmd, deadline,
-        FIVE_GB_CONTAINER_SIZE, clock.millis());
+        FIVE_GB_CONTAINER_SIZE, null, clock.millis());
     pendingOps.completeAddReplica(containerID, dn1, 0);
 
     verify(subscriber, times(1)).opAdded(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
@@ -92,7 +92,7 @@ public class TestECContainerReplicaCount {
     // appears missing
     ContainerReplicaOp op = new ContainerReplicaOp(
         ContainerReplicaOp.PendingOpType.ADD,
-        MockDatanodeDetails.randomDatanodeDetails(), 5, null, Long.MAX_VALUE, 0);
+        MockDatanodeDetails.randomDatanodeDetails(), 5, null, Long.MAX_VALUE, 0, null);
     rcnt.addPendingOp(op);
     assertTrue(rcnt.isSufficientlyReplicated(true));
     assertEquals(0, rcnt.unavailableIndexes(true).size());
@@ -213,7 +213,7 @@ public class TestECContainerReplicaCount {
     // as not over replicated.
     rcnt.addPendingOp(new ContainerReplicaOp(
         ContainerReplicaOp.PendingOpType.DELETE,
-        MockDatanodeDetails.randomDatanodeDetails(), 2, null, Long.MAX_VALUE, 0));
+        MockDatanodeDetails.randomDatanodeDetails(), 2, null, Long.MAX_VALUE, 0, null));
     assertFalse(rcnt.isOverReplicated(true));
   }
 
@@ -229,7 +229,7 @@ public class TestECContainerReplicaCount {
         getContainerReplicaOps(ImmutableList.of(), ImmutableList.of(1));
     pending.add(new ContainerReplicaOp(
         ContainerReplicaOp.PendingOpType.DELETE,
-        MockDatanodeDetails.randomDatanodeDetails(), 2, null, Long.MAX_VALUE, 0));
+        MockDatanodeDetails.randomDatanodeDetails(), 2, null, Long.MAX_VALUE, 0, null));
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
@@ -532,14 +532,14 @@ public class TestECContainerReplicaCount {
       pending.add(new ContainerReplicaOp(
           ContainerReplicaOp.PendingOpType.ADD,
           MockDatanodeDetails.randomDatanodeDetails(), addIndex,
-          null, Long.MAX_VALUE, 0));
+          null, Long.MAX_VALUE, 0, null));
     }
 
     for (Integer deleteIndex : deleteIndexes) {
       pending.add(new ContainerReplicaOp(
           ContainerReplicaOp.PendingOpType.DELETE,
           MockDatanodeDetails.randomDatanodeDetails(), deleteIndex,
-          null, Long.MAX_VALUE, 0));
+          null, Long.MAX_VALUE, 0, null));
     }
     return pending;
   }
@@ -716,7 +716,7 @@ public class TestECContainerReplicaCount {
     pendingOps.add(new ContainerReplicaOp(
         ContainerReplicaOp.PendingOpType.DELETE,
         unhealthyReplica.getDatanodeDetails(),
-        unhealthyReplica.getReplicaIndex(), null, System.currentTimeMillis(), 0));
+        unhealthyReplica.getReplicaIndex(), null, System.currentTimeMillis(), 0, null));
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pendingOps, 1);
@@ -725,7 +725,7 @@ public class TestECContainerReplicaCount {
     // Add another pending delete to an index that is not an unhealthy index
     pendingOps.add(new ContainerReplicaOp(
         ContainerReplicaOp.PendingOpType.DELETE,
-        MockDatanodeDetails.randomDatanodeDetails(), 2, null, System.currentTimeMillis(), 0));
+        MockDatanodeDetails.randomDatanodeDetails(), 2, null, System.currentTimeMillis(), 0, null));
 
     rcnt = new ECContainerReplicaCount(container, replica, pendingOps, 1);
     assertFalse(rcnt.isSufficientlyReplicated(false));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -163,12 +163,12 @@ public class TestECMisReplicationHandler extends MisReplicationHandlerTests {
             anyInt())).thenReturn(mockedContainerPlacementStatus);
     List<ContainerReplicaOp> pendingOp = singletonList(
             new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.ADD,
-                    MockDatanodeDetails.randomDatanodeDetails(), 1, null, Long.MAX_VALUE, 0));
+                    MockDatanodeDetails.randomDatanodeDetails(), 1, null, Long.MAX_VALUE, 0, null));
     testMisReplication(availableReplicas, placementPolicy,
             pendingOp, 0, 1, 0);
     pendingOp = singletonList(new ContainerReplicaOp(
             ContainerReplicaOp.PendingOpType.DELETE, availableReplicas
-                    .stream().findAny().get().getDatanodeDetails(), 1, null, Long.MAX_VALUE, 0));
+                    .stream().findAny().get().getDatanodeDetails(), 1, null, Long.MAX_VALUE, 0, null));
     testMisReplication(availableReplicas, placementPolicy,
             pendingOp, 0, 1, 0);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -137,7 +137,7 @@ public class TestECOverReplicationHandler {
     availableReplicas.add(excess);
     List<ContainerReplicaOp> pendingOps = new ArrayList<>();
     pendingOps.add(new ContainerReplicaOp(DELETE,
-        excess.getDatanodeDetails(), 5, null, Long.MAX_VALUE, 0));
+        excess.getDatanodeDetails(), 5, null, Long.MAX_VALUE, 0, null));
     testOverReplicationWithIndexes(availableReplicas, Collections.emptyMap(),
         pendingOps);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -1073,7 +1073,7 @@ public class TestECUnderReplicationHandler {
     Set<ContainerReplica> availableReplicas = createReplicas(3);
     DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
     List<ContainerReplicaOp> pendingOps = ImmutableList.of(
-        new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.ADD, dn, 4, null, System.currentTimeMillis(), 0));
+        new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.ADD, dn, 4, null, System.currentTimeMillis(), 0, null));
 
     /*
     Mock the placement policy. If the list of nodes to be excluded does not

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckOverReplicationHandler.java
@@ -124,7 +124,7 @@ public class TestQuasiClosedStuckOverReplicationHandler {
         0,
         null,
         Long.MAX_VALUE,
-        0));
+        0, null));
 
     int count = handler.processAndSendCommands(replicas, pendingOps, getOverReplicatedHealthResult(), 1);
     assertEquals(0, count);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestQuasiClosedStuckUnderReplicationHandler.java
@@ -127,7 +127,9 @@ public class TestQuasiClosedStuckUnderReplicationHandler {
         QUASI_CLOSED, Pair.of(origin, IN_SERVICE), Pair.of(origin, IN_SERVICE));
     List<ContainerReplicaOp> pendingOps = new ArrayList<>();
     pendingOps.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ContainerReplicaOp.PendingOpType.ADD,
+        MockDatanodeDetails.randomDatanodeDetails(), 0, null,
+        Long.MAX_VALUE, 0, null));
 
     int count = handler.processAndSendCommands(replicas, pendingOps, getUnderReplicatedHealthResult(), 1);
     assertEquals(0, count);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -569,7 +569,7 @@ class TestRatisContainerReplicaCount {
 
     List<ContainerReplicaOp> ops = new ArrayList<>();
     ops.add(new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-        unhealthyReplica.getDatanodeDetails(), 0, null, System.currentTimeMillis(), 0));
+        unhealthyReplica.getDatanodeDetails(), 0, null, System.currentTimeMillis(), 0, null));
     RatisContainerReplicaCount withoutUnhealthy =
         new RatisContainerReplicaCount(container, replicas, ops, 2, false);
     validate(withoutUnhealthy, true, 0, false, false);
@@ -657,7 +657,7 @@ class TestRatisContainerReplicaCount {
     replicas.addAll(unhealthyReplicas);
     List<ContainerReplicaOp> ops = new ArrayList<>();
     ops.add(new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-        unhealthyReplicas.iterator().next().getDatanodeDetails(), 0, null, System.currentTimeMillis(), 0));
+        unhealthyReplicas.iterator().next().getDatanodeDetails(), 0, null, System.currentTimeMillis(), 0, null));
 
     RatisContainerReplicaCount withoutUnhealthy =
         new RatisContainerReplicaCount(container, replicas, ops, 2, false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -164,12 +164,12 @@ public class TestRatisMisReplicationHandler extends MisReplicationHandlerTests {
             anyInt())).thenReturn(mockedContainerPlacementStatus);
     List<ContainerReplicaOp> pendingOp = Collections.singletonList(
             new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.ADD,
-                    MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+                    MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     testMisReplication(availableReplicas, placementPolicy,
             pendingOp, 0, 1, 0);
     pendingOp = Collections.singletonList(new ContainerReplicaOp(
             ContainerReplicaOp.PendingOpType.DELETE, availableReplicas
-                    .stream().findAny().get().getDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+                    .stream().findAny().get().getDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     testMisReplication(availableReplicas, placementPolicy,
             pendingOp, 0, 1, 0);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -114,7 +114,7 @@ public class TestRatisOverReplicationHandler {
         ContainerReplicaProto.State.CLOSED, 0, 0, 0, 0, 0);
     List<ContainerReplicaOp> pendingOps = ImmutableList.of(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     // 1 replica is already pending delete, so only 1 new command should be
     // created
@@ -221,7 +221,7 @@ public class TestRatisOverReplicationHandler {
         State.UNHEALTHY, 0, 0, 0, 0, 0);
     List<ContainerReplicaOp> pendingOps = ImmutableList.of(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     // 1 replica is already pending delete, so only 1 new command should be
     // created
@@ -410,7 +410,7 @@ public class TestRatisOverReplicationHandler {
         ContainerReplicaProto.State.CLOSED, 0, 0, 0, 0);
     List<ContainerReplicaOp> pendingOps = ImmutableList.of(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     testProcessing(replicas, pendingOps, getOverReplicatedHealthResult(), 0);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -139,7 +139,7 @@ public class TestRatisUnderReplicationHandler {
         = createReplicas(container.containerID(), State.CLOSED, 0);
     List<ContainerReplicaOp> pendingOps = ImmutableList.of(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.ADD,
-            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     testProcessing(replicas, pendingOps, getUnderReplicatedHealthResult(), 2,
         1);
@@ -166,7 +166,7 @@ public class TestRatisUnderReplicationHandler {
         = createReplicas(container.containerID(), State.CLOSED, 0, 0);
     List<ContainerReplicaOp> pendingOps = ImmutableList.of(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.ADD,
-            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     testProcessing(replicas, pendingOps, getUnderReplicatedHealthResult(), 2,
         0);
@@ -338,7 +338,7 @@ public class TestRatisUnderReplicationHandler {
 
     List<ContainerReplicaOp> pending = Collections.singletonList(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-        shouldDelete.getDatanodeDetails(), 0, null, System.currentTimeMillis(), 0));
+        shouldDelete.getDatanodeDetails(), 0, null, System.currentTimeMillis(), 0, null));
 
     assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
@@ -389,7 +389,7 @@ public class TestRatisUnderReplicationHandler {
         = createReplicas(container.containerID(), State.UNHEALTHY, 0);
     List<ContainerReplicaOp> pendingOps = ImmutableList.of(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.ADD,
-            MockDatanodeDetails.randomDatanodeDetails(), 0, null, System.currentTimeMillis(), 0));
+            MockDatanodeDetails.randomDatanodeDetails(), 0, null, System.currentTimeMillis(), 0, null));
 
     testProcessing(replicas, pendingOps, getUnderReplicatedHealthResult(), 2,
         1);
@@ -504,9 +504,9 @@ public class TestRatisUnderReplicationHandler {
     DatanodeDetails pendingAdd = MockDatanodeDetails.randomDatanodeDetails();
     DatanodeDetails pendingRemove = MockDatanodeDetails.randomDatanodeDetails();
     pendingOps.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0, null, System.currentTimeMillis(), 0));
+        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0, null, System.currentTimeMillis(), 0, null));
     pendingOps.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.DELETE, pendingRemove, 0, null, System.currentTimeMillis(), 0));
+        ContainerReplicaOp.PendingOpType.DELETE, pendingRemove, 0, null, System.currentTimeMillis(), 0, null));
 
     handler.processAndSendCommands(replicas, pendingOps,
         getUnderReplicatedHealthResult(), 2);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -65,9 +65,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
@@ -84,6 +86,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.TestContainerInfo;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -230,7 +233,7 @@ public class TestReplicationManager {
   @Test
   public void testPendingOpsClearedWhenStarting() {
     containerReplicaPendingOps.scheduleAddReplica(ContainerID.valueOf(1),
-        MockDatanodeDetails.randomDatanodeDetails(), 1, null, Integer.MAX_VALUE, 5L, clock.millis());
+        MockDatanodeDetails.randomDatanodeDetails(), 1, null, Integer.MAX_VALUE, 5L, null, clock.millis());
     containerReplicaPendingOps.scheduleDeleteReplica(ContainerID.valueOf(2),
         MockDatanodeDetails.randomDatanodeDetails(), 1, null, Integer.MAX_VALUE);
     assertEquals(1, containerReplicaPendingOps
@@ -621,7 +624,7 @@ public class TestReplicationManager {
     addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
     containerReplicaPendingOps.scheduleAddReplica(container.containerID(),
         MockDatanodeDetails.randomDatanodeDetails(), 5, null,
-        clock.millis() + 10000, 5L, clock.millis());
+        clock.millis() + 10000, 5L, null, clock.millis());
 
     replicationManager.processContainer(
         container, repQueue, repReport);
@@ -1200,9 +1203,14 @@ public class TestReplicationManager {
       throws NotLeaderException {
     // create a closed EC container
     ECReplicationConfig ecRepConfig = new ECReplicationConfig(3, 2);
-    ContainerInfo containerInfo =
-        ReplicationTestUtil.createContainerInfo(ecRepConfig, 1,
-            HddsProtos.LifeCycleState.CLOSED, 10, 20);
+    ContainerInfo containerInfo = TestContainerInfo.newBuilderForTest()
+        .setContainerID(1)
+        .setReplicationConfig(ecRepConfig)
+        .setState(HddsProtos.LifeCycleState.CLOSED)
+        .setNumberOfKeys(10)
+        .setUsedBytes(20)
+        .setStorageTier(StorageTier.SSD)
+        .build();
 
     // command will be pushed from source to target
     DatanodeDetails target = MockDatanodeDetails.randomDatanodeDetails();
@@ -1225,6 +1233,7 @@ public class TestReplicationManager {
         ops.get(0).getOpType());
     assertEquals(target, ops.get(0).getTarget());
     assertEquals(1, ops.get(0).getReplicaIndex());
+    assertEquals(StorageType.SSD, ops.get(0).getStorageType());
     assertEquals(1, replicationManager.getMetrics()
         .getEcReplicationCmdsSentTotal());
     assertEquals(0, replicationManager.getMetrics()
@@ -1568,9 +1577,9 @@ public class TestReplicationManager {
         1,
         null,
         Long.MAX_VALUE,
-        0);
+        0, null);
     ContainerReplicaOp delOp = new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.DELETE, dn2, 1, command, commandDeadline, 0);
+        ContainerReplicaOp.PendingOpType.DELETE, dn2, 1, command, commandDeadline, 0, null);
 
     replicationManager.opCompleted(addOp, ContainerID.valueOf(1L), false);
     replicationManager.opCompleted(delOp, ContainerID.valueOf(1L), false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -251,7 +251,7 @@ public class TestReplicationManagerScenarios {
     for (PendingReplica r : scenario.getPendingReplicas()) {
       if (r.getType() == ContainerReplicaOp.PendingOpType.ADD) {
         containerReplicaPendingOps.scheduleAddReplica(container.containerID(), r.getDatanodeDetails(),
-            r.getReplicaIndex(), null, Long.MAX_VALUE, 5L, clock.millis());
+            r.getReplicaIndex(), null, Long.MAX_VALUE, 5L, null, clock.millis());
       } else if (r.getType() == ContainerReplicaOp.PendingOpType.DELETE) {
         containerReplicaPendingOps.scheduleDeleteReplica(container.containerID(), r.getDatanodeDetails(),
             r.getReplicaIndex(), null, Long.MAX_VALUE);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -116,9 +116,9 @@ public class TestReplicationManagerUtil {
     DatanodeDetails pendingDelete = MockDatanodeDetails.randomDatanodeDetails();
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0, null, Long.MAX_VALUE, 0));
+        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0, null, Long.MAX_VALUE, 0, null));
     pending.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0, null, Long.MAX_VALUE, 0));
+        ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0, null, Long.MAX_VALUE, 0, null));
 
     when(replicationManager.getNodeStatus(any())).thenAnswer(
         invocation -> {
@@ -205,9 +205,9 @@ public class TestReplicationManagerUtil {
     DatanodeDetails pendingDelete = MockDatanodeDetails.randomDatanodeDetails();
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0, null, Long.MAX_VALUE, 0));
+        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0, null, Long.MAX_VALUE, 0, null));
     pending.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0, null, Long.MAX_VALUE, 0));
+        ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0, null, Long.MAX_VALUE, 0, null));
 
     when(replicationManager.getNodeStatus(any())).thenAnswer(
         invocation -> {
@@ -288,9 +288,9 @@ public class TestReplicationManagerUtil {
     DatanodeDetails pendingDelete = MockDatanodeDetails.randomDatanodeDetails();
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0, null, Long.MAX_VALUE, 0));
+        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0, null, Long.MAX_VALUE, 0, null));
     pending.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0, null, Long.MAX_VALUE, 0));
+        ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0, null, Long.MAX_VALUE, 0, null));
 
     // set up mocks such ContainerReplicaPendingOps returns the containerSizeScheduled map
     ReplicationManagerConfiguration rmConf = new ReplicationManagerConfiguration();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestDeletingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestDeletingContainerHandler.java
@@ -176,7 +176,7 @@ public class TestDeletingContainerHandler {
     List<ContainerReplicaOp> pendingOps = new ArrayList<>();
     containerReplicas.forEach(r -> pendingOps.add(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-            r.getDatanodeDetails(), r.getReplicaIndex(), null, Long.MAX_VALUE, 0)));
+            r.getDatanodeDetails(), r.getReplicaIndex(), null, Long.MAX_VALUE, 0, null)));
     verifyDeleteCommandCount(containerInfo, containerReplicas, pendingOps, 0);
 
     //EC container
@@ -188,7 +188,7 @@ public class TestDeletingContainerHandler {
     pendingOps.clear();
     containerReplicas.forEach(r -> pendingOps.add(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-            r.getDatanodeDetails(), r.getReplicaIndex(), null, Long.MAX_VALUE, 0)));
+            r.getDatanodeDetails(), r.getReplicaIndex(), null, Long.MAX_VALUE, 0, null)));
     verifyDeleteCommandCount(containerInfo, containerReplicas, pendingOps, 0);
 
   }
@@ -209,7 +209,7 @@ public class TestDeletingContainerHandler {
     List<ContainerReplicaOp> pendingOps = new ArrayList<>();
     containerReplicas.stream().limit(2).forEach(replica -> pendingOps.add(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-            replica.getDatanodeDetails(), replica.getReplicaIndex(), null, Long.MAX_VALUE, 0)));
+            replica.getDatanodeDetails(), replica.getReplicaIndex(), null, Long.MAX_VALUE, 0, null)));
     verifyDeleteCommandCount(containerInfo, containerReplicas, pendingOps, 1);
 
     //EC container
@@ -221,7 +221,7 @@ public class TestDeletingContainerHandler {
     pendingOps.clear();
     containerReplicas.stream().limit(3).forEach(replica -> pendingOps.add(
         new ContainerReplicaOp(ContainerReplicaOp.PendingOpType.DELETE,
-            replica.getDatanodeDetails(), replica.getReplicaIndex(), null, Long.MAX_VALUE, 0)));
+            replica.getDatanodeDetails(), replica.getReplicaIndex(), null, Long.MAX_VALUE, 0, null)));
     //since one delete command is end when testing ratis container, so
     //here should be 1+2 = 3 times
     verifyDeleteCommandCount(containerInfo, containerReplicas, pendingOps, 3);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECMisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECMisReplicationCheckHandler.java
@@ -177,7 +177,7 @@ public class TestECMisReplicationCheckHandler {
 
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 1, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 1, null, Long.MAX_VALUE, 0, null));
 
     Set<ContainerReplica> replicas =  createReplicas(container.containerID(),
         Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
@@ -234,7 +234,7 @@ public class TestECMisReplicationCheckHandler {
     replicas.add(unhealthyReplica);
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        DELETE, unhealthyReplica.getDatanodeDetails(), 1, null, Long.MAX_VALUE, 0));
+        DELETE, unhealthyReplica.getDatanodeDetails(), 1, null, Long.MAX_VALUE, 0, null));
 
     ContainerCheckRequest request = requestBuilder
         .setContainerReplicas(replicas)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -144,7 +144,7 @@ public class TestECReplicationCheckHandler {
         = createReplicas(container.containerID(), 1, 2, 4, 5);
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 3, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 3, null, Long.MAX_VALUE, 0, null));
     ContainerCheckRequest request = requestBuilder
         .setContainerReplicas(replicas)
         .setContainerInfo(container)
@@ -202,7 +202,7 @@ public class TestECReplicationCheckHandler {
         Pair.of(IN_SERVICE, 4), Pair.of(DECOMMISSIONED, 5));
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 5, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 5, null, Long.MAX_VALUE, 0, null));
     ContainerCheckRequest request = requestBuilder
         .setContainerReplicas(replicas)
         .setContainerInfo(container)
@@ -233,7 +233,7 @@ public class TestECReplicationCheckHandler {
         Pair.of(DECOMMISSIONING, 4), Pair.of(DECOMMISSIONED, 5));
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 3, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 3, null, Long.MAX_VALUE, 0, null));
 
     ContainerCheckRequest request = requestBuilder
         .setContainerReplicas(replicas)
@@ -376,7 +376,7 @@ public class TestECReplicationCheckHandler {
         Pair.of(IN_SERVICE, 1), Pair.of(offlineState, 2));
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 2, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 2, null, Long.MAX_VALUE, 0, null));
     ContainerCheckRequest request = requestBuilder
         .setContainerReplicas(replicas)
         .setContainerInfo(container)
@@ -513,9 +513,9 @@ public class TestECReplicationCheckHandler {
 
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 1, null, Long.MAX_VALUE, 0));
+        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 1, null, Long.MAX_VALUE, 0, null));
     pending.add(new ContainerReplicaOp(
-        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 2, null, Long.MAX_VALUE, 0));
+        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 2, null, Long.MAX_VALUE, 0, null));
     ContainerCheckRequest request = requestBuilder
         .setContainerReplicas(replicas)
         .setContainerInfo(container)
@@ -671,7 +671,7 @@ public class TestECReplicationCheckHandler {
     List<ContainerReplicaOp> pendingOps = new ArrayList<>();
     pendingOps.add(new ContainerReplicaOp(DELETE,
         unhealthyReplica.getDatanodeDetails(),
-        unhealthyReplica.getReplicaIndex(), null, Long.MAX_VALUE, 0));
+        unhealthyReplica.getReplicaIndex(), null, Long.MAX_VALUE, 0, null));
 
     ContainerCheckRequest request = requestBuilder
         .setContainerReplicas(replicas)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedStuckReplicationCheck.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedStuckReplicationCheck.java
@@ -225,7 +225,9 @@ public class TestQuasiClosedStuckReplicationCheck {
 
     List<ContainerReplicaOp> pendingOps = new ArrayList<>();
     pendingOps.add(new ContainerReplicaOp(
-        ContainerReplicaOp.PendingOpType.ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ContainerReplicaOp.PendingOpType.ADD,
+        MockDatanodeDetails.randomDatanodeDetails(), 0, null,
+        Long.MAX_VALUE, 0, null));
 
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.emptyList())
@@ -295,7 +297,7 @@ public class TestQuasiClosedStuckReplicationCheck {
         0,
         null,
         Long.MAX_VALUE,
-        0));
+        0, null));
 
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.emptyList())

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -171,7 +171,7 @@ public class TestRatisReplicationCheckHandler {
         = createReplicas(container.containerID(), 0, 0, 0);
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container)
         .setPendingOps(pending);
@@ -196,7 +196,7 @@ public class TestRatisReplicationCheckHandler {
         = createReplicas(container.containerID(), 0, 0);
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     requestBuilder.setContainerReplicas(replicas)
         .setPendingOps(pending)
         .setContainerInfo(container);
@@ -279,7 +279,7 @@ public class TestRatisReplicationCheckHandler {
         Pair.of(DECOMMISSIONED, 0));
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     requestBuilder.setContainerReplicas(replicas)
         .setPendingOps(pending)
@@ -307,7 +307,7 @@ public class TestRatisReplicationCheckHandler {
         Pair.of(IN_SERVICE, 0), Pair.of(DECOMMISSIONED, 0));
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     requestBuilder.setContainerReplicas(replicas)
         .setPendingOps(pending)
@@ -457,9 +457,9 @@ public class TestRatisReplicationCheckHandler {
 
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     pending.add(new ContainerReplicaOp(
-        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     requestBuilder.setContainerReplicas(replicas)
         .setPendingOps(pending)
@@ -671,7 +671,7 @@ public class TestRatisReplicationCheckHandler {
 
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        DELETE, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     requestBuilder.setContainerReplicas(replicas)
         .setPendingOps(pending)
@@ -829,9 +829,9 @@ public class TestRatisReplicationCheckHandler {
 
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container)
@@ -900,9 +900,9 @@ public class TestRatisReplicationCheckHandler {
 
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     pending.add(new ContainerReplicaOp(
-        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+        ADD, MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
 
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
@@ -175,7 +175,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
     List<ContainerReplicaOp> pendingOps =
         ImmutableList.of(new ContainerReplicaOp(
             ContainerReplicaOp.PendingOpType.ADD,
-            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container)
         .setPendingOps(pendingOps);
@@ -208,7 +208,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
     List<ContainerReplicaOp> pendingOps =
         ImmutableList.of(new ContainerReplicaOp(
             ContainerReplicaOp.PendingOpType.ADD,
-            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            MockDatanodeDetails.randomDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container)
         .setPendingOps(pendingOps);
@@ -241,7 +241,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
     List<ContainerReplicaOp> pendingOps =
         ImmutableList.of(new ContainerReplicaOp(
             ContainerReplicaOp.PendingOpType.DELETE,
-            replicas.stream().findFirst().get().getDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            replicas.stream().findFirst().get().getDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container)
         .setPendingOps(pendingOps);
@@ -319,7 +319,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
     List<ContainerReplicaOp> pendingOps =
         ImmutableList.of(new ContainerReplicaOp(
             ContainerReplicaOp.PendingOpType.DELETE,
-            replicas.stream().findFirst().get().getDatanodeDetails(), 0, null, Long.MAX_VALUE, 0));
+            replicas.stream().findFirst().get().getDatanodeDetails(), 0, null, Long.MAX_VALUE, 0, null));
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container)
         .setPendingOps(pendingOps);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
@@ -25,7 +25,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.StorageTypeProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -87,7 +89,7 @@ public class TestPendingContainerTracker {
   public void testRecordPendingAllocation() {
     // Allocate first 100 containers, one per datanode
     for (int i = 0; i < 100; i++) {
-      tracker.checkSpaceAndRecordAllocation(datanodes.get(i), containers.get(i));
+      tracker.checkSpaceAndRecordAllocation(datanodes.get(i), containers.get(i), null);
     }
 
     // Each of the first 100 DNs should have 1 pending container
@@ -106,7 +108,7 @@ public class TestPendingContainerTracker {
   public void testRemovePendingAllocation() {
     // Allocate containers 0-99, one per datanode
     for (int i = 0; i < 100; i++) {
-      tracker.checkSpaceAndRecordAllocation(datanodes.get(i), containers.get(i));
+      tracker.checkSpaceAndRecordAllocation(datanodes.get(i), containers.get(i), null);
     }
 
     // Remove from first 50 DNs
@@ -141,7 +143,7 @@ public class TestPendingContainerTracker {
     PendingContainerTracker shortRollTracker = new PendingContainerTracker(MAX_CONTAINER_SIZE, rollMs, null);
     setupDefaultStorageReport(shortDn);
 
-    shortRollTracker.checkSpaceAndRecordAllocation(shortDn, container1);
+    shortRollTracker.checkSpaceAndRecordAllocation(shortDn, container1, null);
     assertEquals(1, shortDn.getPendingContainerAllocations().getCount());
     assertTrue(shortDn.getPendingContainerAllocations().contains(container1));
 
@@ -160,7 +162,7 @@ public class TestPendingContainerTracker {
 
   @Test
   public void testRemoveNonExistentContainer() {
-    datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, container1));
+    datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, container1, null));
 
     // Remove a container that was never added - should not throw exception
     tracker.removePendingAllocation(dn1.getPendingContainerAllocations(), container2);
@@ -190,7 +192,7 @@ public class TestPendingContainerTracker {
       threads[i] = new Thread(() -> {
         for (int j = 0; j < operationsPerThread; j++) {
           ContainerID cid = ContainerID.valueOf(threadId * 1000L + j);
-          datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, cid));
+          datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, cid, null));
 
           if (j % 2 == 0) {
             tracker.removePendingAllocation(dn1.getPendingContainerAllocations(), cid);
@@ -212,7 +214,7 @@ public class TestPendingContainerTracker {
 
   @Test
   public void testBucketsRetainedWhenEmpty() {
-    datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, container1));
+    datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, container1, null));
 
     assertEquals(1, dn1.getPendingContainerAllocations().getCount());
 
@@ -223,7 +225,7 @@ public class TestPendingContainerTracker {
     assertEquals(1, dn2.getPendingContainerAllocations().getCount());
 
     // Empty bucket for DN1 is still usable for new allocations
-    tracker.checkSpaceAndRecordAllocation(dn1, container2);
+    tracker.checkSpaceAndRecordAllocation(dn1, container2, null);
     assertEquals(1, dn1.getPendingContainerAllocations().getCount());
   }
 
@@ -233,8 +235,8 @@ public class TestPendingContainerTracker {
     // In general, a container could be in previous window after a roll
 
     // Add containers
-    datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, container1));
-    datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, container2));
+    datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, container1, null));
+    datanodes.subList(0, 3).forEach(dn -> tracker.checkSpaceAndRecordAllocation(dn, container2, null));
 
     assertEquals(2, dn1.getPendingContainerAllocations().getCount());
 
@@ -252,7 +254,7 @@ public class TestPendingContainerTracker {
     // Allocate first 1000 containers to the first datanode
     DatanodeInfo dn = datanodes.get(0);
     for (int i = 0; i < 1000; i++) {
-      tracker.checkSpaceAndRecordAllocation(dn, containers.get(i));
+      tracker.checkSpaceAndRecordAllocation(dn, containers.get(i), null);
     }
 
     assertEquals(1000, dn.getPendingContainerAllocations().getCount());
@@ -280,7 +282,7 @@ public class TestPendingContainerTracker {
       DatanodeInfo dn = datanodes.get(dnIdx);
       for (int cIdx = 0; cIdx < 10; cIdx++) {
         int containerIdx = dnIdx * 10 + cIdx;
-        tracker.checkSpaceAndRecordAllocation(dn, containers.get(containerIdx));
+        tracker.checkSpaceAndRecordAllocation(dn, containers.get(containerIdx), null);
       }
     }
 
@@ -318,7 +320,7 @@ public class TestPendingContainerTracker {
 
     for (int round = 0; round < 5; round++) {
       for (int i = 0; i < 100; i++) {
-        tracker.checkSpaceAndRecordAllocation(dn, containers.get(i));
+        tracker.checkSpaceAndRecordAllocation(dn, containers.get(i), null);
       }
     }
 
@@ -337,7 +339,7 @@ public class TestPendingContainerTracker {
     reports.add(createStorageReport(dnInfo, 100 * containerSize, containerSize / 2, 0));
     dnInfo.updateStorageReports(reports);
 
-    assertFalse(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(0)));
+    assertFalse(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(0), null));
   }
 
   @Test
@@ -354,11 +356,11 @@ public class TestPendingContainerTracker {
     dnInfo.updateStorageReports(reports);
 
     // Record 3 allocations atomically, each should succeed
-    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(0)));
-    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(1)));
-    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(2)));
+    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(0), null));
+    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(1), null));
+    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(2), null));
     // All 3 slots consumed, 4th allocation must fail
-    assertFalse(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(3)));
+    assertFalse(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(3), null));
   }
 
   @Test
@@ -371,10 +373,10 @@ public class TestPendingContainerTracker {
     reports.add(createStorageReport(dnInfo, 50 * containerSize, 3 * containerSize, 3 * containerSize));
     dnInfo.updateStorageReports(reports);
 
-    // 1 slot available — first allocation succeeds and consumes it
-    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(0)));
+    // 1 slot available - first allocation succeeds and consumes it
+    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(0), null));
     // 0 slots remaining
-    assertFalse(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(1)));
+    assertFalse(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(1), null));
   }
 
   /**
@@ -391,12 +393,12 @@ public class TestPendingContainerTracker {
     twoSlotReports.add(createStorageReport(dnInfo, 10 * containerSize, 2 * containerSize, 0));
     dnInfo.updateStorageReports(twoSlotReports);
 
-    assertTrue(tracker.hasAvailableSpace(dnInfo)); // 2 slots free
-    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(0)));  // slot 1 used
-    assertTrue(tracker.hasAvailableSpace(dnInfo));               // 1 slot free
-    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(1)));  // slot 2 used
-    assertFalse(tracker.hasAvailableSpace(dnInfo));              // 0 slots free
-    assertFalse(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(2))); // rejected
+    assertTrue(tracker.hasAvailableSpace(dnInfo, null)); // 2 slots free
+    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(0), null));  // slot 1 used
+    assertTrue(tracker.hasAvailableSpace(dnInfo, null));            // 1 slot free
+    assertTrue(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(1), null));  // slot 2 used
+    assertFalse(tracker.hasAvailableSpace(dnInfo, null));           // 0 slots free
+    assertFalse(tracker.checkSpaceAndRecordAllocation(dnInfo, containers.get(2), null)); // rejected
   }
 
   /**
@@ -408,7 +410,7 @@ public class TestPendingContainerTracker {
         MockDatanodeDetails.randomLocalDatanodeDetails(), NodeStatus.inServiceHealthy(), null,
         HddsTestUtils.ROLL_INTERVAL_MS_DEFAULT);
     // No storage reports set
-    assertFalse(tracker.hasAvailableSpace(emptyDn));
+    assertFalse(tracker.hasAvailableSpace(emptyDn, null));
   }
 
   /**
@@ -422,10 +424,10 @@ public class TestPendingContainerTracker {
     StorageReportProto healthy = createStorageReport(dn1,
         10 * MAX_CONTAINER_SIZE, MAX_CONTAINER_SIZE, 0); // 1 real slot
     dn1.updateStorageReports(new ArrayList<>(Arrays.asList(failed, healthy)));
-    assertTrue(tracker.hasAvailableSpace(dn1));                          // healthy vol → 1 slot
-    assertTrue(tracker.checkSpaceAndRecordAllocation(dn1, container1));  // consumes it
-    assertFalse(tracker.hasAvailableSpace(dn1));                         // 0 slots left
-    assertFalse(tracker.checkSpaceAndRecordAllocation(dn1, container2)); // rejected
+    assertTrue(tracker.hasAvailableSpace(dn1, null));                       // healthy vol -> 1 slot
+    assertTrue(tracker.checkSpaceAndRecordAllocation(dn1, container1, null));  // consumes it
+    assertFalse(tracker.hasAvailableSpace(dn1, null));                      // 0 slots left
+    assertFalse(tracker.checkSpaceAndRecordAllocation(dn1, container2, null)); // rejected
   }
 
   @Test
@@ -433,12 +435,74 @@ public class TestPendingContainerTracker {
     dn1.updateStorageReports(new ArrayList<>(Arrays.asList((
         createFailedStorageReport(dn1)),
         createFailedStorageReport(dn1))));
-    assertFalse(tracker.hasAvailableSpace(dn1));
-    assertFalse(tracker.checkSpaceAndRecordAllocation(dn1, container1));
+    assertFalse(tracker.hasAvailableSpace(dn1, null));
+    assertFalse(tracker.checkSpaceAndRecordAllocation(dn1, container1, null));
+  }
+
+  @Test
+  public void testStorageTypeSpecificSpaceCheckIgnoresOtherTypes() {
+    long containerSize = MAX_CONTAINER_SIZE;
+    DatanodeInfo dnInfo = datanodes.get(0);
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        containerSize, StorageTypeProto.SSD));
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        0, StorageTypeProto.DISK));
+    dnInfo.updateStorageReports(reports);
+
+    assertTrue(tracker.hasAvailableSpace(dnInfo, StorageType.SSD));
+    assertFalse(tracker.hasAvailableSpace(dnInfo, StorageType.DISK));
+    assertTrue(tracker.hasAvailableSpace(dnInfo, null));
+  }
+
+  @Test
+  public void testPendingAllocationsAreCountedPerStorageType() {
+    long containerSize = MAX_CONTAINER_SIZE;
+    DatanodeInfo dnInfo = datanodes.get(0);
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        containerSize, StorageTypeProto.SSD));
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        containerSize, StorageTypeProto.DISK));
+    dnInfo.updateStorageReports(reports);
+
+    tracker.recordAllocation(
+        dnInfo, containers.get(0), StorageType.DISK);
+
+    assertEquals(1,
+        dnInfo.getPendingContainerAllocations().getCount(StorageType.DISK));
+    assertEquals(0,
+        dnInfo.getPendingContainerAllocations().getCount(StorageType.SSD));
+    assertFalse(tracker.hasAvailableSpace(dnInfo, StorageType.DISK));
+    assertTrue(tracker.hasAvailableSpace(dnInfo, StorageType.SSD));
+  }
+
+  @Test
+  public void testUnknownStorageTypePendingCountsAgainstTypedChecks() {
+    long containerSize = MAX_CONTAINER_SIZE;
+    DatanodeInfo dnInfo = datanodes.get(0);
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        containerSize, StorageTypeProto.DISK));
+    dnInfo.updateStorageReports(reports);
+
+    tracker.recordAllocation(dnInfo, containers.get(0), null);
+
+    assertEquals(1,
+        dnInfo.getPendingContainerAllocations().getCount(StorageType.DISK));
+    assertEquals(1,
+        dnInfo.getPendingContainerAllocations().getCount(StorageType.SSD));
+    assertFalse(tracker.hasAvailableSpace(dnInfo, StorageType.DISK));
   }
 
   private StorageReportProto createStorageReport(DatanodeInfo dn, long capacity, long remaining, long committed) {
     return HddsTestUtils.createStorageReports(dn.getID(), capacity, remaining, committed).get(0);
+  }
+
+  private StorageReportProto createStorageReport(
+      DatanodeInfo dn, long capacity, long remaining, StorageTypeProto type) {
+    return HddsTestUtils.createStorageReport(
+        dn.getID(), "test-" + type, capacity, 0, remaining, type);
   }
 
   private StorageReportProto createFailedStorageReport(DatanodeInfo dn) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
@@ -419,6 +419,25 @@ public class TestPendingContainerTracker {
         dnInfo, StorageType.SSD));
   }
 
+  @Test
+  public void testUnknownStorageTypePendingCountsAgainstTypedChecks() {
+    long containerSize = MAX_CONTAINER_SIZE;
+    DatanodeInfo dnInfo = datanodes.get(0);
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        containerSize, StorageTypeProto.DISK));
+    dnInfo.updateStorageReports(reports);
+
+    tracker.recordPendingAllocationForDatanode(dnInfo, containers.get(0));
+
+    assertEquals(1,
+        dnInfo.getPendingContainerAllocations().getCount(StorageType.DISK));
+    assertEquals(1,
+        dnInfo.getPendingContainerAllocations().getCount(StorageType.SSD));
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(
+        dnInfo, StorageType.DISK));
+  }
+
   private StorageReportProto createStorageReport(DatanodeInfo dn, long capacity, long remaining, long committed) {
     return HddsTestUtils.createStorageReports(dn.getID(), capacity, remaining, committed).get(0);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestPendingContainerTracker.java
@@ -24,7 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.StorageTypeProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -375,7 +377,55 @@ public class TestPendingContainerTracker {
     assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(dnInfo));
   }
 
+  @Test
+  public void testStorageTypeSpecificSpaceCheckIgnoresOtherTypes() {
+    long containerSize = MAX_CONTAINER_SIZE;
+    DatanodeInfo dnInfo = datanodes.get(0);
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        containerSize, StorageTypeProto.SSD));
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        0, StorageTypeProto.DISK));
+    dnInfo.updateStorageReports(reports);
+
+    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(
+        dnInfo, StorageType.SSD));
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(
+        dnInfo, StorageType.DISK));
+    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(dnInfo));
+  }
+
+  @Test
+  public void testPendingAllocationsAreCountedPerStorageType() {
+    long containerSize = MAX_CONTAINER_SIZE;
+    DatanodeInfo dnInfo = datanodes.get(0);
+    List<StorageReportProto> reports = new ArrayList<>();
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        containerSize, StorageTypeProto.SSD));
+    reports.add(createStorageReport(dnInfo, 100 * containerSize,
+        containerSize, StorageTypeProto.DISK));
+    dnInfo.updateStorageReports(reports);
+
+    tracker.recordPendingAllocationForDatanode(
+        dnInfo, containers.get(0), StorageType.DISK);
+
+    assertEquals(1,
+        dnInfo.getPendingContainerAllocations().getCount(StorageType.DISK));
+    assertEquals(0,
+        dnInfo.getPendingContainerAllocations().getCount(StorageType.SSD));
+    assertFalse(tracker.hasEffectiveAllocatableSpaceForNewContainer(
+        dnInfo, StorageType.DISK));
+    assertTrue(tracker.hasEffectiveAllocatableSpaceForNewContainer(
+        dnInfo, StorageType.SSD));
+  }
+
   private StorageReportProto createStorageReport(DatanodeInfo dn, long capacity, long remaining, long committed) {
     return HddsTestUtils.createStorageReports(dn.getID(), capacity, remaining, committed).get(0);
+  }
+
+  private StorageReportProto createStorageReport(
+      DatanodeInfo dn, long capacity, long remaining, StorageTypeProto type) {
+    return HddsTestUtils.createStorageReport(
+        dn.getID(), "test-" + type, capacity, 0, remaining, type);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -87,6 +87,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -207,6 +208,25 @@ public class TestSCMNodeManager {
         (PipelineManagerImpl) scm.getPipelineManager();
     pipelineManager.setScmContext(scmContext);
     return (SCMNodeManager) scm.getScmNodeManager();
+  }
+
+  @Test
+  public void testAddContainerRemovesPendingAllocation() throws Exception {
+    try (SCMNodeManager nodeManager = createNodeManager(getConf())) {
+      DatanodeDetails datanodeDetails =
+          HddsTestUtils.createRandomDatanodeAndRegister(nodeManager);
+      ContainerID containerID = ContainerID.valueOf(1);
+
+      nodeManager.recordPendingAllocationForDatanode(
+          datanodeDetails.getID(), containerID);
+      DatanodeInfo datanodeInfo = nodeManager.getDatanodeInfo(datanodeDetails);
+      assertNotNull(datanodeInfo);
+      assertEquals(1, datanodeInfo.getPendingContainerAllocations().getCount());
+
+      nodeManager.addContainer(datanodeDetails, containerID);
+
+      assertEquals(0, datanodeInfo.getPendingContainerAllocations().getCount());
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -72,6 +72,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -91,6 +92,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -211,6 +213,25 @@ public class TestSCMNodeManager {
         (PipelineManagerImpl) scm.getPipelineManager();
     pipelineManager.setScmContext(scmContext);
     return (SCMNodeManager) scm.getScmNodeManager();
+  }
+
+  @Test
+  public void testAddContainerRemovesPendingAllocation() throws Exception {
+    try (SCMNodeManager nodeManager = createNodeManager(getConf())) {
+      DatanodeDetails datanodeDetails =
+          HddsTestUtils.createRandomDatanodeAndRegister(nodeManager);
+      ContainerID containerID = ContainerID.valueOf(1);
+
+      DatanodeInfo datanodeInfo = nodeManager.getNode(datanodeDetails.getID());
+      assertNotNull(datanodeInfo);
+      nodeManager.recordAllocationForDatanode(
+          datanodeInfo, containerID, StorageType.DEFAULT);
+      assertEquals(1, datanodeInfo.getPendingContainerAllocations().getCount());
+
+      nodeManager.addContainer(datanodeDetails, containerID);
+
+      assertEquals(0, datanodeInfo.getPendingContainerAllocations().getCount());
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -29,6 +29,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -351,9 +352,18 @@ public class MockPipelineManager implements PipelineManager {
 
   @Override
   public void recordPendingAllocation(Pipeline pipeline, ContainerID containerID) {
+    StorageType storageType = getStorageTypeForPendingAllocation(pipeline);
     for (DatanodeDetails dn : pipeline.getNodes()) {
-      nodeManager.recordPendingAllocationForDatanode(dn.getID(), containerID);
+      nodeManager.recordPendingAllocationForDatanode(dn.getID(), containerID, storageType);
     }
+  }
+
+  private StorageType getStorageTypeForPendingAllocation(Pipeline pipeline) {
+    StorageTier storageTier = pipeline.getSupportedStorageTier();
+    if (storageTier == null || storageTier == StorageTier.EMPTY) {
+      return null;
+    }
+    return storageTier.getUniformStorageType();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -29,6 +29,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -349,12 +350,22 @@ public class MockPipelineManager implements PipelineManager {
 
   @Override
   public boolean checkSpaceAndRecordAllocation(Pipeline pipeline, ContainerID containerID) {
+    StorageType storageType = getStorageType(pipeline);
     for (DatanodeDetails dn : pipeline.getNodes()) {
-      if (!nodeManager.checkSpaceAndRecordAllocation(nodeManager.getNode(dn.getID()), containerID)) {
+      if (!nodeManager.checkSpaceAndRecordAllocation(
+          nodeManager.getNode(dn.getID()), containerID, storageType)) {
         return false;
       }
     }
     return true;
+  }
+
+  private StorageType getStorageType(Pipeline pipeline) {
+    StorageTier storageTier = pipeline.getSupportedStorageTier();
+    if (storageTier == null || storageTier == StorageTier.EMPTY) {
+      return null;
+    }
+    return storageTier.getUniformStorageType();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -1034,21 +1034,28 @@ public class TestPipelineManagerImpl {
         .setNodes(ImmutableList.of(dn1, dn2, dn3))
         .setState(OPEN)
         .setReplicationConfig(ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS, THREE))
+        .setSupportedStorageTier(StorageTier.DISK)
         .build();
 
     // Case 1: All nodes have enough space.
-    doReturn(true).when(mockedNodeManager).hasSpaceForNewContainerAllocation(dn1.getID());
-    doReturn(true).when(mockedNodeManager).hasSpaceForNewContainerAllocation(dn2.getID());
-    doReturn(true).when(mockedNodeManager).hasSpaceForNewContainerAllocation(dn3.getID());
+    doReturn(true).when(mockedNodeManager).hasSpaceForNewContainerAllocation(
+        dn1.getID(), StorageType.DISK);
+    doReturn(true).when(mockedNodeManager).hasSpaceForNewContainerAllocation(
+        dn2.getID(), StorageType.DISK);
+    doReturn(true).when(mockedNodeManager).hasSpaceForNewContainerAllocation(
+        dn3.getID(), StorageType.DISK);
     assertTrue(pipelineManager.hasEnoughSpace(pipeline));
 
     // Case 2: One node does not have enough space — pipeline should be rejected.
-    doReturn(false).when(mockedNodeManager).hasSpaceForNewContainerAllocation(dn1.getID());
+    doReturn(false).when(mockedNodeManager).hasSpaceForNewContainerAllocation(
+        dn1.getID(), StorageType.DISK);
     assertFalse(pipelineManager.hasEnoughSpace(pipeline));
 
     // Case 3: All nodes do not have enough space.
-    doReturn(false).when(mockedNodeManager).hasSpaceForNewContainerAllocation(dn2.getID());
-    doReturn(false).when(mockedNodeManager).hasSpaceForNewContainerAllocation(dn3.getID());
+    doReturn(false).when(mockedNodeManager).hasSpaceForNewContainerAllocation(
+        dn2.getID(), StorageType.DISK);
+    doReturn(false).when(mockedNodeManager).hasSpaceForNewContainerAllocation(
+        dn3.getID(), StorageType.DISK);
     assertFalse(pipelineManager.hasEnoughSpace(pipeline));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
@@ -70,6 +71,7 @@ import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -1006,6 +1008,54 @@ public class TestPipelineManagerImpl {
     for (DatanodeDetails dn : pipeline.getNodes())  {
       assertThat(dns).contains(dn);
     }
+  }
+
+  /**
+   * {@link PipelineManager#checkSpaceAndRecordAllocation(Pipeline, ContainerID)}
+   * should pass the pipeline storage tier as StorageType to NodeManager.
+   */
+  @Test
+  public void testCheckSpaceAndRecordAllocationPassesStorageType() throws IOException {
+    NodeManager mockedNodeManager = mock(NodeManager.class);
+    PipelineManagerImpl pipelineManager = PipelineManagerImpl.newPipelineManager(conf,
+        SCMHAManagerStub.getInstance(true),
+        mockedNodeManager,
+        SCMDBDefinition.PIPELINES.getTable(dbStore),
+        new EventQueue(),
+        scmContext,
+        serviceManager,
+        testClock);
+
+    DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
+    DatanodeDetails dn2 = MockDatanodeDetails.randomDatanodeDetails();
+    DatanodeDetails dn3 = MockDatanodeDetails.randomDatanodeDetails();
+    DatanodeInfo dnInfo1 = new DatanodeInfo(dn1, NodeStatus.inServiceHealthy(),
+        null, HddsTestUtils.ROLL_INTERVAL_MS_DEFAULT);
+    DatanodeInfo dnInfo2 = new DatanodeInfo(dn2, NodeStatus.inServiceHealthy(),
+        null, HddsTestUtils.ROLL_INTERVAL_MS_DEFAULT);
+    DatanodeInfo dnInfo3 = new DatanodeInfo(dn3, NodeStatus.inServiceHealthy(),
+        null, HddsTestUtils.ROLL_INTERVAL_MS_DEFAULT);
+    Pipeline pipeline = Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setNodes(ImmutableList.of(dn1, dn2, dn3))
+        .setState(OPEN)
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
+            ReplicationFactor.THREE))
+        .setSupportedStorageTier(StorageTier.DISK)
+        .build();
+    ContainerID containerID = ContainerID.valueOf(1);
+
+    doReturn(dnInfo1).when(mockedNodeManager).getNode(dn1.getID());
+    doReturn(dnInfo2).when(mockedNodeManager).getNode(dn2.getID());
+    doReturn(dnInfo3).when(mockedNodeManager).getNode(dn3.getID());
+    doReturn(true).when(mockedNodeManager).checkSpaceAndRecordAllocation(
+        dnInfo1, containerID, StorageType.DISK);
+    doReturn(true).when(mockedNodeManager).checkSpaceAndRecordAllocation(
+        dnInfo2, containerID, StorageType.DISK);
+    doReturn(true).when(mockedNodeManager).checkSpaceAndRecordAllocation(
+        dnInfo3, containerID, StorageType.DISK);
+
+    assertTrue(pipelineManager.checkSpaceAndRecordAllocation(pipeline, containerID));
   }
 
   private Set<ContainerReplica> createContainerReplicasList(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
@@ -131,7 +131,8 @@ public class TestPipelinePlacementFactory {
       when(nodeManager.getNode(dn.getID()))
           .thenReturn(dn);
     }
-    doReturn(true).when(nodeManager).hasAvailableSpace(any(DatanodeInfo.class));
+    doReturn(true).when(nodeManager)
+        .hasAvailableSpace(any(DatanodeInfo.class), any());
 
     DBStore dbStore = DBStoreBuilder.createDBStore(conf, SCMDBDefinition.get());
     SCMHAManager scmhaManager = SCMHAManagerStub.getInstance(true);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/NoOpsContainerReplicaPendingOps.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/NoOpsContainerReplicaPendingOps.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.recon.fsck;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
@@ -66,7 +67,7 @@ public class NoOpsContainerReplicaPendingOps extends ContainerReplicaPendingOps 
   @Override
   public void scheduleAddReplica(ContainerID containerID, DatanodeDetails target,
       int replicaIndex, SCMCommand<?> command, long deadlineEpochMillis,
-      long containerSize, long scheduledEpochMillis) {
+      long containerSize, StorageType storageType, long scheduledEpochMillis) {
     // No-op - Recon doesn't send commands
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

PendingContainerTracker currently accounts pending container allocations at the datanode level. With storage policy support, pending allocations should be counted only against the StorageType they target. For example, a pending DISK allocation should not reduce the available space calculated for SSD or ARCHIVE allocations.

This PR makes PendingContainerTracker store the StorageType for each pending container allocation. It adds StorageType-aware APIs in PendingContainerTracker and NodeManager, while keeping the existing untyped APIs and behavior for callers that do not have storage tier information.

PipelineManager derives the StorageType from the pipeline StorageTier and passes it to NodeManager when checking space and recording pending allocations.

The tests cover StorageType-specific pending counts, StorageType-specific space checks, the existing untyped behavior, and propagation from StorageTier.DISK to StorageType.DISK.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16045

## How was this patch tested?

- `mvn -B --no-transfer-progress -pl hadoop-hdds/server-scm -am -Dtest=TestPendingContainerTracker test -DskipShade -DskipRecon -DskipDocs`

CI: https://github.com/F64116045/ozone/actions/runs/30770518425