### PR TITLE
[DO NOT MERGE] Backport some fixes to Ozone 2.2.1

### DIFF
--- a/dev-support/pom.xml
+++ b/dev-support/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-dev-support</artifactId>
   <name>Apache Ozone Dev Support</name>

--- a/hadoop-hdds/annotations/pom.xml
+++ b/hadoop-hdds/annotations/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdds-annotation-processing</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Annotation Processing</name>
   <description>Apache Ozone annotation processing tools for validating custom

--- a/hadoop-hdds/cli-common/pom.xml
+++ b/hadoop-hdds/cli-common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-cli-common</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Common</name>
   <description>Apache Ozone CLI Common</description>

--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
 
   <artifactId>hdds-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Client</name>
   <description>Apache Ozone Distributed Data Store Client Library</description>

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -89,7 +88,6 @@ import org.slf4j.LoggerFactory;
  */
 public class XceiverClientGrpc extends XceiverClientSpi {
   private static final Logger LOG = LoggerFactory.getLogger(XceiverClientGrpc.class);
-  private static final int SHUTDOWN_WAIT_INTERVAL_MILLIS = 100;
   private static final int SHUTDOWN_WAIT_MAX_SECONDS = 5;
   private final Pipeline pipeline;
   private final ConfigurationSource config;
@@ -252,7 +250,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   /**
    * Closes all the communication channels of the client one-by-one.
    * When a channel is closed, no further requests can be sent via the channel,
-   * and the method waits to finish all ongoing communication.
+   * and any in-flight RPCs are cancelled immediately (shutdownNow semantics).
    */
   @Override
   public void close() {
@@ -261,37 +259,23 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       return;
     }
 
+    // Use shutdownNow() (not the graceful shutdown()) so in-flight RPCs are
+    // cancelled and the channel terminates immediately. close() is frequently
+    // invoked from cache eviction while the XceiverClientManager clientCache
+    // monitor is held (HDDS-15849); a blocking graceful drain there serializes
+    // every concurrent acquireClient()/releaseClient() call.
     for (ChannelInfo channelInfo : dnChannelInfoMap.values()) {
-      channelInfo.getChannel().shutdown();
-    }
-
-    final long maxWaitNanos = TimeUnit.SECONDS.toNanos(SHUTDOWN_WAIT_MAX_SECONDS);
-    long deadline = System.nanoTime() + maxWaitNanos;
-    List<ManagedChannel> nonTerminatedChannels = dnChannelInfoMap.values()
-        .stream()
-        .map(ChannelInfo::getChannel)
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
-
-    while (!nonTerminatedChannels.isEmpty() && System.nanoTime() < deadline) {
-      nonTerminatedChannels.removeIf(ManagedChannel::isTerminated);
+      ManagedChannel channel = channelInfo.getChannel();
+      channel.shutdownNow();
       try {
-        Thread.sleep(SHUTDOWN_WAIT_INTERVAL_MILLIS);
+        if (!channel.awaitTermination(SHUTDOWN_WAIT_MAX_SECONDS, TimeUnit.SECONDS)) {
+          LOG.warn("Channel {} did not terminate within {}s.", channel, SHUTDOWN_WAIT_MAX_SECONDS);
+        }
       } catch (InterruptedException e) {
-        LOG.error("Interrupted while waiting for channels to terminate", e);
+        LOG.error("Interrupted while waiting for channel termination", e);
         Thread.currentThread().interrupt();
         break;
       }
-    }
-
-    List<DatanodeID> failedChannels = dnChannelInfoMap.entrySet()
-        .stream()
-        .filter(e -> !e.getValue().getChannel().isTerminated())
-        .map(Map.Entry::getKey)
-        .collect(Collectors.toList());
-
-    if (!failedChannels.isEmpty()) {
-      LOG.warn("Channels {} did not terminate within timeout.", failedChannels);
     }
 
     dnChannelInfoMap.clear();

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientManagerCloseContention.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientManagerCloseContention.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.XceiverClientManager.ScmClientConfig;
+import org.apache.hadoop.hdds.scm.XceiverClientManager.XceiverClientManagerConfigBuilder;
+import org.apache.hadoop.hdds.scm.client.ClientTrustManager;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Regression test for HDDS-15849.
+ *
+ * <p>HDDS-14571 changed {@link XceiverClientGrpc#close()} from a forced
+ * {@code shutdownNow()} (which cancels in-flight RPCs and terminates in ~1ms)
+ * to a graceful {@code shutdown()} followed by a polling loop that always
+ * sleeps at least {@code SHUTDOWN_WAIT_INTERVAL_MILLIS} (100ms) before it can
+ * observe channel termination. Every {@code close()} therefore costs &ge;100ms
+ * instead of ~1ms.
+ *
+ * <p>The damage is amplified by <em>where</em> {@code close()} runs. Clients
+ * are torn down through {@link XceiverClientManager}'s cache eviction, and the
+ * whole acquire / evict / close sequence executes under the {@code clientCache}
+ * monitor:
+ * <pre>
+ *   acquireClient()                    // synchronized (clientCache)
+ *     -&gt; getClient()
+ *       -&gt; clientCache.get(key, newClient)
+ *          -&gt; (Guava evicts an entry on the calling thread)
+ *             -&gt; RemovalListener.onRemoval()   // synchronized (clientCache)
+ *                -&gt; XceiverClientSpi.setEvicted() -&gt; cleanup() -&gt; close()
+ * </pre>
+ * So the blocking graceful-shutdown wait runs while the {@code clientCache}
+ * monitor is held, and every other thread in {@code acquireClient()} /
+ * {@code releaseClient()} serializes behind it.
+ *
+ * <p>This test exercises the <b>real</b> {@code XceiverClientManager} and
+ * {@code XceiverClientGrpc.close()} — nothing is emulated. Real (lazily
+ * connected, plaintext) gRPC channels are created against random local
+ * datanode addresses; no live datanode is required because
+ * {@code close()} only shuts the channels down. {@code maxCacheSize == 1} plus
+ * a distinct pipeline per iteration forces the previously cached client to be
+ * evicted and closed on essentially every acquisition — mirroring the per-file
+ * client churn of EC checksum collection.
+ *
+ * <p>Run it against the pre-fix {@code close()} and the wall-clock is dominated
+ * by serialized 100ms sleeps ({@code ~ evictions * 100ms}); run it against the
+ * fix (immediate {@code shutdownNow()}) and per-close cost collapses. The
+ * assertion below encodes the fixed expectation, so this test FAILS on the
+ * regression and PASSES once HDDS-15849 restores immediate termination.
+ */
+class TestXceiverClientManagerCloseContention {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestXceiverClientManagerCloseContention.class);
+
+  private static final int THREADS = 8;
+  private static final int CYCLES_PER_THREAD = 8;
+
+  /**
+   * Upper bound on acceptable average wall-clock cost per eviction-driven
+   * close(). The pre-fix code has a hard &ge;100ms floor per close (the
+   * mandatory Thread.sleep in the termination polling loop); immediate
+   * shutdownNow() is well under a millisecond. 40ms sits safely between the
+   * two so the assertion is not timing-flaky.
+   */
+  private static final long MAX_MILLIS_PER_CLOSE = 40;
+
+  @Test
+  void evictionDrivenCloseDoesNotSerializeAcquisition() throws Exception {
+    ConfigurationSource conf = new OzoneConfiguration();
+    // maxCacheSize == 1 => each acquisition of a new pipeline evicts (and thus
+    // closes) the previously cached client.
+    ScmClientConfig clientConf = new XceiverClientManagerConfigBuilder()
+        .setMaxCacheSize(1)
+        .setStaleThresholdMs(TimeUnit.SECONDS.toMillis(30))
+        .build();
+
+    try (XceiverClientManager manager =
+             new XceiverClientManager(conf, clientConf, (ClientTrustManager) null)) {
+
+      ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+      CountDownLatch start = new CountDownLatch(1);
+      long wallStartNanos;
+      try {
+        List<Future<?>> futures = IntStream.range(0, THREADS)
+            .mapToObj(t -> pool.submit(() -> {
+              start.await();
+              for (int i = 0; i < CYCLES_PER_THREAD; i++) {
+                // Distinct pipeline per cycle => distinct cache key => the
+                // previously cached client is evicted and closed.
+                Pipeline pipeline = MockPipeline.createPipeline(1);
+                XceiverClientSpi client = manager.acquireClient(pipeline);
+                manager.releaseClient(client, false);
+              }
+              return null;
+            }))
+            .collect(Collectors.toList());
+
+        wallStartNanos = System.nanoTime();
+        start.countDown();
+        for (Future<?> f : futures) {
+          f.get(120, TimeUnit.SECONDS);
+        }
+      } finally {
+        pool.shutdownNow();
+      }
+      long wallMillis =
+          TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - wallStartNanos);
+
+      // recordStats() is enabled on the cache; each eviction drives one close().
+      long evictions = manager.getClientCache().stats().evictionCount();
+      long millisPerClose = evictions == 0 ? 0 : wallMillis / evictions;
+
+      LOG.info("threads={} cyclesPerThread={} acquisitions={} evictions(closes)={}",
+          THREADS, CYCLES_PER_THREAD, THREADS * CYCLES_PER_THREAD, evictions);
+      LOG.info("wall={}ms  ms-per-close={}ms  (regression floor is ~100ms/close)",
+          wallMillis, millisPerClose);
+
+      assertThat(evictions)
+          .as("cache eviction should have driven close() calls")
+          .isPositive();
+
+      assertThat(millisPerClose)
+          .as("HDDS-15849: eviction-driven close() must not serialize "
+              + "acquisition under the clientCache monitor; the pre-fix "
+              + "graceful-shutdown wait forces a ~100ms floor per close")
+          .isLessThan(MAX_MILLIS_PER_CLOSE);
+    }
+  }
+}

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-common</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Common</name>
   <description>Apache Ozone Distributed Data Store Common</description>

--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-config</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Config</name>
   <description>Apache Ozone Distributed Data Store Config Tools</description>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-container-service</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Container Service</name>
   <description>Apache Ozone Distributed Data Store Container Service</description>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -73,8 +73,9 @@ public class ContainerSet implements Iterable<Container<?>> {
       ConcurrentSkipListMap<>();
   private final ConcurrentSkipListSet<Long> missingContainerSet =
       new ConcurrentSkipListSet<>();
-  private final ConcurrentSkipListMap<Long, Long> recoveringContainerMap =
-      new ConcurrentSkipListMap<>();
+
+  private final ConcurrentSkipListSet<RecoveringContainer> recoveringContainerSet =
+      new ConcurrentSkipListSet<>();
   private final Clock clock;
   private long recoveringTimeout;
   @Nullable
@@ -208,8 +209,9 @@ public class ContainerSet implements Iterable<Container<?>> {
       updateContainerIdTable(containerId, container.getContainerData());
       missingContainerSet.remove(containerId);
       if (container.getContainerData().getState() == RECOVERING) {
-        recoveringContainerMap.put(
-            clock.millis() + recoveringTimeout, containerId);
+        recoveringContainerSet.add(
+            new RecoveringContainer(clock.millis() + recoveringTimeout,
+                containerId));
       }
       HddsVolume volume = container.getContainerData().getVolume();
       if (volume != null) {
@@ -421,16 +423,16 @@ public class ContainerSet implements Iterable<Container<?>> {
     Preconditions.checkState(containerId >= 0,
         "Container Id cannot be negative.");
     //it might take a little long time to iterate all the entries
-    // in recoveringContainerMap, but it seems ok here since:
+    // in recoveringContainerSet, but it seems ok here since:
     // 1 In the vast majority of cases，there will not be too
     // many recovering containers.
     // 2 closing container is not a sort of urgent action
     //
     // we can revisit here if any performance problem happens
-    Iterator<Map.Entry<Long, Long>> it = getRecoveringContainerIterator();
+    Iterator<RecoveringContainer> it = getRecoveringContainerIterator();
     while (it.hasNext()) {
-      Map.Entry<Long, Long> entry = it.next();
-      if (entry.getValue() == containerId) {
+      RecoveringContainer entry = it.next();
+      if (entry.getContainerId() == containerId) {
         it.remove();
         return true;
       }
@@ -489,11 +491,11 @@ public class ContainerSet implements Iterable<Container<?>> {
 
   /**
    * Return an container Iterator over
-   * {@link ContainerSet#recoveringContainerMap}.
-   * @return {@literal Iterator<Container<?>>}
+   * {@link ContainerSet#recoveringContainerSet}.
+   * @return {@literal Iterator<RecoveringContainer>}
    */
-  public Iterator<Map.Entry<Long, Long>> getRecoveringContainerIterator() {
-    return recoveringContainerMap.entrySet().iterator();
+  public Iterator<RecoveringContainer> getRecoveringContainerIterator() {
+    return recoveringContainerSet.iterator();
   }
 
   /**
@@ -666,5 +668,53 @@ public class ContainerSet implements Iterable<Container<?>> {
         }
       }
     });
+  }
+
+  /**
+   * A class that holds information about a recovering container.
+   */
+  public static class RecoveringContainer
+      implements Comparable<RecoveringContainer> {
+    private final long timeout;
+    private final long containerId;
+
+    public RecoveringContainer(long timeout, long containerId) {
+      this.timeout = timeout;
+      this.containerId = containerId;
+    }
+
+    public long getTimeout() {
+      return timeout;
+    }
+
+    public long getContainerId() {
+      return containerId;
+    }
+
+    @Override
+    public int compareTo(RecoveringContainer other) {
+      int timeoutCompare = Long.compare(this.timeout, other.timeout);
+      if (timeoutCompare != 0) {
+        return timeoutCompare;
+      }
+      return Long.compare(this.containerId, other.containerId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      RecoveringContainer that = (RecoveringContainer) o;
+      return timeout == that.timeout && containerId == that.containerId;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(timeout, containerId);
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/StaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/StaleRecoveringContainerScrubbingService.java
@@ -18,13 +18,13 @@
 package org.apache.hadoop.ozone.container.keyvalue.statemachine.background;
 
 import java.util.Iterator;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.impl.ContainerSet.RecoveringContainer;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,13 +55,13 @@ public class StaleRecoveringContainerScrubbingService
     BackgroundTaskQueue backgroundTaskQueue =
         new BackgroundTaskQueue();
     long currentTime = containerSet.getCurrentTime();
-    Iterator<Map.Entry<Long, Long>> it =
+    Iterator<RecoveringContainer> it =
         containerSet.getRecoveringContainerIterator();
     while (it.hasNext()) {
-      Map.Entry<Long, Long> entry = it.next();
-      if (currentTime >= entry.getKey()) {
+      RecoveringContainer entry = it.next();
+      if (currentTime >= entry.getTimeout()) {
         backgroundTaskQueue.add(new RecoveringContainerScrubbingTask(
-            containerSet, entry.getValue()));
+            containerSet, entry.getContainerId()));
         it.remove();
       } else {
         break;

--- a/hadoop-hdds/crypto-api/pom.xml
+++ b/hadoop-hdds/crypto-api/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdds-crypto-api</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <name>Apache Ozone HDDS Crypto</name>
   <description>Apache Ozone Distributed Data Store cryptographic functions</description>
 

--- a/hadoop-hdds/crypto-default/pom.xml
+++ b/hadoop-hdds/crypto-default/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdds-crypto-default</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <name>Apache Ozone HDDS Crypto - Default</name>
   <description>Default implementation of Apache Ozone Distributed Data Store's cryptographic functions</description>
 

--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-docs</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Documentation</name>
   <description>Apache Ozone Documentation</description>

--- a/hadoop-hdds/erasurecode/pom.xml
+++ b/hadoop-hdds/erasurecode/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-erasurecode</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Erasurecode</name>
   <description>Apache Ozone Distributed Data Store Earsurecode utils</description>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-server-framework</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Server Framework</name>
   <description>Apache Ozone Distributed Data Store Server Framework</description>

--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-hadoop-dependency-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone HDDS Hadoop Client dependencies</name>
   <description>Apache Ozone Distributed Data Store Hadoop client dependencies</description>

--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-interface-admin</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Admin Interface</name>
   <description>Apache Ozone Distributed Data Store Admin interface</description>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-interface-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Client Interface</name>
   <description>Apache Ozone Distributed Data Store Client interface</description>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-interface-server</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Server Interface</name>
   <description>Apache Ozone Distributed Data Store Server interface</description>

--- a/hadoop-hdds/managed-rocksdb/pom.xml
+++ b/hadoop-hdds/managed-rocksdb/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-managed-rocksdb</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Managed RocksDB</name>
   <description>Apache Ozone Managed RocksDB library</description>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdds</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone HDDS</name>
   <description>Apache Ozone Distributed Data Store Project</description>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-rocks-native</artifactId>
   <name>Apache Ozone HDDS RocksDB Tools</name>

--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>rocksdb-checkpoint-differ</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Checkpoint Differ for RocksDB</name>
   <description>Apache Ozone Checkpoint Differ for RocksDB</description>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-server-scm</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS SCM Server</name>
   <description>Apache Ozone Distributed Data Store Storage Container Manager Server</description>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMMetrics.java
@@ -180,7 +180,9 @@ public class SCMMetrics {
     }
   }
 
-  @Metric("Ratis state machine events")
+  // Ratis state machine events are multi-line logs, which should not be
+  // published as time-series metrics to metrics systems like Prometheus.
+  // Instead, they are exposed via JMX / MXBean endpoints.
   public String getRatisEvents() {
     synchronized (ratisEvents) {
       return String.join("\n", ratisEvents);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ScmListCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ScmListCodec.java
@@ -69,6 +69,12 @@ class ScmListCodec implements ScmCodec<Object> {
           "Missing ListArgument.type: " + argument);
     }
 
+    // Empty list was serialized with type=Object.class.getName() as a sentinel.
+    // Skip element-type resolution — there are no elements to decode.
+    if (argument.getValueCount() == 0) {
+      return new ArrayList<>();
+    }
+
     final Class<?> elementClass = resolver.get(argument.getType());
 
     final ScmCodec<?> elementCodec = ScmCodecFactory.getInstance().getCodec(elementClass);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
@@ -82,4 +82,6 @@ public interface SCMMXBean extends ServiceRuntimeInfo {
    * @return the SCM hostname for the datanode.
    */
   String getHostname();
+
+  String getRatisEvents();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -2238,6 +2238,11 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     return scmHostName;
   }
 
+  @Override
+  public String getRatisEvents() {
+    return metrics != null ? metrics.getRatisEvents() : "";
+  }
+
   public Collection<String> getScmAdminUsernames() {
     return scmAdmins.getAdminUsernames();
   }

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -30,10 +30,10 @@
         templateUrl: 'ratis-events.html',
         controller: function ($http) {
             var ctrl = this;
-            $http.get("jmx?qry=Hadoop:service=StorageContainerManager,name=SCMMetrics")
+            $http.get("jmx?qry=Hadoop:service=StorageContainerManager,name=StorageContainerManagerInfo,component=ServerRuntime")
                 .then(function (result) {
                     var metrics = result.data.beans[0];
-                  var rawEvents = metrics['tag.RatisEvents'] ? metrics['tag.RatisEvents'].split('\n') : [];
+                    var rawEvents = (metrics && metrics['RatisEvents']) ? metrics['RatisEvents'].split('\n') : [];
                     ctrl.events = rawEvents.map(function(e) {
                         var parts = e.split('|');
                         return {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestScmListCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestScmListCodec.java
@@ -17,10 +17,14 @@
 
 package org.apache.hadoop.hdds.scm.ha.io;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
@@ -48,5 +52,70 @@ public class TestScmListCodec {
         () -> codec.deserialize(listArg.toByteString()));
 
     assertTrue(ex.getMessage().contains("Missing ListArgument.type"));
+  }
+
+  /**
+   * An empty list serialized with the Object.class sentinel must round-trip
+   * cleanly without triggering "Failed to resolve java.lang.Object".
+   */
+  @Test
+  public void testEmptyListRoundTrip() throws Exception {
+    ScmListCodec codec = new ScmListCodec(
+        new ScmCodecFactory.ClassResolver(Collections.emptyList()));
+
+    List<?> result = (List<?>) codec.deserialize(codec.serialize(new ArrayList<>()));
+
+    assertEquals(0, result.size());
+  }
+
+  /**
+   * The EMPTY_LIST sentinel (type=java.lang.Object, no values) stored in an
+   * existing Ratis log must deserialize successfully.
+   */
+  @Test
+  public void testEmptyListSentinelDeserialization() throws Exception {
+    SCMRatisProtocol.ListArgument sentinel =
+        SCMRatisProtocol.ListArgument.newBuilder()
+            .setType(Object.class.getName())
+            // no values
+            .build();
+
+    ScmListCodec codec = new ScmListCodec(
+        new ScmCodecFactory.ClassResolver(Collections.emptyList()));
+
+    List<?> result = (List<?>) codec.deserialize(sentinel.toByteString());
+
+    assertEquals(0, result.size());
+  }
+
+  /**
+   * Deserialized empty lists must be concrete {@link ArrayList} instances.
+   * Generated invokers (e.g. DeletedBlockLogStateManagerInvoker) cast the
+   * decoded argument directly to {@code ArrayList}; returning an unmodifiable
+   * or fixed-size list would cause a ClassCastException during Ratis log
+   * replay even though the list is logically empty.
+   */
+  @Test
+  public void testEmptyListDeserializedAsArrayList() throws Exception {
+    ScmListCodec codec = new ScmListCodec(
+        new ScmCodecFactory.ClassResolver(Collections.emptyList()));
+
+    // Round-trip path: serialize an empty list then deserialize it.
+    Object roundTrip = codec.deserialize(codec.serialize(new ArrayList<>()));
+    assertInstanceOf(ArrayList.class, roundTrip,
+        "round-trip empty list must be an ArrayList, not " + roundTrip.getClass());
+
+    // Sentinel path: the exact bytes that older logs contain.
+    SCMRatisProtocol.ListArgument sentinel =
+        SCMRatisProtocol.ListArgument.newBuilder()
+            .setType(Object.class.getName())
+            .build();
+    Object fromSentinel = codec.deserialize(sentinel.toByteString());
+    assertInstanceOf(ArrayList.class, fromSentinel,
+        "sentinel empty list must be an ArrayList, not " + fromSentinel.getClass());
+
+    // Verify the cast that invokers actually perform does not throw.
+    ArrayList<?> cast = (ArrayList<?>) roundTrip;
+    assertEquals(0, cast.size());
   }
 }

--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-test-utils</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Test Utils</name>
   <description>Apache Ozone Distributed Data Store Test Utils</description>

--- a/hadoop-ozone/cli-admin/pom.xml
+++ b/hadoop-ozone/cli-admin/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
 
   <artifactId>ozone-cli-admin</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Admin</name>
   <description>Apache Ozone CLI Admin</description>

--- a/hadoop-ozone/cli-debug/pom.xml
+++ b/hadoop-ozone/cli-debug/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-cli-debug</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Debug Tools</name>
   <description>Apache Ozone Debug Tools</description>

--- a/hadoop-ozone/cli-interactive/pom.xml
+++ b/hadoop-ozone/cli-interactive/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-cli-interactive</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Interactive</name>
   <description>Apache Ozone top-level interactive CLI</description>

--- a/hadoop-ozone/cli-repair/pom.xml
+++ b/hadoop-ozone/cli-repair/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-cli-repair</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Repair Tools</name>
   <description>Apache Ozone Repair Tools</description>

--- a/hadoop-ozone/cli-shell/pom.xml
+++ b/hadoop-ozone/cli-shell/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-cli-shell</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Shell</name>
   <description>Apache Ozone CLI Shell</description>

--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Client</name>
   <description>Apache Ozone Client</description>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-common</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Common</name>
   <description>Apache Ozone Common</description>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-csi</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CSI service</name>
   <description>Apache Ozone CSI service</description>

--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-datanode</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Datanode</name>
 

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-dist</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Distribution</name>
   <properties>

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -24,6 +24,7 @@ export COMPOSE_DIR
 
 export SECURITY_ENABLED=false
 export OZONE_REPLICATION_FACTOR=3
+export COMPOSE_FILE=docker-compose.yaml:monitoring.yaml
 
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
@@ -40,6 +41,7 @@ execute_robot_test scm gdpr
 execute_robot_test scm security/ozone-secure-token.robot
 
 execute_robot_test scm recon
+execute_robot_test scm prometheus
 
 execute_robot_test scm om-ratis
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -33,7 +33,7 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-run_test ha     non-rolling-upgrade 2.1.0 "$OZONE_CURRENT_VERSION"
+run_test ha     non-rolling-upgrade 2.1.1 "$OZONE_CURRENT_VERSION"
 # run_test ha     non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
 #run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 #run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -69,8 +69,8 @@ services:
     image: ${OZONE_IMAGE}:2.0.0${OZONE_IMAGE_FLAVOR}
     <<: *old-config
 
-  old_client_2_1_0:
-    image: ${OZONE_IMAGE}:2.1.0${OZONE_IMAGE_FLAVOR}
+  old_client_2_1_1:
+    image: ${OZONE_IMAGE}:2.1.1${OZONE_IMAGE_FLAVOR}
     <<: *old-config
 
   new_client:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
@@ -24,7 +24,7 @@ source "${COMPOSE_DIR}/../testlib.sh"
 
 current_version="${OZONE_CURRENT_VERSION}"
 # TODO: debug acceptance test failures for client versions 1.0.0 on secure clusters
-old_versions="1.1.0 1.2.1 1.3.0 1.4.1 2.0.0 2.1.0" # container is needed for each version in clients.yaml
+old_versions="1.1.0 1.2.1 1.3.0 1.4.1 2.0.0 2.1.1" # container is needed for each version in clients.yaml
 
 export SECURITY_ENABLED=true
 : ${OZONE_BUCKET_KEY_NAME:=key1}

--- a/hadoop-ozone/dist/src/main/smoketest/prometheus/prometheus.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/prometheus/prometheus.robot
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test Prometheus monitoring integration
+Library             OperatingSystem
+Library             BuiltIn
+Resource            ../commonlib.robot
+
+*** Test Cases ***
+Verify Prometheus targets are healthy
+    Wait Until Keyword Succeeds     90sec      10sec        Check Prometheus Targets Health
+
+*** Keywords ***
+Check Prometheus Targets Health
+    ${result} =         Execute     python3 ${OZONE_DIR}/smoketest/prometheus/prometheus_check.py
+    Should Contain      ${result}   Successfully verified

--- a/hadoop-ozone/dist/src/main/smoketest/prometheus/prometheus_check.py
+++ b/hadoop-ozone/dist/src/main/smoketest/prometheus/prometheus_check.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import urllib.request
+import json
+import sys
+import socket
+
+def is_running(host, port):
+    try:
+        with socket.create_connection((host, int(port)), timeout=2):
+            return True
+    except Exception:
+        return False
+
+def main():
+    try:
+        res = urllib.request.urlopen("http://prometheus:9090/api/v1/targets")
+        data = json.loads(res.read().decode())
+        targets = data.get("data", {}).get("activeTargets", [])
+        if not targets:
+            print("No active targets found in Prometheus")
+            sys.exit(1)
+            
+        failed = False
+        checked = 0
+        for t in targets:
+            url = t.get("scrapeUrl", "")
+            # scrapeUrl is like "http://scm:9876/prom"
+            try:
+                host_port = url.split("//")[1].split("/")[0]
+                if ":" in host_port:
+                    host, port = host_port.split(":")
+                else:
+                    host = host_port
+                    port = 80
+            except Exception:
+                continue
+                
+            if is_running(host, port):
+                checked += 1
+                health = t.get("health", "")
+                print(f"Target {host}:{port} is running. Prometheus health: {health}")
+                if health != "up":
+                    print(f"Error: Target {host}:{port} is running but Prometheus health is '{health}'. Last error: {t.get('lastError')}")
+                    failed = True
+            else:
+                print(f"Target {host}:{port} is not running. Skipping check.")
+                
+        if checked == 0:
+            print("Error: No running targets were checked!")
+            sys.exit(1)
+            
+        if failed:
+            sys.exit(1)
+            
+        print(f"Successfully verified {checked} running targets.")
+    except Exception as e:
+        print(f"Exception during health check: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-fault-injection-test</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>mini-chaos-tests</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <name>Apache Ozone Mini Ozone Chaos Tests</name>
   <description>Apache Ozone Mini Ozone Chaos Tests</description>
 

--- a/hadoop-ozone/fault-injection-test/network-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/network-tests/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-fault-injection-test</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-network-tests</artifactId>
   <packaging>jar</packaging>

--- a/hadoop-ozone/fault-injection-test/pom.xml
+++ b/hadoop-ozone/fault-injection-test/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-fault-injection-test</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone Fault Injection Tests</name>
   <description>Apache Ozone Fault Injection Tests</description>

--- a/hadoop-ozone/freon/pom.xml
+++ b/hadoop-ozone/freon/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-freon</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Freon</name>
   <description>Apache Ozone Freon</description>

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -19,10 +19,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-httpfsgateway</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Apache Ozone HttpFS</name>

--- a/hadoop-ozone/iceberg/pom.xml
+++ b/hadoop-ozone/iceberg/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-iceberg</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Iceberg Integration</name>
   <description>Apache Ozone Iceberg Integration</description>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-insight</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Insight Tool</name>
   <description>Apache Ozone Insight Tool</description>

--- a/hadoop-ozone/integration-test-recon/pom.xml
+++ b/hadoop-ozone/integration-test-recon/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-integration-test-recon</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Recon Integration Tests</name>
   <description>Apache Ozone Integration Tests with Recon</description>

--- a/hadoop-ozone/integration-test-s3/pom.xml
+++ b/hadoop-ozone/integration-test-s3/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-integration-test-s3</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Integration Tests</name>
   <description>Apache Ozone Integration Tests with S3 Gateway</description>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-integration-test</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Integration Tests</name>
   <description>Apache Ozone Integration Tests</description>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMMXBean.java
@@ -86,6 +86,9 @@ public abstract class TestSCMMXBean implements NonHATests.TestCase {
     double containerThreshold = (double) mbs.getAttribute(bean,
         "SafeModeCurrentContainerThreshold");
     assertEquals(scm.getCurrentContainerThreshold(), containerThreshold, 0);
+
+    String ratisEvents = (String) mbs.getAttribute(bean, "RatisEvents");
+    assertEquals(scm.getMetrics().getRatisEvents(), ratisEvents);
   }
 
   @Test

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-interface-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Client Interface</name>
   <description>Apache Ozone Client interface</description>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-interface-storage</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Storage Interface</name>
   <description>Apache Ozone Storage Interface</description>

--- a/hadoop-ozone/mini-cluster/pom.xml
+++ b/hadoop-ozone/mini-cluster/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-mini-cluster</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Mini Cluster</name>
   <description>Apache Ozone Mini Cluster for Integration Tests</description>

--- a/hadoop-ozone/multitenancy-ranger/pom.xml
+++ b/hadoop-ozone/multitenancy-ranger/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-multitenancy-ranger</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Multitenancy with Ranger</name>
   <description>Implementation of multitenancy for Apache Ozone Manager Server using Apache Ranger</description>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-manager</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Manager Server</name>
   <description>Apache Ozone Manager Server</description>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
@@ -41,4 +41,6 @@ public interface OMMXBean extends ServiceRuntimeInfo {
    * @return the OM hostname for the datanode.
    */
   String getHostname();
+
+  String getRatisEvents();
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -1590,7 +1590,9 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     }
   }
 
-  @Metric("Ratis state machine events")
+  // Ratis state machine events are multi-line logs, which should not be
+  // published as time-series metrics to metrics systems like Prometheus.
+  // Instead, they are exposed via JMX / MXBean endpoints.
   public String getRatisEvents() {
     synchronized (ratisEvents) {
       return String.join("\n", ratisEvents);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3307,6 +3307,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     return omHostName;
   }
 
+  @Override
+  public String getRatisEvents() {
+    return metrics != null ? metrics.getRatisEvents() : "";
+  }
+
   @VisibleForTesting
   public OzoneManagerHttpServer getHttpServer() {
     return httpServer;

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
@@ -173,10 +173,10 @@
         templateUrl: 'ratis-events.html',
         controller: function ($http) {
             var ctrl = this;
-            $http.get("jmx?qry=Hadoop:service=OzoneManager,name=OMMetrics")
+            $http.get("jmx?qry=Hadoop:service=OzoneManager,name=OzoneManagerInfo,component=ServerRuntime")
                 .then(function (result) {
                     var metrics = result.data.beans[0];
-                    var rawEvents = metrics['tag.RatisEvents'] ? metrics['tag.RatisEvents'].split('\n') : [];
+                    var rawEvents = (metrics && metrics['RatisEvents']) ? metrics['RatisEvents'].split('\n') : [];
                     ctrl.events = rawEvents.map(function(e) {
                         var parts = e.split('|');
                         return {

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-filesystem-common</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem Common</name>
   <properties>

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-filesystem-hadoop2</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FS Hadoop 2.x compatibility</name>
   <dependencies>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-filesystem-hadoop3</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FS Hadoop 3.x compatibility</name>
   <properties>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-filesystem-shaded</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem Shaded</name>
 

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-filesystem</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem</name>
   <properties>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone</name>
   <description>Apache Ozone Project</description>

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-reconcodegen</artifactId>
   <name>Apache Ozone Recon CodeGen</name>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-recon</artifactId>
   <name>Apache Ozone Recon</name>

--- a/hadoop-ozone/s3-secret-store/pom.xml
+++ b/hadoop-ozone/s3-secret-store/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-s3-secret-store</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Secret Store</name>
   <properties>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-s3gateway</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Gateway</name>
   <properties>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-tools</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Tools</name>
   <description>Apache Ozone Tools</description>

--- a/hadoop-ozone/vapor/pom.xml
+++ b/hadoop-ozone/vapor/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-vapor</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Vapor</name>
   <description>Apache Ozone server-side load testing tools</description>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <metainf-services.version>1.11</metainf-services.version>
     <mockito.version>4.11.0</mockito.version>
     <native.lib.tmp.dir />
-    <netty.version>4.1.133.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <!-- Node.js version number (without the v prefix required by frontend-maven-plugin) -->
     <nodejs.version>20.18.2</nodejs.version>
     <okhttp3.version>4.12.0</okhttp3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <metainf-services.version>1.11</metainf-services.version>
     <mockito.version>4.11.0</mockito.version>
     <native.lib.tmp.dir />
-    <netty.version>4.1.135.Final</netty.version>
+    <netty.version>4.1.136.Final</netty.version>
     <!-- Node.js version number (without the v prefix required by frontend-maven-plugin) -->
     <nodejs.version>20.18.2</nodejs.version>
     <okhttp3.version>4.12.0</okhttp3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -185,10 +185,10 @@
     <protobuf.version>3.25.8</protobuf.version>
     <ranger.version>2.8.0</ranger.version>
     <!-- versions included in ratis-thirdparty, update in sync -->
-    <ratis-thirdparty.grpc.version>1.75.0</ratis-thirdparty.grpc.version>
-    <ratis-thirdparty.netty.version>4.1.127.Final</ratis-thirdparty.netty.version>
+    <ratis-thirdparty.grpc.version>1.77.1</ratis-thirdparty.grpc.version>
+    <ratis-thirdparty.netty.version>4.1.130.Final</ratis-thirdparty.netty.version>
     <ratis-thirdparty.protobuf.version>3.25.8</ratis-thirdparty.protobuf.version>
-    <ratis.thirdparty.version>1.0.10</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.11</ratis.thirdparty.version>
     <ratis.version>3.2.1</ratis.version>
     <re2j.version>1.7</re2j.version>
     <reflections.version>0.10.2</reflections.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.ozone</groupId>
   <artifactId>ozone-main</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone Main</name>
   <description>Apache Ozone Main</description>
@@ -166,7 +166,7 @@
     <ozone.release>Katmai</ozone.release>
     <ozone.shaded.native.prefix>org_apache_ozone_shaded</ozone.shaded.native.prefix>
     <ozone.shaded.prefix>org.apache.ozone.shaded</ozone.shaded.prefix>
-    <ozone.version>2.2.0</ozone.version>
+    <ozone.version>2.2.1-SNAPSHOT</ozone.version>
     <!--
       4.7.6: https://github.com/remkop/picocli/issues/2309
       4.7.7: https://github.com/remkop/picocli/issues/2407
@@ -174,7 +174,7 @@
     <picocli.version>4.7.5</picocli.version>
     <pmd.version>3.28.0</pmd.version>
     <!-- Enable Reproducible Builds mode -->
-    <project.build.outputTimestamp>2026-06-15T02:15:54Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-08-03T10:05:10Z</project.build.outputTimestamp>
     <!-- platform encoding override -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <assertj.version>3.27.7</assertj.version>
     <aws-java-sdk.version>1.12.788</aws-java-sdk.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <cdi-api.version>2.0.SP1</cdi-api.version>
     <checkstyle.version>9.3</checkstyle.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport changes to `ozone-2.2` for Ozone 2.2.1.

Fixes:

* e1b7f0c2d4 HDDS-12669. Race condition between entries of ContainerSet#recoveringContainerMap (#10481)
* 0be1e3c4e3 HDDS-15552. Ratis events should not be published as metrics (#10523)
* 103e2cb3f3 HDDS-15783. Handle empty lists in ScmListCodec deserialization (#10690)
* f62d6432a0 HDDS-15849. Force channel shutdown in XceiverClientGrpc.close (#10747)

Dependency updates:

* 1b29a87d25 HDDS-15722. Bump netty to 4.1.135 (#10646)
* 2a361e5d64 HDDS-15727. Bump ratis-thirdparty to 1.0.11 (#10647)
* 26e19eb8e2 HDDS-15900. Bump netty to 4.1.136 (#10800)
* 2bc0a2e12c HDDS-15974. Bump bouncycastle to 1.85 (#10867)

Misc:

* dda5af177b HDDS-15843. Update upgrade/xcompat tests to use 2.1.1 (#10739)
* e5c27bab70 [RELEASE] Set version to 2.2.1-SNAPSHOT after 2.2.0 release

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/30804466657