### PR TITLE
HDDS-15775. Support IPv6 literal authorities in OzoneFS URI parsing

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -100,7 +100,10 @@ public final class OzoneClientFactory {
     Objects.requireNonNull(omRpcPort, "omRpcPort == null");
     Objects.requireNonNull(config, "config == null");
     OmUtils.resolveOmHost(omHost, omRpcPort);
-    config.set(OZONE_OM_ADDRESS_KEY, omHost + ":" + omRpcPort);
+    // getHostPortString brackets IPv6 literals; a plain host + ":" + port would
+    // produce an ambiguous address such as ::1:9862 for an IPv6 OM host.
+    config.set(OZONE_OM_ADDRESS_KEY,
+        HddsUtils.getHostPortString(omHost, omRpcPort));
     return getRpcClient(getClientProtocol(config), config);
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone;
 
 import static org.apache.hadoop.hdds.HddsUtils.getHostName;
 import static org.apache.hadoop.hdds.HddsUtils.getHostNameFromConfigKeys;
+import static org.apache.hadoop.hdds.HddsUtils.getHostPortString;
 import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.ozone.OzoneConsts.DOUBLE_SLASH_OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
@@ -1143,7 +1144,10 @@ public final class OmUtils {
    */
   public static void resolveOmHost(String omHost, int omPort)
       throws IOException {
-    InetSocketAddress omHostAddress = NetUtils.createSocketAddr(omHost, omPort);
+    // Combine via getHostPortString so an IPv6 literal is bracketed; passing a
+    // bare ::1 to createSocketAddr fails with "not a valid host:port authority".
+    InetSocketAddress omHostAddress =
+        NetUtils.createSocketAddr(getHostPortString(omHost, omPort));
     if (omHostAddress.isUnresolved()) {
       throw new IOException(
           "Cannot resolve OM host " + omHost + " in the URI",

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -384,4 +384,23 @@ public class TestOmUtils {
       }
     }
   }
+
+  @Test
+  public void testResolveOmHostAcceptsIpv6Literal() {
+    // A bracketed or bare IPv6 literal must parse into a host:port authority.
+    // Before HDDS-15775 the bare form made createSocketAddr throw
+    // IllegalArgumentException ("not a valid host:port authority"). Reachability
+    // is environment-dependent, so an IOException here is acceptable; only the
+    // parse failure must not happen.
+    for (String host : new String[] {"::1", "[::1]"}) {
+      try {
+        OmUtils.resolveOmHost(host, 9862);
+      } catch (IllegalArgumentException e) {
+        fail("IPv6 literal '" + host + "' should parse into an address: "
+            + e.getMessage());
+      } catch (IOException ignored) {
+        // Unresolved or unreachable in the test environment is acceptable.
+      }
+    }
+  }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -37,6 +37,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLU
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.net.HostAndPort;
 import io.opentelemetry.api.trace.Span;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -158,21 +159,20 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
     }
 
-    String omHostOrServiceId;
-    int omPort = -1;
-    // Parse hostname and port
-    String[] parts = authority.split(":");
-    if (parts.length > 2) {
+    // Parse hostname and port. HostAndPort is bracket-aware, so IPv6 literal
+    // authorities (for example [::1]:9862) are split correctly instead of on
+    // every colon.
+    final HostAndPort hostAndPort;
+    try {
+      hostAndPort = HostAndPort.fromString(authority);
+    } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
     }
-    omHostOrServiceId = parts[0];
-    if (parts.length == 2) {
-      try {
-        omPort = Integer.parseInt(parts[1]);
-      } catch (NumberFormatException e) {
-        throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
-      }
-    }
+    int omPort = hostAndPort.hasPort() ? hostAndPort.getPort() : -1;
+    String host = hostAndPort.getHost();
+    // Keep IPv6 literals bracketed so the downstream host:port assembly that
+    // builds the OM address stays unambiguous.
+    String omHostOrServiceId = host.contains(":") ? "[" + host + "]" : host;
 
     try {
       uri = new URIBuilder().setScheme(OZONE_OFS_URI_SCHEME)

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -166,7 +166,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     try {
       hostAndPort = HostAndPort.fromString(authority);
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
+      throw new IllegalArgumentException(URI_EXCEPTION_TEXT, e);
     }
     int omPort = hostAndPort.hasPort() ? hostAndPort.getPort() : -1;
     String host = hostAndPort.getHost();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -169,10 +169,9 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       throw new IllegalArgumentException(URI_EXCEPTION_TEXT, e);
     }
     int omPort = hostAndPort.hasPort() ? hostAndPort.getPort() : -1;
+    // Pass the bare host; the adapter builds the OM address via
+    // getHostPortString, which brackets IPv6 literals.
     String host = hostAndPort.getHost();
-    // Keep IPv6 literals bracketed so the downstream host:port assembly that
-    // builds the OM address stays unambiguous.
-    String omHostOrServiceId = host.contains(":") ? "[" + host + "]" : host;
 
     try {
       uri = new URIBuilder().setScheme(OZONE_OFS_URI_SCHEME)
@@ -183,7 +182,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       ConfigurationSource source = getConfSource();
       this.hsyncEnabled = OzoneFSUtils.canEnableHsync(source, true);
       LOG.debug("hsyncEnabled = {}", hsyncEnabled);
-      this.adapter = createAdapter(source, omHostOrServiceId, omPort);
+      this.adapter = createAdapter(source, host, omPort);
       this.adapterImpl = (BasicRootedOzoneClientAdapterImpl) this.adapter;
 
       try {

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -25,12 +25,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import org.apache.hadoop.conf.Configuration;
@@ -39,7 +43,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageSize;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Unit test for Basic*OzoneFileSystem.
@@ -135,6 +141,37 @@ public class TestBasicOzoneFileSystems {
       fail("Test case not implemented for FileSystem: " +
           subject.getClass().getSimpleName());
     }
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      // hostname / IPv4 authority (behaviour unchanged)
+      "ofs://host:9862/, host, 9862",
+      "ofs://omservice1/, omservice1, -1",
+      // service id with an underscore: HostAndPort tolerates it (URI.getHost does not)
+      "ofs://om_service/, om_service, -1",
+      // IPv6 literal authority, with and without a port; the literal stays bracketed
+      "ofs://[::1]:9862/, [::1], 9862",
+      "ofs://[2001:db8::1]/, [2001:db8::1], -1",
+  })
+  public void testRootedAuthorityParsing(String uri, String expectedHost,
+      int expectedPort) throws Exception {
+    BasicRootedOzoneFileSystem ofs = spy(new BasicRootedOzoneFileSystem());
+    BasicRootedOzoneClientAdapterImpl adapter =
+        mock(BasicRootedOzoneClientAdapterImpl.class);
+    doReturn(adapter).when(ofs).createAdapter(any(), anyString(), anyInt());
+
+    ofs.initialize(new URI(uri), new OzoneConfiguration());
+
+    ArgumentCaptor<String> hostCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Integer> portCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(ofs).createAdapter(any(), hostCaptor.capture(),
+        portCaptor.capture());
+    assertEquals(expectedHost, hostCaptor.getValue());
+    assertEquals(expectedPort, portCaptor.getValue().intValue());
+
+    // The rebuilt filesystem URI keeps the (bracketed) IPv6 authority intact.
+    assertEquals(new URI(uri).getAuthority(), ofs.getUri().getAuthority());
   }
 
   private void assertDefaultBlockSize(long expected, FileSystem subject) {

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAU
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
@@ -42,6 +43,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageSize;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -172,6 +174,14 @@ public class TestBasicOzoneFileSystems {
 
     // The rebuilt filesystem URI keeps the (bracketed) IPv6 authority intact.
     assertEquals(new URI(uri).getAuthority(), ofs.getUri().getAuthority());
+  }
+
+  @Test
+  public void testRootedAuthorityRejectsOutOfRangePort() {
+    BasicRootedOzoneFileSystem ofs = spy(new BasicRootedOzoneFileSystem());
+    // HostAndPort rejects ports outside 0-65535, unlike a bare Integer.parseInt.
+    assertThrows(IllegalArgumentException.class,
+        () -> ofs.initialize(new URI("ofs://host:99999/"), new OzoneConfiguration()));
   }
 
   private void assertDefaultBlockSize(long expected, FileSystem subject) {

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -152,9 +152,11 @@ public class TestBasicOzoneFileSystems {
       "ofs://omservice1/, omservice1, -1",
       // service id with an underscore: HostAndPort tolerates it (URI.getHost does not)
       "ofs://om_service/, om_service, -1",
-      // IPv6 literal authority, with and without a port; the literal stays bracketed
-      "ofs://[::1]:9862/, [::1], 9862",
-      "ofs://[2001:db8::1]/, [2001:db8::1], -1",
+      // IPv6 literal authority, with and without a port; the bare literal is
+      // passed to the adapter (which re-brackets it), while the filesystem URI
+      // keeps the bracketed authority.
+      "ofs://[::1]:9862/, ::1, 9862",
+      "ofs://[2001:db8::1]/, 2001:db8::1, -1",
   })
   public void testRootedAuthorityParsing(String uri, String expectedHost,
       int expectedPort) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ofs://[::1]:9862/path` fails because the authority is split on every colon.

`BasicRootedOzoneFileSystem.java`: the authority parsing splits on `:`, so a bracketed IPv6 literal yields more than two parts and throws `IllegalArgumentException` (`URI_EXCEPTION_TEXT`).

This change parses the authority with Guava `HostAndPort`, which understands bracketed IPv6 literals and rejects out-of-range ports. IPv6 hosts are kept bracketed when the OM host:port address is reassembled so the downstream parse stays unambiguous.

### Why ofs only (o3fs is out of scope)

o3fs encodes the OM host inside the authority as `o3fs://bucket.volume.host:port`. For an IPv6 literal that would be `o3fs://bucket.volume.[::1]:9862/`, where the brackets sit in the middle of the authority. `java.net.URI` rejects that form (`URISyntaxException: Illegal character in hostname`), so an o3fs IPv6 authority can never reach the filesystem to begin with. ofs puts the authority at the start (`ofs://[::1]:9862/`), which `java.net.URI` accepts, so ofs is the only scheme where this fix is reachable. `BasicOzoneFileSystem` (o3fs) is left unchanged.

Parent epic: [HDDS-15763](https://issues.apache.org/jira/browse/HDDS-15763).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15775

## How was this patch tested?

Added `TestBasicOzoneFileSystems` cases covering ofs authority parsing (hostname, service id, underscore host, `[::1]:9862`, `[2001:db8::1]`) and out-of-range port rejection.

https://github.com/rich7420/ozone/actions/runs/30821150742
