### PR TITLE
HDDS-15986. Report ozone local startup failures

### DIFF
--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -47,6 +47,10 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -69,6 +69,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-admin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-server-framework</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -92,6 +92,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -153,6 +155,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private static final int LOCAL_RATIS_RPC_TIMEOUT_SECONDS = 1;
   private static final long SCM_CLIENT_MAX_RETRY_TIMEOUT_MILLIS = 30_000;
   private static final long READINESS_POLL_INTERVAL_MILLIS = 500;
+  private static final long READINESS_LOG_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(5);
 
   private static final int MAX_PORT = 65_535;
 
@@ -186,6 +189,8 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   // local ports, so an unbounded count would exhaust local ports; cap it.
   static final int MAX_DATANODES = 20;
 
+  private static final String OZONE_DEFAULT_XML = "ozone-default.xml";
+
   private static final String[] NO_ARGS = new String[0];
 
   private final LocalOzoneClusterConfig config;
@@ -196,6 +201,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private StorageContainerManager scm;
   private OzoneManager om;
   private final List<HddsDatanodeService> datanodes = new ArrayList<>();
+  private final List<String> discardedUserConfigKeys = new ArrayList<>();
   private boolean previousMetricsMiniClusterMode;
   private boolean metricsMiniClusterModeEnabled;
 
@@ -239,6 +245,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       return preparedConfiguration;
     }
 
+    // preparedConfiguration is assigned only on success, so a failed attempt can be retried on this
+    // instance; start from an empty list so a retry does not report an override twice.
+    discardedUserConfigKeys.clear();
+
+    requireSupportedDatanodeCount();
     prepareStorageLayout();
 
     OzoneConfiguration conf = new OzoneConfiguration(seedConfiguration);
@@ -291,6 +302,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   @Override
+  public List<String> getDiscardedUserConfigKeys() {
+    return Collections.unmodifiableList(discardedUserConfigKeys);
+  }
+
+  @Override
   public void close() throws IOException {
     if (closed) {
       return;
@@ -314,8 +330,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
   private void stopServices() {
     try {
-      // Shutdown is best-effort so one failed service cannot leak the others.
-      IOUtils.closeQuietly(this::stopDatanodes, this::stopOm, this::stopScm);
+      // Shutdown is best-effort so one failed service cannot leak the others,
+      // but the failures are logged: stopServices() also runs as start()
+      // rollback, where a silent failure hides leaked threads and ports.
+      IOUtils.close(LOG, this::stopDatanodes, this::stopOm, this::stopScm);
     } finally {
       restoreSameJvmMetricsMode();
     }
@@ -331,7 +349,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       });
     }
     datanodes.clear();
-    IOUtils.closeQuietly(stoppers);
+    IOUtils.close(LOG, stoppers);
   }
 
   private void stopOm() {
@@ -352,33 +370,57 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   private void configureLocalDefaults(OzoneConfiguration conf) {
-    conf.set(OZONE_METADATA_DIRS, metadataDir().toString());
+    setLocalOverride(conf, OZONE_METADATA_DIRS, metadataDir().toString());
     // SCM and OM share one configuration and JVM, so the Jetty base dir is a
     // single service-neutral location; Jetty keeps per-context temp dirs.
     conf.setIfUnset(OZONE_HTTP_BASEDIR, metadataDir() + SERVER_DIR);
-    conf.set(OZONE_REPLICATION, ReplicationFactor.ONE.name());
-    conf.set(OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE.name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
+    setLocalOverride(conf, OZONE_REPLICATION, ReplicationFactor.ONE.name());
+    setLocalOverride(conf, OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
+    setLocalOverride(conf, OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE.name());
+    setLocalOverride(conf, OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
         ReplicationType.STAND_ALONE.name());
-    conf.setBoolean(HDDS_CONTAINER_RATIS_ENABLED_KEY, false);
+    setLocalOverride(conf, HDDS_CONTAINER_RATIS_ENABLED_KEY, "false");
     // A single-node local cluster can heartbeat aggressively; this speeds
-    // datanode registration and safe-mode exit. Use set(), not setIfUnset():
-    // ozone-default.xml supplies the 30s default that would otherwise defeat
-    // the override.
-    conf.set(HDDS_HEARTBEAT_INTERVAL, "1s");
-    conf.setBoolean(HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
-    conf.setInt(HDDS_SCM_SAFEMODE_MIN_DATANODE,
-        Math.max(1, config.getDatanodes()));
-    conf.setTimeDuration(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
-        LOCAL_RATIS_RPC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    conf.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
+    // datanode registration and safe-mode exit.
+    setLocalOverride(conf, HDDS_HEARTBEAT_INTERVAL, "1s");
+    setLocalOverride(conf, HDDS_SCM_SAFEMODE_PIPELINE_CREATION, "false");
+    setLocalOverride(conf, HDDS_SCM_SAFEMODE_MIN_DATANODE,
+        String.valueOf(Math.max(1, config.getDatanodes())));
+    setLocalOverride(conf, OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+        LOCAL_RATIS_RPC_TIMEOUT_SECONDS + "s");
+    setLocalOverride(conf, HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
     conf.setIfUnset(OZONE_SCM_HA_RATIS_SERVER_RPC_FIRST_ELECTION_TIMEOUT,
         "1s");
 
     SCMClientConfig scmClientConfig = conf.getObject(SCMClientConfig.class);
     scmClientConfig.setMaxRetryTimeout(SCM_CLIENT_MAX_RETRY_TIMEOUT_MILLIS);
     conf.setFromObject(scmClientConfig);
+  }
+
+  /**
+   * Applies a value the local runtime requires, reporting the value it replaces. These keys are
+   * set rather than {@code setIfUnset} because ozone-default.xml would otherwise win, so a value
+   * the user put in ozone-site.xml or passed with -D is discarded; reporting happens here, at the
+   * point of the override, so a new override cannot be added without being reported.
+   */
+  private void setLocalOverride(OzoneConfiguration conf, String key, String value) {
+    String configured = conf.get(key);
+    if (!value.equals(configured) && isUserConfigured(conf, key)) {
+      discardedUserConfigKeys.add(key);
+      LOG.warn("ozone local requires {}={}; the configured value {} is ignored.",
+          key, value, configured);
+    }
+    conf.set(key, value);
+  }
+
+  /**
+   * Whether {@code key} carries a value the user chose. A value whose last source is
+   * ozone-default.xml is a shipped default, not a user choice.
+   */
+  private static boolean isUserConfigured(OzoneConfiguration conf, String key) {
+    String[] sources = conf.getPropertySources(key);
+    return sources != null && sources.length > 0
+        && !sources[sources.length - 1].contains(OZONE_DEFAULT_XML);
   }
 
   private int configureScm(OzoneConfiguration conf,
@@ -480,13 +522,6 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private List<OzoneConfiguration> configureDatanodes(OzoneConfiguration conf,
       PersistedPortState persistedPorts, PortAllocator portAllocator)
       throws IOException {
-    int datanodeCount = config.getDatanodes();
-    if (datanodeCount > MAX_DATANODES) {
-      throw new IOException("Datanode count " + datanodeCount
-          + " exceeds the local maximum of " + MAX_DATANODES
-          + "; each datanode reserves " + DATANODE_PORT_KEY_SUFFIXES.length
-          + " local ports.");
-    }
     List<OzoneConfiguration> datanodeConfigurations =
         new ArrayList<>(config.getDatanodes());
     for (int index = 0; index < config.getDatanodes(); index++) {
@@ -643,30 +678,66 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   private void waitForClusterReadiness(Duration timeout) throws Exception {
+    waitForReadiness(this::clusterReadinessBlocker, "Ozone cluster", timeout);
+  }
+
+  /**
+   * Polls {@code blocker} until it reports ready. {@code blocker} returns why {@code subject} is
+   * not ready yet, so the wait can name the unmet condition instead of reporting a bare timeout
+   * that cannot distinguish a slow start from a stuck one.
+   */
+  static void waitForReadiness(Supplier<String> blocker, String subject, Duration timeout)
+      throws InterruptedException, TimeoutException {
     long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    long nextLogNanos = System.nanoTime() + READINESS_LOG_INTERVAL_NANOS;
     while (true) {
-      if (isClusterReady()) {
+      String reason = blocker.get();
+      if (reason == null) {
         return;
       }
       if (System.nanoTime() >= deadlineNanos) {
-        throw new TimeoutException("Timed out waiting " + timeout
-            + " for the local Ozone cluster to become ready.");
+        throw new TimeoutException("Timed out waiting " + timeout + " for the local " + subject
+            + " to become ready: " + reason + ".");
+      }
+      if (System.nanoTime() >= nextLogNanos) {
+        LOG.info("Waiting for the local {} to become ready: {}.", subject, reason);
+        nextLogNanos = System.nanoTime() + READINESS_LOG_INTERVAL_NANOS;
       }
       Thread.sleep(READINESS_POLL_INTERVAL_MILLIS);
     }
   }
 
-  private boolean isClusterReady() {
-    if (!scm.checkLeader() || !om.isLeaderReady()) {
-      return false;
+  /**
+   * Returns why the cluster is not usable yet, or null once it is ready. The cluster is usable
+   * once SCM and OM are leader-ready, every datanode has registered with SCM, and SCM has left
+   * safe mode.
+   */
+  private String clusterReadinessBlocker() {
+    if (!scm.checkLeader()) {
+      return "SCM has no Ratis leader yet";
     }
-    if (config.getDatanodes() == 0) {
-      return true;
+    if (!om.isLeaderReady()) {
+      return "OM is not leader-ready yet";
     }
-    // The cluster is usable once every datanode has registered with SCM and
-    // SCM has left safe mode.
-    return scm.getScmNodeManager().getAllNodes().size() >= config.getDatanodes()
-        && !scm.isInSafeMode();
+    int registered = scm.getScmNodeManager().getAllNodes().size();
+    if (registered < config.getDatanodes()) {
+      return "only " + registered + " of " + config.getDatanodes()
+          + " datanodes have registered with SCM";
+    }
+    // Safe mode is checked even for a zero-datanode cluster: configureLocalDefaults() still
+    // requires one datanode there, so skipping the check would report a cluster that can never
+    // serve requests as ready.
+    if (scm.isInSafeMode()) {
+      return "SCM is still in safe mode (" + unmetSafeModeRules() + ")";
+    }
+    return null;
+  }
+
+  private String unmetSafeModeRules() {
+    return scm.getScmSafeModeManager().getRuleStatus().entrySet().stream()
+        .filter(rule -> !rule.getValue().getLeft())
+        .map(rule -> rule.getKey() + ": " + rule.getValue().getRight())
+        .collect(Collectors.joining("; "));
   }
 
   private void enableSameJvmMetricsMode() {
@@ -684,6 +755,21 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     }
   }
 
+  /**
+   * Rejects a datanode count this host cannot serve. Called before {@link #prepareStorageLayout()}
+   * because format mode ALWAYS deletes the data dir: validating afterwards would destroy local
+   * state for a run that cannot start anyway.
+   */
+  private void requireSupportedDatanodeCount() throws IOException {
+    int datanodeCount = config.getDatanodes();
+    if (datanodeCount > MAX_DATANODES) {
+      throw new IOException("Datanode count " + datanodeCount
+          + " exceeds the local maximum of " + MAX_DATANODES
+          + "; each datanode reserves " + DATANODE_PORT_KEY_SUFFIXES.length
+          + " local ports.");
+    }
+  }
+
   private void prepareStorageLayout() throws IOException {
     Path dataDir = config.getDataDir();
     if (Files.exists(dataDir) && !Files.isDirectory(dataDir)) {
@@ -693,6 +779,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
     switch (config.getFormatMode()) {
     case ALWAYS:
+      LOG.info("Removing local Ozone data dir {} (format mode ALWAYS).", dataDir);
       deleteDirectory(dataDir);
       createBaseLayout();
       break;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneCluster.java
@@ -92,10 +92,14 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.TimeDurationUtil;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -153,6 +157,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private static final int LOCAL_RATIS_RPC_TIMEOUT_SECONDS = 1;
   private static final long SCM_CLIENT_MAX_RETRY_TIMEOUT_MILLIS = 30_000;
   private static final long READINESS_POLL_INTERVAL_MILLIS = 500;
+  private static final long READINESS_LOG_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(5);
 
   private static final int MAX_PORT = 65_535;
 
@@ -185,6 +190,11 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   // Every datanode runs in this JVM and reserves DATANODE_PORT_KEY_SUFFIXES.length
   // local ports, so an unbounded count would exhaust local ports; cap it.
   static final int MAX_DATANODES = 20;
+
+  private static final Set<String> SHIPPED_DEFAULT_RESOURCES = Collections.unmodifiableSet(
+      OzoneConfiguration.getConfigurationResourceFiles().stream()
+          .filter(resource -> resource.endsWith("-default.xml"))
+          .collect(Collectors.toSet()));
 
   private static final String[] NO_ARGS = new String[0];
 
@@ -239,8 +249,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       return preparedConfiguration;
     }
 
-    prepareStorageLayout();
-
+    // Every rejection of user input, validateStorageLayout() and the port checks included, runs before
+    // prepareStorageLayout(), which deletes the data dir in format mode ALWAYS.
+    requireSupportedDatanodeCount();
+    validateStorageLayout();
     OzoneConfiguration conf = new OzoneConfiguration(seedConfiguration);
     configureLocalDefaults(conf);
 
@@ -251,6 +263,8 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     List<OzoneConfiguration> datanodeConfigurations =
         configureDatanodes(conf, persistedPorts, portAllocator);
 
+    prepareStorageLayout();
+    createServiceDirectories();
     persistedPorts.store();
     preparedConfiguration = new PreparedConfiguration(conf, scmPort, omPort,
         datanodeConfigurations);
@@ -314,8 +328,9 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
   private void stopServices() {
     try {
-      // Shutdown is best-effort so one failed service cannot leak the others.
-      IOUtils.closeQuietly(this::stopDatanodes, this::stopOm, this::stopScm);
+      // Logged rather than closeQuietly: stopServices() is also the start() rollback, where a silent
+      // failure hides leaked threads and ports.
+      IOUtils.close(LOG, this::stopDatanodes, this::stopOm, this::stopScm);
     } finally {
       restoreSameJvmMetricsMode();
     }
@@ -331,7 +346,7 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
       });
     }
     datanodes.clear();
-    IOUtils.closeQuietly(stoppers);
+    IOUtils.close(LOG, stoppers);
   }
 
   private void stopOm() {
@@ -351,34 +366,154 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     }
   }
 
-  private void configureLocalDefaults(OzoneConfiguration conf) {
+  private void configureLocalDefaults(OzoneConfiguration conf) throws IOException {
     conf.set(OZONE_METADATA_DIRS, metadataDir().toString());
     // SCM and OM share one configuration and JVM, so the Jetty base dir is a
     // single service-neutral location; Jetty keeps per-context temp dirs.
     conf.setIfUnset(OZONE_HTTP_BASEDIR, metadataDir() + SERVER_DIR);
-    conf.set(OZONE_REPLICATION, ReplicationFactor.ONE.name());
-    conf.set(OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE.name());
-    conf.set(OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
+    setLocalOverrideReplication(conf, OZONE_REPLICATION, ReplicationFactor.ONE);
+    setLocalOverride(conf, OZONE_REPLICATION_TYPE, ReplicationType.STAND_ALONE.name());
+    setLocalOverrideReplication(conf, OZONE_SERVER_DEFAULT_REPLICATION_KEY, ReplicationFactor.ONE);
+    setLocalOverride(conf, OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
         ReplicationType.STAND_ALONE.name());
-    conf.setBoolean(HDDS_CONTAINER_RATIS_ENABLED_KEY, false);
+    setLocalOverride(conf, HDDS_CONTAINER_RATIS_ENABLED_KEY, false);
     // A single-node local cluster can heartbeat aggressively; this speeds
-    // datanode registration and safe-mode exit. Use set(), not setIfUnset():
-    // ozone-default.xml supplies the 30s default that would otherwise defeat
-    // the override.
-    conf.set(HDDS_HEARTBEAT_INTERVAL, "1s");
-    conf.setBoolean(HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
-    conf.setInt(HDDS_SCM_SAFEMODE_MIN_DATANODE,
-        Math.max(1, config.getDatanodes()));
-    conf.setTimeDuration(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
-        LOCAL_RATIS_RPC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    conf.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
+    // datanode registration and safe-mode exit.
+    setLocalOverrideDuration(conf, HDDS_HEARTBEAT_INTERVAL, "1s");
+    setLocalOverride(conf, HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
+    setLocalOverride(conf, HDDS_SCM_SAFEMODE_MIN_DATANODE, config.getDatanodes());
+    setLocalOverrideDuration(conf, OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+        LOCAL_RATIS_RPC_TIMEOUT_SECONDS + "s");
+    setLocalOverrideDuration(conf, HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3s");
     conf.setIfUnset(OZONE_SCM_HA_RATIS_SERVER_RPC_FIRST_ELECTION_TIMEOUT,
         "1s");
 
     SCMClientConfig scmClientConfig = conf.getObject(SCMClientConfig.class);
     scmClientConfig.setMaxRetryTimeout(SCM_CLIENT_MAX_RETRY_TIMEOUT_MILLIS);
     conf.setFromObject(scmClientConfig);
+  }
+
+  /**
+   * Sets a value the local runtime requires and rejects a user-configured conflict. Set rather than
+   * {@code setIfUnset}: ozone-default.xml would otherwise win. The typed overloads compare through the
+   * accessor the services read the key with, so an equivalent spelling is not a conflict.
+   */
+  private void setLocalOverride(OzoneConfiguration conf, String key, String value)
+      throws IOException {
+    // Configuration#unset() keeps the key's source, so a null value is unconfigured, not a conflict.
+    // Trimmed because Hadoop keeps XML whitespace and the value is rewritten below anyway.
+    String configured = conf.get(key);
+    if (configured != null && !value.equals(configured.trim())) {
+      rejectUserConfigured(conf, key, value);
+    }
+    conf.set(key, value);
+  }
+
+  private void setLocalOverride(OzoneConfiguration conf, String key, boolean value)
+      throws IOException {
+    // The default is the negation so a value getBoolean() cannot parse counts as a conflict.
+    String configured = conf.get(key);
+    if (configured != null && conf.getBoolean(key, !value) != value) {
+      rejectUserConfigured(conf, key, String.valueOf(value));
+    }
+    conf.setBoolean(key, value);
+  }
+
+  private void setLocalOverride(OzoneConfiguration conf, String key, int value)
+      throws IOException {
+    String configured = conf.get(key);
+    if (configured != null && !matchesInt(conf, key, value)) {
+      rejectUserConfigured(conf, key, String.valueOf(value));
+    }
+    conf.setInt(key, value);
+  }
+
+  private void setLocalOverrideDuration(OzoneConfiguration conf, String key, String value)
+      throws IOException {
+    long requiredMillis = TimeDurationUtil.getTimeDurationHelper(key, value, TimeUnit.MILLISECONDS);
+    String configured = conf.get(key);
+    if (configured != null && !matchesDuration(conf, key, configured, requiredMillis)) {
+      rejectUserConfigured(conf, key, value);
+    }
+    conf.set(key, value);
+  }
+
+  private void setLocalOverrideReplication(OzoneConfiguration conf, String key,
+      ReplicationFactor value) throws IOException {
+    String configured = conf.get(key);
+    if (configured != null && parseReplicationFactor(configured) != value) {
+      rejectUserConfigured(conf, key, value.name());
+    }
+    conf.set(key, value.name());
+  }
+
+  private static void rejectUserConfigured(OzoneConfiguration conf, String key, String required)
+      throws IOException {
+    String source = userConfiguredSource(conf, key);
+    if (source == null) {
+      return;
+    }
+    throw new IOException("ozone local requires " + key + "=" + required
+        + ", but it is set to " + conf.get(key) + " (source: " + source
+        + "). Remove or change that setting.");
+  }
+
+  private static boolean matchesInt(OzoneConfiguration conf, String key, int value) {
+    try {
+      return conf.getInt(key, value) == value;
+    } catch (NumberFormatException unreadable) {
+      return false;
+    }
+  }
+
+  private static boolean matchesDuration(OzoneConfiguration conf, String key, String configured,
+      long requiredMillis) {
+    if (lacksTimeUnit(configured)) {
+      return false;
+    }
+    try {
+      return conf.getTimeDuration(key, requiredMillis, TimeUnit.MILLISECONDS) == requiredMillis;
+    } catch (NumberFormatException unreadable) {
+      return false;
+    }
+  }
+
+  /**
+   * {@link TimeDurationUtil#getDuration} reads a bare number in the caller's unit with only a warning,
+   * so "120" would mean 120 milliseconds. Every unit suffix it accepts ends in a letter.
+   */
+  static boolean lacksTimeUnit(String value) {
+    String trimmed = value.trim();
+    return !trimmed.isEmpty() && Character.isDigit(trimmed.charAt(trimmed.length() - 1));
+  }
+
+  /** Accepts both spellings {@link org.apache.hadoop.hdds.client.ReplicationConfig#parse} does, "1" and "ONE". */
+  private static ReplicationFactor parseReplicationFactor(String value) {
+    String trimmed = value.trim();
+    try {
+      return ReplicationFactor.valueOf(Integer.parseInt(trimmed));
+    } catch (IllegalArgumentException notNumeric) {
+      try {
+        return ReplicationFactor.valueOf(trimmed);
+      } catch (IllegalArgumentException notNamed) {
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Source of the value the user chose for {@code key}, or null when its last source is a shipped
+   * {@code *-default.xml} classpath resource. The comparison is exact: Configuration records a classpath
+   * resource by its bare name, and {@link OzoneLocal#setConfigurationPath} absolutizes a {@code --conf}
+   * path so a file with the same name stays a user choice.
+   */
+  private static String userConfiguredSource(OzoneConfiguration conf, String key) {
+    String[] sources = conf.getPropertySources(key);
+    if (sources == null || sources.length == 0) {
+      return null;
+    }
+    String source = sources[sources.length - 1];
+    return SHIPPED_DEFAULT_RESOURCES.contains(source) ? null : source;
   }
 
   private int configureScm(OzoneConfiguration conf,
@@ -427,10 +562,9 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     return scmClientPort;
   }
 
-  private void configureScmStorage(OzoneConfiguration conf) throws IOException {
+  private void configureScmStorage(OzoneConfiguration conf) {
     Path scmDir = config.getDataDir().resolve(SCM_DIR_NAME);
     Path scmMetadataDir = scmDir.resolve(OZONE_METADATA_DIR_NAME);
-    Files.createDirectories(scmDir.resolve(DATA_DIR_NAME));
 
     conf.setIfUnset(OZONE_SCM_DB_DIRS,
         scmDir.resolve(DATA_DIR_NAME).toString());
@@ -463,10 +597,9 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     return omRpcPort;
   }
 
-  private void configureOmStorage(OzoneConfiguration conf) throws IOException {
+  private void configureOmStorage(OzoneConfiguration conf) {
     Path omDir = config.getDataDir().resolve(OM_DIR_NAME);
     Path omMetadataDir = omDir.resolve(OZONE_METADATA_DIR_NAME);
-    Files.createDirectories(omDir.resolve(DATA_DIR_NAME));
 
     conf.setIfUnset(OZONE_OM_DB_DIRS, omDir.resolve(DATA_DIR_NAME).toString());
     conf.setIfUnset(OZONE_OM_RATIS_STORAGE_DIR,
@@ -480,13 +613,6 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   private List<OzoneConfiguration> configureDatanodes(OzoneConfiguration conf,
       PersistedPortState persistedPorts, PortAllocator portAllocator)
       throws IOException {
-    int datanodeCount = config.getDatanodes();
-    if (datanodeCount > MAX_DATANODES) {
-      throw new IOException("Datanode count " + datanodeCount
-          + " exceeds the local maximum of " + MAX_DATANODES
-          + "; each datanode reserves " + DATANODE_PORT_KEY_SUFFIXES.length
-          + " local ports.");
-    }
     List<OzoneConfiguration> datanodeConfigurations =
         new ArrayList<>(config.getDatanodes());
     for (int index = 0; index < config.getDatanodes(); index++) {
@@ -534,13 +660,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     return dnConf;
   }
 
-  private void configureDatanodeStorage(OzoneConfiguration dnConf, int index)
-      throws IOException {
+  private void configureDatanodeStorage(OzoneConfiguration dnConf, int index) {
     Path datanodeDir = config.getDataDir()
         .resolve(DATANODE_DIR_PREFIX + index);
     Path datanodeMetadataDir = datanodeDir.resolve(OZONE_METADATA_DIR_NAME);
-    Files.createDirectories(datanodeMetadataDir);
-    Files.createDirectories(datanodeDir.resolve(DATA_DIR_NAME));
 
     dnConf.set(OZONE_METADATA_DIRS, datanodeMetadataDir.toString());
     // Each datanode gets its own Jetty base dir so same-JVM HTTP servers do
@@ -643,30 +766,66 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   private void waitForClusterReadiness(Duration timeout) throws Exception {
-    long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    waitForReadiness(this::clusterReadinessBlocker, "Ozone cluster", timeout);
+  }
+
+  /** {@code blocker} returns why {@code subject} is not ready yet, or null once it is. */
+  static void waitForReadiness(Supplier<String> blocker, String subject, Duration timeout)
+      throws InterruptedException, TimeoutException {
+    long startNanos = System.nanoTime();
+    long nextLogNanos = startNanos + READINESS_LOG_INTERVAL_NANOS;
     while (true) {
-      if (isClusterReady()) {
+      String reason = blocker.get();
+      if (reason == null) {
         return;
       }
-      if (System.nanoTime() >= deadlineNanos) {
-        throw new TimeoutException("Timed out waiting " + timeout
-            + " for the local Ozone cluster to become ready.");
+      long now = System.nanoTime();
+      // Compared as a Duration because timeout.toNanos() overflows for very long timeouts.
+      if (Duration.ofNanos(now - startNanos).compareTo(timeout) >= 0) {
+        throw new TimeoutException("Timed out waiting " + timeout + " for the local " + subject
+            + " to become ready: " + reason + ".");
+      }
+      if (now >= nextLogNanos) {
+        LOG.info("Waiting for the local {} to become ready: {}.", subject, reason);
+        nextLogNanos = now + READINESS_LOG_INTERVAL_NANOS;
       }
       Thread.sleep(READINESS_POLL_INTERVAL_MILLIS);
     }
   }
 
-  private boolean isClusterReady() {
-    if (!scm.checkLeader() || !om.isLeaderReady()) {
-      return false;
+  private String clusterReadinessBlocker() {
+    if (!scm.checkLeader()) {
+      return "SCM has no Ratis leader yet";
     }
-    if (config.getDatanodes() == 0) {
-      return true;
+    if (!om.isLeaderReady()) {
+      return "OM is not leader-ready yet";
     }
-    // The cluster is usable once every datanode has registered with SCM and
-    // SCM has left safe mode.
-    return scm.getScmNodeManager().getAllNodes().size() >= config.getDatanodes()
-        && !scm.isInSafeMode();
+    int registered = scm.getScmNodeManager().getAllNodeCount();
+    if (registered < config.getDatanodes()) {
+      return "only " + registered + " of " + config.getDatanodes()
+          + " datanodes have registered with SCM";
+    }
+    // SCM refuses block allocation until it leaves safe mode (BlockManagerImpl#allocateBlock).
+    if (scm.isInSafeMode()) {
+      return "SCM is still in safe mode ("
+          + formatSafeModeRuleBlocker(scm.getRuleStatus()) + ")";
+    }
+    return null;
+  }
+
+  static String formatSafeModeRuleBlocker(List<SafeModeRuleStatusProto> rules) {
+    if (rules.isEmpty()) {
+      return "safe-mode rule status is not available yet";
+    }
+    String unmetRules = joinSafeModeRules(rules.stream().filter(rule -> !rule.getValidate()));
+    return unmetRules.isEmpty()
+        ? "all rules currently report satisfied: " + joinSafeModeRules(rules.stream())
+        : unmetRules;
+  }
+
+  private static String joinSafeModeRules(Stream<SafeModeRuleStatusProto> rules) {
+    return rules.map(rule -> rule.getRuleName() + ": " + rule.getStatusText())
+        .collect(Collectors.joining("; "));
   }
 
   private void enableSameJvmMetricsMode() {
@@ -684,20 +843,39 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     }
   }
 
-  private void prepareStorageLayout() throws IOException {
+  private void requireSupportedDatanodeCount() throws IOException {
+    int datanodeCount = config.getDatanodes();
+    if (datanodeCount < 1) {
+      throw new IOException("Datanode count " + datanodeCount + " is below the local minimum of 1.");
+    }
+    if (datanodeCount > MAX_DATANODES) {
+      throw new IOException("Datanode count " + datanodeCount
+          + " exceeds the local maximum of " + MAX_DATANODES
+          + "; each datanode reserves " + DATANODE_PORT_KEY_SUFFIXES.length
+          + " local ports.");
+    }
+  }
+
+  private void validateStorageLayout() throws IOException {
     Path dataDir = config.getDataDir();
     if (Files.exists(dataDir) && !Files.isDirectory(dataDir)) {
       throw new IOException("Local Ozone data dir " + dataDir
           + " is not a directory.");
     }
+    if (config.getFormatMode() == LocalOzoneClusterConfig.FormatMode.NEVER) {
+      requireExistingLayout();
+    }
+  }
 
+  private void prepareStorageLayout() throws IOException {
     switch (config.getFormatMode()) {
     case ALWAYS:
-      deleteDirectory(dataDir);
+      LOG.info("Removing local Ozone data dir {} (format mode ALWAYS).", config.getDataDir());
+      deleteDirectory(config.getDataDir());
       createBaseLayout();
       break;
     case NEVER:
-      requireExistingLayout();
+      // validateStorageLayout() already required the existing layout.
       break;
     case IF_NEEDED:
       createBaseLayout();
@@ -705,6 +883,17 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
     default:
       throw new IOException("Unsupported format mode "
           + config.getFormatMode() + ".");
+    }
+  }
+
+  private void createServiceDirectories() throws IOException {
+    Path dataDir = config.getDataDir();
+    Files.createDirectories(dataDir.resolve(SCM_DIR_NAME).resolve(DATA_DIR_NAME));
+    Files.createDirectories(dataDir.resolve(OM_DIR_NAME).resolve(DATA_DIR_NAME));
+    for (int index = 0; index < config.getDatanodes(); index++) {
+      Path datanodeDir = dataDir.resolve(DATANODE_DIR_PREFIX + index);
+      Files.createDirectories(datanodeDir.resolve(OZONE_METADATA_DIR_NAME));
+      Files.createDirectories(datanodeDir.resolve(DATA_DIR_NAME));
     }
   }
 
@@ -734,6 +923,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
   }
 
   private PersistedPortState loadPersistedPortState() throws IOException {
+    if (config.getFormatMode() == LocalOzoneClusterConfig.FormatMode.ALWAYS) {
+      // Format mode ALWAYS deletes the data dir in prepareStorageLayout(), so the persisted ports would be stale.
+      return PersistedPortState.empty(portStateFile());
+    }
     PersistedPortState persistedPorts =
         PersistedPortState.load(portStateFile());
     if (config.getFormatMode() == LocalOzoneClusterConfig.FormatMode.NEVER) {
@@ -886,6 +1079,10 @@ public final class LocalOzoneCluster implements LocalOzoneRuntime {
 
     private PersistedPortState(Path path) {
       this.path = path;
+    }
+
+    static PersistedPortState empty(Path path) {
+      return new PersistedPortState(path);
     }
 
     static PersistedPortState load(Path path) throws IOException {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/LocalOzoneRuntime.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.local;
 
+import java.util.List;
+
 /**
  * Runtime contract for local Ozone cluster commands.
  */
@@ -70,6 +72,16 @@ public interface LocalOzoneRuntime extends AutoCloseable {
    * @return S3 Gateway endpoint, including scheme, host, and port
    */
   String getS3Endpoint();
+
+  /**
+   * Returns the configuration keys whose user-supplied value the local runtime had to replace.
+   *
+   * <p>Callers report these: {@code ozone local} runs with service logging off, so a warning that
+   * only reaches the log is invisible by default.</p>
+   *
+   * @return overridden keys, empty if the user configured none of them
+   */
+  List<String> getDiscardedUserConfigKeys();
 
   /**
    * Stops the local runtime and releases resources created during startup.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.local;
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.concurrent.Callable;
@@ -109,8 +110,55 @@ public class OzoneLocal extends GenericCli {
     super(factory);
   }
 
+  @Override
+  public void setConfigurationPath(String configPath) {
+    // Configuration records a classpath resource by its bare name and LocalOzoneCluster#userConfiguredSource
+    // compares names exactly, so a scheme-less path is absolutized: ./ozone-default.xml must stay a user
+    // choice. A scheme (file:, hdfs:) cannot collide and java.nio would mangle it into a literal path, so
+    // it passes through. fs.Path does the scheme check because it also rejects an empty value at parse.
+    if (new org.apache.hadoop.fs.Path(configPath).toUri().getScheme() == null) {
+      configPath = Paths.get(configPath).toAbsolutePath().normalize().toString();
+    }
+    super.setConfigurationPath(configPath);
+  }
+
+  @Override
+  public void printError(Throwable error) {
+    if (!(error instanceof StartupFailureException)) {
+      super.printError(error);
+      return;
+    }
+
+    super.printError(error.getCause());
+    String hint = startupFailureHint(LOG.isInfoEnabled(), isVerbose());
+    if (hint != null) {
+      err().println(hint);
+    }
+  }
+
+  static String startupFailureHint(boolean infoEnabled, boolean verbose) {
+    if (infoEnabled && verbose) {
+      return null;
+    }
+    if (!infoEnabled && !verbose) {
+      return "For more detail, re-run with `ozone --loglevel INFO local run` for service logs,"
+          + " or add --verbose for the full stack trace.";
+    }
+    if (!infoEnabled) {
+      return "For service logs, re-run with `ozone --loglevel INFO local run`.";
+    }
+    return "For the full stack trace, add --verbose.";
+  }
+
   public static void main(String[] args) {
     new OzoneLocal().run(args);
+  }
+
+  private static final class StartupFailureException extends Exception {
+
+    private StartupFailureException(Throwable cause) {
+      super(cause);
+    }
   }
 
   @Command(name = "run",
@@ -197,11 +245,20 @@ public class OzoneLocal extends GenericCli {
     public Void call() throws Exception {
       LocalOzoneClusterConfig config = resolveConfig();
       try (LocalOzoneRuntime runtime = createRuntime(config, getOzoneConf())) {
-        runtime.start();
+        start(runtime);
         printSummary(runtime, config);
         awaitShutdown(runtime);
       }
       return null;
+    }
+
+    /** Wraps startup failures so {@link OzoneLocal#printError} can print the cause and then the hint. */
+    private void start(LocalOzoneRuntime runtime) throws Exception {
+      try {
+        runtime.start();
+      } catch (Exception ex) {
+        throw new StartupFailureException(ex);
+      }
     }
 
     LocalOzoneRuntime createRuntime(LocalOzoneClusterConfig config, OzoneConfiguration seedConfiguration) {
@@ -293,8 +350,9 @@ public class OzoneLocal extends GenericCli {
         try {
           return LocalOzoneClusterConfig.FormatMode.fromString(value);
         } catch (IllegalArgumentException ex) {
-          throw new CommandLine.TypeConversionException(
-              "Expected one of: if-needed, always, never.");
+          // picocli's wrapper names the option but not the value, which may come from OZONE_LOCAL_FORMAT.
+          throw new CommandLine.TypeConversionException("Invalid format mode '" + value
+              + "'. Expected one of: if-needed, always, never.");
         }
       }
     }
@@ -304,19 +362,25 @@ public class OzoneLocal extends GenericCli {
 
       @Override
       public Duration convert(String value) {
+        String trimmed = value.trim();
         try {
-          return Duration.parse(value.trim());
+          return Duration.parse(trimmed);
         } catch (DateTimeParseException ignored) {
-          return parseHadoopStyleDuration(value);
+          return parseHadoopStyleDuration(trimmed);
         }
       }
 
       private static Duration parseHadoopStyleDuration(String value) {
+        if (LocalOzoneCluster.lacksTimeUnit(value)) {
+          throw new CommandLine.TypeConversionException("Missing time unit in '" + value
+              + "'. " + durationMessage());
+        }
         try {
           return TimeDurationUtil.getDuration("--startup-timeout", value,
               TimeUnit.MILLISECONDS);
         } catch (RuntimeException ex) {
-          throw new CommandLine.TypeConversionException(durationMessage());
+          throw new CommandLine.TypeConversionException("Invalid duration '" + value
+              + "'. " + durationMessage());
         }
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/local/OzoneLocal.java
@@ -17,10 +17,12 @@
 
 package org.apache.hadoop.ozone.local;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -197,11 +199,56 @@ public class OzoneLocal extends GenericCli {
     public Void call() throws Exception {
       LocalOzoneClusterConfig config = resolveConfig();
       try (LocalOzoneRuntime runtime = createRuntime(config, getOzoneConf())) {
-        runtime.start();
+        start(runtime);
         printSummary(runtime, config);
         awaitShutdown(runtime);
       }
       return null;
+    }
+
+    /**
+     * Starts {@code runtime}, restating a failure in a form the user can act on. Service logs are
+     * off by default for this command, so the detail goes to the log for {@code --loglevel INFO}
+     * while the message keeps {@link GenericCli}'s single-line path: an exception with no message
+     * would otherwise print a raw stack trace.
+     */
+    private void start(LocalOzoneRuntime runtime) throws Exception {
+      try {
+        runtime.start();
+      } catch (Exception ex) {
+        LOG.error("Local Ozone cluster failed to start.", ex);
+        throw new IOException("Local Ozone failed to start: " + failureMessage(ex)
+            + " Re-run with `ozone --loglevel INFO local run` for service logs,"
+            + " or add --verbose for the full stack trace.", ex);
+      } finally {
+        reportDiscardedConfig(runtime);
+      }
+    }
+
+    /**
+     * Reports configuration the local runtime had to replace. The runtime also logs each
+     * replacement, but service logging is off by default for this command, so the keys are
+     * repeated here where the user will actually see them. Reported even when startup fails:
+     * a discarded override can be the very setting the user is debugging.
+     */
+    private void reportDiscardedConfig(LocalOzoneRuntime runtime) {
+      List<String> discarded = runtime.getDiscardedUserConfigKeys();
+      if (!discarded.isEmpty()) {
+        err().println("Ignoring configured " + String.join(", ", discarded)
+            + ": ozone local requires its own values for these."
+            + " Re-run with `ozone --loglevel INFO local run` to see them.");
+      }
+    }
+
+    /** Returns the nearest message in {@code error}'s cause chain, since the outermost may be null. */
+    private static String failureMessage(Throwable error) {
+      for (Throwable cause = error; cause != null; cause = cause.getCause()) {
+        String message = cause.getMessage();
+        if (message != null && !message.isEmpty()) {
+          return message.endsWith(".") ? message : message + ".";
+        }
+      }
+      return error.getClass().getSimpleName() + ".";
     }
 
     LocalOzoneRuntime createRuntime(LocalOzoneClusterConfig config, OzoneConfiguration seedConfiguration) {
@@ -213,6 +260,7 @@ public class OzoneLocal extends GenericCli {
       writer.println("Local Ozone is running from " + config.getDataDir());
       writer.println("SCM RPC: " + runtime.getDisplayHost() + ":" + runtime.getScmPort());
       writer.println("OM RPC: " + runtime.getDisplayHost() + ":" + runtime.getOmPort());
+      writer.println("Datanodes: " + config.getDatanodes());
       writer.println("Press Ctrl+C to stop.");
       writer.flush();
     }
@@ -293,8 +341,11 @@ public class OzoneLocal extends GenericCli {
         try {
           return LocalOzoneClusterConfig.FormatMode.fromString(value);
         } catch (IllegalArgumentException ex) {
-          throw new CommandLine.TypeConversionException(
-              "Expected one of: if-needed, always, never.");
+          // The value can come from OZONE_LOCAL_FORMAT, so name it: the user may not realize the
+          // environment supplied it. picocli's conversion-error line names the option but not the
+          // value, so the message has to carry it.
+          throw new CommandLine.TypeConversionException("Invalid format mode '" + value
+              + "'. Expected one of: if-needed, always, never.");
         }
       }
     }
@@ -304,19 +355,29 @@ public class OzoneLocal extends GenericCli {
 
       @Override
       public Duration convert(String value) {
+        String trimmed = value.trim();
         try {
-          return Duration.parse(value.trim());
+          return Duration.parse(trimmed);
         } catch (DateTimeParseException ignored) {
-          return parseHadoopStyleDuration(value);
+          return parseHadoopStyleDuration(trimmed);
         }
       }
 
       private static Duration parseHadoopStyleDuration(String value) {
+        // TimeDurationUtil.getDuration() only warns about a missing unit and then assumes the one
+        // it is given, which would read "120" as 120 milliseconds. Reject it instead of silently
+        // interpreting the value a thousand times smaller than the user meant. Every unit suffix
+        // TimeDurationUtil accepts ends in a letter, so a trailing digit means the unit is missing.
+        if (!value.isEmpty() && Character.isDigit(value.charAt(value.length() - 1))) {
+          throw new CommandLine.TypeConversionException("Missing time unit in '" + value
+              + "'. " + durationMessage());
+        }
         try {
           return TimeDurationUtil.getDuration("--startup-timeout", value,
               TimeUnit.MILLISECONDS);
         } catch (RuntimeException ex) {
-          throw new CommandLine.TypeConversionException(durationMessage());
+          throw new CommandLine.TypeConversionException("Invalid duration '" + value
+              + "'. " + durationMessage());
         }
       }
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -18,8 +18,10 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
@@ -29,6 +31,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,10 +45,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -350,6 +359,255 @@ class TestLocalOzoneCluster {
   }
 
   @Test
+  void zeroDatanodesIsRejected() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setDatanodes(0)
+        .build();
+
+    IOException error = assertPrepareFails(config);
+
+    assertMessageContains(error, "Datanode count 0");
+  }
+
+  /** Configuration#unset() keeps the source, so the key must read as unconfigured, not as a conflict. */
+  @Test
+  void keyUnsetAfterBeingConfiguredIsNotRejected() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "test-ozone-site.xml");
+    seed.unset(OZONE_REPLICATION);
+
+    assertEquals(ReplicationFactor.ONE.name(), prepared(seed).get(OZONE_REPLICATION));
+  }
+
+  @Test
+  void configuredMetadataDirIsReplacedByTheLocalDataDir() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_METADATA_DIRS, "/real/cluster/metadata", "test-ozone-site.xml");
+
+    assertEquals(metadataDir(tempDir.resolve("local-ozone")).toString(),
+        prepared(seed).get(OZONE_METADATA_DIRS));
+  }
+
+  @Test
+  void defaultsFileNamedByPathCountsAsUserConfig() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "/home/me/ozone-default.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, OZONE_REPLICATION);
+  }
+
+  @Test
+  void tooManyDatanodesIsRejectedBeforeFormatDeletesDataDir() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    Path marker = writeMarker(dataDir, "keep me");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.ALWAYS)
+        .setDatanodes(LocalOzoneCluster.MAX_DATANODES + 1)
+        .build();
+
+    assertPrepareFails(config);
+
+    assertTrue(Files.exists(marker),
+        "format ALWAYS must not delete the data dir for a run that cannot start");
+  }
+
+  @Test
+  void conflictingUserConfigIsRejected() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "test-ozone-site.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, OZONE_REPLICATION);
+    assertMessageContains(error, ReplicationFactor.ONE.name());
+    assertMessageContains(error, ReplicationFactor.THREE.name());
+    assertMessageContains(error, "test-ozone-site.xml");
+  }
+
+  @Test
+  void userConfigMatchingTheLocalRequirementIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.ONE.name(), "test-ozone-site.xml");
+
+    assertEquals(ReplicationFactor.ONE.name(), prepared(seed).get(OZONE_REPLICATION));
+  }
+
+  @Test
+  void conflictingUserConfigIsRejectedBeforeFormatDeletesDataDir() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    Path marker = writeMarker(dataDir, "keep me");
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "test-ozone-site.xml");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.ALWAYS)
+        .build();
+
+    assertPrepareFails(config, seed);
+
+    assertTrue(Files.exists(marker),
+        "format ALWAYS must not delete the data dir for a run that cannot start");
+  }
+
+  @Test
+  void duplicateConfiguredPortsAreRejectedBeforeFormatDeletesDataDir() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    Path marker = writeMarker(dataDir, "keep me");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.ALWAYS)
+        .setScmPort(9860)
+        .setOmPort(9860)
+        .build();
+
+    IOException error = assertPrepareFails(config);
+
+    assertMessageContains(error, "more than once");
+    assertTrue(Files.exists(marker),
+        "format ALWAYS must not delete the data dir for a run that cannot start");
+  }
+
+  /** Hadoop keeps XML whitespace, so padding around the required value is not a conflict. */
+  @Test
+  void paddedValueMatchingTheLocalRequirementIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION_TYPE, "\n  STAND_ALONE\n", "test-ozone-site.xml");
+
+    assertEquals(ReplicationType.STAND_ALONE.name(), prepared(seed).get(OZONE_REPLICATION_TYPE));
+  }
+
+  /** Duration#toNanos throws ArithmeticException for this timeout, so the wait must not call it. */
+  @Test
+  void readinessAcceptsTimeoutBeyondNanoTimeRange() throws Exception {
+    LocalOzoneCluster.waitForReadiness(() -> null, "Ozone cluster",
+        Duration.ofDays(999_999_999L));
+  }
+
+  @Test
+  void equivalentDurationSpellingIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(HDDS_HEARTBEAT_INTERVAL, "1000ms", "test-ozone-site.xml");
+    seed.set(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY, "1000ms", "test-ozone-site.xml");
+    seed.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3000ms", "test-ozone-site.xml");
+
+    OzoneConfiguration conf = prepared(seed);
+
+    assertEquals("1s", conf.get(HDDS_HEARTBEAT_INTERVAL));
+    assertEquals("1s", conf.get(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY));
+    assertEquals("3s", conf.get(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT));
+  }
+
+  @Test
+  void unitlessConfigurationDurationsAreRejected() {
+    assertUnitlessDurationRejected(HDDS_HEARTBEAT_INTERVAL, "1000");
+    assertUnitlessDurationRejected(OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY, "1");
+    assertUnitlessDurationRejected(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "3000");
+  }
+
+  @Test
+  void equivalentBooleanSpellingIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(HDDS_CONTAINER_RATIS_ENABLED_KEY, "FALSE", "test-ozone-site.xml");
+
+    assertFalse(prepared(seed).getBoolean(HDDS_CONTAINER_RATIS_ENABLED_KEY, true));
+  }
+
+  @Test
+  void numericReplicationIsAccepted() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_SERVER_DEFAULT_REPLICATION_KEY, "1", "test-ozone-site.xml");
+
+    assertEquals(ReplicationFactor.ONE.name(),
+        prepared(seed).get(OZONE_SERVER_DEFAULT_REPLICATION_KEY));
+  }
+
+  @Test
+  void conflictingDurationIsRejected() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(HDDS_HEARTBEAT_INTERVAL, "30s", "test-ozone-site.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, HDDS_HEARTBEAT_INTERVAL);
+    assertMessageContains(error, "30s");
+  }
+
+  @Test
+  void unparseableValueIsRejected() {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(HDDS_HEARTBEAT_INTERVAL, "banana", "test-ozone-site.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, HDDS_HEARTBEAT_INTERVAL);
+    assertMessageContains(error, "banana");
+  }
+
+  /**
+   * Regression guard: ozone-default.xml ships hdds.heartbeat.interval=30s, so a shipped default read as a
+   * user choice would reject every run.
+   */
+  @Test
+  void shippedDefaultIsNotTreatedAsUserConfig() throws Exception {
+    assertEquals("1s", prepared(new OzoneConfiguration()).get(HDDS_HEARTBEAT_INTERVAL));
+    assertNotEquals("1s", new OzoneConfiguration().get(HDDS_HEARTBEAT_INTERVAL),
+        "the shipped default must differ from the local value, or this guards nothing");
+  }
+
+  @Test
+  void generatedShippedDefaultIsNotTreatedAsUserConfig() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name(), "hdds-server-scm-default.xml");
+
+    assertEquals(ReplicationFactor.ONE.name(), prepared(seed).get(OZONE_REPLICATION));
+  }
+
+  @Test
+  void safeModeRuleBlockerListsOnlyUnmetRules() {
+    String blocker = LocalOzoneCluster.formatSafeModeRuleBlocker(Arrays.asList(
+        safeModeRule("registered datanodes", true, "registered"),
+        safeModeRule("healthy containers", false, "1 of 3 reported")));
+
+    assertEquals("healthy containers: 1 of 3 reported", blocker);
+  }
+
+  @Test
+  void safeModeRuleBlockerFallsBackToSatisfiedRuleStatuses() {
+    String blocker = LocalOzoneCluster.formatSafeModeRuleBlocker(Collections.singletonList(
+        safeModeRule("registered datanodes", true, "registered")));
+
+    assertEquals("all rules currently report satisfied: registered datanodes: registered", blocker);
+  }
+
+  @Test
+  void safeModeRuleBlockerExplainsUnavailableRuleStatus() {
+    assertEquals("safe-mode rule status is not available yet",
+        LocalOzoneCluster.formatSafeModeRuleBlocker(Collections.emptyList()));
+  }
+
+  @Test
+  void readinessTimeoutNamesTheUnmetCondition() {
+    TimeoutException error = assertThrows(TimeoutException.class,
+        () -> LocalOzoneCluster.waitForReadiness(() -> "only 1 of 3 datanodes have registered",
+            "Ozone cluster", Duration.ZERO));
+
+    assertMessageContains(error, "only 1 of 3 datanodes have registered");
+    assertMessageContains(error, "Ozone cluster");
+  }
+
+  @Test
+  void readinessReturnsOnceBlockerReportsReady() throws Exception {
+    AtomicInteger attempts = new AtomicInteger();
+
+    LocalOzoneCluster.waitForReadiness(
+        () -> attempts.incrementAndGet() < 2 ? "not yet" : null, "Ozone cluster",
+        Duration.ofSeconds(30));
+
+    assertEquals(2, attempts.get());
+  }
+
+  @Test
   void persistedPortFileContainsDatanodePorts() throws Exception {
     Path dataDir = tempDir.resolve("local-ozone");
     LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
@@ -425,15 +683,46 @@ class TestLocalOzoneCluster {
     return new LocalOzoneCluster(config, new OzoneConfiguration());
   }
 
+  private OzoneConfiguration prepared(OzoneConfiguration seed) throws IOException {
+    LocalOzoneClusterConfig config = defaultConfig();
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+      return cluster.prepareConfiguration().getConfiguration();
+    }
+  }
+
+  private LocalOzoneClusterConfig defaultConfig() {
+    return LocalOzoneClusterConfig.builder(tempDir.resolve("local-ozone")).build();
+  }
+
   private IOException assertPrepareFails(LocalOzoneClusterConfig config) {
+    return assertPrepareFails(config, new OzoneConfiguration());
+  }
+
+  private IOException assertPrepareFails(OzoneConfiguration seed) {
+    return assertPrepareFails(defaultConfig(), seed);
+  }
+
+  private IOException assertPrepareFails(LocalOzoneClusterConfig config,
+      OzoneConfiguration seed) {
     return assertThrows(IOException.class, () -> {
-      try (LocalOzoneCluster cluster = newCluster(config)) {
+      try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
         cluster.prepareConfiguration();
       }
     });
   }
 
-  private void assertMessageContains(IOException error, String expectedText) {
+  private void assertUnitlessDurationRejected(String key, String value) {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(key, value, "test-ozone-site.xml");
+
+    IOException error = assertPrepareFails(seed);
+
+    assertMessageContains(error, key);
+    assertMessageContains(error, value);
+    assertMessageContains(error, "test-ozone-site.xml");
+  }
+
+  private void assertMessageContains(Exception error, String expectedText) {
     assertTrue(error.getMessage().contains(expectedText), error.getMessage());
   }
 
@@ -454,6 +743,14 @@ class TestLocalOzoneCluster {
 
   private void assertPositivePort(Properties properties, String key) {
     assertTrue(Integer.parseInt(properties.getProperty(key)) > 0, key);
+  }
+
+  private static SafeModeRuleStatusProto safeModeRule(String name, boolean validated, String status) {
+    return SafeModeRuleStatusProto.newBuilder()
+        .setRuleName(name)
+        .setValidate(validated)
+        .setStatusText(status)
+        .build();
   }
 
   private Path metadataDir(Path dataDir) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestLocalOzoneCluster.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_CONTAINER_RATIS_ENABLED_KEY;
@@ -42,10 +43,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -143,6 +148,27 @@ class TestLocalOzoneCluster {
       assertSame(first, second);
       assertEquals(first.getScmPort(), second.getScmPort());
       assertEquals(first.getOmPort(), second.getOmPort());
+    }
+  }
+
+  @Test
+  void retryAfterFailedPrepareDoesNotRepeatDiscardedKeys() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name());
+    // Duplicate ports fail in configureOm(), after configureLocalDefaults() has recorded the
+    // override, so the second attempt re-runs the recording.
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+            tempDir.resolve("local-ozone"))
+        .setScmPort(9860)
+        .setOmPort(9860)
+        .build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+      assertThrows(IOException.class, cluster::prepareConfiguration);
+      assertThrows(IOException.class, cluster::prepareConfiguration);
+
+      assertEquals(singletonList(OZONE_REPLICATION),
+          cluster.getDiscardedUserConfigKeys());
     }
   }
 
@@ -347,6 +373,79 @@ class TestLocalOzoneCluster {
     assertEquals("Datanode count " + (LocalOzoneCluster.MAX_DATANODES + 1)
         + " exceeds the local maximum of " + LocalOzoneCluster.MAX_DATANODES
         + "; each datanode reserves 8 local ports.", error.getMessage());
+  }
+
+  @Test
+  void tooManyDatanodesIsRejectedBeforeFormatDeletesDataDir() throws Exception {
+    Path dataDir = tempDir.resolve("local-ozone");
+    Path marker = writeMarker(dataDir, "keep me");
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(dataDir)
+        .setFormatMode(LocalOzoneClusterConfig.FormatMode.ALWAYS)
+        .setDatanodes(LocalOzoneCluster.MAX_DATANODES + 1)
+        .build();
+
+    assertPrepareFails(config);
+
+    assertTrue(Files.exists(marker),
+        "format ALWAYS must not delete the data dir for a run that cannot start");
+  }
+
+  @Test
+  void forcedLocalDefaultWarnsAboutDiscardedUserValue() throws Exception {
+    OzoneConfiguration seed = new OzoneConfiguration();
+    seed.set(OZONE_REPLICATION, ReplicationFactor.THREE.name());
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    LogCapturer logs = LogCapturer.captureLogs(LocalOzoneCluster.class);
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+      cluster.prepareConfiguration();
+
+      assertTrue(logs.getOutput().contains(OZONE_REPLICATION), logs.getOutput());
+      assertTrue(logs.getOutput().contains(ReplicationFactor.THREE.name()),
+          logs.getOutput());
+      // The CLI repeats these, because the log above is off by default for ozone local.
+      assertEquals(singletonList(OZONE_REPLICATION),
+          cluster.getDiscardedUserConfigKeys());
+    } finally {
+      logs.stopCapturing();
+    }
+  }
+
+  @Test
+  void forcedLocalDefaultIsQuietWhenUserConfiguredNothing() throws Exception {
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    try (LocalOzoneCluster cluster = new LocalOzoneCluster(config,
+        new OzoneConfiguration())) {
+      cluster.prepareConfiguration();
+
+      assertTrue(cluster.getDiscardedUserConfigKeys().isEmpty(),
+          cluster.getDiscardedUserConfigKeys().toString());
+    }
+  }
+
+  @Test
+  void readinessTimeoutNamesTheUnmetCondition() {
+    TimeoutException error = assertThrows(TimeoutException.class,
+        () -> LocalOzoneCluster.waitForReadiness(() -> "only 1 of 3 datanodes have registered",
+            "Ozone cluster", Duration.ofMillis(1)));
+
+    assertTrue(error.getMessage().contains("only 1 of 3 datanodes have registered"),
+        error.getMessage());
+    assertTrue(error.getMessage().contains("Ozone cluster"), error.getMessage());
+  }
+
+  @Test
+  void readinessReturnsOnceBlockerReportsReady() throws Exception {
+    AtomicInteger attempts = new AtomicInteger();
+
+    LocalOzoneCluster.waitForReadiness(
+        () -> attempts.incrementAndGet() < 2 ? "not yet" : null, "Ozone cluster",
+        Duration.ofSeconds(30));
+
+    assertEquals(2, attempts.get());
   }
 
   @Test

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -18,20 +18,28 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IDefaultValueProvider;
@@ -108,6 +116,7 @@ class TestOzoneLocal {
     assertTrue(text.contains("Local Ozone is running from"), text);
     assertTrue(text.contains("SCM RPC: localhost:9860"), text);
     assertTrue(text.contains("OM RPC: localhost:9862"), text);
+    assertFalse(text.contains("Datanodes:"), text);
     assertTrue(text.contains("Press Ctrl+C to stop."), text);
   }
 
@@ -121,6 +130,107 @@ class TestOzoneLocal {
 
     assertEquals(1, exitCode);
     assertTrue(runtime.closed);
+  }
+
+  @Test
+  void runCommandPreservesStartupFailureAsTheCause() throws Exception {
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    runtime.failStart = true;
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setErr(new PrintWriter(new OutputStreamWriter(err, UTF_8), true));
+    commandLine.parseArgs();
+
+    Exception error = assertThrows(Exception.class, command::call);
+
+    assertTrue(error.getCause() instanceof IllegalStateException, error.toString());
+    assertEquals("startup failed", error.getCause().getMessage());
+    assertEquals("", err.toString(UTF_8.name()));
+    assertTrue(runtime.closed);
+  }
+
+  /** Preemptive timeout: execute() otherwise blocks in awaitShutdown() until a JVM shutdown hook fires. */
+  @Test
+  void conflictingConfigReachesStderrThroughGenericCli(@TempDir Path dataDir) throws Exception {
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    OzoneLocal ozoneLocal = new OzoneLocal();
+    ozoneLocal.getCmd().setErr(new PrintWriter(new OutputStreamWriter(err, UTF_8), true));
+
+    int exitCode = assertTimeoutPreemptively(Duration.ofSeconds(30),
+        () -> ozoneLocal.execute(new String[] {"-D", OZONE_REPLICATION + "=THREE",
+            "run", "--data-dir", dataDir.toString()}));
+
+    assertEquals(GenericCli.EXECUTION_ERROR_EXIT_CODE, exitCode);
+    String[] lines = err.toString(UTF_8.name()).trim().split("\n");
+    assertEquals(2, lines.length, err.toString(UTF_8.name()));
+    assertTrue(lines[0].contains(OZONE_REPLICATION), lines[0]);
+    assertTrue(lines[0].contains("THREE"), lines[0]);
+    assertTrue(lines[1].contains("--verbose"), lines[1]);
+  }
+
+  @Test
+  void relativeDefaultNamedConfigFileCountsAsUserConfig(@TempDir Path tempDir) throws Exception {
+    Path customConfig = tempDir.resolve("ozone-default.xml").toAbsolutePath();
+    Files.write(customConfig, ("<configuration><property><name>" + OZONE_REPLICATION
+        + "</name><value>THREE</value></property></configuration>").getBytes(UTF_8));
+    Path relativeConfig = Paths.get("").toAbsolutePath().relativize(customConfig);
+    OzoneLocal ozoneLocal = new OzoneLocal();
+
+    ozoneLocal.getCmd().parseArgs("--conf", relativeConfig.toString(), "run");
+
+    OzoneConfiguration seed = ozoneLocal.getOzoneConf();
+    assertEquals("THREE", seed.get(OZONE_REPLICATION));
+    String[] sources = seed.getPropertySources(OZONE_REPLICATION);
+    String source = sources[sources.length - 1];
+    assertEquals(customConfig.normalize().toString(), source);
+    LocalOzoneClusterConfig config = LocalOzoneClusterConfig.builder(
+        tempDir.resolve("local-ozone")).build();
+
+    IOException error = assertThrows(IOException.class, () -> {
+      try (LocalOzoneCluster cluster = new LocalOzoneCluster(config, seed)) {
+        cluster.prepareConfiguration();
+      }
+    });
+
+    assertTrue(error.getMessage().contains(source), error.getMessage());
+  }
+
+  @Test
+  void fileUriConfigPathLoadsTheNamedFile(@TempDir Path tempDir) throws Exception {
+    Path customConfig = tempDir.resolve("my-ozone-site.xml").toAbsolutePath();
+    Files.write(customConfig, ("<configuration><property><name>" + OZONE_REPLICATION
+        + "</name><value>THREE</value></property></configuration>").getBytes(UTF_8));
+    OzoneLocal ozoneLocal = new OzoneLocal();
+
+    ozoneLocal.getCmd().parseArgs("--conf", customConfig.toUri().toString(), "run");
+
+    assertEquals("THREE", ozoneLocal.getOzoneConf().get(OZONE_REPLICATION));
+  }
+
+  @Test
+  void emptyConfigPathIsRejectedAtParse() {
+    OzoneLocal ozoneLocal = new OzoneLocal();
+
+    assertThrows(CommandLine.ParameterException.class,
+        () -> ozoneLocal.getCmd().parseArgs("--conf", "", "run"));
+  }
+
+  @Test
+  void startupFailureHintOnlySuggestsMissingDetail() {
+    String noDetail = OzoneLocal.startupFailureHint(false, false);
+    assertTrue(noDetail.contains("--loglevel INFO"), noDetail);
+    assertTrue(noDetail.contains("--verbose"), noDetail);
+
+    String logsEnabled = OzoneLocal.startupFailureHint(true, false);
+    assertFalse(logsEnabled.contains("--loglevel INFO"), logsEnabled);
+    assertTrue(logsEnabled.contains("--verbose"), logsEnabled);
+
+    String verboseEnabled = OzoneLocal.startupFailureHint(false, true);
+    assertTrue(verboseEnabled.contains("--loglevel INFO"), verboseEnabled);
+    assertFalse(verboseEnabled.contains("--verbose"), verboseEnabled);
+
+    assertNull(OzoneLocal.startupFailureHint(true, true));
   }
 
   @Test
@@ -230,7 +340,7 @@ class TestOzoneLocal {
 
   @Test
   void resolveConfigRejectsInvalidFormat() {
-    assertParseError("--format", "sometimes", "--format");
+    assertParseError("--format", "sometimes", "sometimes");
   }
 
   @Test
@@ -250,12 +360,24 @@ class TestOzoneLocal {
 
   @Test
   void resolveConfigRejectsInvalidDuration() {
-    assertParseError("--startup-timeout", "forever", "--startup-timeout");
+    assertParseError("--startup-timeout", "forever", "Invalid duration 'forever'");
   }
 
   @Test
   void resolveConfigRejectsNonPositiveDuration() {
     assertConfigError("--startup-timeout", "0s", "--startup-timeout");
+  }
+
+  /** Without the unit check "120" parsed as 120 milliseconds; the quotes are asserted because "120s" is in the hint. */
+  @Test
+  void resolveConfigRejectsDurationWithoutTimeUnit() {
+    assertParseError("--startup-timeout", "120", "Missing time unit in '120'");
+  }
+
+  @Test
+  void resolveConfigAcceptsHadoopStyleMinutes() {
+    assertEquals(Duration.ofMinutes(2), resolve("--startup-timeout", "2m")
+        .getStartupTimeout());
   }
 
   @Test

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/local/TestOzoneLocal.java
@@ -18,18 +18,23 @@
 package org.apache.hadoop.ozone.local;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.List;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
@@ -120,6 +125,60 @@ class TestOzoneLocal {
     int exitCode = new CommandLine(command).execute();
 
     assertEquals(1, exitCode);
+    assertTrue(runtime.closed);
+  }
+
+  @Test
+  void runCommandReportsDiscardedConfigToStdErr() throws Exception {
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    runtime.discardedUserConfigKeys = singletonList("ozone.replication");
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setErr(new PrintWriter(new OutputStreamWriter(err, UTF_8), true));
+
+    int exitCode = commandLine.execute();
+
+    assertEquals(0, exitCode);
+    // Service logging is off by default for this command, so the CLI has to say it itself.
+    assertTrue(err.toString(UTF_8.name()).contains("ozone.replication"),
+        err.toString(UTF_8.name()));
+  }
+
+  @Test
+  void runCommandReportsDiscardedConfigWhenStartupFails() throws Exception {
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    runtime.failStart = true;
+    runtime.discardedUserConfigKeys = singletonList("ozone.replication");
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    CommandLine commandLine = new CommandLine(command);
+    commandLine.setErr(new PrintWriter(new OutputStreamWriter(err, UTF_8), true));
+
+    int exitCode = commandLine.execute();
+
+    assertEquals(1, exitCode);
+    // A discarded override can be the very setting that made startup fail, so it is reported
+    // even on the failure path.
+    assertTrue(err.toString(UTF_8.name()).contains("ozone.replication"),
+        err.toString(UTF_8.name()));
+  }
+
+  @Test
+  void runCommandStartupFailureReportsCauseAndHowToGetDetail() {
+    StubRuntime runtime = new StubRuntime("localhost", 9860, 9862);
+    runtime.failStart = true;
+    TestableRunCommand command = new TestableRunCommand(runtime);
+    new CommandLine(command).parseArgs();
+
+    IOException error = assertThrows(IOException.class, command::call);
+
+    // GenericCli prints only the first line of the message, so it has to carry the cause itself.
+    String message = error.getMessage();
+    assertTrue(message.contains("startup failed"), message);
+    assertTrue(message.contains("--loglevel INFO"), message);
+    assertTrue(message.contains("--verbose"), message);
+    assertInstanceOf(IllegalStateException.class, error.getCause());
     assertTrue(runtime.closed);
   }
 
@@ -250,12 +309,33 @@ class TestOzoneLocal {
 
   @Test
   void resolveConfigRejectsInvalidDuration() {
-    assertParseError("--startup-timeout", "forever", "--startup-timeout");
+    // Pins the value echo: picocli's wrapper already names the option, so asserting on the
+    // option alone would pass even if the converter dropped the value from its message.
+    assertParseError("--startup-timeout", "forever", "Invalid duration 'forever'");
   }
 
   @Test
   void resolveConfigRejectsNonPositiveDuration() {
     assertConfigError("--startup-timeout", "0s", "--startup-timeout");
+  }
+
+  @Test
+  void resolveConfigRejectsDurationWithoutTimeUnit() {
+    // Without the unit check this parses as 120 milliseconds, so the run dies with an unrelated
+    // timeout instead of telling the user the value was misread. Asserts the quoted value: the
+    // bare digits also occur in the static "like 120s" hint, which would mask a dropped echo.
+    assertParseError("--startup-timeout", "120", "Missing time unit in '120'");
+  }
+
+  @Test
+  void resolveConfigAcceptsHadoopStyleMinutes() {
+    assertEquals(Duration.ofMinutes(2), resolve("--startup-timeout", "2m")
+        .getStartupTimeout());
+  }
+
+  @Test
+  void invalidFormatModeMessageNamesOffendingValue() {
+    assertParseError("--format", "sometimes", "sometimes");
   }
 
   @Test
@@ -364,6 +444,7 @@ class TestOzoneLocal {
     private final int omPort;
     private boolean failStart;
     private boolean started;
+    private List<String> discardedUserConfigKeys = emptyList();
     private boolean closed;
 
     private StubRuntime(String displayHost, int scmPort, int omPort) {
@@ -403,6 +484,11 @@ class TestOzoneLocal {
     @Override
     public String getS3Endpoint() {
       return "";
+    }
+
+    @Override
+    public List<String> getDiscardedUserConfigKeys() {
+      return discardedUserConfigKeys;
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR improves the error reporting and handling. 

`ozone local run` swallowed every failure it hit: shutdown and start() rollback errors went to IOUtils.closeQuietly with a null logger, the readiness wait collapsed its conditions into a single boolean, and the CLI converters rejected a value without naming it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15986

## How was this patch tested?

https://github.com/apache/ozone/actions/runs/30844781369