### PR TITLE
HDDS-14753. Do not prematurely serialize client version

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -513,14 +513,14 @@ public class DatanodeDetails extends NodeImpl implements Comparable<DatanodeDeta
    */
   @JsonIgnore
   public HddsProtos.DatanodeDetailsProto getProtoBufMessage() {
-    return toProto(ClientVersion.CURRENT.serialize());
+    return toProto(ClientVersion.CURRENT);
   }
 
-  public HddsProtos.DatanodeDetailsProto toProto(int clientVersion) {
+  public HddsProtos.DatanodeDetailsProto toProto(ClientVersion clientVersion) {
     return toProtoBuilder(clientVersion, Collections.emptySet()).build();
   }
 
-  public HddsProtos.DatanodeDetailsProto toProto(int clientVersion, Set<Port.Name> filterPorts) {
+  public HddsProtos.DatanodeDetailsProto toProto(ClientVersion clientVersion, Set<Port.Name> filterPorts) {
     return toProtoBuilder(clientVersion, filterPorts).build();
   }
 
@@ -533,7 +533,7 @@ public class DatanodeDetails extends NodeImpl implements Comparable<DatanodeDeta
    * @return A {@link HddsProtos.DatanodeDetailsProto.Builder} Object.
    */
   public HddsProtos.DatanodeDetailsProto.Builder toProtoBuilder(
-      int clientVersion, Set<Port.Name> filterPorts) {
+      ClientVersion clientVersion, Set<Port.Name> filterPorts) {
 
     final HddsProtos.DatanodeIDProto idProto = id.toProto();
     final HddsProtos.DatanodeDetailsProto.Builder builder =
@@ -1172,7 +1172,7 @@ public class DatanodeDetails extends NodeImpl implements Comparable<DatanodeDeta
 
   @Override
   public HddsProtos.NetworkNode toProtobuf(
-      int clientVersion) {
+      ClientVersion clientVersion) {
     return HddsProtos.NetworkNode.newBuilder()
         .setDatanodeDetails(toProtoBuilder(clientVersion, Collections.emptySet()).build())
         .build();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ContainerWithPipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ContainerWithPipeline.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.ozone.ClientVersion;
 
 /**
  * Class wraps ozone container info.
@@ -53,7 +54,7 @@ public class ContainerWithPipeline implements Comparator<ContainerWithPipeline>,
         Pipeline.getFromProtobuf(allocatedContainer.getPipeline()));
   }
 
-  public HddsProtos.ContainerWithPipeline getProtobuf(int clientVersion) {
+  public HddsProtos.ContainerWithPipeline getProtobuf(ClientVersion clientVersion) {
     return HddsProtos.ContainerWithPipeline.newBuilder()
         .setContainerInfo(getContainerInfo().getProtobuf())
         .setPipeline(getPipeline().getProtobufMessage(clientVersion, Name.IO_PORTS))

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNode.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNode.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.net;
 import java.util.Collection;
 import java.util.List;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.ClientVersion;
 
 /**
  * The interface defines an inner node in a network topology.
@@ -92,7 +93,7 @@ public interface InnerNode extends Node {
       Collection<Node> excludedNodes, int ancestorGen);
 
   @Override
-  HddsProtos.NetworkNode toProtobuf(int clientVersion);
+  HddsProtos.NetworkNode toProtobuf(ClientVersion clientVersion);
 
   @Override
   boolean equals(Object o);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/Node.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/Node.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.net;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.ClientVersion;
 
 /**
  * The interface defines a node in a network topology.
@@ -130,7 +131,7 @@ public interface Node {
   boolean isDescendant(String nodePath);
 
   default HddsProtos.NetworkNode toProtobuf(
-      int clientVersion) {
+      ClientVersion clientVersion) {
     return null;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -67,7 +67,7 @@ public final class Pipeline {
   private static final Codec<Pipeline> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(HddsProtos.Pipeline.getDefaultInstance()),
       Pipeline::getFromProtobufSetCreationTimestamp,
-      p -> p.getProtobufMessage(ClientVersion.CURRENT.serialize()),
+      p -> p.getProtobufMessage(ClientVersion.CURRENT),
       Pipeline.class,
       DelegatedCodec.CopyType.UNSUPPORTED);
 
@@ -363,11 +363,12 @@ public final class Pipeline {
     return replicationConfig;
   }
 
-  public HddsProtos.Pipeline getProtobufMessage(int clientVersion) {
+  public HddsProtos.Pipeline getProtobufMessage(ClientVersion clientVersion) {
     return getProtobufMessage(clientVersion, Collections.emptySet());
   }
 
-  public HddsProtos.Pipeline getProtobufMessage(int clientVersion, Set<DatanodeDetails.Port.Name> filterPorts) {
+  public HddsProtos.Pipeline getProtobufMessage(ClientVersion clientVersion,
+      Set<DatanodeDetails.Port.Name> filterPorts) {
     List<HddsProtos.DatanodeDetailsProto> members = new ArrayList<>();
     List<Integer> memberReplicaIndexes = new ArrayList<>();
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.HDDSVersion;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -44,11 +45,11 @@ public class TestDatanodeDetails {
     DatanodeDetails subject = MockDatanodeDetails.randomDatanodeDetails();
 
     HddsProtos.DatanodeDetailsProto proto =
-        subject.toProto(DEFAULT_VERSION.serialize());
+        subject.toProto(DEFAULT_VERSION);
     assertPorts(proto, V0_PORTS);
 
     HddsProtos.DatanodeDetailsProto protoV1 =
-        subject.toProto(VERSION_HANDLES_UNKNOWN_DN_PORTS.serialize());
+        subject.toProto(VERSION_HANDLES_UNKNOWN_DN_PORTS);
     assertPorts(protoV1, ALL_PORTS);
   }
 
@@ -58,11 +59,11 @@ public class TestDatanodeDetails {
     Set<Port.Name> requiredPorts = Stream.of(Port.Name.STANDALONE, Port.Name.RATIS)
         .collect(Collectors.toSet());
     HddsProtos.DatanodeDetailsProto proto =
-        subject.toProto(subject.getCurrentVersion(), requiredPorts);
+        subject.toProto(ClientVersion.deserialize(subject.getCurrentVersion()), requiredPorts);
     assertPorts(proto, ImmutableSet.copyOf(requiredPorts));
 
     HddsProtos.DatanodeDetailsProto ioPortProto =
-        subject.toProto(subject.getCurrentVersion(), Name.IO_PORTS);
+        subject.toProto(ClientVersion.deserialize(subject.getCurrentVersion()), Name.IO_PORTS);
     assertPorts(ioPortProto, ImmutableSet.copyOf(Name.IO_PORTS));
   }
 
@@ -74,7 +75,7 @@ public class TestDatanodeDetails {
     Set<Port.Name> requiredPorts = Stream.of(Port.Name.STANDALONE, Port.Name.RATIS)
         .collect(Collectors.toSet());
     HddsProtos.DatanodeDetailsProto.Builder protoBuilder =
-        dn.toProtoBuilder(DEFAULT_VERSION.serialize(), requiredPorts);
+        dn.toProtoBuilder(DEFAULT_VERSION, requiredPorts);
     protoBuilder.clearCurrentVersion();
     DatanodeDetails dn2 = DatanodeDetails.newBuilder(protoBuilder.build()).build();
     assertEquals(HDDSVersion.SEPARATE_RATIS_PORTS_AVAILABLE,
@@ -82,7 +83,7 @@ public class TestDatanodeDetails {
 
     // test that if the current version is set, it is used
     protoBuilder =
-        dn.toProtoBuilder(DEFAULT_VERSION.serialize(), requiredPorts);
+        dn.toProtoBuilder(DEFAULT_VERSION, requiredPorts);
     DatanodeDetails dn3 = DatanodeDetails.newBuilder(protoBuilder.build()).build();
     assertEquals(HDDSVersion.SOFTWARE_VERSION,
         HDDSVersion.deserialize(dn3.getCurrentVersion()));

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -47,13 +47,13 @@ public class TestPipeline {
     Pipeline subject = MockPipeline.createPipeline(3);
 
     HddsProtos.Pipeline proto =
-        subject.getProtobufMessage(DEFAULT_VERSION.serialize());
+        subject.getProtobufMessage(DEFAULT_VERSION);
     for (HddsProtos.DatanodeDetailsProto dn : proto.getMembersList()) {
       assertPorts(dn, V0_PORTS);
     }
 
     HddsProtos.Pipeline protoV1 = subject.getProtobufMessage(
-        VERSION_HANDLES_UNKNOWN_DN_PORTS.serialize());
+        VERSION_HANDLES_UNKNOWN_DN_PORTS);
     for (HddsProtos.DatanodeDetailsProto dn : protoV1.getMembersList()) {
       assertPorts(dn, ALL_PORTS);
     }
@@ -64,14 +64,14 @@ public class TestPipeline {
     Pipeline subject = MockPipeline.createPipeline(3);
 
     //when EC config is empty/null
-    HddsProtos.Pipeline protobufMessage = subject.getProtobufMessage(1);
+    HddsProtos.Pipeline protobufMessage = subject.getProtobufMessage(VERSION_HANDLES_UNKNOWN_DN_PORTS);
     assertEquals(0, protobufMessage.getEcReplicationConfig().getData());
 
 
     //when EC config is NOT empty
     subject = MockPipeline.createEcPipeline();
 
-    protobufMessage = subject.getProtobufMessage(1);
+    protobufMessage = subject.getProtobufMessage(VERSION_HANDLES_UNKNOWN_DN_PORTS);
     assertEquals(3, protobufMessage.getEcReplicationConfig().getData());
     assertEquals(2, protobufMessage.getEcReplicationConfig().getParity());
 
@@ -80,7 +80,7 @@ public class TestPipeline {
   @Test
   public void testReplicaIndexesSerialisedCorrectly() {
     Pipeline pipeline = MockPipeline.createEcPipeline();
-    HddsProtos.Pipeline protobufMessage = pipeline.getProtobufMessage(1);
+    HddsProtos.Pipeline protobufMessage = pipeline.getProtobufMessage(VERSION_HANDLES_UNKNOWN_DN_PORTS);
     Pipeline reloadedPipeline = Pipeline.getFromProtobuf(protobufMessage);
 
     for (DatanodeDetails dn : pipeline.getNodes()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerProtocolServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerProtocolServer.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDiskBalancerInfo
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DiskBalancerConfigurationProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DiskBalancerRunningStatus;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.slf4j.Logger;
@@ -70,7 +71,7 @@ public class DiskBalancerProtocolServer implements DiskBalancerProtocol {
     DatanodeDetails datanodeDetails = datanodeStateMachine.getDatanodeDetails();
 
     return DatanodeDiskBalancerInfoProto.newBuilder()
-        .setNode(datanodeDetails.toProto(request.getClientVersion()))
+        .setNode(datanodeDetails.toProto(ClientVersion.deserialize(request.getClientVersion())))
         .setCurrentVolumeDensitySum(info.getVolumeDataDensity())
         .setDiskBalancerConf(DiskBalancerConfigurationProto.newBuilder()
                 .setThreshold(info.getThreshold())

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/MoveDataNodePair.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/MoveDataNodePair.java
@@ -35,7 +35,7 @@ public class MoveDataNodePair {
   private static final Codec<MoveDataNodePair> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(MoveDataNodePairProto.getDefaultInstance()),
       MoveDataNodePair::getFromProtobuf,
-      pair -> pair.getProtobufMessage(ClientVersion.CURRENT.serialize()),
+      pair -> pair.getProtobufMessage(ClientVersion.CURRENT),
       MoveDataNodePair.class,
       DelegatedCodec.CopyType.SHALLOW);
 
@@ -66,7 +66,7 @@ public class MoveDataNodePair {
     return src;
   }
 
-  public MoveDataNodePairProto getProtobufMessage(int clientVersion) {
+  public MoveDataNodePairProto getProtobufMessage(ClientVersion clientVersion) {
     return MoveDataNodePairProto.newBuilder()
         .setSrc(src.toProto(clientVersion))
         .setTgt(tgt.toProto(clientVersion))

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -460,7 +461,7 @@ public class InnerNodeImpl extends NodeImpl implements InnerNode {
 
   @Override
   public HddsProtos.NetworkNode toProtobuf(
-      int clientVersion) {
+      ClientVersion clientVersion) {
 
     HddsProtos.InnerNode.Builder innerNode =
         HddsProtos.InnerNode.newBuilder()

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerListResult;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.security.token.Token;
@@ -122,7 +123,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
    * @throws IOException
    */
   List<HddsProtos.SCMContainerReplicaProto> getContainerReplicas(
-      long containerId, int clientVersion) throws IOException;
+      long containerId, ClientVersion clientVersion) throws IOException;
 
   /**
    * Ask SCM the location of a batch of containers. SCM responds with a group of
@@ -281,7 +282,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
    */
   List<HddsProtos.Node> queryNode(HddsProtos.NodeOperationalState opState,
       HddsProtos.NodeState state, HddsProtos.QueryScope queryScope,
-      String poolName, int clientVersion) throws IOException;
+      String poolName, ClientVersion clientVersion) throws IOException;
 
   HddsProtos.Node queryNode(UUID uuid) throws IOException;
 
@@ -495,7 +496,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
    * @see org.apache.hadoop.ozone.ClientVersion
    */
   List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
-      String address, String uuid, int clientVersion) throws IOException;
+      String address, String uuid, ClientVersion clientVersion) throws IOException;
 
   /**
    * Get usage information of most or least used datanodes.
@@ -509,7 +510,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
    * @see org.apache.hadoop.ozone.ClientVersion
    */
   List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
-      boolean mostUsed, int count, int clientVersion) throws IOException;
+      boolean mostUsed, int count, ClientVersion clientVersion) throws IOException;
 
   @Deprecated
   StatusAndMessages finalizeScmUpgrade(String upgradeClientID)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -341,7 +341,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    */
   @Override
   public List<HddsProtos.SCMContainerReplicaProto> getContainerReplicas(
-      long containerID, int clientVersion) throws IOException {
+      long containerID, ClientVersion clientVersion) throws IOException {
     Preconditions.checkState(containerID >= 0,
         "Container ID cannot be negative");
 
@@ -563,7 +563,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   public List<HddsProtos.Node> queryNode(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState
       nodeState, HddsProtos.QueryScope queryScope, String poolName,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     // TODO : We support only cluster wide query right now. So ignoring checking
     // queryScope and poolName
     NodeQueryRequestProto.Builder builder = NodeQueryRequestProto.newBuilder()
@@ -1135,7 +1135,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    */
   @Override
   public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
-      String address, String uuid, int clientVersion) throws IOException {
+      String address, String uuid, ClientVersion clientVersion) throws IOException {
 
     DatanodeUsageInfoRequestProto request =
         DatanodeUsageInfoRequestProto.newBuilder()
@@ -1161,7 +1161,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    */
   @Override
   public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
-      boolean mostUsed, int count, int clientVersion) throws IOException {
+      boolean mostUsed, int count, ClientVersion clientVersion) throws IOException {
     DatanodeUsageInfoRequestProto request =
         DatanodeUsageInfoRequestProto.newBuilder()
             .setMostUsed(mostUsed)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeUsageInfoProto;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+import org.apache.hadoop.ozone.ClientVersion;
 
 /**
  * Bundles datanode details with usage statistics.
@@ -221,11 +222,11 @@ public class DatanodeUsageInfo {
    *
    * @return Protobuf HddsProtos.DatanodeUsageInfo
    */
-  public DatanodeUsageInfoProto toProto(int clientVersion) {
+  public DatanodeUsageInfoProto toProto(ClientVersion clientVersion) {
     return toProtoBuilder(clientVersion).build();
   }
 
-  private DatanodeUsageInfoProto.Builder toProtoBuilder(int clientVersion) {
+  private DatanodeUsageInfoProto.Builder toProtoBuilder(ClientVersion clientVersion) {
     DatanodeUsageInfoProto.Builder builder =
         DatanodeUsageInfoProto.newBuilder();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -268,7 +268,7 @@ public class PipelineManagerImpl implements PipelineManager {
   private void addPipelineToManager(Pipeline pipeline)
       throws IOException {
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     acquireWriteLock();
     try {
       stateManager.addPipeline(pipelineProto);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
 import org.slf4j.Logger;
@@ -120,6 +121,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
 
   private SCMBlockLocationResponse processMessage(
       SCMBlockLocationRequest request) throws ServiceException {
+    final ClientVersion clientVersion = ClientVersion.deserialize(request.getVersion());
     SCMBlockLocationResponse.Builder response = createSCMBlockResponse(
         request.getCmdType(),
         request.getTraceID());
@@ -139,7 +141,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
           }
         }
         response.setAllocateScmBlockResponse(allocateScmBlock(
-            request.getAllocateScmBlockRequest(), request.getVersion()));
+            request.getAllocateScmBlockRequest(), clientVersion));
         break;
       case DeleteScmKeyBlocks:
         response.setDeleteScmKeyBlocksResponse(
@@ -155,12 +157,12 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
         break;
       case SortDatanodes:
         response.setSortDatanodesResponse(sortDatanodes(
-            request.getSortDatanodesRequest(), request.getVersion()
+            request.getSortDatanodesRequest(), clientVersion
         ));
         break;
       case GetClusterTree:
         response.setGetClusterTreeResponse(
-            getClusterTree(request.getVersion()));
+            getClusterTree(clientVersion));
         break;
       default:
         // Should never happen
@@ -189,7 +191,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
   }
 
   public AllocateScmBlockResponseProto allocateScmBlock(
-      AllocateScmBlockRequestProto request, int clientVersion)
+      AllocateScmBlockRequestProto request, ClientVersion clientVersion)
       throws IOException {
     List<AllocatedBlock> allocatedBlocks =
         impl.allocateBlock(request.getSize(),
@@ -261,7 +263,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
   }
 
   public SortDatanodesResponseProto sortDatanodes(
-      SortDatanodesRequestProto request, int clientVersion)
+      SortDatanodesRequestProto request, ClientVersion clientVersion)
       throws ServiceException {
     SortDatanodesResponseProto.Builder resp =
         SortDatanodesResponseProto.newBuilder();
@@ -280,7 +282,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     }
   }
 
-  public GetClusterTreeResponseProto getClusterTree(int clientVersion)
+  public GetClusterTreeResponseProto getClusterTree(ClientVersion clientVersion)
       throws IOException {
     GetClusterTreeResponseProto.Builder resp =
         GetClusterTreeResponseProto.newBuilder();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -228,8 +228,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
     // this server interface, this should be removed and solved via new
     // annotated interceptors.
     boolean checkResponseForECRepConfig = false;
-    if (!ClientVersion.ERASURE_CODING_SUPPORT.isSupportedBy(
-        ClientVersion.deserialize(request.getVersion()))) {
+    if (!ClientVersion.ERASURE_CODING_SUPPORT.isSupportedBy(request.getVersion())) {
       if (request.getCmdType() == GetContainer
           || request.getCmdType() == ListContainer
           || request.getCmdType() == GetContainerWithPipeline

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -229,7 +229,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
     // annotated interceptors.
     boolean checkResponseForECRepConfig = false;
     if (!ClientVersion.ERASURE_CODING_SUPPORT.isSupportedBy(
-        request.getVersion())) {
+        ClientVersion.deserialize(request.getVersion()))) {
       if (request.getCmdType() == GetContainer
           || request.getCmdType() == ListContainer
           || request.getCmdType() == GetContainerWithPipeline
@@ -419,6 +419,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   @SuppressWarnings("checkstyle:methodlength")
   public ScmContainerLocationResponse processRequest(
       ScmContainerLocationRequest request) throws ServiceException {
+    final ClientVersion clientVersion = ClientVersion.deserialize(request.getVersion());
     try {
       switch (request.getCmdType()) {
       case AllocateContainer:
@@ -426,7 +427,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setContainerResponse(allocateContainer(
-                request.getContainerRequest(), request.getVersion()))
+                request.getContainerRequest(), clientVersion))
             .build();
       case GetContainer:
         return ScmContainerLocationResponse.newBuilder()
@@ -448,7 +449,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setStatus(Status.OK)
             .setGetContainerWithPipelineResponse(getContainerWithPipeline(
                 request.getGetContainerWithPipelineRequest(),
-                request.getVersion()))
+                clientVersion))
             .build();
       case GetContainerWithPipelineBatch:
         return ScmContainerLocationResponse.newBuilder()
@@ -457,7 +458,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setGetContainerWithPipelineBatchResponse(
                 getContainerWithPipelineBatch(
                     request.getGetContainerWithPipelineBatchRequest(),
-                    request.getVersion()))
+                    clientVersion))
             .build();
       case GetExistContainerWithPipelinesInBatch:
         return ScmContainerLocationResponse.newBuilder()
@@ -466,7 +467,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setGetExistContainerWithPipelinesInBatchResponse(
                 getExistContainerWithPipelinesInBatch(
                     request.getGetExistContainerWithPipelinesInBatchRequest(),
-                    request.getVersion()))
+                    clientVersion))
             .build();
       case ListContainer:
         return ScmContainerLocationResponse.newBuilder()
@@ -480,7 +481,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setNodeQueryResponse(queryNode(request.getNodeQueryRequest(),
-                request.getVersion()))
+                clientVersion))
             .build();
       case SingleNodeQuery:
         return ScmContainerLocationResponse.newBuilder()
@@ -512,14 +513,14 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setPipelineResponse(allocatePipeline(
-                request.getPipelineRequest(), request.getVersion()))
+                request.getPipelineRequest(), clientVersion))
             .build();
       case ListPipelines:
         return ScmContainerLocationResponse.newBuilder()
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setListPipelineResponse(listPipelines(
-                request.getListPipelineRequest(), request.getVersion()))
+                request.getListPipelineRequest(), clientVersion))
             .build();
       case ActivatePipeline:
         return ScmContainerLocationResponse.newBuilder()
@@ -624,7 +625,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setGetPipelineResponse(getPipeline(
-                request.getGetPipelineRequest(), request.getVersion()))
+                request.getGetPipelineRequest(), clientVersion))
             .build();
       case GetSafeModeRuleStatuses:
         return ScmContainerLocationResponse.newBuilder()
@@ -680,7 +681,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setStatus(Status.OK)
             .setDatanodeUsageInfoResponse(getDatanodeUsageInfo(
                 request.getDatanodeUsageInfoRequest(),
-                request.getVersion()))
+                clientVersion))
             .build();
       case GetContainerCount:
         return ScmContainerLocationResponse.newBuilder()
@@ -702,7 +703,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
           .setStatus(Status.OK)
           .setGetContainerReplicasResponse(getContainerReplicas(
               request.getGetContainerReplicasRequest(),
-              request.getVersion()))
+              clientVersion))
           .build();
       case GetFailedDeletedBlocksTransaction:
         return ScmContainerLocationResponse.newBuilder()
@@ -791,7 +792,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   }
 
   public GetContainerReplicasResponseProto getContainerReplicas(
-      GetContainerReplicasRequestProto request, int clientVersion)
+      GetContainerReplicasRequestProto request, ClientVersion clientVersion)
       throws IOException {
     List<HddsProtos.SCMContainerReplicaProto> replicas
         = impl.getContainerReplicas(request.getContainerID(), clientVersion);
@@ -800,7 +801,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   }
 
   public ContainerResponseProto allocateContainer(ContainerRequestProto request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     ReplicationConfig replicationConfig = ReplicationConfig.fromProto(request.getReplicationType(), 
         request.getReplicationFactor(),
         request.getEcReplicationConfig()
@@ -834,7 +835,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
 
   public GetContainerWithPipelineResponseProto getContainerWithPipeline(
       GetContainerWithPipelineRequestProto request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     ContainerWithPipeline container = impl
         .getContainerWithPipeline(request.getContainerID());
     return GetContainerWithPipelineResponseProto.newBuilder()
@@ -845,7 +846,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   public GetContainerWithPipelineBatchResponseProto
       getContainerWithPipelineBatch(
       GetContainerWithPipelineBatchRequestProto request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     List<ContainerWithPipeline> containers = impl
         .getContainerWithPipelineBatch(request.getContainerIDsList());
     GetContainerWithPipelineBatchResponseProto.Builder builder =
@@ -859,7 +860,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   public GetExistContainerWithPipelinesInBatchResponseProto
       getExistContainerWithPipelinesInBatch(
       GetExistContainerWithPipelinesInBatchRequestProto request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     List<ContainerWithPipeline> containers = impl
         .getExistContainerWithPipelinesInBatch(request.getContainerIDsList());
     GetExistContainerWithPipelinesInBatchResponseProto.Builder builder =
@@ -939,7 +940,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
 
   public NodeQueryResponseProto queryNode(
       StorageContainerLocationProtocolProtos.NodeQueryRequestProto request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
 
     HddsProtos.NodeOperationalState opState = null;
     HddsProtos.NodeState nodeState = null;
@@ -989,7 +990,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
 
   public PipelineResponseProto allocatePipeline(
       StorageContainerLocationProtocolProtos.PipelineRequestProto request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     Pipeline pipeline = impl.createReplicationPipeline(
         request.getReplicationType(), request.getReplicationFactor(),
         HddsProtos.NodePool.getDefaultInstance());
@@ -1003,7 +1004,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   }
 
   public ListPipelineResponseProto listPipelines(
-      ListPipelineRequestProto request, int clientVersion)
+      ListPipelineRequestProto request, ClientVersion clientVersion)
       throws IOException {
     ListPipelineResponseProto.Builder builder = ListPipelineResponseProto
         .newBuilder();
@@ -1016,7 +1017,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
 
   public GetPipelineResponseProto getPipeline(
       GetPipelineRequestProto request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     GetPipelineResponseProto.Builder builder = GetPipelineResponseProto
         .newBuilder();
     Pipeline pipeline = impl.getPipeline(request.getPipelineID());
@@ -1351,7 +1352,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
 
   public DatanodeUsageInfoResponseProto getDatanodeUsageInfo(
       StorageContainerLocationProtocolProtos.DatanodeUsageInfoRequestProto
-          request, int clientVersion) throws IOException {
+          request, ClientVersion clientVersion) throws IOException {
     List<HddsProtos.DatanodeUsageInfoProto> infoList;
 
     // get info by ip or uuid

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -113,6 +113,7 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc_.ProtobufRpcEngine;
 import org.apache.hadoop.ipc_.RPC;
 import org.apache.hadoop.ipc_.Server;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
@@ -354,7 +355,7 @@ public class SCMClientProtocolServer implements
 
   @Override
   public List<HddsProtos.SCMContainerReplicaProto> getContainerReplicas(
-      long containerId, int clientVersion) throws IOException {
+      long containerId, ClientVersion clientVersion) throws IOException {
     List<HddsProtos.SCMContainerReplicaProto> results = new ArrayList<>();
     Map<String, String> auditMap = new HashMap<>();
     auditMap.put("containerId", String.valueOf(containerId));
@@ -677,7 +678,7 @@ public class SCMClientProtocolServer implements
   @Override
   public List<HddsProtos.Node> queryNode(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState state,
-      HddsProtos.QueryScope queryScope, String poolName, int clientVersion)
+      HddsProtos.QueryScope queryScope, String poolName, ClientVersion clientVersion)
       throws IOException {
     final Map<String, String> auditMap = Maps.newHashMap();
     auditMap.put("opState", String.valueOf(opState));
@@ -1466,7 +1467,7 @@ public class SCMClientProtocolServer implements
    */
   @Override
   public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
-      String address, String uuid, int clientVersion) throws IOException {
+      String address, String uuid, ClientVersion clientVersion) throws IOException {
 
     final Map<String, String> auditMap = Maps.newHashMap();
     auditMap.put("address", address);
@@ -1511,7 +1512,7 @@ public class SCMClientProtocolServer implements
    * @return Usage info such as capacity, SCMUsed, and remaining space.
    */
   private HddsProtos.DatanodeUsageInfoProto getUsageInfoFromDatanodeDetails(
-      DatanodeDetails node, int clientVersion) {
+      DatanodeDetails node, ClientVersion clientVersion) {
     DatanodeUsageInfo usageInfo = scm.getScmNodeManager().getUsageInfo(node);
     return usageInfo.toProto(clientVersion);
   }
@@ -1530,7 +1531,7 @@ public class SCMClientProtocolServer implements
    */
   @Override
   public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
-      boolean mostUsed, int count, int clientVersion)
+      boolean mostUsed, int count, ClientVersion clientVersion)
       throws IOException, IllegalArgumentException {
 
     final Map<String, String> auditMap = Maps.newHashMap();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeUsageInfo.java
@@ -41,7 +41,7 @@ class TestDatanodeUsageInfo {
     );
 
     DatanodeUsageInfo info = new DatanodeUsageInfo(dn, stat);
-    DatanodeUsageInfoProto proto = info.toProto(ClientVersion.CURRENT.serialize());
+    DatanodeUsageInfoProto proto = info.toProto(ClientVersion.CURRENT);
 
     assertThat(proto.hasFsCapacity()).isFalse();
     assertThat(proto.hasFsAvailable()).isFalse();
@@ -59,7 +59,7 @@ class TestDatanodeUsageInfo {
     DatanodeUsageInfo info = new DatanodeUsageInfo(dn, stat);
     info.setFilesystemUsage(2000L, 1500L);
 
-    DatanodeUsageInfoProto proto = info.toProto(ClientVersion.CURRENT.serialize());
+    DatanodeUsageInfoProto proto = info.toProto(ClientVersion.CURRENT);
 
     assertThat(proto.hasFsCapacity()).isTrue();
     assertThat(proto.hasFsAvailable()).isTrue();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -87,7 +87,7 @@ public class MockPipelineManager implements PipelineManager {
     }
 
     stateManager.addPipeline(pipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize()));
+        ClientVersion.CURRENT));
     return pipeline;
   }
 
@@ -111,7 +111,7 @@ public class MockPipelineManager implements PipelineManager {
   public void addEcPipeline(Pipeline pipeline)
       throws IOException {
     stateManager.addPipeline(pipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize()));
+        ClientVersion.CURRENT));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
@@ -110,7 +110,7 @@ public class TestPipelineDatanodesIntersection {
         Pipeline pipeline = provider.create(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
         HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-            ClientVersion.CURRENT.serialize());
+            ClientVersion.CURRENT);
         stateManager.addPipeline(pipelineProto);
         nodeManager.addPipeline(pipeline);
         List<Pipeline> overlapPipelines = RatisPipelineUtils

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -292,7 +292,7 @@ public class TestPipelinePlacementPolicy {
             .setNodes(nodes)
             .build();
         HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-            ClientVersion.CURRENT.serialize());
+            ClientVersion.CURRENT);
         nodeManager.addPipeline(pipeline);
         stateManager.addPipeline(pipelineProto);
       } catch (SCMException e) {
@@ -648,7 +648,7 @@ public class TestPipelinePlacementPolicy {
               .build();
 
           pipelineProto = pipeline.getProtobufMessage(
-              ClientVersion.CURRENT.serialize());
+              ClientVersion.CURRENT);
           nodeManager.addPipeline(pipeline);
           stateManager.addPipeline(pipelineProto);
           pipelineCount++;
@@ -791,7 +791,7 @@ public class TestPipelinePlacementPolicy {
         .build();
 
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     nodeManager.addPipeline(pipeline);
     stateManager.addPipeline(pipelineProto);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -110,14 +110,14 @@ public class TestPipelineStateManagerImpl {
   public void testAddAndGetPipeline() throws IOException, TimeoutException {
     Exception e = assertThrows(SCMException.class,
         () -> stateManager.addPipeline(createDummyPipeline(0)
-            .getProtobufMessage(ClientVersion.CURRENT.serialize())));
+            .getProtobufMessage(ClientVersion.CURRENT)));
     // replication factor and number of nodes in the pipeline do not match
     assertThat(e.getMessage()).contains("do not match");
 
     // add a pipeline
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
 
     try {
       stateManager.addPipeline(pipelineProto);
@@ -144,11 +144,11 @@ public class TestPipelineStateManagerImpl {
 
     Set<HddsProtos.Pipeline> pipelines = new HashSet<>();
     HddsProtos.Pipeline pipeline = createDummyPipeline(1).getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     stateManager.addPipeline(pipeline);
     pipelines.add(pipeline);
     pipeline = createDummyPipeline(1).getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     stateManager.addPipeline(pipeline);
     pipelines.add(pipeline);
 
@@ -179,19 +179,19 @@ public class TestPipelineStateManagerImpl {
           // 5 pipelines in allocated state for each type and factor
           HddsProtos.Pipeline pipeline =
               createDummyPipeline(type, factor, factor.getNumber())
-                  .getProtobufMessage(ClientVersion.CURRENT.serialize());
+                  .getProtobufMessage(ClientVersion.CURRENT);
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in open state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.CURRENT.serialize());
+              .getProtobufMessage(ClientVersion.CURRENT);
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in closed state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.CURRENT.serialize());
+              .getProtobufMessage(ClientVersion.CURRENT);
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
         }
@@ -232,20 +232,20 @@ public class TestPipelineStateManagerImpl {
           // 5 pipelines in allocated state for each type and factor
           HddsProtos.Pipeline pipeline =
               createDummyPipeline(type, factor, factor.getNumber())
-                  .getProtobufMessage(ClientVersion.CURRENT.serialize());
+                  .getProtobufMessage(ClientVersion.CURRENT);
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in open state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.CURRENT.serialize());
+              .getProtobufMessage(ClientVersion.CURRENT);
           stateManager.addPipeline(pipeline);
           openPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in dormant state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.CURRENT.serialize());
+              .getProtobufMessage(ClientVersion.CURRENT);
           stateManager.addPipeline(pipeline);
           openPipeline(pipeline);
           deactivatePipeline(pipeline);
@@ -253,7 +253,7 @@ public class TestPipelineStateManagerImpl {
 
           // 5 pipelines in closed state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.CURRENT.serialize());
+              .getProtobufMessage(ClientVersion.CURRENT);
           stateManager.addPipeline(pipeline);
           finalizePipeline(pipeline);
           pipelines.add(pipeline);
@@ -292,7 +292,7 @@ public class TestPipelineStateManagerImpl {
     long containerID = 0;
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     pipeline = stateManager.getPipeline(pipeline.getId());
     stateManager.addContainerToPipeline(pipeline.getId(),
@@ -325,7 +325,7 @@ public class TestPipelineStateManagerImpl {
   public void testRemovePipeline() throws IOException, TimeoutException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     // close the pipeline
     openPipeline(pipelineProto);
@@ -347,7 +347,7 @@ public class TestPipelineStateManagerImpl {
     long containerID = 1;
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     // create an open pipeline in stateMap
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
@@ -387,7 +387,7 @@ public class TestPipelineStateManagerImpl {
   public void testFinalizePipeline() throws IOException, TimeoutException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     // finalize on ALLOCATED pipeline
     finalizePipeline(pipelineProto);
@@ -398,7 +398,7 @@ public class TestPipelineStateManagerImpl {
 
     pipeline = createDummyPipeline(1);
     pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
     // finalize on OPEN pipeline
@@ -410,7 +410,7 @@ public class TestPipelineStateManagerImpl {
 
     pipeline = createDummyPipeline(1);
     pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
     finalizePipeline(pipelineProto);
@@ -426,7 +426,7 @@ public class TestPipelineStateManagerImpl {
   public void testOpenPipeline() throws IOException, TimeoutException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     // open on ALLOCATED pipeline
     openPipeline(pipelineProto);
@@ -448,7 +448,7 @@ public class TestPipelineStateManagerImpl {
         HddsProtos.ReplicationFactor.THREE, 3);
     // pipeline in allocated state should not be reported
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     assertEquals(0, stateManager
         .getPipelines(RatisReplicationConfig
@@ -470,7 +470,7 @@ public class TestPipelineStateManagerImpl {
         .setState(Pipeline.PipelineState.OPEN)
         .build();
     HddsProtos.Pipeline pipelineProto2 = pipeline2
-        .getProtobufMessage(ClientVersion.CURRENT.serialize());
+        .getProtobufMessage(ClientVersion.CURRENT);
     // pipeline in open state should be reported
     stateManager.addPipeline(pipelineProto2);
     assertEquals(2, stateManager

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -141,14 +141,14 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     nodeManager.addPipeline(pipeline);
 
     Pipeline pipeline1 = provider.create(RatisReplicationConfig
         .getInstance(factor));
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     // New pipeline should not overlap with the previous created pipeline
@@ -190,7 +190,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
 
     factor = HddsProtos.ReplicationFactor.ONE;
@@ -199,7 +199,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto1);
     // With enough pipeline quote on datanodes, they should not share
     // the same set of datanodes.
@@ -279,7 +279,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     nodeManager.addPipeline(pipeline);
     stateManager.addPipeline(pipelineProto);
 
@@ -406,7 +406,7 @@ public class TestRatisPipelineProvider {
       Pipeline p = provider.create(
           RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
           new ArrayList<>(), new ArrayList<>());
-      stateManager.addPipeline(p.getProtobufMessage(ClientVersion.CURRENT.serialize()));
+      stateManager.addPipeline(p.getProtobufMessage(ClientVersion.CURRENT));
     }
 
     // Next pipeline creation should fail with default limit message.
@@ -431,7 +431,7 @@ public class TestRatisPipelineProvider {
     for (int i = 0; i < pipelineCount; i++) {
       stateManager.addPipeline(
           provider.create(RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
-              new ArrayList<>(), new ArrayList<>()).getProtobufMessage(ClientVersion.CURRENT.serialize())
+              new ArrayList<>(), new ArrayList<>()).getProtobufMessage(ClientVersion.CURRENT)
       );
     }
 
@@ -458,7 +458,7 @@ public class TestRatisPipelineProvider {
         .setId(PipelineID.randomId())
         .build();
     HddsProtos.Pipeline pipelineProto = openPipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
 
     stateManager.addPipeline(pipelineProto);
     nodeManager.addPipeline(openPipeline);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -81,7 +81,7 @@ public class TestSimplePipelineProvider {
     Pipeline pipeline =
         provider.create(StandaloneReplicationConfig.getInstance(factor));
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto);
     assertEquals(pipeline.getType(), HddsProtos.ReplicationType.STAND_ALONE);
     assertEquals(pipeline.getReplicationConfig().getRequiredNodes(), factor.getNumber());
@@ -92,7 +92,7 @@ public class TestSimplePipelineProvider {
     Pipeline pipeline1 =
         provider.create(StandaloneReplicationConfig.getInstance(factor));
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     stateManager.addPipeline(pipelineProto1);
     assertEquals(pipeline1.getType(), HddsProtos.ReplicationType.STAND_ALONE);
     assertEquals(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -274,7 +274,7 @@ public class TestSCMBlockProtocolServer {
             .setClient(client)
             .build();
     ScmBlockLocationProtocolProtos.SortDatanodesResponseProto resp =
-        service.sortDatanodes(request, ClientVersion.CURRENT.serialize());
+        service.sortDatanodes(request, ClientVersion.CURRENT);
     assertEquals(NODE_COUNT, resp.getNodeList().size());
     System.out.println("client = " + client);
     resp.getNodeList().stream().forEach(
@@ -290,7 +290,7 @@ public class TestSCMBlockProtocolServer {
         .addAllNodeNetworkName(nodes)
         .setClient(client)
         .build();
-    resp = service.sortDatanodes(request, ClientVersion.CURRENT.serialize());
+    resp = service.sortDatanodes(request, ClientVersion.CURRENT);
     System.out.println("client = " + client);
     assertEquals(0, resp.getNodeList().size());
     resp.getNodeList().stream().forEach(

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -252,7 +252,7 @@ public class ContainerOperationClient implements ScmClient {
       HddsProtos.QueryScope queryScope, String poolName)
       throws IOException {
     return storageContainerLocationClient.queryNode(opState, nodeState,
-        queryScope, poolName, ClientVersion.CURRENT.serialize());
+        queryScope, poolName, ClientVersion.CURRENT);
   }
 
   @Override
@@ -467,7 +467,7 @@ public class ContainerOperationClient implements ScmClient {
   public List<ContainerReplicaInfo> getContainerReplicas(long containerId) throws IOException {
     List<HddsProtos.SCMContainerReplicaProto> protos =
         storageContainerLocationClient.getContainerReplicas(containerId,
-            ClientVersion.CURRENT.serialize());
+            ClientVersion.CURRENT);
     List<ContainerReplicaInfo> replicas = new ArrayList<>();
     for (HddsProtos.SCMContainerReplicaProto p : protos) {
       replicas.add(ContainerReplicaInfo.fromProto(p));
@@ -590,14 +590,14 @@ public class ContainerOperationClient implements ScmClient {
   public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       String address, String uuid) throws IOException {
     return storageContainerLocationClient.getDatanodeUsageInfo(address,
-        uuid, ClientVersion.CURRENT.serialize());
+        uuid, ClientVersion.CURRENT);
   }
 
   @Override
   public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       boolean mostUsed, int count) throws IOException {
     return storageContainerLocationClient.getDatanodeUsageInfo(mostUsed, count,
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
   }
 
   @Override

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
@@ -88,7 +88,7 @@ public class ContainerMapper {
                 keyValueTableIterator.next();
             OmKeyInfo omKeyInfo = keyValue.getValue();
             byte[] value = omKeyInfo
-                .getProtobuf(true, ClientVersion.CURRENT.serialize())
+                .getProtobuf(true, ClientVersion.CURRENT)
                 .toByteArray();
             OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(
                 OzoneManagerProtocolProtos.KeyInfo.parseFrom(value));

--- a/hadoop-ozone/cli-debug/src/test/java/org/apache/hadoop/ozone/debug/om/TestContainerToKeyMapping.java
+++ b/hadoop-ozone/cli-debug/src/test/java/org/apache/hadoop/ozone/debug/om/TestContainerToKeyMapping.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.debug.OzoneDebug;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -304,7 +305,7 @@ public class TestContainerToKeyMapping {
     // Create part 1 with a block in container 4
     OmKeyInfo part1Info = createOBSKeyInfo(
         mpuKeyName + "/" + uploadId + "/part-1", MPU_PART1_ID, CONTAINER_ID_4);
-    KeyInfo part1Proto = part1Info.getProtobuf(true, 0);
+    KeyInfo part1Proto = part1Info.getProtobuf(true, ClientVersion.DEFAULT_VERSION);
     PartKeyInfo partKeyInfo1 = PartKeyInfo.newBuilder()
         .setPartName(mpuKeyName + "/" + uploadId + "/part-1")
         .setPartNumber(1)
@@ -314,7 +315,7 @@ public class TestContainerToKeyMapping {
     // Create part 2 with a block in container 4
     OmKeyInfo part2Info = createOBSKeyInfo(
         mpuKeyName + "/" + uploadId + "/part-2", MPU_PART2_ID, CONTAINER_ID_4);
-    KeyInfo part2Proto = part2Info.getProtobuf(true, 0);
+    KeyInfo part2Proto = part2Info.getProtobuf(true, ClientVersion.DEFAULT_VERSION);
     PartKeyInfo partKeyInfo2 = PartKeyInfo.newBuilder()
         .setPartName(mpuKeyName + "/" + uploadId + "/part-2")
         .setPartNumber(2)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/KeyInfoWithVolumeContext.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/KeyInfoWithVolumeContext.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import java.io.IOException;
 import java.util.Optional;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetKeyInfoResponse;
 
 /**
@@ -55,7 +56,7 @@ public class KeyInfoWithVolumeContext {
         .build();
   }
 
-  public GetKeyInfoResponse toProtobuf(int clientVersion) {
+  public GetKeyInfoResponse toProtobuf(ClientVersion clientVersion) {
     GetKeyInfoResponse.Builder builder = GetKeyInfoResponse.newBuilder();
     volumeArgs.ifPresent(v -> builder.setVolumeInfo(v.getProtobuf()));
     userPrincipal.ifPresent(builder::setUserPrincipal);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -143,7 +143,7 @@ public final class OmKeyInfo extends WithParentObjectId
     return new DelegatedCodec<>(
         Proto2Codec.get(KeyInfo.getDefaultInstance()),
         OmKeyInfo::getFromProtobuf,
-        k -> k.getProtobuf(true, ClientVersion.CURRENT.serialize(), isOpenKey),
+        k -> k.getProtobuf(true, ClientVersion.CURRENT, isOpenKey),
         OmKeyInfo.class);
   }
 
@@ -724,7 +724,7 @@ public final class OmKeyInfo extends WithParentObjectId
    * For network transmit.
    * @return KeyInfo
    */
-  public KeyInfo getProtobuf(int clientVersion) {
+  public KeyInfo getProtobuf(ClientVersion clientVersion) {
     return getProtobuf(false, clientVersion);
   }
 
@@ -734,7 +734,7 @@ public final class OmKeyInfo extends WithParentObjectId
    * @param latestVersion
    * @return key info.
    */
-  public KeyInfo getNetworkProtobuf(int clientVersion, boolean latestVersion) {
+  public KeyInfo getNetworkProtobuf(ClientVersion clientVersion, boolean latestVersion) {
     return getProtobuf(false, null, clientVersion, latestVersion);
   }
 
@@ -746,7 +746,7 @@ public final class OmKeyInfo extends WithParentObjectId
    * @param latestVersion
    * @return key info with the user given full key name
    */
-  public KeyInfo getNetworkProtobuf(String fullKeyName, int clientVersion,
+  public KeyInfo getNetworkProtobuf(String fullKeyName, ClientVersion clientVersion,
       boolean latestVersion) {
     return getProtobuf(false, fullKeyName, clientVersion, latestVersion);
   }
@@ -756,7 +756,7 @@ public final class OmKeyInfo extends WithParentObjectId
    * @param ignorePipeline true for persist to DB, false for network transmit.
    * @return KeyInfo
    */
-  public KeyInfo getProtobuf(boolean ignorePipeline, int clientVersion) {
+  public KeyInfo getProtobuf(boolean ignorePipeline, ClientVersion clientVersion) {
     return getProtobuf(ignorePipeline, null, clientVersion, false, true);
   }
 
@@ -768,7 +768,7 @@ public final class OmKeyInfo extends WithParentObjectId
    * @param isOpenKey true for openKeyTable, false for keyTable
    * @return KeyInfo
    */
-  public KeyInfo getProtobuf(boolean ignorePipeline, int clientVersion,
+  public KeyInfo getProtobuf(boolean ignorePipeline, ClientVersion clientVersion,
                              boolean isOpenKey) {
     return getProtobuf(ignorePipeline, null, clientVersion, false, isOpenKey);
   }
@@ -781,7 +781,7 @@ public final class OmKeyInfo extends WithParentObjectId
    * @return key info object
    */
   private KeyInfo getProtobuf(boolean ignorePipeline, String fullKeyName,
-                              int clientVersion, boolean latestVersionBlocks) {
+                              ClientVersion clientVersion, boolean latestVersionBlocks) {
     return getProtobuf(ignorePipeline, fullKeyName, clientVersion, latestVersionBlocks, true);
   }
 
@@ -796,7 +796,7 @@ public final class OmKeyInfo extends WithParentObjectId
    * @return key info object
    */
   private KeyInfo getProtobuf(boolean ignorePipeline, String fullKeyName,
-                              int clientVersion, boolean latestVersionBlocks,
+                              ClientVersion clientVersion, boolean latestVersionBlocks,
                               boolean isOpenKey) {
     long latestVersion = keyLocationVersions.isEmpty() ? -1 :
         keyLocationVersions.get(keyLocationVersions.size() - 1).getVersion();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockLocationInfo;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.security.token.Token;
@@ -88,11 +89,11 @@ public final class OmKeyLocationInfo extends BlockLocationInfo {
     }
   }
 
-  public KeyLocation getProtobuf(int clientVersion) {
+  public KeyLocation getProtobuf(ClientVersion clientVersion) {
     return getProtobuf(false, clientVersion);
   }
 
-  public KeyLocation getProtobuf(boolean ignorePipeline, int clientVersion) {
+  public KeyLocation getProtobuf(boolean ignorePipeline, ClientVersion clientVersion) {
     KeyLocation.Builder builder = KeyLocation.newBuilder()
         .setBlockID(getBlockID().getProtobuf())
         .setLength(getLength())

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocationList;
 
@@ -125,7 +126,7 @@ public class OmKeyLocationInfoGroup {
   }
 
   public KeyLocationList getProtobuf(boolean ignorePipeline,
-      int clientVersion) {
+      ClientVersion clientVersion) {
     KeyLocationList.Builder builder = KeyLocationList.newBuilder()
         .setVersion(version).setIsMultipartKey(isMultipartKey);
     List<OzoneManagerProtocolProtos.KeyLocation> keyLocationList =

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartPartInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartPartInfo.java
@@ -338,7 +338,7 @@ public final class OmMultipartPartInfo {
     if (keyLocationInfos == null || keyLocationInfos.isEmpty()) {
       throw new IllegalArgumentException("keyLocationList is required");
     }
-    return keyLocationInfos.get(0).getProtobuf(true, ClientVersion.CURRENT.serialize());
+    return keyLocationInfos.get(0).getProtobuf(true, ClientVersion.CURRENT);
   }
 
   private static List<OmKeyLocationInfoGroup> getKeyLocationInfosFromProto(

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 
 import java.io.IOException;
 import java.util.Objects;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto.Builder;
 
@@ -92,7 +93,7 @@ public class OzoneFileStatus {
     return !isDirectory();
   }
 
-  public OzoneFileStatusProto getProtobuf(int clientVersion) {
+  public OzoneFileStatusProto getProtobuf(ClientVersion clientVersion) {
     Builder builder = OzoneFileStatusProto.newBuilder()
         .setBlockSize(blockSize)
         .setIsDirectory(isDirectory);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -60,7 +60,7 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
     return new DelegatedCodec<>(
         Proto2Codec.get(RepeatedKeyInfo.getDefaultInstance()),
         RepeatedOmKeyInfo::getFromProto,
-        k -> k.getProto(ignorePipeline, ClientVersion.CURRENT.serialize(), isOpenKey),
+        k -> k.getProto(ignorePipeline, ClientVersion.CURRENT, isOpenKey),
         RepeatedOmKeyInfo.class);
   }
 
@@ -151,7 +151,7 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
   /**
    * @param compact true for persistence, false for network transmit
    */
-  public RepeatedKeyInfo getProto(boolean compact, int clientVersion) {
+  public RepeatedKeyInfo getProto(boolean compact, ClientVersion clientVersion) {
     return getProto(compact, clientVersion, true);
   }
 
@@ -160,7 +160,7 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
    * @param clientVersion the client version
    * @param isOpenKey true for openKeyTable, false for keyTable/deletedTable
    */
-  public RepeatedKeyInfo getProto(boolean compact, int clientVersion, boolean isOpenKey) {
+  public RepeatedKeyInfo getProto(boolean compact, ClientVersion clientVersion, boolean isOpenKey) {
     List<KeyInfo> list = new ArrayList<>();
     for (OmKeyInfo k : cloneOmKeyInfoList()) {
       list.add(k.getProtobuf(compact, clientVersion, isOpenKey));

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -855,7 +855,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .addAllMetadata(KeyValueUtil.toProtobuf(args.getMetadata()))
         .addAllKeyLocations(locationInfoList.stream()
             // TODO use OM version?
-            .map(info -> info.getProtobuf(ClientVersion.CURRENT.serialize()))
+            .map(info -> info.getProtobuf(ClientVersion.CURRENT))
             .collect(Collectors.toList()));
 
     setReplicationConfig(args.getReplicationConfig(), keyArgsBuilder);
@@ -1774,7 +1774,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .addAllMetadata(KeyValueUtil.toProtobuf(omKeyArgs.getMetadata()))
         .addAllKeyLocations(locationInfoList.stream()
             // TODO use OM version?
-            .map(info -> info.getProtobuf(ClientVersion.CURRENT.serialize()))
+            .map(info -> info.getProtobuf(ClientVersion.CURRENT))
             .collect(Collectors.toList()));
     multipartCommitUploadPartRequest.setClientID(clientId);
     multipartCommitUploadPartRequest.setKeyArgs(keyArgs.build());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -854,7 +854,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setDataSize(args.getDataSize())
         .addAllMetadata(KeyValueUtil.toProtobuf(args.getMetadata()))
         .addAllKeyLocations(locationInfoList.stream()
-            // TODO use OM version?
             .map(info -> info.getProtobuf(ClientVersion.CURRENT))
             .collect(Collectors.toList()));
 
@@ -1773,7 +1772,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setDataSize(omKeyArgs.getDataSize())
         .addAllMetadata(KeyValueUtil.toProtobuf(omKeyArgs.getMetadata()))
         .addAllKeyLocations(locationInfoList.stream()
-            // TODO use OM version?
             .map(info -> info.getProtobuf(ClientVersion.CURRENT))
             .collect(Collectors.toList()));
     multipartCommitUploadPartRequest.setClientID(clientId);

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -60,7 +60,7 @@ public class TestOmKeyInfo {
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
 
     OmKeyInfo keyAfterSerialization = OmKeyInfo.getFromProtobuf(
-        key.getProtobuf(ClientVersion.CURRENT.serialize()));
+        key.getProtobuf(ClientVersion.CURRENT));
 
     assertNotNull(keyAfterSerialization);
     assertEquals(key, keyAfterSerialization);
@@ -78,7 +78,7 @@ public class TestOmKeyInfo {
     OmKeyInfo key = createOmKeyInfo(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     OzoneManagerProtocolProtos.KeyInfo omKeyProto =
-        key.getProtobuf(ClientVersion.CURRENT.serialize());
+        key.getProtobuf(ClientVersion.CURRENT);
 
     // No EC Config
     assertFalse(omKeyProto.hasEcReplicationConfig());
@@ -95,7 +95,7 @@ public class TestOmKeyInfo {
     // EC Config
     key = createOmKeyInfo(new ECReplicationConfig(3, 2));
     assertFalse(key.isHsync());
-    omKeyProto = key.getProtobuf(ClientVersion.CURRENT.serialize());
+    omKeyProto = key.getProtobuf(ClientVersion.CURRENT);
 
     assertEquals(3,
         omKeyProto.getEcReplicationConfig().getData());

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/AbstractTestStorageDistributionEndpoint.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/AbstractTestStorageDistributionEndpoint.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -229,7 +230,8 @@ public abstract class AbstractTestStorageDistributionEndpoint {
 
       List<DatanodeStorageReport> reports = storageResponse.getDataNodeUsage();
       List<HddsProtos.DatanodeUsageInfoProto> scmReports =
-          scm.getClientProtocolServer().getDatanodeUsageInfo(true, getNumDatanodes(), 1);
+          scm.getClientProtocolServer().getDatanodeUsageInfo(true, getNumDatanodes(),
+              ClientVersion.VERSION_HANDLES_UNKNOWN_DN_PORTS);
 
       long totalReserved = 0;
       long totalMinFreeSpace = 0;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestScmApplyTransactionFailure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestScmApplyTransactionFailure.java
@@ -94,7 +94,7 @@ public abstract class TestScmApplyTransactionFailure implements HATests.TestCase
         replication, PipelineState.OPEN).get(0);
 
     HddsProtos.Pipeline pipelineToCreate =
-        existing.getProtobufMessage(CURRENT.serialize());
+        existing.getProtobufMessage(CURRENT);
     Throwable ex = assertThrows(SCMException.class,
         () -> pipelineManager.getStateManager().addPipeline(
             pipelineToCreate));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -500,7 +500,7 @@ public class TestLDBCli {
       OmKeyInfo value = OMRequestTestUtils.createOmKeyInfo("vol1", "buck1",
           key, ReplicationConfig.fromProtoTypeAndFactor(STAND_ALONE,
               HddsProtos.ReplicationFactor.ONE)).build();
-      keyTable.put(key.getBytes(UTF_8), value.getProtobuf(ClientVersion.CURRENT.serialize()).toByteArray());
+      keyTable.put(key.getBytes(UTF_8), value.getProtobuf(ClientVersion.CURRENT).toByteArray());
       // Populate map
       dbMap.put(key, toMap(value));
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/checksum/TestContainerCommandReconciliation.java
@@ -511,7 +511,7 @@ public class TestContainerCommandReconciliation {
     // Check non-zero checksum after container close
     StorageContainerLocationProtocolClientSideTranslatorPB scmClient = cluster.getStorageContainerLocationClient();
     List<HddsProtos.SCMContainerReplicaProto> containerReplicas = scmClient.getContainerReplicas(containerID,
-        ClientVersion.CURRENT.serialize());
+        ClientVersion.CURRENT);
     assertEquals(3, containerReplicas.size());
     for (HddsProtos.SCMContainerReplicaProto containerReplica: containerReplicas) {
       assertNotEquals(0, containerReplica.getDataChecksum());
@@ -545,7 +545,7 @@ public class TestContainerCommandReconciliation {
     scmClient.reconcileContainer(containerID);
     waitForDataChecksumsAtSCM(containerID, 1);
     // Check non-zero checksum after container reconciliation
-    containerReplicas = scmClient.getContainerReplicas(containerID, ClientVersion.CURRENT.serialize());
+    containerReplicas = scmClient.getContainerReplicas(containerID, ClientVersion.CURRENT);
     assertEquals(3, containerReplicas.size());
     for (HddsProtos.SCMContainerReplicaProto containerReplica: containerReplicas) {
       assertNotEquals(0, containerReplica.getDataChecksum());
@@ -559,7 +559,7 @@ public class TestContainerCommandReconciliation {
     }
     cluster.waitForClusterToBeReady();
     waitForDataChecksumsAtSCM(containerID, 1);
-    containerReplicas = scmClient.getContainerReplicas(containerID, ClientVersion.CURRENT.serialize());
+    containerReplicas = scmClient.getContainerReplicas(containerID, ClientVersion.CURRENT);
     assertEquals(3, containerReplicas.size());
     for (HddsProtos.SCMContainerReplicaProto containerReplica: containerReplicas) {
       assertNotEquals(0, containerReplica.getDataChecksum());
@@ -571,7 +571,7 @@ public class TestContainerCommandReconciliation {
     GenericTestUtils.waitFor(() -> {
       try {
         Set<Long> dataChecksums = cluster.getStorageContainerLocationClient().getContainerReplicas(containerID,
-                ClientVersion.CURRENT.serialize()).stream()
+                ClientVersion.CURRENT).stream()
             .map(HddsProtos.SCMContainerReplicaProto::getDataChecksum)
             .collect(Collectors.toSet());
         LOG.info("Waiting for {} total unique checksums from container {} to be reported to SCM. Currently {} unique" +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1501,7 +1501,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
                 .map(OmKeyLocationInfoGroup::getLocationList)
                 .map(Collection::stream)
                 .orElseGet(Stream::empty)
-                .map(loc -> loc.getProtobuf(ClientVersion.CURRENT.serialize()))
+                .map(loc -> loc.getProtobuf(ClientVersion.CURRENT))
                 .forEach(keyArgs::addKeyLocations);
 
             OzoneManagerProtocolClientSideTranslatorPB.setReplicationConfig(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.utils.UniqueId;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -135,7 +136,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
         .setDataSize(requestedSize);
 
     newKeyArgs.addAllKeyLocations(omKeyLocationInfoList.stream()
-        .map(info -> info.getProtobuf(getOmRequest().getVersion()))
+        .map(info -> info.getProtobuf(
+            ClientVersion.deserialize(getOmRequest().getVersion())))
         .collect(Collectors.toList()));
 
     generateRequiredEncryptionInfo(keyArgs, newKeyArgs, ozoneManager);
@@ -279,7 +281,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
 
       // Prepare response
       omResponse.setCreateFileResponse(CreateFileResponse.newBuilder()
-          .setKeyInfo(omKeyInfo.getNetworkProtobuf(getOmRequest().getVersion(),
+          .setKeyInfo(omKeyInfo.getNetworkProtobuf(
+              ClientVersion.deserialize(getOmRequest().getVersion()),
               keyArgs.getLatestVersionLocation()))
           .setID(clientID)
           .setOpenVersion(openVersion).build())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -207,7 +208,7 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
 
       // Prepare response. Sets user given full key name in the 'keyName'
       // attribute in response object.
-      int clientVersion = getOmRequest().getVersion();
+      ClientVersion clientVersion = ClientVersion.deserialize(getOmRequest().getVersion());
       omResponse.setCreateFileResponse(CreateFileResponse.newBuilder()
           .setKeyInfo(omFileInfo.getNetworkProtobuf(keyName, clientVersion,
               keyArgs.getLatestVersionLocation()))

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -257,8 +258,10 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
     }
 
     RecoverLeaseResponse.Builder rb = RecoverLeaseResponse.newBuilder();
-    rb.setKeyInfo(keyInfo.getNetworkProtobuf(getOmRequest().getVersion(), true));
-    rb.setOpenKeyInfo(openKeyInfo.getNetworkProtobuf(getOmRequest().getVersion(), true));
+    rb.setKeyInfo(keyInfo.getNetworkProtobuf(
+        ClientVersion.deserialize(getOmRequest().getVersion()), true));
+    rb.setOpenKeyInfo(openKeyInfo.getNetworkProtobuf(
+        ClientVersion.deserialize(getOmRequest().getVersion()), true));
     return rb.build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -258,10 +258,9 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
     }
 
     RecoverLeaseResponse.Builder rb = RecoverLeaseResponse.newBuilder();
-    rb.setKeyInfo(keyInfo.getNetworkProtobuf(
-        ClientVersion.deserialize(getOmRequest().getVersion()), true));
-    rb.setOpenKeyInfo(openKeyInfo.getNetworkProtobuf(
-        ClientVersion.deserialize(getOmRequest().getVersion()), true));
+    ClientVersion clientVersion = ClientVersion.deserialize(getOmRequest().getVersion());
+    rb.setKeyInfo(keyInfo.getNetworkProtobuf(clientVersion, true));
+    rb.setOpenKeyInfo(openKeyInfo.getNetworkProtobuf(clientVersion, true));
     return rb.build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.OMAction;
@@ -131,7 +132,8 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
 
     // Add allocated block info.
     newAllocatedBlockRequest.setKeyLocation(
-        omKeyLocationInfoList.get(0).getProtobuf(getOmRequest().getVersion()));
+        omKeyLocationInfoList.get(0).getProtobuf(
+            ClientVersion.deserialize(getOmRequest().getVersion())));
 
     return getOmRequest().toBuilder().setUserInfo(userInfo)
         .setAllocateBlockRequest(newAllocatedBlockRequest).build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.utils.UniqueId;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
@@ -163,7 +164,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
       newKeyArgs.addAllKeyLocations(omKeyLocationInfoList.stream()
           .map(info -> info.getProtobuf(false,
-              getOmRequest().getVersion()))
+              ClientVersion.deserialize(getOmRequest().getVersion())))
           .collect(Collectors.toList()));
     } else {
       newKeyArgs = keyArgs.toBuilder().setModificationTime(Time.now());
@@ -336,7 +337,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
       // Prepare response
       omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
-          .setKeyInfo(omKeyInfo.getNetworkProtobuf(getOmRequest().getVersion(),
+          .setKeyInfo(omKeyInfo.getNetworkProtobuf(
+              ClientVersion.deserialize(getOmRequest().getVersion()),
               keyArgs.getLatestVersionLocation()))
           .setID(clientID)
           .setOpenVersion(openVersion).build())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -201,7 +202,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
 
       // Prepare response. Sets user given full key name in the 'keyName'
       // attribute in response object.
-      int clientVersion = getOmRequest().getVersion();
+      ClientVersion clientVersion = ClientVersion.deserialize(getOmRequest().getVersion());
       omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
               .setKeyInfo(omFileInfo.getNetworkProtobuf(keyName, clientVersion,
                   keyArgs.getLatestVersionLocation()))

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -217,7 +218,8 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           OzoneManagerProtocolProtos.PartKeyInfo.newBuilder();
       partKeyInfo.setPartName(partName);
       partKeyInfo.setPartNumber(partNumber);
-      partKeyInfo.setPartKeyInfo(omKeyInfo.getProtobuf(getOmRequest().getVersion()));
+      partKeyInfo.setPartKeyInfo(omKeyInfo.getProtobuf(
+          ClientVersion.deserialize(getOmRequest().getVersion())));
 
       if (multipartKeyInfo.getSchemaVersion() == OmMultipartKeyInfo.LEGACY_SCHEMA_VERSION) {
         // Add this part information in to multipartKeyInfo.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -605,7 +606,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       partKeyInfos.put(entry.getKey(), PartKeyInfo.newBuilder()
           .setPartName(partInfo.getPartName())
           .setPartNumber(partInfo.getPartNumber())
-          .setPartKeyInfo(partKeyInfo.getProtobuf(getOmRequest().getVersion()))
+          .setPartKeyInfo(partKeyInfo.getProtobuf(
+              ClientVersion.deserialize(getOmRequest().getVersion())))
           .build());
     }
     return new OmMultipartKeyInfo.PartKeyInfoMap(partKeyInfos);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -521,14 +521,14 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
 
     for (OmKeyInfo purgeFile : purgeDeletedFiles) {
       purgePathsRequest.addDeletedSubFiles(
-          purgeFile.getProtobuf(true, ClientVersion.CURRENT.serialize()));
+          purgeFile.getProtobuf(true, ClientVersion.CURRENT));
     }
 
     // Add these directories to deletedDirTable, so that its sub-paths will be
     // traversed in next iteration to ensure cleanup all sub-children.
     for (OmKeyInfo dir : markDirsAsDeleted) {
       purgePathsRequest.addMarkDeletedSubDirs(
-          dir.getProtobuf(ClientVersion.CURRENT.serialize()));
+          dir.getProtobuf(ClientVersion.CURRENT));
     }
 
     return purgePathsRequest.build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -333,7 +333,7 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
         keyToUpdate.setKey(keyToModify.getKey());
         List<OzoneManagerProtocolProtos.KeyInfo> keyInfos =
             keyToModify.getValue().getOmKeyInfoList().stream()
-                .map(k -> k.getProtobuf(ClientVersion.CURRENT.serialize()))
+                .map(k -> k.getProtobuf(ClientVersion.CURRENT))
                 .collect(Collectors.toList());
         keyToUpdate.addAllKeyInfos(keyInfos);
         keyToUpdate.setBucketId(keyToModify.getValue().getBucketId());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -196,14 +196,14 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
               for (Table.KeyValue<String, List<OmKeyInfo>> deletedEntry : deletedKeyEntries) {
                 deletedKeys.add(SnapshotMoveKeyInfos.newBuilder().setKey(deletedEntry.getKey())
                     .addAllKeyInfos(deletedEntry.getValue()
-                        .stream().map(val -> val.getProtobuf(ClientVersion.CURRENT.serialize()))
+                        .stream().map(val -> val.getProtobuf(ClientVersion.CURRENT))
                         .collect(Collectors.toList())).build());
               }
 
               // Convert deletedDirEntries to SnapshotMoveKeyInfos.
               for (Table.KeyValue<String, OmKeyInfo> deletedDirEntry : deletedDirEntries) {
                 deletedDirs.add(SnapshotMoveKeyInfos.newBuilder().setKey(deletedDirEntry.getKey())
-                    .addKeyInfos(deletedDirEntry.getValue().getProtobuf(ClientVersion.CURRENT.serialize())).build());
+                    .addKeyInfos(deletedDirEntry.getValue().getProtobuf(ClientVersion.CURRENT)).build());
               }
 
               // Convert renamedEntries to KeyValue.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.TransferLeadershipRespon
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.UpgradeFinalizationStatus;
 import org.apache.hadoop.hdds.scm.protocolPB.OzonePBHelper;
 import org.apache.hadoop.hdds.utils.FaultInjector;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -200,6 +201,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     Type cmdType = request.getCmdType();
     OMResponse.Builder responseBuilder = OmResponseUtil.getOMResponseBuilder(
         request);
+    final ClientVersion clientVersion = ClientVersion.deserialize(request.getVersion());
     try {
       switch (cmdType) {
       case CheckVolumeAccess:
@@ -229,12 +231,12 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         break;
       case LookupKey:
         LookupKeyResponse lookupKeyResponse = lookupKey(
-            request.getLookupKeyRequest(), request.getVersion());
+            request.getLookupKeyRequest(), clientVersion);
         responseBuilder.setLookupKeyResponse(lookupKeyResponse);
         break;
       case ListKeys:
         ListKeysResponse listKeysResponse = listKeys(
-            request.getListKeysRequest(), request.getVersion());
+            request.getListKeysRequest(), clientVersion);
         responseBuilder.setListKeysResponse(listKeysResponse);
         break;
       case ListKeysLight:
@@ -254,7 +256,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         break;
       case ListOpenFiles:
         ListOpenFilesResponse listOpenFilesResponse = listOpenFiles(
-            request.getListOpenFilesRequest(), request.getVersion());
+            request.getListOpenFilesRequest(), clientVersion);
         responseBuilder.setListOpenFilesResponse(listOpenFilesResponse);
         break;
       case ServiceList:
@@ -274,23 +276,22 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         break;
       case GetFileStatus:
         GetFileStatusResponse getFileStatusResponse = getOzoneFileStatus(
-            request.getGetFileStatusRequest(), request.getVersion());
+            request.getGetFileStatusRequest(), clientVersion);
         responseBuilder.setGetFileStatusResponse(getFileStatusResponse);
         break;
       case LookupFile:
         LookupFileResponse lookupFileResponse =
-            lookupFile(request.getLookupFileRequest(), request.getVersion());
+            lookupFile(request.getLookupFileRequest(), clientVersion);
         responseBuilder.setLookupFileResponse(lookupFileResponse);
         break;
       case ListStatus:
         ListStatusResponse listStatusResponse =
-            listStatus(request.getListStatusRequest(), request.getVersion());
+            listStatus(request.getListStatusRequest(), clientVersion);
         responseBuilder.setListStatusResponse(listStatusResponse);
         break;
       case ListStatusLight:
         ListStatusLightResponse listStatusLightResponse =
-            listStatusLight(request.getListStatusRequest(),
-                request.getVersion());
+            listStatusLight(request.getListStatusRequest());
         responseBuilder.setListStatusLightResponse(listStatusLightResponse);
         break;
       case GetAcl:
@@ -343,7 +344,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         break;
       case GetKeyInfo:
         responseBuilder.setGetKeyInfoResponse(
-            getKeyInfo(request.getGetKeyInfoRequest(), request.getVersion()));
+            getKeyInfo(request.getGetKeyInfoRequest(), clientVersion));
         break;
       case ListSnapshot:
         OzoneManagerProtocolProtos.ListSnapshotResponse listSnapshotResponse =
@@ -649,7 +650,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   private LookupKeyResponse lookupKey(LookupKeyRequest request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     LookupKeyResponse.Builder resp =
         LookupKeyResponse.newBuilder();
     KeyArgs keyArgs = request.getKeyArgs();
@@ -669,7 +670,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   private GetKeyInfoResponse getKeyInfo(GetKeyInfoRequest request,
-                                        int clientVersion) throws IOException {
+                                        ClientVersion clientVersion) throws IOException {
     KeyArgs keyArgs = request.getKeyArgs();
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(keyArgs.getVolumeName())
@@ -766,7 +767,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     return resp.build();
   }
 
-  private ListKeysResponse listKeys(ListKeysRequest request, int clientVersion)
+  private ListKeysResponse listKeys(ListKeysRequest request, ClientVersion clientVersion)
       throws IOException {
     ListKeysResponse.Builder resp =
         ListKeysResponse.newBuilder();
@@ -947,7 +948,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
   @DisallowedUntilLayoutVersion(HBASE_SUPPORT)
   private ListOpenFilesResponse listOpenFiles(ListOpenFilesRequest req,
-                                              int clientVersion)
+                                              ClientVersion clientVersion)
       throws IOException {
     ListOpenFilesResponse.Builder resp = ListOpenFilesResponse.newBuilder();
 
@@ -1086,7 +1087,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   private GetFileStatusResponse getOzoneFileStatus(
-      GetFileStatusRequest request, int clientVersion) throws IOException {
+      GetFileStatusRequest request, ClientVersion clientVersion) throws IOException {
     KeyArgs keyArgs = request.getKeyArgs();
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(keyArgs.getVolumeName())
@@ -1191,7 +1192,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   private LookupFileResponse lookupFile(LookupFileRequest request,
-      int clientVersion) throws IOException {
+      ClientVersion clientVersion) throws IOException {
     KeyArgs keyArgs = request.getKeyArgs();
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(keyArgs.getVolumeName())
@@ -1265,7 +1266,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   private ListStatusResponse listStatus(
-      ListStatusRequest request, int clientVersion) throws IOException {
+      ListStatusRequest request, ClientVersion clientVersion) throws IOException {
     KeyArgs keyArgs = request.getKeyArgs();
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(keyArgs.getVolumeName())
@@ -1289,8 +1290,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     return listStatusResponseBuilder.build();
   }
 
-  private ListStatusLightResponse listStatusLight(
-      ListStatusRequest request, int clientVersion) throws IOException {
+  private ListStatusLightResponse listStatusLight(ListStatusRequest request) throws IOException {
     KeyArgs keyArgs = request.getKeyArgs();
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(keyArgs.getVolumeName())

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -1381,7 +1381,7 @@ public final class OMRequestTestUtils {
               .setKey(deletedKey.getKey())
               .addAllKeyInfos(
                   deletedKey.getValue().stream()
-                      .map(omKeyInfo -> omKeyInfo.getProtobuf(ClientVersion.CURRENT.serialize()))
+                      .map(omKeyInfo -> omKeyInfo.getProtobuf(ClientVersion.CURRENT))
                       .collect(Collectors.toList()))
               .build();
       deletedMoveKeys.add(snapshotMoveKeyInfos);
@@ -1394,7 +1394,7 @@ public final class OMRequestTestUtils {
               .setKey(deletedKey.getKey())
               .addAllKeyInfos(
                   deletedKey.getValue().stream()
-                      .map(omKeyInfo -> omKeyInfo.getProtobuf(ClientVersion.CURRENT.serialize()))
+                      .map(omKeyInfo -> omKeyInfo.getProtobuf(ClientVersion.CURRENT))
                       .collect(Collectors.toList()))
               .build();
       deletedDirMoveKeys.add(snapshotMoveKeyInfos);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -377,7 +377,7 @@ public class TestOMRecoverLeaseRequest extends OMKeyRequestTests {
         .setDataSize(keyArgs.getDataSize())
         .addAllMetadata(KeyValueUtil.toProtobuf(keyArgs.getMetadata()))
         .addAllKeyLocations(locationInfoList.stream()
-            .map(info -> info.getProtobuf(ClientVersion.CURRENT.serialize()))
+            .map(info -> info.getProtobuf(ClientVersion.CURRENT))
             .collect(Collectors.toList()));
     setReplicationConfig(keyArgs.getReplicationConfig(), keyArgsBuilder);
     return keyArgsBuilder.build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -207,14 +207,14 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends OMKeyRequestTests 
 
     for (OmKeyInfo purgeFile : purgeDeletedFiles) {
       purgePathsRequest.addDeletedSubFiles(
-          purgeFile.getProtobuf(true, ClientVersion.CURRENT.serialize()));
+          purgeFile.getProtobuf(true, ClientVersion.CURRENT));
     }
 
     // Add these directories to deletedDirTable, so that its sub-paths will be
     // traversed in next iteration to ensure cleanup all sub-children.
     for (OmKeyInfo dir : markDirsAsDeleted) {
       purgePathsRequest.addMarkDeletedSubDirs(
-          dir.getProtobuf(ClientVersion.CURRENT.serialize()));
+          dir.getProtobuf(ClientVersion.CURRENT));
     }
 
     return purgePathsRequest.build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotMoveTableKeysResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotMoveTableKeysResponse.java
@@ -147,13 +147,13 @@ public class TestOMSnapshotMoveTableKeysResponse extends SnapshotRequestAndRespo
           .forEachRemaining(entry -> {
             deletedTable.add(OzoneManagerProtocolProtos.SnapshotMoveKeyInfos.newBuilder().setKey(entry.getKey())
                 .addAllKeyInfos(entry.getValue().getOmKeyInfoList().stream().map(omKeyInfo -> omKeyInfo.getProtobuf(
-                    ClientVersion.CURRENT.serialize())).collect(Collectors.toList())).build());
+                    ClientVersion.CURRENT)).collect(Collectors.toList())).build());
           });
 
       snapshot.getMetadataManager().getDeletedDirTable().iterator()
           .forEachRemaining(entry -> {
             deletedDirTable.add(OzoneManagerProtocolProtos.SnapshotMoveKeyInfos.newBuilder().setKey(entry.getKey())
-                .addKeyInfos(entry.getValue().getProtobuf(ClientVersion.CURRENT.serialize())).build());
+                .addKeyInfos(entry.getValue().getProtobuf(ClientVersion.CURRENT)).build());
           });
       snapshot.getMetadataManager().getSnapshotRenamedTable().iterator().forEachRemaining(entry -> {
         renamedTable.add(HddsProtos.KeyValue.newBuilder().setKey(entry.getKey()).setValue(entry.getValue()).build());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
@@ -336,7 +336,7 @@ public class TestSnapshotDeletingService {
       SnapshotMoveKeyInfos moveKeyInfo = SnapshotMoveKeyInfos.newBuilder()
           .setKey(largeKeyName)
           .addAllKeyInfos(keyInfos.stream()
-              .map(k -> k.getProtobuf(ClientVersion.CURRENT.serialize()))
+              .map(k -> k.getProtobuf(ClientVersion.CURRENT))
               .collect(Collectors.toList()))
           .build();
       deletedKeys.add(moveKeyInfo);
@@ -371,7 +371,7 @@ public class TestSnapshotDeletingService {
       
       SnapshotMoveKeyInfos moveDirInfo = SnapshotMoveKeyInfos.newBuilder()
           .setKey(largeDirName)
-          .addKeyInfos(dirInfo.getProtobuf(ClientVersion.CURRENT.serialize()))
+          .addKeyInfos(dirInfo.getProtobuf(ClientVersion.CURRENT))
           .build();
       deletedDirs.add(moveDirInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
@@ -77,8 +78,8 @@ public class TestOzoneManagerRequestHandler {
         OzoneManagerProtocolProtos.KeyInfo.newBuilder().setBucketName("bucket").setKeyName("key").setVolumeName(
                 "volume").setDataSize(0).setType(HddsProtos.ReplicationType.RATIS).setCreationTime(0)
             .setModificationTime(0).build();
-    Mockito.when(keyInfo.getProtobuf(Mockito.anyBoolean(), Mockito.anyInt())).thenReturn(info);
-    Mockito.when(keyInfo.getProtobuf(Mockito.anyInt())).thenReturn(info);
+    Mockito.when(keyInfo.getProtobuf(Mockito.anyBoolean(), any(ClientVersion.class))).thenReturn(info);
+    Mockito.when(keyInfo.getProtobuf(any(ClientVersion.class))).thenReturn(info);
     return keyInfo;
   }
 
@@ -176,7 +177,7 @@ public class TestOzoneManagerRequestHandler {
                           .setVersion(0).build())
                   .build())
               .build();
-      Mockito.when(status.getProtobuf(Mockito.anyInt())).thenReturn(proto);
+      Mockito.when(status.getProtobuf(any(ClientVersion.class))).thenReturn(proto);
       ArgumentCaptor<OmKeyArgs> captor = ArgumentCaptor.forClass(OmKeyArgs.class);
       Mockito.when(ozoneManager.getFileStatus(captor.capture())).thenReturn(status);
 
@@ -212,7 +213,7 @@ public class TestOzoneManagerRequestHandler {
     OzoneManager ozoneManager = requestHandler.getOzoneManager();
 
     OzoneFileStatus status = Mockito.mock(OzoneFileStatus.class);
-    Mockito.when(status.getProtobuf(Mockito.anyInt())).thenReturn(
+    Mockito.when(status.getProtobuf(any(ClientVersion.class))).thenReturn(
         OzoneManagerProtocolProtos.OzoneFileStatusProto.newBuilder()
             .setIsDirectory(true).build());
     Mockito.when(ozoneManager.getFileStatus(Mockito.any())).thenReturn(status);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
@@ -357,7 +357,7 @@ public class NodeEndpoint {
     Response.ResponseBuilder builder = Response.status(Response.Status.OK);
     Map<String, Object> responseMap = new HashMap<>();
     Stream<HddsProtos.Node> allNodes = scmClient.queryNode(DECOMMISSIONING,
-        null, HddsProtos.QueryScope.CLUSTER, "", ClientVersion.CURRENT.serialize()).stream();
+        null, HddsProtos.QueryScope.CLUSTER, "", ClientVersion.CURRENT).stream();
     List<HddsProtos.Node> decommissioningNodes =
         DecommissionUtils.getDecommissioningNodesList(allNodes, uuid, ipAddress);
     String metricsJson = scmClient.getMetrics("Hadoop:service=StorageContainerManager,name=NodeDecommissionMetrics");

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
@@ -166,7 +166,7 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
       if (containsPipeline(pipeline.getId())) {
         return false;
       }
-      getStateManager().addPipeline(pipeline.getProtobufMessage(ClientVersion.CURRENT.serialize()));
+      getStateManager().addPipeline(pipeline.getProtobufMessage(ClientVersion.CURRENT));
       return true;
     } finally {
       releaseWriteLock();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -114,7 +114,7 @@ public class StorageContainerServiceProviderImpl
   @Override
   public List<HddsProtos.Node> getNodes() throws IOException {
     return scmClient.queryNode(null, null, HddsProtos.QueryScope.CLUSTER,
-        "", ClientVersion.CURRENT.serialize());
+        "", ClientVersion.CURRENT);
   }
 
   @Override

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -100,6 +100,7 @@ import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -1359,7 +1360,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
 
   @Test
   public void testSuccessWhenDecommissionStatus() throws IOException {
-    when(mockScmClient.queryNode(any(), any(), any(), any(), any(Integer.class))).thenReturn(
+    when(mockScmClient.queryNode(any(), any(), any(), any(), any(ClientVersion.class))).thenReturn(
         nodes); // 2 nodes decommissioning
     when(mockScmClient.getContainersOnDecomNode(any())).thenReturn(containerOnDecom);
     when(mockScmClient.getMetrics(any())).thenReturn(metrics.get(1));
@@ -1385,7 +1386,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
 
   @Test
   public void testSuccessWhenDecommissionStatusWithUUID() throws IOException {
-    when(mockScmClient.queryNode(any(), any(), any(), any(), any(Integer.class))).thenReturn(
+    when(mockScmClient.queryNode(any(), any(), any(), any(), any(ClientVersion.class))).thenReturn(
         getNodeDetailsForUuid("654c4b89-04ef-4015-8a3b-50d0fb0e1684")); // 1 nodes decommissioning
     when(mockScmClient.getContainersOnDecomNode(any())).thenReturn(containerOnDecom);
     Response datanodesDecommissionInfo =


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the new versioning framework, the `ClientVersion` class should be used within the java code, and only delegate to `ClientVersion#serialize/deserialize` at the translation layers of the client and server. This PR updates existing usage of `ClientVersion` to follow this practice. The main change was in the protobuf translators for `DatanodeDetails`, which now take a `ClientVersion` and call `serialize` since those methods are already in charge of serialization. This creates a ripple effect to classes that use `DatanodeDetails` which have been updated to pass it a `ClientVersion` instead of serializing the version themselves before passing it in.

Many files were touched, but it is a simple substitution that does not amount in a large number of lines changed.

## What is the link to the Apache JIRA

HDDS-14753

## How was this patch tested?

No functional change. All existing tests should pass. Changes do not affect protobuf/disk/wire protocols
