### PR TITLE
HDDS-15889. Show failed MoveResult breakdown in ozone admin containerbalancer status -v

### DIFF
--- a/hadoop-hdds/docs/content/feature/ContainerBalancer.md
+++ b/hadoop-hdds/docs/content/feature/ContainerBalancer.md
@@ -78,6 +78,10 @@ To get a more detailed status, including the history of iterations:
 ozone admin containerbalancer status -v --history
 ```
 
+With `-v`/`--verbose`, when failures occur, a **Failed container moves** section lists each failure reason
+(e.g. `REPLICATION_FAIL_TIME_OUT`, `ITERATION_MOVE_TIMEOUT`, `PRE_MOVE_CONTAINER_NOT_FOUND` and more)
+with the total count and a per-datanode breakdown of which source and target nodes were involved.
+
 ### Stop
 
 To stop the Container Balancer:

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -675,20 +675,19 @@ message ContainerBalancerTaskIterationStatusInfoProto {
   repeated NodeTransferInfoProto sizeEnteringNodes = 9;
   repeated NodeTransferInfoProto sizeLeavingNodes = 10;
   optional int64 iterationDuration = 11;
-  repeated ContainerMoveFailureSummaryProto containerMoveFailuresByReason = 12;
-  repeated ContainerMoveFailureDetailProto containerMoveFailureDetails = 13;
-}
-
-message ContainerMoveFailureSummaryProto {
-  optional string reason = 1;
-  optional int64 count = 2;
+  repeated ContainerMoveFailureDetailProto containerMoveFailures = 12;
 }
 
 message ContainerMoveFailureDetailProto {
-  optional uint64 containerId = 1;
-  optional string sourceDatanodeUuid = 2;
-  optional string targetDatanodeUuid = 3;
-  optional string reason = 4;
+  optional string reason = 1;
+  optional int64 count = 2;
+  repeated NodeFailureCountProto sourceFailureCounts = 3;
+  repeated NodeFailureCountProto targetFailureCounts = 4;
+}
+
+message NodeFailureCountProto {
+  optional string datanodeUuid = 1;
+  optional int64 count = 2;
 }
 
 message NodeTransferInfoProto {

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -675,6 +675,20 @@ message ContainerBalancerTaskIterationStatusInfoProto {
   repeated NodeTransferInfoProto sizeEnteringNodes = 9;
   repeated NodeTransferInfoProto sizeLeavingNodes = 10;
   optional int64 iterationDuration = 11;
+  repeated ContainerMoveFailureSummaryProto containerMoveFailuresByReason = 12;
+  repeated ContainerMoveFailureDetailProto containerMoveFailureDetails = 13;
+}
+
+message ContainerMoveFailureSummaryProto {
+  optional string reason = 1;
+  optional int64 count = 2;
+}
+
+message ContainerMoveFailureDetailProto {
+  optional uint64 containerId = 1;
+  optional string sourceDatanodeUuid = 2;
+  optional string targetDatanodeUuid = 3;
+  optional string reason = 4;
 }
 
 message NodeTransferInfoProto {

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -688,6 +688,7 @@ message ContainerMoveFailureDetailProto {
 message NodeFailureCountProto {
   optional string datanodeUuid = 1;
   optional int64 count = 2;
+  optional string hostname = 3;
 }
 
 message NodeTransferInfoProto {

--- a/hadoop-hdds/interface-admin/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-admin/src/main/resources/proto.lock
@@ -2339,6 +2339,64 @@
                 "name": "iterationDuration",
                 "type": "int64",
                 "optional": true
+              },
+              {
+                "id": 12,
+                "name": "containerMoveFailuresByReason",
+                "type": "ContainerMoveFailureSummaryProto",
+                "is_repeated": true
+              },
+              {
+                "id": 13,
+                "name": "containerMoveFailureDetails",
+                "type": "ContainerMoveFailureDetailProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerMoveFailureSummaryProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "reason",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "count",
+                "type": "int64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerMoveFailureDetailProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerId",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "sourceDatanodeUuid",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "targetDatanodeUuid",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "reason",
+                "type": "string",
+                "optional": true
               }
             ]
           },

--- a/hadoop-hdds/interface-admin/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-admin/src/main/resources/proto.lock
@@ -2342,20 +2342,14 @@
               },
               {
                 "id": 12,
-                "name": "containerMoveFailuresByReason",
-                "type": "ContainerMoveFailureSummaryProto",
-                "is_repeated": true
-              },
-              {
-                "id": 13,
-                "name": "containerMoveFailureDetails",
+                "name": "containerMoveFailures",
                 "type": "ContainerMoveFailureDetailProto",
                 "is_repeated": true
               }
             ]
           },
           {
-            "name": "ContainerMoveFailureSummaryProto",
+            "name": "ContainerMoveFailureDetailProto",
             "fields": [
               {
                 "id": 1,
@@ -2368,34 +2362,34 @@
                 "name": "count",
                 "type": "int64",
                 "optional": true
+              },
+              {
+                "id": 3,
+                "name": "sourceFailureCounts",
+                "type": "NodeFailureCountProto",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "targetFailureCounts",
+                "type": "NodeFailureCountProto",
+                "is_repeated": true
               }
             ]
           },
           {
-            "name": "ContainerMoveFailureDetailProto",
+            "name": "NodeFailureCountProto",
             "fields": [
               {
                 "id": 1,
-                "name": "containerId",
-                "type": "uint64",
+                "name": "datanodeUuid",
+                "type": "string",
                 "optional": true
               },
               {
                 "id": 2,
-                "name": "sourceDatanodeUuid",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 3,
-                "name": "targetDatanodeUuid",
-                "type": "string",
-                "optional": true
-              },
-              {
-                "id": 4,
-                "name": "reason",
-                "type": "string",
+                "name": "count",
+                "type": "int64",
                 "optional": true
               }
             ]

--- a/hadoop-hdds/interface-admin/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-admin/src/main/resources/proto.lock
@@ -2391,6 +2391,12 @@
                 "name": "count",
                 "type": "int64",
                 "optional": true
+              },
+              {
+                "id": 3,
+                "name": "hostname",
+                "type": "string",
+                "optional": true
               }
             ]
           },

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -796,8 +796,7 @@ public class ContainerBalancerTask implements Runnable {
         LOG.warn("Container balancer is interrupted");
         Thread.currentThread().interrupt();
       } catch (TimeoutException e) {
-        long timeoutCounts = cancelMovesThatExceedTimeoutDuration(
-            ContainerMoveFailureReason.ITERATION_MOVE_TIMEOUT.name());
+        long timeoutCounts = cancelMovesThatExceedTimeoutDuration();
         LOG.warn("{} Container moves are canceled.", timeoutCounts);
         metrics.incrementNumContainerMovesTimeoutInLatestIteration(
             timeoutCounts);
@@ -840,7 +839,7 @@ public class ContainerBalancerTask implements Runnable {
    * @return number of moves that did not complete (timed out) and were
    * cancelled.
    */
-  private long cancelMovesThatExceedTimeoutDuration(String reason) {
+  private long cancelMovesThatExceedTimeoutDuration() {
     Set<Map.Entry<ContainerMoveSelection,
         CompletableFuture<MoveManager.MoveResult>>>
         entries = moveSelectionToFutureMap.entrySet();
@@ -861,7 +860,7 @@ public class ContainerBalancerTask implements Runnable {
         DatanodeDetails target = moveSelection.getTargetNode();
         LOG.warn("Container move timed out for container {} from source {}" +
                 " to target {}.", containerID, source, target);
-        moveFailureTracker.recordFailure(reason, source, target);
+        moveFailureTracker.recordFailure(ContainerMoveFailureReason.ITERATION_MOVE_TIMEOUT, source, target);
         entry.getValue().cancel(true);
         numCancelled += 1;
       }
@@ -1043,19 +1042,19 @@ public class ContainerBalancerTask implements Runnable {
       // exclude the container which caused failure of move to avoid error in next run.
       selectionCriteria.addToExcludeDueToFailContainers(moveSelection.getContainerID());
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
-      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_CONTAINER_NOT_FOUND.name(),
+      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_CONTAINER_NOT_FOUND,
           source, moveSelection.getTargetNode());
       return false;
     } catch (NodeNotFoundException e) {
       LOG.warn("Container move failed for container {}", containerID, e);
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
-      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_NODE_NOT_FOUND.name(),
+      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_NODE_NOT_FOUND,
           source, moveSelection.getTargetNode());
       return false;
     } catch (ContainerReplicaNotFoundException e) {
       LOG.warn("Container move failed for container {}", containerID, e);
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
-      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_REPLICA_NOT_FOUND.name(),
+      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_REPLICA_NOT_FOUND,
           source, moveSelection.getTargetNode());
       // add source back to queue for replica not found only
       // the container is not excluded as it is a replica related failure
@@ -1366,8 +1365,13 @@ public class ContainerBalancerTask implements Runnable {
   }
 
   /**
-   * Recorded when a scheduled container move fails before {@link MoveManager#move}
-   * completes, or when the balancer stops waiting for in-flight moves.
+   * Failure reasons recorded by {@link ContainerBalancerTask} that are not represented by
+   * {@link MoveManager.MoveResult}. Other move failures use {@code MoveResult} names in the
+   * failure breakdown.
+   * <p>
+   * {@code PRE_MOVE_*} values are recorded when {@link MoveManager#move} throws before returning
+   * a completed future. {@link #ITERATION_MOVE_TIMEOUT} is recorded when an in-flight move does
+   * not finish before the iteration move wait timeout expires.
    */
   enum ContainerMoveFailureReason {
     PRE_MOVE_CONTAINER_NOT_FOUND,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -94,6 +95,7 @@ public class ContainerBalancerTask implements Runnable {
   private Set<String> includeNodes;
   private ContainerBalancerConfiguration config;
   private ContainerBalancerMetrics metrics;
+  private final ContainerMoveFailureTracker moveFailureTracker;
   private double upperLimit;
   private double lowerLimit;
   private ContainerBalancerSelectionCriteria selectionCriteria;
@@ -151,6 +153,7 @@ public class ContainerBalancerTask implements Runnable {
     this.containerBalancer = containerBalancer;
     this.config = config;
     this.metrics = metrics;
+    this.moveFailureTracker = new ContainerMoveFailureTracker();
     this.scmContext = scm.getScmContext();
     this.overUtilizedNodes = new ArrayList<>();
     this.underUtilizedNodes = new ArrayList<>();
@@ -346,7 +349,7 @@ public class ContainerBalancerTask implements Runnable {
         currentIterationResultName,
         iterationDuration
     );
-    ContainerMoveInfo containerMoveInfo = new ContainerMoveInfo(metrics);
+    ContainerMoveInfo containerMoveInfo = new ContainerMoveInfo(metrics, moveFailureTracker);
 
     DataMoveInfo dataMoveInfo =
         getDataMoveInfo(sizeEnteringDataToNodes, sizeLeavingDataFromNodes);
@@ -793,7 +796,8 @@ public class ContainerBalancerTask implements Runnable {
         LOG.warn("Container balancer is interrupted");
         Thread.currentThread().interrupt();
       } catch (TimeoutException e) {
-        long timeoutCounts = cancelMovesThatExceedTimeoutDuration();
+        long timeoutCounts = cancelMovesThatExceedTimeoutDuration(
+            ContainerMoveFailureReason.ITERATION_MOVE_TIMEOUT.name());
         LOG.warn("{} Container moves are canceled.", timeoutCounts);
         metrics.incrementNumContainerMovesTimeoutInLatestIteration(
             timeoutCounts);
@@ -836,7 +840,7 @@ public class ContainerBalancerTask implements Runnable {
    * @return number of moves that did not complete (timed out) and were
    * cancelled.
    */
-  private long cancelMovesThatExceedTimeoutDuration() {
+  private long cancelMovesThatExceedTimeoutDuration(String reason) {
     Set<Map.Entry<ContainerMoveSelection,
         CompletableFuture<MoveManager.MoveResult>>>
         entries = moveSelectionToFutureMap.entrySet();
@@ -851,11 +855,13 @@ public class ContainerBalancerTask implements Runnable {
           CompletableFuture<MoveManager.MoveResult>>
           entry = iterator.next();
       if (!entry.getValue().isDone()) {
+        ContainerMoveSelection moveSelection = entry.getKey();
+        ContainerID containerID = moveSelection.getContainerID();
+        DatanodeDetails source = containerToSourceMap.get(containerID);
+        DatanodeDetails target = moveSelection.getTargetNode();
         LOG.warn("Container move timed out for container {} from source {}" +
-                " to target {}.", entry.getKey().getContainerID(),
-            containerToSourceMap.get(entry.getKey().getContainerID()),
-            entry.getKey().getTargetNode());
-
+                " to target {}.", containerID, source, target);
+        moveFailureTracker.recordFailure(reason, containerID, source, target);
         entry.getValue().cancel(true);
         numCancelled += 1;
       }
@@ -1004,11 +1010,15 @@ public class ContainerBalancerTask implements Runnable {
         metrics.incrementCurrentIterationContainerMoveMetric(result, 1);
         moveSelectionToFutureMap.remove(moveSelection);
         if (ex != null) {
-          LOG.info("Container move for container {} from source {} to " +
-                  "target {} failed with exceptions.",
-              containerID, source,
-              moveSelection.getTargetNode(), ex);
-          metrics.incrementNumContainerMovesFailedInLatestIteration(1);
+          if (!isCancellationCause(ex)) {
+            LOG.info("Container move for container {} from source {} to " +
+                    "target {} failed with exceptions.",
+                containerID, source,
+                moveSelection.getTargetNode(), ex);
+            metrics.incrementNumContainerMovesFailedInLatestIteration(1);
+            moveFailureTracker.recordFailure(MoveManager.MoveResult.FAIL_UNEXPECTED_ERROR,
+                containerID, source, moveSelection.getTargetNode());
+          }
         } else {
           if (result == MoveManager.MoveResult.COMPLETED) {
             metrics.incrementDataSizeMovedInLatestIteration(containerInfo.getUsedBytes());
@@ -1021,6 +1031,7 @@ public class ContainerBalancerTask implements Runnable {
                     " {} failed: {}",
                 moveSelection.getContainerID(), source,
                 moveSelection.getTargetNode(), result);
+            moveFailureTracker.recordFailure(result, containerID, source, moveSelection.getTargetNode());
           }
         }
       });
@@ -1032,14 +1043,20 @@ public class ContainerBalancerTask implements Runnable {
       // exclude the container which caused failure of move to avoid error in next run.
       selectionCriteria.addToExcludeDueToFailContainers(moveSelection.getContainerID());
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
+      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_CONTAINER_NOT_FOUND.name(),
+          containerID, source, moveSelection.getTargetNode());
       return false;
     } catch (NodeNotFoundException e) {
       LOG.warn("Container move failed for container {}", containerID, e);
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
+      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_NODE_NOT_FOUND.name(),
+          containerID, source, moveSelection.getTargetNode());
       return false;
     } catch (ContainerReplicaNotFoundException e) {
       LOG.warn("Container move failed for container {}", containerID, e);
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
+      moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_REPLICA_NOT_FOUND.name(),
+          containerID, source, moveSelection.getTargetNode());
       // add source back to queue for replica not found only
       // the container is not excluded as it is a replica related failure
       findSourceStrategy.addBackSourceDataNode(source);
@@ -1225,6 +1242,11 @@ public class ContainerBalancerTask implements Runnable {
     metrics.resetDataSizeUnbalancedGB();
     metrics.resetNumDatanodesUnbalanced();
     metrics.resetNumContainerMovesFailedInLatestIteration();
+    moveFailureTracker.reset();
+  }
+
+  private static boolean isCancellationCause(Throwable ex) {
+    return ex instanceof CancellationException;
   }
 
   /**
@@ -1341,5 +1363,19 @@ public class ContainerBalancerTask implements Runnable {
     RUNNING,
     STOPPING,
     STOPPED
+  }
+
+  /**
+   * Recorded when a scheduled container move fails before {@link MoveManager#move}
+   * completes, or when the balancer stops waiting for in-flight moves.
+   */
+  enum ContainerMoveFailureReason {
+    PRE_MOVE_CONTAINER_NOT_FOUND,
+    PRE_MOVE_NODE_NOT_FOUND,
+    PRE_MOVE_REPLICA_NOT_FOUND,
+    /**
+     * Move did not complete before the iteration move wait timeout expired.
+     */
+    ITERATION_MOVE_TIMEOUT
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -861,7 +861,7 @@ public class ContainerBalancerTask implements Runnable {
         DatanodeDetails target = moveSelection.getTargetNode();
         LOG.warn("Container move timed out for container {} from source {}" +
                 " to target {}.", containerID, source, target);
-        moveFailureTracker.recordFailure(reason, containerID, source, target);
+        moveFailureTracker.recordFailure(reason, source, target);
         entry.getValue().cancel(true);
         numCancelled += 1;
       }
@@ -1017,7 +1017,7 @@ public class ContainerBalancerTask implements Runnable {
                 moveSelection.getTargetNode(), ex);
             metrics.incrementNumContainerMovesFailedInLatestIteration(1);
             moveFailureTracker.recordFailure(MoveManager.MoveResult.FAIL_UNEXPECTED_ERROR,
-                containerID, source, moveSelection.getTargetNode());
+                source, moveSelection.getTargetNode());
           }
         } else {
           if (result == MoveManager.MoveResult.COMPLETED) {
@@ -1031,7 +1031,7 @@ public class ContainerBalancerTask implements Runnable {
                     " {} failed: {}",
                 moveSelection.getContainerID(), source,
                 moveSelection.getTargetNode(), result);
-            moveFailureTracker.recordFailure(result, containerID, source, moveSelection.getTargetNode());
+            moveFailureTracker.recordFailure(result, source, moveSelection.getTargetNode());
           }
         }
       });
@@ -1044,19 +1044,19 @@ public class ContainerBalancerTask implements Runnable {
       selectionCriteria.addToExcludeDueToFailContainers(moveSelection.getContainerID());
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
       moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_CONTAINER_NOT_FOUND.name(),
-          containerID, source, moveSelection.getTargetNode());
+          source, moveSelection.getTargetNode());
       return false;
     } catch (NodeNotFoundException e) {
       LOG.warn("Container move failed for container {}", containerID, e);
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
       moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_NODE_NOT_FOUND.name(),
-          containerID, source, moveSelection.getTargetNode());
+          source, moveSelection.getTargetNode());
       return false;
     } catch (ContainerReplicaNotFoundException e) {
       LOG.warn("Container move failed for container {}", containerID, e);
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
       moveFailureTracker.recordFailure(ContainerMoveFailureReason.PRE_MOVE_REPLICA_NOT_FOUND.name(),
-          containerID, source, moveSelection.getTargetNode());
+          source, moveSelection.getTargetNode());
       // add source back to queue for replica not found only
       // the container is not excluded as it is a replica related failure
       findSourceStrategy.addBackSourceDataNode(source);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
@@ -167,25 +167,33 @@ public class ContainerBalancerTaskIterationStatusInfo {
       List<ContainerMoveFailureDetail> failures) {
     return failures.stream()
         .map(failure -> {
+          Map<String, String> datanodeHostnames = failure.getDatanodeHostnames();
           StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.Builder builder =
               StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
                   .setReason(failure.getReason())
                   .setCount(failure.getCount());
           failure.getSourceFailureCounts().forEach((uuid, count) ->
               builder.addSourceFailureCounts(
-                  StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                      .setDatanodeUuid(uuid)
-                      .setCount(count)
-                      .build()));
+                  toNodeFailureCountProto(uuid, count, datanodeHostnames)));
           failure.getTargetFailureCounts().forEach((uuid, count) ->
               builder.addTargetFailureCounts(
-                  StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                      .setDatanodeUuid(uuid)
-                      .setCount(count)
-                      .build()));
+                  toNodeFailureCountProto(uuid, count, datanodeHostnames)));
           return builder.build();
         })
         .collect(Collectors.toList());
+  }
+
+  private StorageContainerLocationProtocolProtos.NodeFailureCountProto toNodeFailureCountProto(
+      String uuid, long count, Map<String, String> datanodeHostnames) {
+    StorageContainerLocationProtocolProtos.NodeFailureCountProto.Builder builder =
+        StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+            .setDatanodeUuid(uuid)
+            .setCount(count);
+    String hostname = datanodeHostnames.get(uuid);
+    if (hostname != null && !hostname.isEmpty()) {
+      builder.setHostname(hostname);
+    }
+    return builder.build();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
@@ -107,19 +107,11 @@ public class ContainerBalancerTaskIterationStatusInfo {
   }
 
   /**
-   * Get failure counts grouped by reason for this iteration.
-   * @return map of reason to count
+   * Get per-reason failure summaries with per-datanode counts for this iteration.
+   * @return list of failure details, one entry per failure reason
    */
-  public Map<String, Long> getFailuresByReason() {
-    return containerMoveInfo.getFailuresByReason();
-  }
-
-  /**
-   * Get details of individual failed container moves in this iteration.
-   * @return list of failure details, may be capped
-   */
-  public List<ContainerMoveFailureDetail> getFailureDetails() {
-    return containerMoveInfo.getFailureDetails();
+  public List<ContainerMoveFailureDetail> getFailures() {
+    return containerMoveInfo.getFailures();
   }
 
   /**
@@ -167,41 +159,32 @@ public class ContainerBalancerTaskIterationStatusInfo {
         .addAllSizeLeavingNodes(
             mapToProtoNodeTransferInfo(getSizeLeavingNodes())
         )
-        .addAllContainerMoveFailuresByReason(
-            mapToProtoFailureSummary(getFailuresByReason())
-        )
-        .addAllContainerMoveFailureDetails(
-            mapToProtoFailureDetails(getFailureDetails())
-        )
+        .addAllContainerMoveFailures(mapToProtoFailures(getFailures()))
         .build();
   }
 
-  private List<StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto> mapToProtoFailureSummary(
-      Map<String, Long> failuresByReason) {
-    return failuresByReason.entrySet().stream()
-        .sorted((left, right) -> {
-          int countCompare = Long.compare(right.getValue(), left.getValue());
-          if (countCompare != 0) {
-            return countCompare;
-          }
-          return left.getKey().compareTo(right.getKey());
+  private List<StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto> mapToProtoFailures(
+      List<ContainerMoveFailureDetail> failures) {
+    return failures.stream()
+        .map(failure -> {
+          StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.Builder builder =
+              StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
+                  .setReason(failure.getReason())
+                  .setCount(failure.getCount());
+          failure.getSourceFailureCounts().forEach((uuid, count) ->
+              builder.addSourceFailureCounts(
+                  StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+                      .setDatanodeUuid(uuid)
+                      .setCount(count)
+                      .build()));
+          failure.getTargetFailureCounts().forEach((uuid, count) ->
+              builder.addTargetFailureCounts(
+                  StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+                      .setDatanodeUuid(uuid)
+                      .setCount(count)
+                      .build()));
+          return builder.build();
         })
-        .map(entry -> StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto.newBuilder()
-            .setReason(entry.getKey())
-            .setCount(entry.getValue())
-            .build())
-        .collect(Collectors.toList());
-  }
-
-  private List<StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto> mapToProtoFailureDetails(
-      List<ContainerMoveFailureDetail> failureDetails) {
-    return failureDetails.stream()
-        .map(detail -> StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
-            .setContainerId(detail.getContainerId())
-            .setSourceDatanodeUuid(detail.getSourceDatanodeUuid())
-            .setTargetDatanodeUuid(detail.getTargetDatanodeUuid())
-            .setReason(detail.getReason())
-            .build())
         .collect(Collectors.toList());
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
@@ -107,6 +107,22 @@ public class ContainerBalancerTaskIterationStatusInfo {
   }
 
   /**
+   * Get failure counts grouped by reason for this iteration.
+   * @return map of reason to count
+   */
+  public Map<String, Long> getFailuresByReason() {
+    return containerMoveInfo.getFailuresByReason();
+  }
+
+  /**
+   * Get details of individual failed container moves in this iteration.
+   * @return list of failure details, may be capped
+   */
+  public List<ContainerMoveFailureDetail> getFailureDetails() {
+    return containerMoveInfo.getFailureDetails();
+  }
+
+  /**
    * Get a map of the node IDs and the corresponding data sizes moved to each node.
    * @return nodeId to size entering from node map
    */
@@ -151,7 +167,42 @@ public class ContainerBalancerTaskIterationStatusInfo {
         .addAllSizeLeavingNodes(
             mapToProtoNodeTransferInfo(getSizeLeavingNodes())
         )
+        .addAllContainerMoveFailuresByReason(
+            mapToProtoFailureSummary(getFailuresByReason())
+        )
+        .addAllContainerMoveFailureDetails(
+            mapToProtoFailureDetails(getFailureDetails())
+        )
         .build();
+  }
+
+  private List<StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto> mapToProtoFailureSummary(
+      Map<String, Long> failuresByReason) {
+    return failuresByReason.entrySet().stream()
+        .sorted((left, right) -> {
+          int countCompare = Long.compare(right.getValue(), left.getValue());
+          if (countCompare != 0) {
+            return countCompare;
+          }
+          return left.getKey().compareTo(right.getKey());
+        })
+        .map(entry -> StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto.newBuilder()
+            .setReason(entry.getKey())
+            .setCount(entry.getValue())
+            .build())
+        .collect(Collectors.toList());
+  }
+
+  private List<StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto> mapToProtoFailureDetails(
+      List<ContainerMoveFailureDetail> failureDetails) {
+    return failureDetails.stream()
+        .map(detail -> StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
+            .setContainerId(detail.getContainerId())
+            .setSourceDatanodeUuid(detail.getSourceDatanodeUuid())
+            .setTargetDatanodeUuid(detail.getTargetDatanodeUuid())
+            .setReason(detail.getReason())
+            .build())
+        .collect(Collectors.toList());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureDetail.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureDetail.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+/**
+ * Details about a single failed container move in a balancer iteration.
+ */
+public final class ContainerMoveFailureDetail {
+  private final long containerId;
+  private final String sourceDatanodeUuid;
+  private final String targetDatanodeUuid;
+  private final String reason;
+
+  public ContainerMoveFailureDetail(long containerId, String sourceDatanodeUuid,
+      String targetDatanodeUuid, String reason) {
+    this.containerId = containerId;
+    this.sourceDatanodeUuid = sourceDatanodeUuid;
+    this.targetDatanodeUuid = targetDatanodeUuid;
+    this.reason = reason;
+  }
+
+  public long getContainerId() {
+    return containerId;
+  }
+
+  public String getSourceDatanodeUuid() {
+    return sourceDatanodeUuid;
+  }
+
+  public String getTargetDatanodeUuid() {
+    return targetDatanodeUuid;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureDetail.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureDetail.java
@@ -28,13 +28,16 @@ public final class ContainerMoveFailureDetail {
   private final long count;
   private final Map<String, Long> sourceFailureCounts;
   private final Map<String, Long> targetFailureCounts;
+  private final Map<String, String> datanodeHostnames;
 
   public ContainerMoveFailureDetail(String reason, long count,
-      Map<String, Long> sourceFailureCounts, Map<String, Long> targetFailureCounts) {
+      Map<String, Long> sourceFailureCounts, Map<String, Long> targetFailureCounts,
+      Map<String, String> datanodeHostnames) {
     this.reason = reason;
     this.count = count;
     this.sourceFailureCounts = Collections.unmodifiableMap(sourceFailureCounts);
     this.targetFailureCounts = Collections.unmodifiableMap(targetFailureCounts);
+    this.datanodeHostnames = Collections.unmodifiableMap(datanodeHostnames);
   }
 
   public String getReason() {
@@ -51,5 +54,9 @@ public final class ContainerMoveFailureDetail {
 
   public Map<String, Long> getTargetFailureCounts() {
     return targetFailureCounts;
+  }
+
+  public Map<String, String> getDatanodeHostnames() {
+    return datanodeHostnames;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureDetail.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureDetail.java
@@ -17,36 +17,39 @@
 
 package org.apache.hadoop.hdds.scm.container.balancer;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
- * Details about a single failed container move in a balancer iteration.
+ * Per-reason container move failure summary with per-datanode failure counts.
  */
 public final class ContainerMoveFailureDetail {
-  private final long containerId;
-  private final String sourceDatanodeUuid;
-  private final String targetDatanodeUuid;
   private final String reason;
+  private final long count;
+  private final Map<String, Long> sourceFailureCounts;
+  private final Map<String, Long> targetFailureCounts;
 
-  public ContainerMoveFailureDetail(long containerId, String sourceDatanodeUuid,
-      String targetDatanodeUuid, String reason) {
-    this.containerId = containerId;
-    this.sourceDatanodeUuid = sourceDatanodeUuid;
-    this.targetDatanodeUuid = targetDatanodeUuid;
+  public ContainerMoveFailureDetail(String reason, long count,
+      Map<String, Long> sourceFailureCounts, Map<String, Long> targetFailureCounts) {
     this.reason = reason;
-  }
-
-  public long getContainerId() {
-    return containerId;
-  }
-
-  public String getSourceDatanodeUuid() {
-    return sourceDatanodeUuid;
-  }
-
-  public String getTargetDatanodeUuid() {
-    return targetDatanodeUuid;
+    this.count = count;
+    this.sourceFailureCounts = Collections.unmodifiableMap(sourceFailureCounts);
+    this.targetFailureCounts = Collections.unmodifiableMap(targetFailureCounts);
   }
 
   public String getReason() {
     return reason;
+  }
+
+  public long getCount() {
+    return count;
+  }
+
+  public Map<String, Long> getSourceFailureCounts() {
+    return sourceFailureCounts;
+  }
+
+  public Map<String, Long> getTargetFailureCounts() {
+    return targetFailureCounts;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureTracker.java
@@ -27,17 +27,22 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 /**
  * Tracks per-iteration container move failures by reason and per-datanode counts.
  */
-public final class ContainerMoveFailureTracker {
+final class ContainerMoveFailureTracker {
   private final Map<String, Long> failuresByReason = new HashMap<>();
   private final Map<String, Map<String, Long>> sourceFailureCountsByReason = new HashMap<>();
   private final Map<String, Map<String, Long>> targetFailureCountsByReason = new HashMap<>();
 
-  public synchronized void recordFailure(MoveManager.MoveResult result, DatanodeDetails source,
+  synchronized void recordFailure(MoveManager.MoveResult result, DatanodeDetails source,
                                          DatanodeDetails target) {
     recordFailure(result.name(), source, target);
   }
 
-  public synchronized void recordFailure(String reason, DatanodeDetails source, DatanodeDetails target) {
+  synchronized void recordFailure(ContainerBalancerTask.ContainerMoveFailureReason result,
+                                         DatanodeDetails source, DatanodeDetails target) {
+    recordFailure(result.name(), source, target);
+  }
+
+  synchronized void recordFailure(String reason, DatanodeDetails source, DatanodeDetails target) {
     failuresByReason.merge(reason, 1L, Long::sum);
     if (source != null) {
       sourceFailureCountsByReason.computeIfAbsent(reason, k -> new HashMap<>())
@@ -49,13 +54,13 @@ public final class ContainerMoveFailureTracker {
     }
   }
 
-  public synchronized void reset() {
+  synchronized void reset() {
     failuresByReason.clear();
     sourceFailureCountsByReason.clear();
     targetFailureCountsByReason.clear();
   }
 
-  public synchronized List<ContainerMoveFailureDetail> getFailures() {
+  synchronized List<ContainerMoveFailureDetail> getFailures() {
     List<ContainerMoveFailureDetail> result = new ArrayList<>();
     for (Map.Entry<String, Long> entry : failuresByReason.entrySet()) {
       String reason = entry.getKey();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureTracker.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+
+/**
+ * Tracks per-iteration container move failures by reason and optional details.
+ */
+public final class ContainerMoveFailureTracker {
+  public static final int DEFAULT_MAX_FAILURE_DETAILS = 100;
+  public static final int DEFAULT_MAX_FAILURE_DETAILS_PER_REASON = 10;
+
+  private final int maxFailureDetails;
+  private final int maxFailureDetailsPerReason;
+  private final Map<String, Long> failuresByReason = new HashMap<>();
+  private final Map<String, Integer> failureDetailCountByReason = new HashMap<>();
+  private final List<ContainerMoveFailureDetail> failureDetails = new ArrayList<>();
+
+  public ContainerMoveFailureTracker() {
+    this(DEFAULT_MAX_FAILURE_DETAILS, DEFAULT_MAX_FAILURE_DETAILS_PER_REASON);
+  }
+
+  public ContainerMoveFailureTracker(int maxFailureDetails, int maxFailureDetailsPerReason) {
+    this.maxFailureDetails = maxFailureDetails;
+    this.maxFailureDetailsPerReason = Math.min(maxFailureDetailsPerReason, maxFailureDetails);
+  }
+
+  public synchronized void recordFailure(MoveManager.MoveResult result, ContainerID containerId,
+      DatanodeDetails source, DatanodeDetails target) {
+    recordFailure(result.name(), containerId, source, target);
+  }
+
+  public synchronized void recordFailure(String reason, ContainerID containerId,
+      DatanodeDetails source, DatanodeDetails target) {
+    failuresByReason.merge(reason, 1L, Long::sum);
+    if (shouldRecordFailureDetail(reason)) {
+      failureDetails.add(new ContainerMoveFailureDetail(
+          containerId.getId(),
+          source.getUuidString(),
+          target.getUuidString(),
+          reason));
+      failureDetailCountByReason.merge(reason, 1, Integer::sum);
+    }
+  }
+
+  private boolean shouldRecordFailureDetail(String reason) {
+    if (failureDetails.size() >= maxFailureDetails) {
+      return false;
+    }
+    int reasonDetailCount = failureDetailCountByReason.getOrDefault(reason, 0);
+    if (reasonDetailCount == 0) {
+      return true;
+    }
+    return reasonDetailCount < maxFailureDetailsPerReason;
+  }
+
+  public synchronized void reset() {
+    failuresByReason.clear();
+    failureDetailCountByReason.clear();
+    failureDetails.clear();
+  }
+
+  public synchronized Map<String, Long> getFailuresByReason() {
+    return Collections.unmodifiableMap(new HashMap<>(failuresByReason));
+  }
+
+  public synchronized List<ContainerMoveFailureDetail> getFailureDetails() {
+    return Collections.unmodifiableList(new ArrayList<>(failureDetails));
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureTracker.java
@@ -31,6 +31,7 @@ final class ContainerMoveFailureTracker {
   private final Map<String, Long> failuresByReason = new HashMap<>();
   private final Map<String, Map<String, Long>> sourceFailureCountsByReason = new HashMap<>();
   private final Map<String, Map<String, Long>> targetFailureCountsByReason = new HashMap<>();
+  private final Map<String, String> datanodeHostnames = new HashMap<>();
 
   synchronized void recordFailure(MoveManager.MoveResult result, DatanodeDetails source,
                                          DatanodeDetails target) {
@@ -45,10 +46,12 @@ final class ContainerMoveFailureTracker {
   synchronized void recordFailure(String reason, DatanodeDetails source, DatanodeDetails target) {
     failuresByReason.merge(reason, 1L, Long::sum);
     if (source != null) {
+      datanodeHostnames.putIfAbsent(source.getUuidString(), source.getHostName());
       sourceFailureCountsByReason.computeIfAbsent(reason, k -> new HashMap<>())
           .merge(source.getUuidString(), 1L, Long::sum);
     }
     if (target != null) {
+      datanodeHostnames.putIfAbsent(target.getUuidString(), target.getHostName());
       targetFailureCountsByReason.computeIfAbsent(reason, k -> new HashMap<>())
           .merge(target.getUuidString(), 1L, Long::sum);
     }
@@ -58,6 +61,7 @@ final class ContainerMoveFailureTracker {
     failuresByReason.clear();
     sourceFailureCountsByReason.clear();
     targetFailureCountsByReason.clear();
+    datanodeHostnames.clear();
   }
 
   synchronized List<ContainerMoveFailureDetail> getFailures() {
@@ -67,8 +71,23 @@ final class ContainerMoveFailureTracker {
       long count = entry.getValue();
       Map<String, Long> srcCounts = sourceFailureCountsByReason.getOrDefault(reason, Collections.emptyMap());
       Map<String, Long> tgtCounts = targetFailureCountsByReason.getOrDefault(reason, Collections.emptyMap());
-      result.add(new ContainerMoveFailureDetail(reason, count, new HashMap<>(srcCounts), new HashMap<>(tgtCounts)));
+      result.add(new ContainerMoveFailureDetail(reason, count, new HashMap<>(srcCounts), new HashMap<>(tgtCounts),
+          copyHostnamesForDetail(srcCounts, tgtCounts)));
     }
     return result;
+  }
+
+  private Map<String, String> copyHostnamesForDetail(Map<String, Long> srcCounts, Map<String, Long> tgtCounts) {
+    Map<String, String> hostnames = new HashMap<>();
+    srcCounts.keySet().forEach(uuid -> copyHostnameIfPresent(uuid, hostnames));
+    tgtCounts.keySet().forEach(uuid -> copyHostnameIfPresent(uuid, hostnames));
+    return hostnames;
+  }
+
+  private void copyHostnameIfPresent(String uuid, Map<String, String> hostnames) {
+    String hostname = datanodeHostnames.get(uuid);
+    if (hostname != null && !hostname.isEmpty()) {
+      hostnames.put(uuid, hostname);
+    }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureTracker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveFailureTracker.java
@@ -23,70 +23,47 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
 
 /**
- * Tracks per-iteration container move failures by reason and optional details.
+ * Tracks per-iteration container move failures by reason and per-datanode counts.
  */
 public final class ContainerMoveFailureTracker {
-  public static final int DEFAULT_MAX_FAILURE_DETAILS = 100;
-  public static final int DEFAULT_MAX_FAILURE_DETAILS_PER_REASON = 10;
-
-  private final int maxFailureDetails;
-  private final int maxFailureDetailsPerReason;
   private final Map<String, Long> failuresByReason = new HashMap<>();
-  private final Map<String, Integer> failureDetailCountByReason = new HashMap<>();
-  private final List<ContainerMoveFailureDetail> failureDetails = new ArrayList<>();
+  private final Map<String, Map<String, Long>> sourceFailureCountsByReason = new HashMap<>();
+  private final Map<String, Map<String, Long>> targetFailureCountsByReason = new HashMap<>();
 
-  public ContainerMoveFailureTracker() {
-    this(DEFAULT_MAX_FAILURE_DETAILS, DEFAULT_MAX_FAILURE_DETAILS_PER_REASON);
+  public synchronized void recordFailure(MoveManager.MoveResult result, DatanodeDetails source,
+                                         DatanodeDetails target) {
+    recordFailure(result.name(), source, target);
   }
 
-  public ContainerMoveFailureTracker(int maxFailureDetails, int maxFailureDetailsPerReason) {
-    this.maxFailureDetails = maxFailureDetails;
-    this.maxFailureDetailsPerReason = Math.min(maxFailureDetailsPerReason, maxFailureDetails);
-  }
-
-  public synchronized void recordFailure(MoveManager.MoveResult result, ContainerID containerId,
-      DatanodeDetails source, DatanodeDetails target) {
-    recordFailure(result.name(), containerId, source, target);
-  }
-
-  public synchronized void recordFailure(String reason, ContainerID containerId,
-      DatanodeDetails source, DatanodeDetails target) {
+  public synchronized void recordFailure(String reason, DatanodeDetails source, DatanodeDetails target) {
     failuresByReason.merge(reason, 1L, Long::sum);
-    if (shouldRecordFailureDetail(reason)) {
-      failureDetails.add(new ContainerMoveFailureDetail(
-          containerId.getId(),
-          source.getUuidString(),
-          target.getUuidString(),
-          reason));
-      failureDetailCountByReason.merge(reason, 1, Integer::sum);
+    if (source != null) {
+      sourceFailureCountsByReason.computeIfAbsent(reason, k -> new HashMap<>())
+          .merge(source.getUuidString(), 1L, Long::sum);
     }
-  }
-
-  private boolean shouldRecordFailureDetail(String reason) {
-    if (failureDetails.size() >= maxFailureDetails) {
-      return false;
+    if (target != null) {
+      targetFailureCountsByReason.computeIfAbsent(reason, k -> new HashMap<>())
+          .merge(target.getUuidString(), 1L, Long::sum);
     }
-    int reasonDetailCount = failureDetailCountByReason.getOrDefault(reason, 0);
-    if (reasonDetailCount == 0) {
-      return true;
-    }
-    return reasonDetailCount < maxFailureDetailsPerReason;
   }
 
   public synchronized void reset() {
     failuresByReason.clear();
-    failureDetailCountByReason.clear();
-    failureDetails.clear();
+    sourceFailureCountsByReason.clear();
+    targetFailureCountsByReason.clear();
   }
 
-  public synchronized Map<String, Long> getFailuresByReason() {
-    return Collections.unmodifiableMap(new HashMap<>(failuresByReason));
-  }
-
-  public synchronized List<ContainerMoveFailureDetail> getFailureDetails() {
-    return Collections.unmodifiableList(new ArrayList<>(failureDetails));
+  public synchronized List<ContainerMoveFailureDetail> getFailures() {
+    List<ContainerMoveFailureDetail> result = new ArrayList<>();
+    for (Map.Entry<String, Long> entry : failuresByReason.entrySet()) {
+      String reason = entry.getKey();
+      long count = entry.getValue();
+      Map<String, Long> srcCounts = sourceFailureCountsByReason.getOrDefault(reason, Collections.emptyMap());
+      Map<String, Long> tgtCounts = targetFailureCountsByReason.getOrDefault(reason, Collections.emptyMap());
+      result.add(new ContainerMoveFailureDetail(reason, count, new HashMap<>(srcCounts), new HashMap<>(tgtCounts)));
+    }
+    return result;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveInfo.java
@@ -17,6 +17,9 @@
 
 package org.apache.hadoop.hdds.scm.container.balancer;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Information about moving containers.
  */
@@ -25,20 +28,27 @@ public class ContainerMoveInfo {
   private final long containerMovesCompleted;
   private final long containerMovesFailed;
   private final long containerMovesTimeout;
+  private final Map<String, Long> failuresByReason;
+  private final List<ContainerMoveFailureDetail> failureDetails;
 
   public ContainerMoveInfo(long containerMovesScheduled, long containerMovesCompleted, long containerMovesFailed,
-                           long containerMovesTimeout) {
+                           long containerMovesTimeout, Map<String, Long> failuresByReason,
+                           List<ContainerMoveFailureDetail> failureDetails) {
     this.containerMovesScheduled = containerMovesScheduled;
     this.containerMovesCompleted = containerMovesCompleted;
     this.containerMovesFailed = containerMovesFailed;
     this.containerMovesTimeout = containerMovesTimeout;
+    this.failuresByReason = failuresByReason;
+    this.failureDetails = failureDetails;
   }
 
-  public ContainerMoveInfo(ContainerBalancerMetrics metrics) {
+  public ContainerMoveInfo(ContainerBalancerMetrics metrics, ContainerMoveFailureTracker failureTracker) {
     this.containerMovesScheduled = metrics.getNumContainerMovesScheduledInLatestIteration();
     this.containerMovesCompleted = metrics.getNumContainerMovesCompletedInLatestIteration();
     this.containerMovesFailed = metrics.getNumContainerMovesFailedInLatestIteration();
     this.containerMovesTimeout = metrics.getNumContainerMovesTimeoutInLatestIteration();
+    this.failuresByReason = failureTracker.getFailuresByReason();
+    this.failureDetails = failureTracker.getFailureDetails();
   }
 
   public long getContainerMovesScheduled() {
@@ -55,5 +65,13 @@ public class ContainerMoveInfo {
 
   public long getContainerMovesTimeout() {
     return containerMovesTimeout;
+  }
+
+  public Map<String, Long> getFailuresByReason() {
+    return failuresByReason;
+  }
+
+  public List<ContainerMoveFailureDetail> getFailureDetails() {
+    return failureDetails;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerMoveInfo.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.container.balancer;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Information about moving containers.
@@ -28,18 +27,15 @@ public class ContainerMoveInfo {
   private final long containerMovesCompleted;
   private final long containerMovesFailed;
   private final long containerMovesTimeout;
-  private final Map<String, Long> failuresByReason;
-  private final List<ContainerMoveFailureDetail> failureDetails;
+  private final List<ContainerMoveFailureDetail> failures;
 
   public ContainerMoveInfo(long containerMovesScheduled, long containerMovesCompleted, long containerMovesFailed,
-                           long containerMovesTimeout, Map<String, Long> failuresByReason,
-                           List<ContainerMoveFailureDetail> failureDetails) {
+                           long containerMovesTimeout, List<ContainerMoveFailureDetail> failures) {
     this.containerMovesScheduled = containerMovesScheduled;
     this.containerMovesCompleted = containerMovesCompleted;
     this.containerMovesFailed = containerMovesFailed;
     this.containerMovesTimeout = containerMovesTimeout;
-    this.failuresByReason = failuresByReason;
-    this.failureDetails = failureDetails;
+    this.failures = failures;
   }
 
   public ContainerMoveInfo(ContainerBalancerMetrics metrics, ContainerMoveFailureTracker failureTracker) {
@@ -47,8 +43,7 @@ public class ContainerMoveInfo {
     this.containerMovesCompleted = metrics.getNumContainerMovesCompletedInLatestIteration();
     this.containerMovesFailed = metrics.getNumContainerMovesFailedInLatestIteration();
     this.containerMovesTimeout = metrics.getNumContainerMovesTimeoutInLatestIteration();
-    this.failuresByReason = failureTracker.getFailuresByReason();
-    this.failureDetails = failureTracker.getFailureDetails();
+    this.failures = failureTracker.getFailures();
   }
 
   public long getContainerMovesScheduled() {
@@ -67,11 +62,7 @@ public class ContainerMoveInfo {
     return containerMovesTimeout;
   }
 
-  public Map<String, Long> getFailuresByReason() {
-    return failuresByReason;
-  }
-
-  public List<ContainerMoveFailureDetail> getFailureDetails() {
-    return failureDetails;
+  public List<ContainerMoveFailureDetail> getFailures() {
+    return failures;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
@@ -20,18 +20,24 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
+import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Tests that {@link ContainerBalancerTask} records failure breakdown and details
@@ -51,8 +57,8 @@ class TestContainerBalancerMoveFailureBreakdown {
     ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
     ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
 
-    assertThat(iteration.getContainerMovesTimeout()).isGreaterThan(0);
-    assertFailureBreakdown(iteration, MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT.name());
+    assertThat(iteration.getContainerMovesTimeout()).isEqualTo(1);
+    assertFailureBreakdown(mockedScm, iteration, MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT.name(), 0);
   }
 
   @Test
@@ -64,8 +70,9 @@ class TestContainerBalancerMoveFailureBreakdown {
     ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
     ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
 
-    assertThat(iteration.getContainerMovesFailed()).isGreaterThan(0);
-    assertFailureBreakdown(iteration, MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_AFTER_MOVE.name());
+    assertThat(iteration.getContainerMovesFailed()).isEqualTo(1);
+    assertFailureBreakdown(mockedScm, iteration,
+            MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_AFTER_MOVE.name(), 0);
   }
 
   @Test
@@ -77,8 +84,8 @@ class TestContainerBalancerMoveFailureBreakdown {
     ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
     ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
 
-    assertThat(iteration.getContainerMovesTimeout()).isGreaterThan(0);
-    assertFailureBreakdown(iteration, MoveManager.MoveResult.DELETION_FAIL_TIME_OUT.name());
+    assertThat(iteration.getContainerMovesTimeout()).isEqualTo(1);
+    assertFailureBreakdown(mockedScm, iteration, MoveManager.MoveResult.DELETION_FAIL_TIME_OUT.name(), 0);
   }
 
   @Test
@@ -87,17 +94,14 @@ class TestContainerBalancerMoveFailureBreakdown {
     MockedSCM mockedScm = createMockedScm();
     ContainerBalancerConfiguration config = buildConfig(mockedScm);
     config.setMoveTimeout(Duration.ofMillis(50));
-
-    when(mockedScm.getMoveManager().move(any(ContainerID.class),
-        any(DatanodeDetails.class), any(DatanodeDetails.class)))
-        .thenAnswer(invocation -> slowMoveFuture(150));
+    mockFirstMoveNeverCompletes(mockedScm);
 
     ContainerBalancerTask task = mockedScm.startBalancerTask(config);
     ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
 
-    assertThat(iteration.getContainerMovesTimeout()).isGreaterThanOrEqualTo(1);
-    assertFailureBreakdown(iteration,
-        ContainerBalancerTask.ContainerMoveFailureReason.ITERATION_MOVE_TIMEOUT.name());
+    assertThat(iteration.getContainerMovesTimeout()).isEqualTo(1);
+    assertFailureBreakdown(mockedScm, iteration,
+            ContainerBalancerTask.ContainerMoveFailureReason.ITERATION_MOVE_TIMEOUT.name(), 0);
   }
 
   @Test
@@ -117,6 +121,8 @@ class TestContainerBalancerMoveFailureBreakdown {
 
     assertThat(iteration.getContainerMovesTimeout()).isEqualTo(1);
     assertThat(iteration.getContainerMovesFailed()).isEqualTo(1);
+    verify(mockedScm.getMoveManager(), atLeast(2)).move(
+            any(ContainerID.class), any(DatanodeDetails.class), any(DatanodeDetails.class));
     assertBreakdownTotalsMatchHeadlineCounters(iteration);
   }
 
@@ -132,9 +138,57 @@ class TestContainerBalancerMoveFailureBreakdown {
     ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
     ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
 
-    assertThat(iteration.getContainerMovesFailed()).isGreaterThan(0);
-    assertFailureBreakdown(iteration,
-        ContainerBalancerTask.ContainerMoveFailureReason.PRE_MOVE_CONTAINER_NOT_FOUND.name());
+    assertThat(iteration.getContainerMovesFailed()).isEqualTo(1);
+    assertFailureBreakdown(mockedScm, iteration,
+            ContainerBalancerTask.ContainerMoveFailureReason.PRE_MOVE_CONTAINER_NOT_FOUND.name(), 0);
+  }
+
+  @Test
+  void testSameReasonAggregatesSourceFailureCountsFromMultipleSources()
+          throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    ContainerBalancerConfiguration config = buildConfig(mockedScm);
+
+    // Pin two over-utilized sources and one under-utilized target so two different sources are used.
+    DatanodeUsageInfo[] nodes = mockedScm.getCluster().getNodesInCluster();
+    config.setIncludeNodes(
+            nodes[NODE_COUNT - 2].getDatanodeDetails().getHostName() + ","
+                    + nodes[NODE_COUNT - 1].getDatanodeDetails().getHostName() + ","
+                    + nodes[0].getDatanodeDetails().getHostName());
+
+    when(mockedScm.getMoveManager().move(any(ContainerID.class),
+            any(DatanodeDetails.class), any(DatanodeDetails.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                    MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT))
+            .thenReturn(CompletableFuture.completedFuture(
+                    MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT))
+            .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+
+    ContainerBalancerTask task = mockedScm.startBalancerTask(config);
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+
+    assertThat(iteration.getContainerMovesTimeout()).isEqualTo(2);
+
+    ArgumentCaptor<DatanodeDetails> sourceCaptor = ArgumentCaptor.forClass(DatanodeDetails.class);
+    ArgumentCaptor<DatanodeDetails> targetCaptor = ArgumentCaptor.forClass(DatanodeDetails.class);
+    verify(mockedScm.getMoveManager(), atLeast(2)).move(
+            any(ContainerID.class), sourceCaptor.capture(), targetCaptor.capture());
+
+    String sourceUuid1 = sourceCaptor.getAllValues().get(0).getUuidString();
+    String sourceUuid2 = sourceCaptor.getAllValues().get(1).getUuidString();
+    assertThat(sourceUuid1).isNotEqualTo(sourceUuid2);
+
+    String expectedReason = MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT.name();
+    ContainerMoveFailureDetail detail = iteration.getFailures().stream()
+            .filter(f -> expectedReason.equals(f.getReason()))
+            .findFirst()
+            .orElse(null);
+    assertThat(detail).as("failure detail for reason " + expectedReason).isNotNull();
+    assertThat(detail.getCount()).isEqualTo(2L);
+    assertThat(detail.getSourceFailureCounts())
+            .hasSize(2)
+            .containsEntry(sourceUuid1, 1L)
+            .containsEntry(sourceUuid2, 1L);
   }
 
   private static MockedSCM createMockedScm() {
@@ -147,6 +201,19 @@ class TestContainerBalancerMoveFailureBreakdown {
         any(DatanodeDetails.class), any(DatanodeDetails.class)))
         .thenReturn(CompletableFuture.completedFuture(failureResult))
         .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+  }
+
+  private static void mockFirstMoveNeverCompletes(MockedSCM mockedScm)
+          throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    AtomicInteger moveInvocations = new AtomicInteger(0);
+    when(mockedScm.getMoveManager().move(any(ContainerID.class),
+            any(DatanodeDetails.class), any(DatanodeDetails.class)))
+            .thenAnswer(invocation -> {
+              if (moveInvocations.getAndIncrement() == 0) {
+                return new CompletableFuture<>();
+              }
+              return CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED);
+            });
   }
 
   private static ContainerBalancerConfiguration buildConfig(MockedSCM mockedScm) {
@@ -167,17 +234,6 @@ class TestContainerBalancerMoveFailureBreakdown {
     return iteration;
   }
 
-  private static CompletableFuture<MoveManager.MoveResult> slowMoveFuture(int sleepMillis) {
-    return CompletableFuture.supplyAsync(() -> {
-      try {
-        Thread.sleep(sleepMillis);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-      return MoveManager.MoveResult.COMPLETED;
-    });
-  }
-
   private static void assertBreakdownTotalsMatchHeadlineCounters(
       ContainerBalancerTaskIterationStatusInfo iteration) {
     long breakdownTotal = iteration.getFailures().stream()
@@ -188,8 +244,18 @@ class TestContainerBalancerMoveFailureBreakdown {
         "sum(failure breakdown) should equal failed + timeout counters");
   }
 
-  private static void assertFailureBreakdown(
-      ContainerBalancerTaskIterationStatusInfo iteration, String expectedReason) {
+  private static void assertFailureBreakdown(MockedSCM mockedScm, ContainerBalancerTaskIterationStatusInfo iteration,
+      String expectedReason, int moveIndex) throws NodeNotFoundException, ContainerReplicaNotFoundException,
+      ContainerNotFoundException {
+    ArgumentCaptor<DatanodeDetails> sourceCaptor = ArgumentCaptor.forClass(DatanodeDetails.class);
+    ArgumentCaptor<DatanodeDetails> targetCaptor = ArgumentCaptor.forClass(DatanodeDetails.class);
+    verify(mockedScm.getMoveManager(), atLeastOnce()).move(
+            any(ContainerID.class), sourceCaptor.capture(), targetCaptor.capture());
+    assertThat(sourceCaptor.getAllValues().size()).isGreaterThan(moveIndex);
+    assertThat(targetCaptor.getAllValues().size()).isGreaterThan(moveIndex);
+    String sourceUuid = sourceCaptor.getAllValues().get(moveIndex).getUuidString();
+    String targetUuid = targetCaptor.getAllValues().get(moveIndex).getUuidString();
+
     List<ContainerMoveFailureDetail> failures = iteration.getFailures();
     assertThat(failures).as("failure details").isNotEmpty();
     ContainerMoveFailureDetail detail = failures.stream()
@@ -197,8 +263,8 @@ class TestContainerBalancerMoveFailureBreakdown {
         .findFirst()
         .orElse(null);
     assertThat(detail).as("failure detail for reason " + expectedReason).isNotNull();
-    assertThat(detail.getCount()).isGreaterThanOrEqualTo(1L);
-    assertThat(detail.getSourceFailureCounts()).isNotEmpty();
-    assertThat(detail.getTargetFailureCounts()).isNotEmpty();
+    assertThat(detail.getCount()).isEqualTo(1L);
+    assertThat(detail.getSourceFailureCounts()).hasSize(1).containsEntry(sourceUuid, 1L);
+    assertThat(detail.getTargetFailureCounts()).hasSize(1).containsEntry(targetUuid, 1L);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@link ContainerBalancerTask} records failure breakdown and details
+ * in iteration statistics for common move failure reasons.
+ */
+class TestContainerBalancerMoveFailureBreakdown {
+
+  private static final int NODE_COUNT = 5;
+  private static final long STORAGE_UNIT = OzoneConsts.GB;
+
+  @Test
+  void testReplicationTimeoutRecordedInFailureBreakdown()
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    mockMoveFailureOnce(mockedScm, MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT);
+
+    ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+
+    assertThat(iteration.getContainerMovesTimeout()).isGreaterThan(0);
+    assertFailureBreakdown(iteration, MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT.name());
+  }
+
+  @Test
+  void testReplicationNotHealthyAfterMoveRecordedInFailureBreakdown()
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    mockMoveFailureOnce(mockedScm, MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_AFTER_MOVE);
+
+    ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+
+    assertThat(iteration.getContainerMovesFailed()).isGreaterThan(0);
+    assertFailureBreakdown(iteration, MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_AFTER_MOVE.name());
+  }
+
+  @Test
+  void testDeletionTimeoutRecordedInFailureBreakdown()
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    mockMoveFailureOnce(mockedScm, MoveManager.MoveResult.DELETION_FAIL_TIME_OUT);
+
+    ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+
+    assertThat(iteration.getContainerMovesTimeout()).isGreaterThan(0);
+    assertFailureBreakdown(iteration, MoveManager.MoveResult.DELETION_FAIL_TIME_OUT.name());
+  }
+
+  @Test
+  void testIterationMoveTimeoutRecordedInFailureBreakdown()
+      throws NodeNotFoundException, ContainerNotFoundException, ContainerReplicaNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    ContainerBalancerConfiguration config = buildConfig(mockedScm);
+    config.setMoveTimeout(Duration.ofMillis(50));
+
+    when(mockedScm.getMoveManager().move(any(ContainerID.class),
+        any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenAnswer(invocation -> slowMoveFuture(150));
+
+    ContainerBalancerTask task = mockedScm.startBalancerTask(config);
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+
+    assertThat(iteration.getContainerMovesTimeout()).isGreaterThanOrEqualTo(1);
+    assertFailureBreakdown(iteration,
+        ContainerBalancerTask.ContainerMoveFailureReason.ITERATION_MOVE_TIMEOUT.name());
+  }
+
+  @Test
+  void testFailureBreakdownTotalsMatchHeadlineCountersInControlledScenario()
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    when(mockedScm.getMoveManager().move(any(ContainerID.class),
+        any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenReturn(CompletableFuture.completedFuture(
+            MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT))
+        .thenReturn(CompletableFuture.completedFuture(
+            MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_AFTER_MOVE))
+        .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+
+    ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+
+    assertThat(iteration.getContainerMovesTimeout()).isEqualTo(1);
+    assertThat(iteration.getContainerMovesFailed()).isEqualTo(1);
+    assertBreakdownTotalsMatchHeadlineCounters(iteration);
+  }
+
+  @Test
+  void testPreMoveContainerNotFoundRecordedInFailureBreakdown()
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    when(mockedScm.getMoveManager().move(any(ContainerID.class),
+        any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenThrow(ContainerNotFoundException.newInstanceForTesting())
+        .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+
+    ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+
+    assertThat(iteration.getContainerMovesFailed()).isGreaterThan(0);
+    assertFailureBreakdown(iteration,
+        ContainerBalancerTask.ContainerMoveFailureReason.PRE_MOVE_CONTAINER_NOT_FOUND.name());
+  }
+
+  private static MockedSCM createMockedScm() {
+    return new MockedSCM(new MockCluster(NODE_COUNT, STORAGE_UNIT));
+  }
+
+  private static void mockMoveFailureOnce(MockedSCM mockedScm, MoveManager.MoveResult failureResult)
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    when(mockedScm.getMoveManager().move(any(ContainerID.class),
+        any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenReturn(CompletableFuture.completedFuture(failureResult))
+        .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+  }
+
+  private static ContainerBalancerConfiguration buildConfig(MockedSCM mockedScm) {
+    ContainerBalancerConfiguration config = new ContainerBalancerConfigBuilder(mockedScm.getNodeCount()).build();
+    config.setMaxSizeToMovePerIteration(5 * STORAGE_UNIT);
+    config.setMaxSizeEnteringTarget(5 * STORAGE_UNIT);
+    config.setMaxDatanodesPercentageToInvolvePerIteration(100);
+    return config;
+  }
+
+  private static ContainerBalancerTaskIterationStatusInfo getCompletedIteration(
+      ContainerBalancerTask task) {
+    List<ContainerBalancerTaskIterationStatusInfo> iterations =
+        task.getCurrentIterationsStatistic();
+    assertEquals(1, iterations.size());
+    ContainerBalancerTaskIterationStatusInfo iteration = iterations.get(0);
+    assertEquals("ITERATION_COMPLETED", iteration.getIterationResult());
+    return iteration;
+  }
+
+  private static CompletableFuture<MoveManager.MoveResult> slowMoveFuture(int sleepMillis) {
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        Thread.sleep(sleepMillis);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return MoveManager.MoveResult.COMPLETED;
+    });
+  }
+
+  private static void assertBreakdownTotalsMatchHeadlineCounters(
+      ContainerBalancerTaskIterationStatusInfo iteration) {
+    long breakdownTotal = iteration.getFailuresByReason().values().stream()
+        .mapToLong(Long::longValue)
+        .sum();
+    long headlineTotal = iteration.getContainerMovesFailed() + iteration.getContainerMovesTimeout();
+    assertEquals(headlineTotal, breakdownTotal,
+        "sum(failure breakdown) should equal failed + timeout counters");
+  }
+
+  private static void assertFailureBreakdown(
+      ContainerBalancerTaskIterationStatusInfo iteration, String expectedReason) {
+    Map<String, Long> failuresByReason = iteration.getFailuresByReason();
+    assertThat(failuresByReason).as("failure breakdown").containsKey(expectedReason);
+    assertThat(failuresByReason.get(expectedReason)).isGreaterThanOrEqualTo(1L);
+
+    List<ContainerMoveFailureDetail> details = iteration.getFailureDetails();
+    assertThat(details).isNotEmpty();
+    assertThat(details.stream().anyMatch(detail ->
+        expectedReason.equals(detail.getReason())
+            && detail.getContainerId() > 0
+            && detail.getSourceDatanodeUuid() != null
+            && !detail.getSourceDatanodeUuid().isEmpty()
+            && detail.getTargetDatanodeUuid() != null
+            && !detail.getTargetDatanodeUuid().isEmpty())).isTrue();
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
@@ -30,10 +30,10 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
-import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.jupiter.api.Test;
@@ -144,51 +144,29 @@ class TestContainerBalancerMoveFailureBreakdown {
   }
 
   @Test
-  void testSameReasonAggregatesSourceFailureCountsFromMultipleSources()
-          throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
-    MockedSCM mockedScm = createMockedScm();
-    ContainerBalancerConfiguration config = buildConfig(mockedScm);
+  void testSameReasonAggregatesSourceFailureCountsFromMultipleSources() {
+    ContainerMoveFailureTracker tracker = new ContainerMoveFailureTracker();
+    DatanodeDetails source1 = MockDatanodeDetails.createDatanodeDetails("1.1.1.1", "/r1");
+    DatanodeDetails source2 = MockDatanodeDetails.createDatanodeDetails("2.2.2.2", "/r1");
+    DatanodeDetails target = MockDatanodeDetails.createDatanodeDetails("3.3.3.3", "/r2");
 
-    // Pin two over-utilized sources and one under-utilized target so two different sources are used.
-    DatanodeUsageInfo[] nodes = mockedScm.getCluster().getNodesInCluster();
-    config.setIncludeNodes(
-            nodes[NODE_COUNT - 2].getDatanodeDetails().getHostName() + ","
-                    + nodes[NODE_COUNT - 1].getDatanodeDetails().getHostName() + ","
-                    + nodes[0].getDatanodeDetails().getHostName());
+    String reason = MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT.name();
+    tracker.recordFailure(reason, source1, target);
+    tracker.recordFailure(reason, source2, target);
 
-    when(mockedScm.getMoveManager().move(any(ContainerID.class),
-            any(DatanodeDetails.class), any(DatanodeDetails.class)))
-            .thenReturn(CompletableFuture.completedFuture(
-                    MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT))
-            .thenReturn(CompletableFuture.completedFuture(
-                    MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT))
-            .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
-
-    ContainerBalancerTask task = mockedScm.startBalancerTask(config);
-    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
-
-    assertThat(iteration.getContainerMovesTimeout()).isEqualTo(2);
-
-    ArgumentCaptor<DatanodeDetails> sourceCaptor = ArgumentCaptor.forClass(DatanodeDetails.class);
-    ArgumentCaptor<DatanodeDetails> targetCaptor = ArgumentCaptor.forClass(DatanodeDetails.class);
-    verify(mockedScm.getMoveManager(), atLeast(2)).move(
-            any(ContainerID.class), sourceCaptor.capture(), targetCaptor.capture());
-
-    String sourceUuid1 = sourceCaptor.getAllValues().get(0).getUuidString();
-    String sourceUuid2 = sourceCaptor.getAllValues().get(1).getUuidString();
-    assertThat(sourceUuid1).isNotEqualTo(sourceUuid2);
-
-    String expectedReason = MoveManager.MoveResult.REPLICATION_FAIL_TIME_OUT.name();
-    ContainerMoveFailureDetail detail = iteration.getFailures().stream()
-            .filter(f -> expectedReason.equals(f.getReason()))
-            .findFirst()
-            .orElse(null);
-    assertThat(detail).as("failure detail for reason " + expectedReason).isNotNull();
+    ContainerMoveFailureDetail detail = tracker.getFailures().stream()
+        .filter(f -> reason.equals(f.getReason()))
+        .findFirst()
+        .orElse(null);
+    assertThat(detail).as("failure detail for reason " + reason).isNotNull();
     assertThat(detail.getCount()).isEqualTo(2L);
     assertThat(detail.getSourceFailureCounts())
-            .hasSize(2)
-            .containsEntry(sourceUuid1, 1L)
-            .containsEntry(sourceUuid2, 1L);
+        .hasSize(2)
+        .containsEntry(source1.getUuidString(), 1L)
+        .containsEntry(source2.getUuidString(), 1L);
+    assertThat(detail.getTargetFailureCounts())
+        .hasSize(1)
+        .containsEntry(target.getUuidString(), 2L);
   }
 
   private static MockedSCM createMockedScm() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -181,8 +180,8 @@ class TestContainerBalancerMoveFailureBreakdown {
 
   private static void assertBreakdownTotalsMatchHeadlineCounters(
       ContainerBalancerTaskIterationStatusInfo iteration) {
-    long breakdownTotal = iteration.getFailuresByReason().values().stream()
-        .mapToLong(Long::longValue)
+    long breakdownTotal = iteration.getFailures().stream()
+        .mapToLong(ContainerMoveFailureDetail::getCount)
         .sum();
     long headlineTotal = iteration.getContainerMovesFailed() + iteration.getContainerMovesTimeout();
     assertEquals(headlineTotal, breakdownTotal,
@@ -191,18 +190,15 @@ class TestContainerBalancerMoveFailureBreakdown {
 
   private static void assertFailureBreakdown(
       ContainerBalancerTaskIterationStatusInfo iteration, String expectedReason) {
-    Map<String, Long> failuresByReason = iteration.getFailuresByReason();
-    assertThat(failuresByReason).as("failure breakdown").containsKey(expectedReason);
-    assertThat(failuresByReason.get(expectedReason)).isGreaterThanOrEqualTo(1L);
-
-    List<ContainerMoveFailureDetail> details = iteration.getFailureDetails();
-    assertThat(details).isNotEmpty();
-    assertThat(details.stream().anyMatch(detail ->
-        expectedReason.equals(detail.getReason())
-            && detail.getContainerId() > 0
-            && detail.getSourceDatanodeUuid() != null
-            && !detail.getSourceDatanodeUuid().isEmpty()
-            && detail.getTargetDatanodeUuid() != null
-            && !detail.getTargetDatanodeUuid().isEmpty())).isTrue();
+    List<ContainerMoveFailureDetail> failures = iteration.getFailures();
+    assertThat(failures).as("failure details").isNotEmpty();
+    ContainerMoveFailureDetail detail = failures.stream()
+        .filter(f -> expectedReason.equals(f.getReason()))
+        .findFirst()
+        .orElse(null);
+    assertThat(detail).as("failure detail for reason " + expectedReason).isNotNull();
+    assertThat(detail.getCount()).isGreaterThanOrEqualTo(1L);
+    assertThat(detail.getSourceFailureCounts()).isNotEmpty();
+    assertThat(detail.getTargetFailureCounts()).isNotEmpty();
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerMoveFailureBreakdown.java
@@ -144,6 +144,36 @@ class TestContainerBalancerMoveFailureBreakdown {
   }
 
   @Test
+  void testNodeNotFoundRecordedInFailureBreakdown()
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    when(mockedScm.getMoveManager().move(any(ContainerID.class),
+        any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenThrow(new NodeNotFoundException())
+        .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+    ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+    assertThat(iteration.getContainerMovesFailed()).isEqualTo(1);
+    assertFailureBreakdown(mockedScm, iteration,
+        ContainerBalancerTask.ContainerMoveFailureReason.PRE_MOVE_NODE_NOT_FOUND.name(), 0);
+  }
+
+  @Test
+  void testReplicaNotFoundRecordedInFailureBreakdown()
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MockedSCM mockedScm = createMockedScm();
+    when(mockedScm.getMoveManager().move(any(ContainerID.class),
+        any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenThrow(new ContainerReplicaNotFoundException("test"))
+        .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+    ContainerBalancerTask task = mockedScm.startBalancerTask(buildConfig(mockedScm));
+    ContainerBalancerTaskIterationStatusInfo iteration = getCompletedIteration(task);
+    assertThat(iteration.getContainerMovesFailed()).isEqualTo(1);
+    assertFailureBreakdown(mockedScm, iteration,
+        ContainerBalancerTask.ContainerMoveFailureReason.PRE_MOVE_REPLICA_NOT_FOUND.name(), 0);
+  }
+
+  @Test
   void testSameReasonAggregatesSourceFailureCountsFromMultipleSources() {
     ContainerMoveFailureTracker tracker = new ContainerMoveFailureTracker();
     DatanodeDetails source1 = MockDatanodeDetails.createDatanodeDetails("1.1.1.1", "/r1");

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
@@ -27,13 +27,19 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerTaskIterationStatusInfoProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.ozone.OzoneConsts;
 import picocli.CommandLine;
@@ -232,6 +238,11 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
     if (leavingDataNodeList.isEmpty()) {
       leavingDataNodeList = " -" + System.lineSeparator();
     }
+    String failureBreakdown = formatFailureBreakdown(
+        iterationStatusInfo.getContainerMoveFailuresByReasonList());
+    String failureDetails = formatFailureDetails(
+        iterationStatusInfo.getContainerMoveFailuresByReasonList(),
+        iterationStatusInfo.getContainerMoveFailureDetailsList());
     return String.format(
             "%-50s %s%n" +
                     "%-50s %s%n" +
@@ -243,6 +254,8 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
                     "%-50s %s%n" +
                     "%-50s %s%n" +
                     "%-50s %s%n" +
+                    "%s" +
+                    "%s" +
                     "%-50s %n%s" +
                     "%-50s %n%s",
             "Key", "Value",
@@ -256,8 +269,74 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
             "Already moved containers", containerMovesCompleted,
             "Failed to move containers", containerMovesFailed,
             "Failed to move containers by timeout", containerMovesTimeout,
+            failureBreakdown,
+            failureDetails,
             "Entered data to nodes", enteringDataNodeList,
             "Exited data from nodes", leavingDataNodeList);
+  }
+
+  private String formatFailureBreakdown(List<ContainerMoveFailureSummaryProto> summaries) {
+    List<ContainerMoveFailureSummaryProto> sortedSummaries = summaries.stream()
+        .sorted(Comparator.comparingLong(ContainerMoveFailureSummaryProto::getCount).reversed()
+            .thenComparing(ContainerMoveFailureSummaryProto::getReason))
+        .collect(Collectors.toList());
+    if (sortedSummaries.isEmpty()) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder();
+    builder.append(String.format("%-50s %n", "Failure breakdown"));
+    for (ContainerMoveFailureSummaryProto summary : sortedSummaries) {
+      builder.append(String.format("  %-48s %d%n", summary.getReason(), summary.getCount()));
+    }
+    return builder.toString();
+  }
+
+  private String formatFailureDetails(List<ContainerMoveFailureSummaryProto> summaries,
+                                      List<ContainerMoveFailureDetailProto> failureDetails) {
+    if (failureDetails.isEmpty()) {
+      return "";
+    }
+
+    Map<String, List<ContainerMoveFailureDetailProto>> detailsByReason = new LinkedHashMap<>();
+    for (ContainerMoveFailureDetailProto detail : failureDetails) {
+      detailsByReason.computeIfAbsent(detail.getReason(), ignored -> new ArrayList<>())
+          .add(detail);
+    }
+
+    long totalFailures = summaries.stream()
+        .mapToLong(ContainerMoveFailureSummaryProto::getCount)
+        .sum();
+    int shownDetails = failureDetails.size();
+
+    StringBuilder builder = new StringBuilder();
+    builder.append(String.format("%-50s %n", "Failed move details"));
+    if (totalFailures > shownDetails) {
+      builder.append(String.format("  (Showing %d of %d failures)%n", shownDetails, totalFailures));
+    }
+
+    summaries.stream()
+        .sorted(Comparator.comparingLong(ContainerMoveFailureSummaryProto::getCount).reversed()
+            .thenComparing(ContainerMoveFailureSummaryProto::getReason))
+        .filter(summary -> detailsByReason.containsKey(summary.getReason()))
+        .forEach(summary -> {
+          String reason = summary.getReason();
+          List<ContainerMoveFailureDetailProto> reasonDetails = detailsByReason.get(reason);
+          long reasonTotal = summary.getCount();
+          if (reasonTotal > reasonDetails.size()) {
+            builder.append(String.format("  %s (showing %d of %d)%n",
+                reason, reasonDetails.size(), reasonTotal));
+          } else {
+            builder.append(String.format("  %s%n", reason));
+          }
+          for (ContainerMoveFailureDetailProto detail : reasonDetails) {
+            builder.append(String.format("    container %d  source %s  target %s%n",
+                detail.getContainerId(),
+                detail.getSourceDatanodeUuid(),
+                detail.getTargetDatanodeUuid()));
+          }
+        });
+
+    return builder.toString();
   }
 
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
@@ -235,7 +235,7 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
     if (leavingDataNodeList.isEmpty()) {
       leavingDataNodeList = " -" + System.lineSeparator();
     }
-    String failures = formatFailures(iterationStatusInfo.getContainerMoveFailuresList());
+    String failures = formatFailures(containerMovesFailed, iterationStatusInfo.getContainerMoveFailuresList());
     return String.format(
             "%-50s %s%n" +
                     "%-50s %s%n" +
@@ -266,7 +266,10 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
             "Exited data from nodes", leavingDataNodeList);
   }
 
-  private String formatFailures(List<ContainerMoveFailureDetailProto> failures) {
+  private String formatFailures(long containerMovesFailed, List<ContainerMoveFailureDetailProto> failures) {
+    if (containerMovesFailed > 0 && failures.isEmpty()) {
+      return String.format("%-50s %s%n", "Failed container moves", "(no breakdown available)");
+    }
     if (failures.isEmpty()) {
       return "";
     }
@@ -281,17 +284,23 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
       if (!failure.getSourceFailureCountsList().isEmpty()) {
         builder.append(String.format("    %-46s %n", "Source datanodes"));
         for (NodeFailureCountProto src : failure.getSourceFailureCountsList()) {
-          builder.append(String.format("      %-44s %d%n", src.getDatanodeUuid(), src.getCount()));
+          builder.append(String.format("      %-44s %d%n", formatDatanodeLabel(src), src.getCount()));
         }
       }
       if (!failure.getTargetFailureCountsList().isEmpty()) {
         builder.append(String.format("    %-46s %n", "Target datanodes"));
         for (NodeFailureCountProto tgt : failure.getTargetFailureCountsList()) {
-          builder.append(String.format("      %-44s %d%n", tgt.getDatanodeUuid(), tgt.getCount()));
+          builder.append(String.format("      %-44s %d%n", formatDatanodeLabel(tgt), tgt.getCount()));
         }
       }
     }
     return builder.toString();
+  }
+
+  private static String formatDatanodeLabel(NodeFailureCountProto node) {
+    return node.hasHostname()
+        ? node.getHostname() + " (" + node.getDatanodeUuid() + ")"
+        : node.getDatanodeUuid();
   }
 
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStatusSubcommand.java
@@ -27,11 +27,8 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -39,7 +36,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerTaskIterationStatusInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.NodeFailureCountProto;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.ozone.OzoneConsts;
 import picocli.CommandLine;
@@ -238,11 +235,7 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
     if (leavingDataNodeList.isEmpty()) {
       leavingDataNodeList = " -" + System.lineSeparator();
     }
-    String failureBreakdown = formatFailureBreakdown(
-        iterationStatusInfo.getContainerMoveFailuresByReasonList());
-    String failureDetails = formatFailureDetails(
-        iterationStatusInfo.getContainerMoveFailuresByReasonList(),
-        iterationStatusInfo.getContainerMoveFailureDetailsList());
+    String failures = formatFailures(iterationStatusInfo.getContainerMoveFailuresList());
     return String.format(
             "%-50s %s%n" +
                     "%-50s %s%n" +
@@ -254,7 +247,6 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
                     "%-50s %s%n" +
                     "%-50s %s%n" +
                     "%-50s %s%n" +
-                    "%s" +
                     "%s" +
                     "%-50s %n%s" +
                     "%-50s %n%s",
@@ -269,73 +261,36 @@ public class ContainerBalancerStatusSubcommand extends ScmSubcommand {
             "Already moved containers", containerMovesCompleted,
             "Failed to move containers", containerMovesFailed,
             "Failed to move containers by timeout", containerMovesTimeout,
-            failureBreakdown,
-            failureDetails,
+            failures,
             "Entered data to nodes", enteringDataNodeList,
             "Exited data from nodes", leavingDataNodeList);
   }
 
-  private String formatFailureBreakdown(List<ContainerMoveFailureSummaryProto> summaries) {
-    List<ContainerMoveFailureSummaryProto> sortedSummaries = summaries.stream()
-        .sorted(Comparator.comparingLong(ContainerMoveFailureSummaryProto::getCount).reversed()
-            .thenComparing(ContainerMoveFailureSummaryProto::getReason))
+  private String formatFailures(List<ContainerMoveFailureDetailProto> failures) {
+    if (failures.isEmpty()) {
+      return "";
+    }
+    List<ContainerMoveFailureDetailProto> sorted = failures.stream()
+        .sorted(Comparator.comparingLong(ContainerMoveFailureDetailProto::getCount).reversed()
+            .thenComparing(ContainerMoveFailureDetailProto::getReason))
         .collect(Collectors.toList());
-    if (sortedSummaries.isEmpty()) {
-      return "";
-    }
     StringBuilder builder = new StringBuilder();
-    builder.append(String.format("%-50s %n", "Failure breakdown"));
-    for (ContainerMoveFailureSummaryProto summary : sortedSummaries) {
-      builder.append(String.format("  %-48s %d%n", summary.getReason(), summary.getCount()));
+    builder.append(String.format("%-50s %n", "Failed container moves"));
+    for (ContainerMoveFailureDetailProto failure : sorted) {
+      builder.append(String.format("  %-48s %d%n", failure.getReason(), failure.getCount()));
+      if (!failure.getSourceFailureCountsList().isEmpty()) {
+        builder.append(String.format("    %-46s %n", "Source datanodes"));
+        for (NodeFailureCountProto src : failure.getSourceFailureCountsList()) {
+          builder.append(String.format("      %-44s %d%n", src.getDatanodeUuid(), src.getCount()));
+        }
+      }
+      if (!failure.getTargetFailureCountsList().isEmpty()) {
+        builder.append(String.format("    %-46s %n", "Target datanodes"));
+        for (NodeFailureCountProto tgt : failure.getTargetFailureCountsList()) {
+          builder.append(String.format("      %-44s %d%n", tgt.getDatanodeUuid(), tgt.getCount()));
+        }
+      }
     }
-    return builder.toString();
-  }
-
-  private String formatFailureDetails(List<ContainerMoveFailureSummaryProto> summaries,
-                                      List<ContainerMoveFailureDetailProto> failureDetails) {
-    if (failureDetails.isEmpty()) {
-      return "";
-    }
-
-    Map<String, List<ContainerMoveFailureDetailProto>> detailsByReason = new LinkedHashMap<>();
-    for (ContainerMoveFailureDetailProto detail : failureDetails) {
-      detailsByReason.computeIfAbsent(detail.getReason(), ignored -> new ArrayList<>())
-          .add(detail);
-    }
-
-    long totalFailures = summaries.stream()
-        .mapToLong(ContainerMoveFailureSummaryProto::getCount)
-        .sum();
-    int shownDetails = failureDetails.size();
-
-    StringBuilder builder = new StringBuilder();
-    builder.append(String.format("%-50s %n", "Failed move details"));
-    if (totalFailures > shownDetails) {
-      builder.append(String.format("  (Showing %d of %d failures)%n", shownDetails, totalFailures));
-    }
-
-    summaries.stream()
-        .sorted(Comparator.comparingLong(ContainerMoveFailureSummaryProto::getCount).reversed()
-            .thenComparing(ContainerMoveFailureSummaryProto::getReason))
-        .filter(summary -> detailsByReason.containsKey(summary.getReason()))
-        .forEach(summary -> {
-          String reason = summary.getReason();
-          List<ContainerMoveFailureDetailProto> reasonDetails = detailsByReason.get(reason);
-          long reasonTotal = summary.getCount();
-          if (reasonTotal > reasonDetails.size()) {
-            builder.append(String.format("  %s (showing %d of %d)%n",
-                reason, reasonDetails.size(), reasonTotal));
-          } else {
-            builder.append(String.format("  %s%n", reason));
-          }
-          for (ContainerMoveFailureDetailProto detail : reasonDetails) {
-            builder.append(String.format("    container %d  source %s  target %s%n",
-                detail.getContainerId(),
-                detail.getSourceDatanodeUuid(),
-                detail.getTargetDatanodeUuid()));
-          }
-        });
-
     return builder.toString();
   }
 

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -726,36 +726,33 @@ class TestContainerBalancerSubCommand {
             .setContainerMovesCompleted(3)
             .setContainerMovesFailed(1)
             .setContainerMovesTimeout(2)
-            .addContainerMoveFailuresByReason(
-                StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto.newBuilder()
+            .addContainerMoveFailures(
+                StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
                     .setReason("REPLICATION_FAIL_TIME_OUT")
                     .setCount(2)
+                    .addSourceFailureCounts(
+                        StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+                            .setDatanodeUuid("source-uuid-1").setCount(1).build())
+                    .addSourceFailureCounts(
+                        StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+                            .setDatanodeUuid("source-uuid-2").setCount(1).build())
+                    .addTargetFailureCounts(
+                        StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+                            .setDatanodeUuid("target-uuid-1").setCount(1).build())
+                    .addTargetFailureCounts(
+                        StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+                            .setDatanodeUuid("target-uuid-2").setCount(1).build())
                     .build())
-            .addContainerMoveFailuresByReason(
-                StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto.newBuilder()
+            .addContainerMoveFailures(
+                StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
                     .setReason("PRE_MOVE_CONTAINER_NOT_FOUND")
                     .setCount(1)
-                    .build())
-            .addContainerMoveFailureDetails(
-                StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
-                    .setContainerId(42)
-                    .setSourceDatanodeUuid("source-uuid-1")
-                    .setTargetDatanodeUuid("target-uuid-1")
-                    .setReason("REPLICATION_FAIL_TIME_OUT")
-                    .build())
-            .addContainerMoveFailureDetails(
-                StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
-                    .setContainerId(43)
-                    .setSourceDatanodeUuid("source-uuid-2")
-                    .setTargetDatanodeUuid("target-uuid-2")
-                    .setReason("REPLICATION_FAIL_TIME_OUT")
-                    .build())
-            .addContainerMoveFailureDetails(
-                StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
-                    .setContainerId(44)
-                    .setSourceDatanodeUuid("source-uuid-3")
-                    .setTargetDatanodeUuid("target-uuid-3")
-                    .setReason("PRE_MOVE_CONTAINER_NOT_FOUND")
+                    .addSourceFailureCounts(
+                        StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+                            .setDatanodeUuid("source-uuid-3").setCount(1).build())
+                    .addTargetFailureCounts(
+                        StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
+                            .setDatanodeUuid("target-uuid-3").setCount(1).build())
                     .build())
             .build();
 
@@ -779,16 +776,14 @@ class TestContainerBalancerSubCommand {
     statusCmd.execute(scmClient);
 
     assertThat(out.get())
-        .contains("Failure breakdown")
+        .contains("Failed container moves")
         .contains("REPLICATION_FAIL_TIME_OUT")
         .contains("PRE_MOVE_CONTAINER_NOT_FOUND")
-        .contains("Failed move details")
-        .contains("container 42")
-        .contains("container 43")
-        .contains("container 44")
         .contains("source-uuid-1")
         .contains("target-uuid-1")
         .contains("source-uuid-3")
-        .contains("target-uuid-3");
+        .contains("target-uuid-3")
+        .doesNotContain("Failure breakdown")
+        .doesNotContain("Failed move details");
   }
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -712,4 +712,83 @@ class TestContainerBalancerSubCommand {
         .contains(ITERATION_2_COMPLETED_OUTPUT)
         .doesNotContain(ITERATION_3_COMPLETED_OUTPUT);
   }
+
+  @Test
+  void testContainerBalancerStatusVerboseShowsFailureBreakdown() throws IOException {
+    ScmClient scmClient = mock(ScmClient.class);
+    ContainerBalancerConfiguration config = getContainerBalancerConfiguration();
+    StorageContainerLocationProtocolProtos.ContainerBalancerTaskIterationStatusInfoProto iteration =
+        StorageContainerLocationProtocolProtos.ContainerBalancerTaskIterationStatusInfoProto.newBuilder()
+            .setIterationNumber(1)
+            .setIterationResult("ITERATION_COMPLETED")
+            .setIterationDuration(120L)
+            .setContainerMovesScheduled(5)
+            .setContainerMovesCompleted(3)
+            .setContainerMovesFailed(1)
+            .setContainerMovesTimeout(2)
+            .addContainerMoveFailuresByReason(
+                StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto.newBuilder()
+                    .setReason("REPLICATION_FAIL_TIME_OUT")
+                    .setCount(2)
+                    .build())
+            .addContainerMoveFailuresByReason(
+                StorageContainerLocationProtocolProtos.ContainerMoveFailureSummaryProto.newBuilder()
+                    .setReason("PRE_MOVE_CONTAINER_NOT_FOUND")
+                    .setCount(1)
+                    .build())
+            .addContainerMoveFailureDetails(
+                StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
+                    .setContainerId(42)
+                    .setSourceDatanodeUuid("source-uuid-1")
+                    .setTargetDatanodeUuid("target-uuid-1")
+                    .setReason("REPLICATION_FAIL_TIME_OUT")
+                    .build())
+            .addContainerMoveFailureDetails(
+                StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
+                    .setContainerId(43)
+                    .setSourceDatanodeUuid("source-uuid-2")
+                    .setTargetDatanodeUuid("target-uuid-2")
+                    .setReason("REPLICATION_FAIL_TIME_OUT")
+                    .build())
+            .addContainerMoveFailureDetails(
+                StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
+                    .setContainerId(44)
+                    .setSourceDatanodeUuid("source-uuid-3")
+                    .setTargetDatanodeUuid("target-uuid-3")
+                    .setReason("PRE_MOVE_CONTAINER_NOT_FOUND")
+                    .build())
+            .build();
+
+    long stoppedAt = OffsetDateTime.now().toEpochSecond();
+    ContainerBalancerStatusInfoProto statusInfo = ContainerBalancerStatusInfoProto.newBuilder()
+        .setStartedAt(stoppedAt - 600)
+        .setStoppedAt(stoppedAt)
+        .setStopReason("USER_REQUESTED")
+        .setStopMessage("Stopped by user request.")
+        .setConfiguration(config.toProtobufBuilder().setShouldRun(false))
+        .addIterationsStatusInfo(iteration)
+        .build();
+
+    when(scmClient.getContainerBalancerStatusInfo())
+        .thenReturn(ContainerBalancerStatusInfoResponseProto.newBuilder()
+            .setIsRunning(false)
+            .setContainerBalancerStatusInfo(statusInfo)
+            .build());
+
+    verbose.set(true);
+    statusCmd.execute(scmClient);
+
+    assertThat(out.get())
+        .contains("Failure breakdown")
+        .contains("REPLICATION_FAIL_TIME_OUT")
+        .contains("PRE_MOVE_CONTAINER_NOT_FOUND")
+        .contains("Failed move details")
+        .contains("container 42")
+        .contains("container 43")
+        .contains("container 44")
+        .contains("source-uuid-1")
+        .contains("target-uuid-1")
+        .contains("source-uuid-3")
+        .contains("target-uuid-3");
+  }
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -732,16 +732,16 @@ class TestContainerBalancerSubCommand {
                     .setCount(2)
                     .addSourceFailureCounts(
                         StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                            .setDatanodeUuid("source-uuid-1").setCount(1).build())
+                            .setDatanodeUuid("source-uuid-1").setHostname("datanode1.example.com").setCount(1).build())
                     .addSourceFailureCounts(
                         StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                            .setDatanodeUuid("source-uuid-2").setCount(1).build())
+                            .setDatanodeUuid("source-uuid-2").setHostname("datanode2.example.com").setCount(1).build())
                     .addTargetFailureCounts(
                         StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                            .setDatanodeUuid("target-uuid-1").setCount(1).build())
+                            .setDatanodeUuid("target-uuid-1").setHostname("datanode3.example.com").setCount(1).build())
                     .addTargetFailureCounts(
                         StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                            .setDatanodeUuid("target-uuid-2").setCount(1).build())
+                            .setDatanodeUuid("target-uuid-2").setHostname("datanode4.example.com").setCount(1).build())
                     .build())
             .addContainerMoveFailures(
                 StorageContainerLocationProtocolProtos.ContainerMoveFailureDetailProto.newBuilder()
@@ -749,10 +749,10 @@ class TestContainerBalancerSubCommand {
                     .setCount(1)
                     .addSourceFailureCounts(
                         StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                            .setDatanodeUuid("source-uuid-3").setCount(1).build())
+                            .setDatanodeUuid("source-uuid-3").setHostname("datanode5.example.com").setCount(1).build())
                     .addTargetFailureCounts(
                         StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                            .setDatanodeUuid("target-uuid-3").setCount(1).build())
+                            .setDatanodeUuid("target-uuid-3").setHostname("datanode6.example.com").setCount(1).build())
                     .build())
             .build();
 
@@ -779,11 +779,46 @@ class TestContainerBalancerSubCommand {
         .contains("Failed container moves")
         .contains("REPLICATION_FAIL_TIME_OUT")
         .contains("PRE_MOVE_CONTAINER_NOT_FOUND")
-        .contains("source-uuid-1")
-        .contains("target-uuid-1")
-        .contains("source-uuid-3")
-        .contains("target-uuid-3")
+        .contains("datanode1.example.com (source-uuid-1)")
+        .contains("datanode3.example.com (target-uuid-1)")
+        .contains("datanode5.example.com (source-uuid-3)")
+        .contains("datanode6.example.com (target-uuid-3)")
         .doesNotContain("Failure breakdown")
         .doesNotContain("Failed move details");
+  }
+
+  @Test
+  void testContainerBalancerStatusVerboseShowsNoBreakdownWhenFailuresMissing() throws IOException {
+    ScmClient scmClient = mock(ScmClient.class);
+    ContainerBalancerConfiguration config = getContainerBalancerConfiguration();
+    StorageContainerLocationProtocolProtos.ContainerBalancerTaskIterationStatusInfoProto iteration =
+        StorageContainerLocationProtocolProtos.ContainerBalancerTaskIterationStatusInfoProto.newBuilder()
+            .setIterationNumber(1)
+            .setIterationResult("ITERATION_COMPLETED")
+            .setIterationDuration(120L)
+            .setContainerMovesFailed(3)
+            .build();
+
+    long stoppedAt = OffsetDateTime.now().toEpochSecond();
+    ContainerBalancerStatusInfoProto statusInfo = ContainerBalancerStatusInfoProto.newBuilder()
+        .setStartedAt(stoppedAt - 600)
+        .setStoppedAt(stoppedAt)
+        .setStopReason("USER_REQUESTED")
+        .setConfiguration(config.toProtobufBuilder().setShouldRun(false))
+        .addIterationsStatusInfo(iteration)
+        .build();
+
+    when(scmClient.getContainerBalancerStatusInfo())
+        .thenReturn(ContainerBalancerStatusInfoResponseProto.newBuilder()
+            .setIsRunning(false)
+            .setContainerBalancerStatusInfo(statusInfo)
+            .build());
+
+    verbose.set(true);
+    statusCmd.execute(scmClient);
+
+    assertThat(out.get())
+        .contains("Failed to move containers                          3")
+        .contains("Failed container moves                             (no breakdown available)");
   }
 }

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -735,7 +735,7 @@ class TestContainerBalancerSubCommand {
                             .setDatanodeUuid("source-uuid-1").setHostname("datanode1.example.com").setCount(1).build())
                     .addSourceFailureCounts(
                         StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
-                            .setDatanodeUuid("source-uuid-2").setHostname("datanode2.example.com").setCount(1).build())
+                            .setDatanodeUuid("source-uuid-2").setCount(1).build())
                     .addTargetFailureCounts(
                         StorageContainerLocationProtocolProtos.NodeFailureCountProto.newBuilder()
                             .setDatanodeUuid("target-uuid-1").setHostname("datanode3.example.com").setCount(1).build())
@@ -780,11 +780,11 @@ class TestContainerBalancerSubCommand {
         .contains("REPLICATION_FAIL_TIME_OUT")
         .contains("PRE_MOVE_CONTAINER_NOT_FOUND")
         .contains("datanode1.example.com (source-uuid-1)")
+        .contains("source-uuid-2")
+        .doesNotContain("(source-uuid-2)")
         .contains("datanode3.example.com (target-uuid-1)")
         .contains("datanode5.example.com (source-uuid-3)")
-        .contains("datanode6.example.com (target-uuid-3)")
-        .doesNotContain("Failure breakdown")
-        .doesNotContain("Failed move details");
+        .contains("datanode6.example.com (target-uuid-3)");
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improves observability of Container Balancer move failures in `ozone admin containerbalancer status -v`.

Previously, verbose status only showed aggregate counts (“Failed to move containers”, “Failed to move containers by timeout”) with no breakdown of why moves failed, so users had to dig through SCM logs.

This change tracks per-iteration move failures on the SCM side and surfaces them in the CLI under a Failed container moves section. For each failure reason (e.g. REPLICATION_FAIL_TIME_OUT, PRE_MOVE_CONTAINER_NOT_FOUND, ITERATION_MOVE_TIMEOUT, plus other MoveResult values), verbose status shows:

- Total count for that reason
- Source datanode counts — how many failures involved each source datanode UUID
- Target datanode counts — how many failures involved each target datanode UUID

Counts are aggregated per iteration (not capped), so users can see both the failure type and which datanodes are most affected without scanning SCM logs.

## What is the link to the Apache JIRA

[HDDS-15889](https://issues.apache.org/jira/browse/HDDS-15889)

## How was this patch tested?
Added test cases.
Tested in docker ozone-balancer cluster:

```
bash-5.1$ ozone admin containerbalancer start \
  -t 0.1 -d 100 -i 2 \
  --move-replication-timeout-minutes 1 \
  --move-timeout-minutes 16 \
  --balancing-iteration-interval-minutes 1
Container Balancer started successfully.
bash-5.1$
```

```
bash-5.1$ ozone admin containerbalancer status --verbose -H
ContainerBalancer is Running.
Started at: 2026-08-24 08:08:16
Balancing duration: 6m 22s

Container Balancer Configuration values:
Key                                                Value
Threshold                                          0.001
Max Datanodes to Involve per Iteration(percent)    100
Max Size to Move per Iteration                     500GB
Max Size Entering Target per Iteration             26GB
Max Size Leaving Source per Iteration              26GB
Number of Iterations                               2
Time Limit for Single Container's Movement         16min
Time Limit for Single Container's Replication      1min
Interval between each Iteration                    1min
Whether to Enable Network Topology                 false
Whether to Trigger Refresh Datanode Usage Info     false
Container IDs to Include in Balancing              None
Container IDs to Exclude from Balancing            None
Datanodes Specified to be Balanced                 None
Datanodes Excluded from Balancing                  None

Current iteration info:
Key                                                Value
Iteration number                                   2
Iteration duration                                 9s
Iteration result                                   -
Size scheduled to move                             2.34 MB
Moved data size                                    0 B
Scheduled to move containers                       6
Already moved containers                           0
Failed to move containers                          0
Failed to move containers by timeout               0
Entered data to nodes                              
6b209544-0274-4f9d-9a18-63f6fb3d4d8e <- 800 KB
9069dc38-9567-496f-a90c-19d8a3d77b5f <- 800 KB
ecd458af-4b42-4447-a240-07ea0c5749df <- 800 KB
Exited data from nodes                             
ea3ed538-99a6-4dbe-bb84-b8be7b8ce0e9 -> 800 KB
12c7e80e-3d81-4fc0-8ab1-0eb509fb5936 -> 800 KB
c9a0c4f9-0428-42fe-9469-2cdad77f0bd0 -> 800 KB

Completed iteration history:
Key                                                Value
Iteration number                                   1
Iteration duration                                 5m 13s
Iteration result                                   ITERATION_COMPLETED
Size scheduled to move                             2.34 MB
Moved data size                                    0 B
Scheduled to move containers                       6
Already moved containers                           0
Failed to move containers                          0
Failed to move containers by timeout               6
Failed container moves                             
  REPLICATION_FAIL_TIME_OUT                        6
    Source datanodes                               
      ozone-balancer-datanode3-1.ozone-balancer_default (ea3ed538-99a6-4dbe-bb84-b8be7b8ce0e9) 2
      ozone-balancer-datanode2-1.ozone-balancer_default (12c7e80e-3d81-4fc0-8ab1-0eb509fb5936) 2
      ozone-balancer-datanode4-1.ozone-balancer_default (c9a0c4f9-0428-42fe-9469-2cdad77f0bd0) 2
    Target datanodes                               
      ozone-balancer-datanode1-1.ozone-balancer_default (9069dc38-9567-496f-a90c-19d8a3d77b5f) 2
      ozone-balancer-datanode5-1.ozone-balancer_default (ecd458af-4b42-4447-a240-07ea0c5749df) 2
      ozone-balancer-datanode6-1.ozone-balancer_default (6b209544-0274-4f9d-9a18-63f6fb3d4d8e) 2
Entered data to nodes                              
6b209544-0274-4f9d-9a18-63f6fb3d4d8e <- 800 KB
9069dc38-9567-496f-a90c-19d8a3d77b5f <- 800 KB
ecd458af-4b42-4447-a240-07ea0c5749df <- 800 KB
Exited data from nodes                             
ea3ed538-99a6-4dbe-bb84-b8be7b8ce0e9 -> 800 KB
12c7e80e-3d81-4fc0-8ab1-0eb509fb5936 -> 800 KB
c9a0c4f9-0428-42fe-9469-2cdad77f0bd0 -> 800 KB


bash-5.1$ 

```

Green CI : https://github.com/sreejasahithi/ozone/actions/runs/30628368322
