### PR TITLE
HDDS-16067. Intermittent timeout in testNodeWithOpenPipelineCanBeDecommissionedAndRecommissioned

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
@@ -38,6 +38,7 @@ import static org.apache.hadoop.hdds.scm.node.NodeTestUtil.getDNHostAndPort;
 import static org.apache.hadoop.hdds.scm.node.NodeTestUtil.waitForDnToReachHealthState;
 import static org.apache.hadoop.hdds.scm.node.NodeTestUtil.waitForDnToReachOpState;
 import static org.apache.hadoop.hdds.scm.node.NodeTestUtil.waitForDnToReachPersistedOpState;
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -77,6 +78,7 @@ import org.apache.hadoop.ozone.DataTestUtil;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneClusterProvider;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.UniformDatanodesFactory;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.ozone.test.GenericTestUtils;
@@ -148,7 +150,10 @@ public class TestDecommissionAndMaintenance {
     conf.setFromObject(replicationConf);
 
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(DATANODE_COUNT);
+        .setNumDatanodes(DATANODE_COUNT)
+        .setDatanodeFactory(UniformDatanodesFactory.newBuilder()
+            .setLayoutVersion(maxLayoutVersion())
+            .build());
 
     clusterProvider = new MiniOzoneClusterProvider(builder, 9);
   }
@@ -235,11 +240,13 @@ public class TestDecommissionAndMaintenance {
     // In the EC case, there should be 5 online
     waitForContainerReplicas(ecContainer, 5);
 
-    cluster.restartHddsDatanode(dnIndex, true);
+    cluster.restartHddsDatanode(dnIndex, false);
+    waitForDnToReachHealthState(nm, toDecommission, HEALTHY);
+    DatanodeDetails restarted = nm.getNode(dnID);
     scmClient.recommissionNodes(Arrays.asList(
-        getDNHostAndPort(toDecommission)));
-    waitForDnToReachOpState(nm, toDecommission, IN_SERVICE);
-    waitForDnToReachPersistedOpState(toDecommission, IN_SERVICE);
+        getDNHostAndPort(restarted)));
+    waitForDnToReachOpState(nm, restarted, IN_SERVICE);
+    waitForDnToReachPersistedOpState(restarted, IN_SERVICE);
   }
 
   @Test
@@ -481,7 +488,7 @@ public class TestDecommissionAndMaintenance {
     // has, then the SCM state should be used and the DN state updated.
     waitForDnToReachHealthState(nm, newDn, HEALTHY);
     waitForDnToReachOpState(nm, newDn, IN_SERVICE);
-    waitForDnToReachPersistedOpState(dn, IN_SERVICE);
+    waitForDnToReachPersistedOpState(newDn, IN_SERVICE);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
@@ -240,13 +240,11 @@ public class TestDecommissionAndMaintenance {
     // In the EC case, there should be 5 online
     waitForContainerReplicas(ecContainer, 5);
 
-    cluster.restartHddsDatanode(dnIndex, false);
-    waitForDnToReachHealthState(nm, toDecommission, HEALTHY);
-    DatanodeDetails restarted = nm.getNode(dnID);
+    cluster.restartHddsDatanode(dnIndex, true);
     scmClient.recommissionNodes(Arrays.asList(
-        getDNHostAndPort(restarted)));
-    waitForDnToReachOpState(nm, restarted, IN_SERVICE);
-    waitForDnToReachPersistedOpState(restarted, IN_SERVICE);
+        getDNHostAndPort(toDecommission)));
+    waitForDnToReachOpState(nm, toDecommission, IN_SERVICE);
+    waitForDnToReachPersistedOpState(toDecommission, IN_SERVICE);
   }
 
   @Test
@@ -488,7 +486,7 @@ public class TestDecommissionAndMaintenance {
     // has, then the SCM state should be used and the DN state updated.
     waitForDnToReachHealthState(nm, newDn, HEALTHY);
     waitForDnToReachOpState(nm, newDn, IN_SERVICE);
-    waitForDnToReachPersistedOpState(newDn, IN_SERVICE);
+    waitForDnToReachPersistedOpState(dn, IN_SERVICE);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR stabilizes `TestDecommissionAndMaintenance` by starting datanodes with the latest layout version.
This avoids intermittent metadata initialization timeouts without increasing the existing timeout.

Generated-by: Codex (GPT-5)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16067

## How was this patch tested?

Local Test
```
mvn -pl :ozone-integration-test test \
    -Dtest=TestDecommissionAndMaintenance#testNodeWithOpenPipelineCanBeDecommissionedAndRecommissioned \
    -DskipShade -DskipRecon -DskipDocs
```
<img width="1260" height="174" alt="截圖 2026-08-04 上午11 45 44" src="https://github.com/user-attachments/assets/fe963897-a15b-4746-a4dc-24e690936ee7" />

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/30869467058

Flaky-test-check: https://github.com/echonesis/ozone/actions/runs/30869665597