### PR TITLE
HDDS-16086. installCheckpoint sets OM transaction info inconsistent with the checkpoint index

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -697,8 +697,9 @@ public class TestOMRatisSnapshots {
     assertNotNull(installed, "Install should have succeeded");
     assertEquals(leaderCheckpointTrxnInfo.getTransactionIndex(), installed.getIndex());
 
-    assertEquals(installed, followerOM.getTransactionInfo().getTermIndex(),
-        "In-memory transaction info must match the index the state machine was unpaused at");
+    assertEquals(followerOM.getOmRatisServer().getLastAppliedTermIndex(),
+        followerOM.getTransactionInfo().getTermIndex(),
+        "In-memory transaction info must match the position the state machine was unpaused at");
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -653,6 +653,54 @@ public class TestOMRatisSnapshots {
     }
   }
 
+  /**
+   * After a successful install the in-memory transaction info must describe the
+   * position the state machine was unpaused at, not the follower's pre-install
+   * index. Asserted immediately after the call: a later takeSnapshot recomputes
+   * the value from the applied index and would mask a regression here.
+   *
+   * This pins an Ozone-internal invariant, not the Ratis contract. Calling
+   * installCheckpoint directly queues no Ratis reload, so the pre-fix value seen
+   * here is starker than a real install leaves behind.
+   */
+  @Test
+  public void testInstallCheckpointPublishesNewTransactionInfo() throws Exception {
+    final String leaderOMNodeId = OmTestUtil.getCurrentOmProxyNodeId(objectStore);
+    OzoneManager leaderOM = cluster.getOzoneManager(leaderOMNodeId);
+    OzoneManagerRatisServer leaderRatisServer = leaderOM.getOmRatisServer();
+
+    String followerNodeId = leaderOM.getPeerNodes().get(0).getNodeId();
+    if (cluster.isOMActive(followerNodeId)) {
+      followerNodeId = leaderOM.getPeerNodes().get(1).getNodeId();
+    }
+    OzoneManager followerOM = cluster.getOzoneManager(followerNodeId);
+
+    writeKeysToIncreaseLogIndex(leaderRatisServer, 100);
+
+    DBCheckpoint leaderDbCheckpoint =
+        leaderOM.getMetadataManager().getStore().getCheckpoint(false);
+    Path leaderCheckpointLocation = leaderDbCheckpoint.getCheckpointLocation();
+    assertNotNull(leaderCheckpointLocation);
+    Path omDbDir = leaderCheckpointLocation.resolve(OM_DB_NAME);
+    assertTrue(omDbDir.toFile().mkdir());
+    moveCheckpointContentsToOmDbDir(leaderCheckpointLocation, omDbDir);
+    TransactionInfo leaderCheckpointTrxnInfo =
+        OzoneManagerRatisUtils.getTrxnInfoFromCheckpoint(conf, omDbDir);
+
+    // The follower was never started, so restarting its RPC server at the end of
+    // installCheckpoint fails. That happens after the transaction info is published
+    // and is not what this test is about, so swallow the exit.
+    followerOM.setExitManagerForTesting(new DummyExitManager());
+
+    TermIndex installed = followerOM.installCheckpoint(
+        leaderOMNodeId, leaderCheckpointLocation, leaderCheckpointTrxnInfo);
+    assertNotNull(installed, "Install should have succeeded");
+    assertEquals(leaderCheckpointTrxnInfo.getTransactionIndex(), installed.getIndex());
+
+    assertEquals(installed, followerOM.getTransactionInfo().getTermIndex(),
+        "In-memory transaction info must match the index the state machine was unpaused at");
+  }
+
   @Test
   public void testInstallSnapshotFromLeaderFailedDownloadCleanupSucceeds()
       throws Exception {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4387,9 +4387,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (oldOmMetadataManagerStopped) {
         time = Time.monotonicNow();
         reloadOMState();
-        // Ratis reads this field as the state machine's latest snapshot. Most callers survive
-        // a stale value by also consulting latestInstalledSnapshot; getLastEntry() does not,
-        // and decideVote() uses it. Publish the index we unpause at, not the one before it.
+        // Ratis may read this field through getLatestSnapshot() when decideVote()
+        // obtains the last entry. Publish the position used to unpause. After a failed
+        // DB replacement, these values still identify the restored pre-install state.
         setTransactionInfo(TransactionInfo.valueOf(term, lastAppliedIndex));
         omRatisServer.getOmStateMachine().unpause(lastAppliedIndex, term);
         newMetadataManagerStarted = true;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4387,7 +4387,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (oldOmMetadataManagerStopped) {
         time = Time.monotonicNow();
         reloadOMState();
-        setTransactionInfo(TransactionInfo.valueOf(termIndex));
+        // Ratis reads this field as the state machine's latest snapshot. Most callers survive
+        // a stale value by also consulting latestInstalledSnapshot; getLastEntry() does not,
+        // and decideVote() uses it. Publish the index we unpause at, not the one before it.
+        setTransactionInfo(TransactionInfo.valueOf(term, lastAppliedIndex));
         omRatisServer.getOmStateMachine().unpause(lastAppliedIndex, term);
         newMetadataManagerStarted = true;
         LOG.info("Reloaded OM state with Term: {} and Index: {}. Spend {} ms",


### PR DESCRIPTION
Generated-by: Claude Code (Opus 5)

## What changes were proposed in this pull request?

Before this change, two functions wrote different values to the OM's in-memory transaction info.

`loadSnapshotInfoFromDB()` reads the value from the installed checkpoint DB, and that value is correct. [installCheckpoint](https://github.com/apache/ozone/blob/40cd903440e7b84017461eccdaf4075f72f58a89/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java#L4390) writes the TermIndex from before the installation. But the next line [unpauses](https://github.com/apache/ozone/blob/40cd903440e7b84017461eccdaf4075f72f58a89/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java#L4391) the state machine at the index of the checkpoint.

The one-line change makes `installCheckpoint()` publish the same term and index that it uses to unpause the state machine.

No failure is demonstrated, but one vote path can read stale state. The OM checkpoint install and the Ratis state reload happen across separate notification RPCs. `installCheckpoint()` unpauses the OM at the checkpoint index. Ratis updates `ServerState.latestInstalledSnapshot` and asks `StateMachineUpdater` to reload only when the leader sends a later notification.

Before that notification, both `getLatestSnapshot()` and `latestInstalledSnapshot` are stale, but the Raft log is still intact. During the later notification, `ServerState.reloadStateMachine()` signals the updater, purges the log with `onSnapshotInstalled()`, and then records `latestInstalledSnapshot`. `getSnapshotIndex()` and `containsTermIndex()` can use `latestInstalledSnapshot` after it is recorded. `getLastEntry()` cannot: when the log is empty, it falls back only to `getLatestSnapshot()`.

The client/admin snapshot path refuses to run while an installation is in progress. The automatic snapshot path does not check the installation state, but the OM's `takeSnapshotImpl()` recomputes the snapshot position from the applied and notified indexes instead of reading `getLatestSnapshot()`.

`decideVote()` calls `getLastEntry()`. It grants a vote when the last entry of this server is less than the last entry of the candidate. Thus an index that is too low can grant a vote that the server must refuse. The vote path does not test `getInProgressInstallSnapshotIndex()`, and thus an installation does not stop it. `RaftLog.onSnapshotInstalled()` can make the log empty, and `SegmentedRaftLogCache.getLastTermIndex()` gives null for an empty log.

This is a Raft election-restriction violation, not proof that the only possible result is an unnecessary election. The pre-install value is the OM's applied index. A follower replies successfully after its log append completes, while the OM advances its applied index only after the double-buffer flush. The range between the applied and acknowledged indexes can therefore include entries that this follower acknowledged and helped commit. A candidate missing such an entry can receive this follower's vote.

A lost commit or successful log truncation was not demonstrated. For such an outcome, the leader would also have to be unavailable, a vote would have to be cast during the vulnerable interval, and progress would have to be made by the resulting leader despite the follower's higher installed snapshot index.

The vulnerable interval requires both a stale `getLatestSnapshot()` value and an empty Raft log. It starts only if the later notification purges the log before the updater calls `loadSnapshotInfoFromDB()` at the start of `reinitialize()`. This scheduling window is likely short, but it was not measured or reproduced. The candidate's position must also fall between the stale and correct indexes.

The change publishes the correct value before the unpause, so the field remains correct throughout the window.

On the path where the DB replacement fails, the change makes no difference. The code reassigns `term` and `lastAppliedIndex` only after `replaceOMDBWithCheckpoint()` returns successfully. Therefore, both variables still identify the restored pre-install position when replacement fails. Also, `valueOf(long, long)` calls `valueOf(TermIndex)` ([TransactionInfo.java:81](https://github.com/apache/ozone/blob/40cd903440e7b84017461eccdaf4075f72f58a89/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java#L81)). On that path this call is necessary, because no other function writes the field. Thus I corrected the call, and I did not remove it.

A TLA+ model of the follower snapshot-installation path found this issue. The model checks that the three views of the transaction index agree after an installation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16086

## How was this patch tested?

* New test `TestOMRatisSnapshots#testInstallCheckpointPublishesNewTransactionInfo` calls `installCheckpoint` directly. Then it compares the transaction info with the OM state machine's last-applied TermIndex, which `unpause()` updates. The direct call does not trigger a Ratis reload. Before the fix, the test therefore observes `INITIAL_VALUE` instead of the pre-install position that would be exposed by a real installation. The test must do the comparison immediately because `takeSnapshotImpl()` also recalculates the field.
  * Without the change, the new test fails on this base and gives: `In-memory transaction info must match the position the state machine was unpaused at ==> expected: <(t:1, i:102)> but was: <<INITIAL_VALUE>>`. With the change it passes.

(The test does not exercise the vote path. That would require an election inside the short scheduling window described above. I did not find a stable method to cause it.)