### PR TITLE
HDDS-16019. Publish httpfs gateway metrics to Prometheus via /prom endpoint

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -155,26 +155,7 @@ public abstract class BaseHttpServer implements AutoCloseable {
                                     conf.getBoolean(HddsConfigKeys.HDDS_PROFILER_ENABLED, false);
 
       if (prometheusSupport) {
-        prometheusMetricsSink = new PrometheusMetricsSink(name);
-        httpServer.getWebAppContext().getServletContext()
-            .setAttribute(PROMETHEUS_SINK, prometheusMetricsSink);
-        HddsPrometheusConfig prometheusConfig =
-            conf.getObject(HddsPrometheusConfig.class);
-        String token = prometheusConfig.getPrometheusEndpointToken();
-        if (StringUtils.isNotEmpty(token)) {
-          httpServer.getWebAppContext().getServletContext()
-              .setAttribute(PrometheusServlet.SECURITY_TOKEN, token);
-          // Adding as internal servlet since we want to have token based
-          // auth and hence SPNEGO should be disabled if security is enabled.
-          httpServer.addInternalServlet("prometheus", "/prom",
-              PrometheusServlet.class);
-        } else {
-          // If token is not configured, keeping as regular servlet and not
-          // internal servlet since we do not want to expose /prom endpoint
-          // without authentication in a secure cluster.
-          httpServer.addServlet("prometheus", "/prom",
-              PrometheusServlet.class);
-        }
+        prometheusMetricsSink = addPrometheusEndpoint(httpServer, conf, name);
       }
 
       if (profilerSupport) {
@@ -241,6 +222,27 @@ public abstract class BaseHttpServer implements AutoCloseable {
       LOG.info("Starting Web-server for {} at: {}", name, uri);
     }
     return builder;
+  }
+
+  /**
+   * Add the Prometheus endpoint at {@code /prom} to an existing {@link HttpServer2} instance.
+   * Returns the registered sink for use in start/stop lifecycle calls.
+   */
+  public static PrometheusMetricsSink addPrometheusEndpoint(
+      HttpServer2 httpServer, ConfigurationSource conf, String name) {
+    PrometheusMetricsSink sink = new PrometheusMetricsSink(name);
+    httpServer.getWebAppContext().getServletContext().setAttribute(PROMETHEUS_SINK, sink);
+    String token = conf.getObject(HddsPrometheusConfig.class).getPrometheusEndpointToken();
+    if (StringUtils.isNotEmpty(token)) {
+      httpServer.getWebAppContext().getServletContext()
+          .setAttribute(PrometheusServlet.SECURITY_TOKEN, token);
+      // Token-based auth: use internal servlet so SPNEGO is bypassed.
+      httpServer.addInternalServlet("prometheus", "/prom", PrometheusServlet.class);
+    } else {
+      // No token: regular servlet, protected by the server's auth filter in secure mode.
+      httpServer.addServlet("prometheus", "/prom", PrometheusServlet.class);
+    }
+    return sink;
   }
 
   /**

--- a/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
@@ -52,3 +52,5 @@ services:
     <<: *monitoring-config
   recon:
     <<: *monitoring-config
+  httpfs:
+    <<: *monitoring-config

--- a/hadoop-ozone/dist/src/main/compose/ozone/prometheus.yml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/prometheus.yml
@@ -61,3 +61,12 @@ scrape_configs:
          - "recon:9888"
        labels:
          component: recon
+  - job_name: ozone-httpfs
+    metrics_path: /prom
+    params:
+      user.name: [hadoop]
+    static_configs:
+      - targets:
+          - "httpfs:14000"
+        labels:
+          component: httpfs

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java
@@ -28,10 +28,14 @@ import java.net.URL;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.server.http.BaseHttpServer;
 import org.apache.hadoop.hdds.server.http.HttpServer2;
+import org.apache.hadoop.hdds.server.http.PrometheusMetricsSink;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.security.AuthenticationFilterInitializer;
 import org.apache.hadoop.security.authentication.server.ProxyUserAuthenticationFilterInitializer;
 import org.apache.hadoop.security.authorize.AccessControlList;
@@ -72,6 +76,7 @@ public class HttpFSServerWebServer {
 
   private final HttpServer2 httpServer;
   private final String scheme;
+  private PrometheusMetricsSink prometheusMetricsSink;
 
   HttpFSServerWebServer(OzoneConfiguration conf, Configuration sslConf) throws
       Exception {
@@ -129,6 +134,10 @@ public class HttpFSServerWebServer {
         .setACL(new AccessControlList(conf.get(HTTP_ADMINS_KEY, " ")))
         .addEndpoint(endpoint)
         .build();
+
+    if (conf.getBoolean(HddsConfigKeys.HDDS_PROMETHEUS_ENABLED, true)) {
+      prometheusMetricsSink = BaseHttpServer.addPrometheusEndpoint(httpServer, conf, NAME);
+    }
   }
 
   /**
@@ -153,6 +162,10 @@ public class HttpFSServerWebServer {
 
   public void start() throws IOException {
     httpServer.start();
+    if (prometheusMetricsSink != null) {
+      DefaultMetricsSystem.instance()
+          .register("prometheus", "Hadoop metrics prometheus exporter", prometheusMetricsSink);
+    }
   }
 
   public void join() throws InterruptedException {
@@ -161,6 +174,9 @@ public class HttpFSServerWebServer {
 
   public void stop() throws Exception {
     httpServer.stop();
+    if (prometheusMetricsSink != null) {
+      DefaultMetricsSystem.instance().unregisterSource("prometheus");
+    }
   }
 
   public URL getUrl() {

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java
@@ -174,9 +174,6 @@ public class HttpFSServerWebServer {
 
   public void stop() throws Exception {
     httpServer.stop();
-    if (prometheusMetricsSink != null) {
-      DefaultMetricsSystem.instance().unregisterSource("prometheus");
-    }
   }
 
   public URL getUrl() {


### PR DESCRIPTION
What changes were proposed in this pull request?
HttpFSServerWebServer builds an HttpServer2 directly rather than extending BaseHttpServer, so it had no /prom endpoint and could not be scraped by Prometheus. This meant httpfs metrics were invisible to any Prometheus-based monitoring, and httpfs was absent from Grafana dashboards that group by component.

Changes:

Extract the Prometheus servlet wiring from BaseHttpServer into a new public static helper method addPrometheusEndpoint(HttpServer2, ConfigurationSource, String). This lives in the same package as BaseHttpServer so it retains access to the package-private PROMETHEUS_SINK constant and HttpServer2.getWebAppContext().

Refactor BaseHttpServer to call the helper — no behaviour change for existing services.

Wire the helper into HttpFSServerWebServer: call addPrometheusEndpoint in the constructor (after HttpServer2 is built), register the returned sink with DefaultMetricsSystem in start(), and unregister in stop(). Gated by hdds.prometheus.endpoint.enabled (default: true), matching the behaviour of other services.

The security model is preserved: if hdds.prometheus.endpoint.token is set, /prom is added as an internal servlet (token-based auth, SPNEGO bypassed); otherwise it is a regular servlet protected by the server's auth filter.

This is a prerequisite for [HDDS-15858](https://issues.apache.org/jira/browse/HDDS-15858) (add httpfs to the ZDU Rolling Upgrade Grafana dashboard), which will add the httpfs scrape target and build-info metrics on top.

What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16019

Prereq for: [HDDS-15858](https://issues.apache.org/jira/browse/HDDS-15858)
Epic: [HDDS-14496](https://issues.apache.org/jira/browse/HDDS-14496) (Zero Downtime Upgrade)

How was this patch tested?
Local verification against upstream/master:

mvn -pl :ozone-httpfsgateway,:hdds-server-framework -am install -DskipTests -DskipShade -DskipRecon -DskipDocs — builds clean.
mvn -pl :ozone-httpfsgateway,:hdds-server-framework checkstyle:check — 0 violations on both modules.
mvn -pl :ozone-httpfsgateway,:hdds-server-framework apache-rat:check — 0 unapproved licences.
mvn -pl :ozone-httpfsgateway,:hdds-server-framework test — 573 tests, 0 failures (1 pre-existing skip in TestNetworkTopologyImpl).
TestBaseHttpServer and TestPrometheusServletAuthorization in hdds-server-framework
pass without modification, confirming the refactor does not change existing behaviour.