### PR TITLE
HDDS-13671. Reduce CLI calls in ozone admin container Robot test

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
@@ -36,16 +36,18 @@ Container is closed
 
 Container checksums should match
     [arguments]    ${container}    ${expected_checksum}
-    ${data_checksum1} =  Execute     ozone admin container reconcile --status "${container}" | jq -r '.[].replicas[0].dataChecksum'
-    ${data_checksum2} =  Execute     ozone admin container reconcile --status "${container}" | jq -r '.[].replicas[1].dataChecksum'
-    ${data_checksum3} =  Execute     ozone admin container reconcile --status "${container}" | jq -r '.[].replicas[2].dataChecksum'
+    ${reconcile_output} =  Execute     ozone admin container reconcile --status "${container}"
+    ${data_checksum1} =    Execute     echo '${reconcile_output}' | jq -r '.[].replicas[0].dataChecksum'
+    ${data_checksum2} =    Execute     echo '${reconcile_output}' | jq -r '.[].replicas[1].dataChecksum'
+    ${data_checksum3} =    Execute     echo '${reconcile_output}' | jq -r '.[].replicas[2].dataChecksum'
                          Should be equal as strings    ${data_checksum1}    ${expected_checksum}
                          Should be equal as strings    ${data_checksum2}    ${expected_checksum}
                          Should be equal as strings    ${data_checksum3}    ${expected_checksum}
     # Verify that container info shows the same checksums as reconcile status
-    ${info_checksum1} =  Execute     ozone admin container info "${container}" --json | jq -r '.replicas[0].dataChecksum'
-    ${info_checksum2} =  Execute     ozone admin container info "${container}" --json | jq -r '.replicas[1].dataChecksum'
-    ${info_checksum3} =  Execute     ozone admin container info "${container}" --json | jq -r '.replicas[2].dataChecksum'
+    ${info_output} =       Execute     ozone admin container info "${container}" --json
+    ${info_checksum1} =    Execute     echo '${info_output}' | jq -r '.replicas[0].dataChecksum'
+    ${info_checksum2} =    Execute     echo '${info_output}' | jq -r '.replicas[1].dataChecksum'
+    ${info_checksum3} =    Execute     echo '${info_output}' | jq -r '.replicas[2].dataChecksum'
                          Should be equal as strings    ${data_checksum1}    ${info_checksum1}
                          Should be equal as strings    ${data_checksum2}    ${info_checksum2}
                          Should be equal as strings    ${data_checksum3}    ${info_checksum3}


### PR DESCRIPTION
## What changes were proposed in this pull request?
The following test case executes the same ozone admin commands three times.

https://github.com/apache/ozone/blob/20dca25d393d4257aaff41ed872aca4b4e02d761/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot#L37-L51

It should execute them once, save the output, and feed that to jq ([example](https://github.com/apache/ozone/blob/20dca25d393d4257aaff41ed872aca4b4e02d761/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot#L132-L136)).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13671

## How was this patch tested?

[Passed CI](https://github.com/sravani-revuri/ozone/actions/runs/30898135767)
