### PR TITLE
HDDS-16091. Recon fills disk with leaked checkpoints and crashes on startup when local OM DB is missing.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -294,7 +294,16 @@ public class OzoneManagerServiceProviderImpl
                   deltaTaskStatusUpdater.getLastUpdatedSeqNumber()) < 0; // Condition 3
         })
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));  // Collect into desired Map
-    if (!reconOmTaskMap.isEmpty()) {
+    if (!reconOmTaskMap.isEmpty() && omMetadataManager.getStore() == null) {
+      // Fresh start (or the local OM snapshot DB is missing) while stale task
+      // status rows still exist in the Recon SQL DB. There is no local OM DB to
+      // checkpoint/reprocess yet, so attempting reinitialization here would fail
+      // (checkpoint creation dereferences a null DB store). Skip it; the full
+      // snapshot sync scheduled below will download the OM DB and initialize tasks.
+      LOG.info("Skipping startup task reinitialization because the local OM DB store " +
+          "is not initialized yet (no OM snapshot present). The scheduled full snapshot " +
+          "sync will download the OM DB and initialize tasks.");
+    } else if (!reconOmTaskMap.isEmpty()) {
       LOG.info("Task name and last updated sequence number of tasks, that are not matching with " +
           "the last updated sequence number of OmDeltaRequest task:\n");
       LOG.info("{} -> {}", deltaTaskStatusUpdater.getTaskName(), deltaTaskStatusUpdater.getLastUpdatedSeqNumber());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -665,7 +665,9 @@ public class ReconTaskControllerImpl implements ReconTaskController {
       }
 
       // Buffer full - drop the event and clean up the fresh checkpoint (in finally) to avoid leaking it.
-      LOG.warn("Failed to queue reinitialization event (buffer full); discarding fresh checkpoint");
+      LOG.warn("Failed to queue reinitialization event (buffer full); discarding fresh checkpoint at {}",
+          checkpointedOMMetadataManager.getStore() != null
+              ? checkpointedOMMetadataManager.getStore().getDbLocation() : "<unknown>");
       handleEventFailure();
       return ReInitializationResult.RETRY_LATER;
     } finally {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -715,15 +715,7 @@ public class ReconTaskControllerImpl implements ReconTaskController {
           ReconOMMetadataManager checkpointedManager = reinitEvent.getCheckpointedOMMetadataManager();
           if (checkpointedManager != null) {
             LOG.info("Cleaning up unprocessed checkpoint from drained ReconTaskReInitializationEvent");
-            // Close the database connections first
-            try {
-              checkpointedManager.close();
-              LOG.debug("Closed checkpointed OM metadata manager database connections");
-            } catch (Exception e) {
-              LOG.warn("Failed to close checkpointed OM metadata manager", e);
-            }
-            // Then clean up the files
-            cleanupCheckpointFiles(checkpointedManager);
+            cleanupCheckpoint(checkpointedManager);
           }
         }
       }
@@ -770,6 +762,10 @@ public class ReconTaskControllerImpl implements ReconTaskController {
    * @throws IOException if directory operations fail
    */
   private String cleanTempCheckPointPath(ReconOMMetadataManager omMetaManager) throws IOException {
+    if (omMetaManager == null || omMetaManager.getStore() == null) {
+      throw new IOException("OM DB store is not initialized yet; cannot create "
+          + "reinitialization checkpoint. A full OM snapshot must be fetched first.");
+    }
     File dbLocation = omMetaManager.getStore().getDbLocation();
     if (dbLocation == null) {
       throw new IOException("OM DB location is null");
@@ -793,9 +789,9 @@ public class ReconTaskControllerImpl implements ReconTaskController {
         event.getReason(), event.getTimestamp());
     resetTasksFailureFlag();
     // Use the checkpointed OM metadata manager for reinitialization to prevent data inconsistency
-    ReconOMMetadataManager checkpointedOMMetadataManager = null;
-    try (ReconOMMetadataManager manager = event.getCheckpointedOMMetadataManager()) {
-      checkpointedOMMetadataManager = manager;
+    ReconOMMetadataManager checkpointedOMMetadataManager =
+        event.getCheckpointedOMMetadataManager();
+    try {
       if (checkpointedOMMetadataManager != null) {
         LOG.info("Starting async task reinitialization with checkpointed OM metadata manager due to: {}",
                  event.getReason());
@@ -817,9 +813,8 @@ public class ReconTaskControllerImpl implements ReconTaskController {
     } catch (Exception e) {
       LOG.error("Error processing reinitialization event", e);
     } finally {
-      if (checkpointedOMMetadataManager != null) {
-        cleanupCheckpointFiles(checkpointedOMMetadataManager);
-      }
+      // Clean up the checkpointed metadata manager and its files after use
+      cleanupCheckpoint(checkpointedOMMetadataManager);
     }
   }
 
@@ -882,6 +877,14 @@ public class ReconTaskControllerImpl implements ReconTaskController {
         return;
       }
       
+      // The DB store is only initialized after Recon downloads its first DB
+      // snapshot from the OM. On a fresh startup it may still be null.
+      if (currentOMMetadataManager.getStore() == null) {
+        LOG.debug("OM metadata manager DB store not yet initialized, "
+            + "skipping pre-existing checkpoint cleanup");
+        return;
+      }
+
       // Get the base directory where checkpoints are created
       File dbLocation = currentOMMetadataManager.getStore().getDbLocation();
       if (dbLocation == null || dbLocation.getParent() == null) {
@@ -924,21 +927,20 @@ public class ReconTaskControllerImpl implements ReconTaskController {
   }
   
   /**
-   * Cleanup checkpoint files for a checkpointed OM metadata manager.
-   * This method only removes the temporary checkpoint files without closing database connections.
-   * Used when the manager is closed via try-with-resources.
-   * 
-   * @param checkpointedManager the checkpointed OM metadata manager
+   * Cleanup checkpointed OM metadata manager and associated checkpoint files.
+   * This method closes the database connections and removes the temporary checkpoint files.
+   *
+   * @param checkpointedManager the checkpointed OM metadata manager to clean up
    */
-  private void cleanupCheckpointFiles(ReconOMMetadataManager checkpointedManager) {
+  private void cleanupCheckpoint(ReconOMMetadataManager checkpointedManager) {
     if (checkpointedManager == null) {
       return;
     }
     try {
-      // Get the checkpoint location
+      // Get the checkpoint location before closing
       File checkpointLocation = null;
       try {
-        if (checkpointedManager.getStore() != null && 
+        if (checkpointedManager.getStore() != null &&
             checkpointedManager.getStore().getDbLocation() != null) {
           // The checkpoint location is typically the parent directory of the DB location
           checkpointLocation = checkpointedManager.getStore().getDbLocation().getParentFile();
@@ -946,7 +948,11 @@ public class ReconTaskControllerImpl implements ReconTaskController {
       } catch (Exception e) {
         LOG.warn("Failed to get checkpoint location for cleanup", e);
       }
-      
+
+      // Close the database connections first
+      checkpointedManager.stop();
+      LOG.debug("Closed checkpointed OM metadata manager database connections");
+
       // Clean up the checkpoint files if we have the location
       if (checkpointLocation != null && checkpointLocation.exists()) {
         try {
@@ -956,9 +962,9 @@ public class ReconTaskControllerImpl implements ReconTaskController {
           LOG.warn("Failed to cleanup checkpoint directory: {}", checkpointLocation, e);
         }
       }
-      
+
     } catch (Exception e) {
-      LOG.warn("Failed to cleanup checkpoint files", e);
+      LOG.warn("Failed to cleanup checkpointed OM metadata manager", e);
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -633,30 +633,43 @@ public class ReconTaskControllerImpl implements ReconTaskController {
 
     // Try checkpoint creation (single attempt per iteration)
     ReconOMMetadataManager checkpointedOMMetadataManager = null;
-    
+    // Whether the checkpoint has been handed off to the event buffer. If not,
+    // this method owns its cleanup (the finally block below).
+    boolean handedOff = false;
+
     try {
       LOG.info("Attempting checkpoint creation (retry attempt: {})", eventProcessRetryCount.get() + 1);
-      checkpointedOMMetadataManager = createOMCheckpoint(currentOMMetadataManager);
-      LOG.info("Checkpoint creation succeeded");
-    } catch (IOException e) {
-      LOG.error("Checkpoint creation failed: {}", e.getMessage());
+      try {
+        checkpointedOMMetadataManager = createOMCheckpoint(currentOMMetadataManager);
+        LOG.info("Checkpoint creation succeeded");
+      } catch (IOException e) {
+        LOG.error("Checkpoint creation failed: {}", e.getMessage());
+        handleEventFailure();
+        return ReInitializationResult.RETRY_LATER;
+      }
+
+      // Create and queue the reinitialization event with checkpointed metadata manager
+      ReconTaskReInitializationEvent reinitEvent =
+          new ReconTaskReInitializationEvent(reason, checkpointedOMMetadataManager);
+      // If reinitialization event queued successfully, reset event buffer overflow flag and task failure flag,
+      // so that we can resume queuing the delta events.
+      if (eventBuffer.offer(reinitEvent)) {
+        // The downstream consumer now owns the checkpoint and its cleanup.
+        handedOff = true;
+        resetEventFlags();
+        LOG.info("Successfully queued reinitialization event after {} retries", eventProcessRetryCount.get() + 1);
+        return ReconTaskController.ReInitializationResult.SUCCESS;
+      }
+
+      // Buffer full - drop the event and clean up the fresh checkpoint (in finally) to avoid leaking it.
+      LOG.warn("Failed to queue reinitialization event (buffer full); discarding fresh checkpoint");
       handleEventFailure();
       return ReInitializationResult.RETRY_LATER;
+    } finally {
+      if (!handedOff && checkpointedOMMetadataManager != null) {
+        cleanupCheckpoint(checkpointedOMMetadataManager);
+      }
     }
-
-    // Create and queue the reinitialization event with checkpointed metadata manager
-    ReconTaskReInitializationEvent reinitEvent =
-        new ReconTaskReInitializationEvent(reason, checkpointedOMMetadataManager);
-    boolean queued = eventBuffer.offer(reinitEvent);
-    // If reinitialization event queued successfully, reset event buffer overflow flag and task failure flag,
-    // so that we can resume queuing the delta events.
-    if (queued) {
-      resetEventFlags();
-      // Success - reset retry counters and flags
-      LOG.info("Successfully queued reinitialization event after {} retries", eventProcessRetryCount.get() + 1);
-      return ReconTaskController.ReInitializationResult.SUCCESS;
-    }
-    return null;
   }
 
   private ReconTaskController.ReInitializationResult validateRetryCountAndDelay() {
@@ -936,35 +949,35 @@ public class ReconTaskControllerImpl implements ReconTaskController {
     if (checkpointedManager == null) {
       return;
     }
+    // Get the checkpoint location before closing.
+    File checkpointLocation = null;
     try {
-      // Get the checkpoint location before closing
-      File checkpointLocation = null;
-      try {
-        if (checkpointedManager.getStore() != null &&
-            checkpointedManager.getStore().getDbLocation() != null) {
-          // The checkpoint location is typically the parent directory of the DB location
-          checkpointLocation = checkpointedManager.getStore().getDbLocation().getParentFile();
-        }
-      } catch (Exception e) {
-        LOG.warn("Failed to get checkpoint location for cleanup", e);
+      if (checkpointedManager.getStore() != null &&
+          checkpointedManager.getStore().getDbLocation() != null) {
+        // The checkpoint location is typically the parent directory of the DB location
+        checkpointLocation = checkpointedManager.getStore().getDbLocation().getParentFile();
       }
+    } catch (Exception e) {
+      LOG.warn("Failed to get checkpoint location for cleanup", e);
+    }
 
-      // Close the database connections first
+    // Close the database connections first, but always attempt to delete the
+    // checkpoint files afterwards - even if stop() throws - so the directory
+    // (a full copy of the OM DB) is never leaked.
+    try {
       checkpointedManager.stop();
       LOG.debug("Closed checkpointed OM metadata manager database connections");
-
-      // Clean up the checkpoint files if we have the location
+    } catch (Exception e) {
+      LOG.warn("Failed to stop checkpointed OM metadata manager", e);
+    } finally {
       if (checkpointLocation != null && checkpointLocation.exists()) {
         try {
           FileUtils.deleteDirectory(checkpointLocation);
-          LOG.debug("Cleaned up checkpoint directory: {}", checkpointLocation);
+          LOG.info("Cleaned up checkpoint directory: {}", checkpointLocation);
         } catch (IOException e) {
           LOG.warn("Failed to cleanup checkpoint directory: {}", checkpointLocation, e);
         }
       }
-
-    } catch (Exception e) {
-      LOG.warn("Failed to cleanup checkpointed OM metadata manager", e);
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -106,6 +106,9 @@ public class ReconTaskControllerImpl implements ReconTaskController {
   // Clock for the retry-delay gate; overridable in tests via the
   // @VisibleForTesting constructor to drive the gate with a MockClock.
   private Clock clock = Clock.systemUTC();
+  // Log the 1st cleanup and every Nth after that at INFO; the rest at DEBUG.
+  private static final int CHECKPOINT_CLEANUP_LOG_SAMPLE_RATE = 20;
+  private final AtomicLong checkpointCleanupCount = new AtomicLong(0);
 
   @Inject
   @SuppressWarnings("checkstyle:ParameterNumber")
@@ -968,7 +971,13 @@ public class ReconTaskControllerImpl implements ReconTaskController {
       if (checkpointLocation != null && checkpointLocation.exists()) {
         try {
           FileUtils.deleteDirectory(checkpointLocation);
-          LOG.info("Cleaned up checkpoint directory: {}", checkpointLocation);
+          long cleaned = checkpointCleanupCount.incrementAndGet();
+          if (cleaned % CHECKPOINT_CLEANUP_LOG_SAMPLE_RATE == 1) {
+            LOG.info("Cleaned up checkpoint directory: {} (total cleaned so far: {})",
+                checkpointLocation, cleaned);
+          } else {
+            LOG.debug("Cleaned up checkpoint directory: {}", checkpointLocation);
+          }
         } catch (IOException e) {
           LOG.warn("Failed to cleanup checkpoint directory: {}", checkpointLocation, e);
         }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -885,15 +885,10 @@ public class ReconTaskControllerImpl implements ReconTaskController {
    */
   private void cleanupPreExistingCheckpoints() {
     try {
-      if (currentOMMetadataManager == null || currentOMMetadataManager.getStore() == null) {
-        LOG.debug("No current OM metadata manager or store, skipping pre-existing checkpoint cleanup");
-        return;
-      }
-      
       // The DB store is only initialized after Recon downloads its first DB
       // snapshot from the OM. On a fresh startup it may still be null.
-      if (currentOMMetadataManager.getStore() == null) {
-        LOG.debug("OM metadata manager DB store not yet initialized, "
+      if (currentOMMetadataManager == null || currentOMMetadataManager.getStore() == null) {
+        LOG.debug("No current OM metadata manager or DB store not yet initialized, "
             + "skipping pre-existing checkpoint cleanup");
         return;
       }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -597,6 +599,38 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     verify(mockCheckpointedManager, times(1)).stop();
     assertFalse(checkpointDir.exists(),
         "checkpoint directory must be deleted even when stop() throws");
+  }
+
+  @Test
+  public void testRealCheckpointCreatedThenCleanedUp(
+      @TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+    // End-to-end with real RocksDB (no mocked manager): create a real reinit
+    // checkpoint, then verify the real cleanup path deletes it from disk.
+
+    // Halt the async processor so our explicit drain owns the enqueued event.
+    reconTaskController.stop();
+    ReconTaskControllerImpl controllerImpl = (ReconTaskControllerImpl) reconTaskController;
+
+    // Real source OM DB + real RocksDB-backed Recon OM metadata manager.
+    OMMetadataManager omMetadataManager = initializeNewOmMetadataManager(dirOmMetadata);
+    ReconOMMetadataManager reconOMMetadataManager =
+        getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata);
+    controllerImpl.updateOMMetadataManager(reconOMMetadataManager);
+
+    // Real checkpoint creation -> temp-recon-reinit-checkpoint_<UUID>/ on disk.
+    ReconOMMetadataManager checkpointed = controllerImpl.createOMCheckpoint(reconOMMetadataManager);
+    File checkpointDir = checkpointed.getStore().getDbLocation().getParentFile();
+    assertTrue(checkpointDir.exists(), "checkpoint dir should exist after creation");
+    assertTrue(checkpointDir.getName().startsWith("temp-recon-reinit-checkpoint"),
+        "checkpoint dir should be the reinit temp dir");
+
+    // Real cleanup path: closes the real RocksDB and deletes the directory.
+    controllerImpl.getEventBuffer().offer(new ReconTaskReInitializationEvent(
+        ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW, checkpointed));
+    controllerImpl.drainEventBufferAndCleanExistingCheckpoints();
+
+    assertFalse(checkpointDir.exists(),
+        "real checkpoint directory must be deleted by the cleanup path");
   }
   
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -811,7 +811,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     assertFalse(controllerSpy.hasTasksFailed(), "tasksFailed should remain false after successful reinitialization");
     
     // Verify cleanup was called on the checkpointed manager
-    verify(mockCheckpointedManager, times(1)).close();
+    verify(mockCheckpointedManager, times(1)).stop();
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -77,8 +77,6 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
   private ReconTaskController reconTaskController;
   private ReconTaskStatusDao reconTaskStatusDao;
   private MockClock testClock;
-  @TempDir
-  private Path tempDir;
 
   public TestReconTaskControllerImpl() {
     super();
@@ -570,7 +568,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
   }
 
   @Test
-  public void testCleanupCheckpointDeletesDirEvenWhenStopThrows() throws Exception {
+  public void testCleanupCheckpointDeletesDirEvenWhenStopThrows(@TempDir File tempDir) throws Exception {
     // Verify the cleanupCheckpoint try/finally: even if stop() throws, the checkpoint
     // directory (a full copy of the OM DB) is still deleted and not leaked.
 
@@ -579,7 +577,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     ReconTaskControllerImpl controllerImpl = (ReconTaskControllerImpl) reconTaskController;
 
     // Real on-disk checkpoint directory (with content) that cleanup must delete.
-    File checkpointDir = new File(tempDir.toFile(), "temp-recon-reinit-checkpoint_test");
+    File checkpointDir = new File(tempDir, "temp-recon-reinit-checkpoint_test");
     assertTrue(checkpointDir.mkdirs(), "precondition: checkpoint dir created");
     assertTrue(new File(checkpointDir, "CURRENT").createNewFile(), "precondition: dir has content");
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -63,6 +65,7 @@ import org.apache.ozone.test.MockClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Class used to test ReconTaskControllerImpl.
@@ -72,6 +75,8 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
   private ReconTaskController reconTaskController;
   private ReconTaskStatusDao reconTaskStatusDao;
   private MockClock testClock;
+  @TempDir
+  private Path tempDir;
 
   public TestReconTaskControllerImpl() {
     super();
@@ -506,27 +511,92 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
   
   @Test
   public void testCheckpointManagerCleanupOnQueueFailure() throws Exception {
-    // Set up properly mocked ReconOMMetadataManager with required dependencies
-    ReconOMMetadataManager mockOMMetadataManager = mock(ReconOMMetadataManager.class);
+    // Verify the buffer-full branch of queueReInitializationEvent: when the freshly
+    // created checkpoint cannot be handed off to the event buffer, it must be cleaned
+    // up (not leaked) and the call must return RETRY_LATER.
+
+    // Stop the async processor from setUp so it can't consume buffered events.
+    reconTaskController.stop();
+
+    // Build a controller with a capacity-1 event buffer so a single pre-filled event
+    // makes the internal eventBuffer.offer(...) return false (buffer full).
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.setInt("ozone.recon.om.event.buffer.capacity", 1);
+    ReconTaskStatusUpdaterManager reconTaskStatusUpdaterManagerMock = mock(ReconTaskStatusUpdaterManager.class);
+    when(reconTaskStatusUpdaterManagerMock.getTaskStatusUpdater(anyString()))
+        .thenAnswer(i -> {
+          String taskName = i.getArgument(0);
+          return new ReconTaskStatusUpdater(reconTaskStatusDao, taskName);
+        });
+    ReconDBProvider reconDbProvider = mock(ReconDBProvider.class);
+    when(reconDbProvider.getDbStore()).thenReturn(mock(DBStore.class));
+    when(reconDbProvider.getStagedReconDBProvider()).thenReturn(reconDbProvider);
+    ReconTaskControllerImpl controller = new ReconTaskControllerImpl(ozoneConfiguration, new HashSet<>(),
+        reconTaskStatusUpdaterManagerMock, reconDbProvider, mock(ReconContainerMetadataManager.class),
+        mock(ReconNamespaceSummaryManager.class), mock(ReconGlobalStatsManager.class),
+        mock(ReconFileMetadataManager.class));
+    // Do not start async processing.
+
+    // Checkpointed manager whose cleanup (stop()) we verify.
+    ReconOMMetadataManager mockCheckpointedManager = mock(ReconOMMetadataManager.class);
     DBStore mockDBStore = mock(DBStore.class);
     File mockDbLocation = mock(File.class);
-    DBCheckpoint mockCheckpoint = mock(DBCheckpoint.class);
-    Path mockCheckpointPath = Paths.get("/tmp/test/checkpoint");
-    
-    when(mockOMMetadataManager.getStore()).thenReturn(mockDBStore);
+    when(mockCheckpointedManager.getStore()).thenReturn(mockDBStore);
     when(mockDBStore.getDbLocation()).thenReturn(mockDbLocation);
-    when(mockDbLocation.getParent()).thenReturn("/tmp/test");
-    when(mockDBStore.getCheckpoint(any(String.class), any(Boolean.class))).thenReturn(mockCheckpoint);
-    when(mockCheckpoint.getCheckpointLocation()).thenReturn(mockCheckpointPath);
-    
-    reconTaskController.updateOMMetadataManager(mockOMMetadataManager);
-    reconTaskController.stop();
-    
-    // This test verifies the successful path - in practice, queue failure after clear is very rare
-    // since we clear the buffer before queueing the reinitialization event
-    ReconTaskController.ReInitializationResult result = reconTaskController.queueReInitializationEvent(
+    when(mockDbLocation.getParentFile()).thenReturn(mockDbLocation);
+
+    ReconTaskControllerImpl controllerSpy = spy(controller);
+    // Keep the buffer full through the drain step, and return our checkpoint without
+    // touching RocksDB.
+    doNothing().when(controllerSpy).drainEventBufferAndCleanExistingCheckpoints();
+    doReturn(mockCheckpointedManager).when(controllerSpy).createOMCheckpoint(any());
+    controllerSpy.updateOMMetadataManager(mock(ReconOMMetadataManager.class));
+
+    // Fill the capacity-1 buffer so the real offer(...) inside the method fails.
+    OMUpdateEventBatch fillerBatch = mock(OMUpdateEventBatch.class);
+    when(fillerBatch.getEventType()).thenReturn(ReconEvent.EventType.OM_UPDATE_BATCH);
+    when(fillerBatch.getEventCount()).thenReturn(1);
+    assertTrue(controllerSpy.getEventBuffer().offer(fillerBatch), "precondition: filler event queued");
+
+    ReconTaskController.ReInitializationResult result = controllerSpy.queueReInitializationEvent(
         ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW);
-    assertEquals(ReconTaskController.ReInitializationResult.SUCCESS, result, "Should succeed under normal conditions");
+
+    assertEquals(ReconTaskController.ReInitializationResult.RETRY_LATER, result,
+        "Buffer-full offer should result in RETRY_LATER");
+    // The fresh checkpoint was never handed off, so it must be cleaned up.
+    verify(mockCheckpointedManager, times(1)).stop();
+  }
+
+  @Test
+  public void testCleanupCheckpointDeletesDirEvenWhenStopThrows() throws Exception {
+    // Verify the cleanupCheckpoint try/finally: even if stop() throws, the checkpoint
+    // directory (a full copy of the OM DB) is still deleted and not leaked.
+
+    // Halt the async processor so the buffered event isn't consumed before we drain.
+    reconTaskController.stop();
+    ReconTaskControllerImpl controllerImpl = (ReconTaskControllerImpl) reconTaskController;
+
+    // Real on-disk checkpoint directory (with content) that cleanup must delete.
+    File checkpointDir = new File(tempDir.toFile(), "temp-recon-reinit-checkpoint_test");
+    assertTrue(checkpointDir.mkdirs(), "precondition: checkpoint dir created");
+    assertTrue(new File(checkpointDir, "CURRENT").createNewFile(), "precondition: dir has content");
+
+    ReconOMMetadataManager mockCheckpointedManager = mock(ReconOMMetadataManager.class);
+    DBStore mockDBStore = mock(DBStore.class);
+    when(mockCheckpointedManager.getStore()).thenReturn(mockDBStore);
+    // getDbLocation().getParentFile() resolves to the real checkpointDir.
+    when(mockDBStore.getDbLocation()).thenReturn(new File(checkpointDir, "om.db"));
+    // stop() throws - cleanup must still delete the directory.
+    doThrow(new IOException("stop failed")).when(mockCheckpointedManager).stop();
+
+    controllerImpl.getEventBuffer().offer(new ReconTaskReInitializationEvent(
+        ReconTaskReInitializationEvent.ReInitializationReason.BUFFER_OVERFLOW, mockCheckpointedManager));
+
+    controllerImpl.drainEventBufferAndCleanExistingCheckpoints();
+
+    verify(mockCheckpointedManager, times(1)).stop();
+    assertFalse(checkpointDir.exists(),
+        "checkpoint directory must be deleted even when stop() throws");
   }
   
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recon makes a temporary checkpoint (a full copy of the OM DB) each time it reinitializes tasks, and is supposed to delete it afterwards. This PR fixes two bugs in that flow.

**1. Leaked checkpoints fill the disk (regression from HDDS-13809).**
HDDS-13809 started reading the checkpoint's location *after* closing the DB store, but closing sets the store to `null`, so the location was lost and the checkpoint directory was never deleted. These copies pile up and fill the disk (~501 GB seen in `/var/lib/hadoop-ozone/recon`). This reverts the Recon-side part of HDDS-13809 so the location is captured *before* closing, then deleted. The OM-side changes from HDDS-13809 are correct and left as-is.

**2. NPE crash on startup when the OM DB is missing.**
If the local OM DB is gone but old task-status rows remain, startup tries to checkpoint a `null` store and crashes:

```
NullPointerException: ...getStore() is null at ReconTaskControllerImpl.cleanTempCheckPointPath(...)
```

This adds null-store guards and skips reinitialization when the OM DB isn't loaded yet, so the normal full-snapshot sync downloads a fresh OM DB instead of crashing.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16091

## How was this patch tested?

- Updated unit test `TestReconTaskControllerImpl#testProcessReInitializationEventWithCheckpointedManager`.

## Manual Testing :- 

## Objective
Verify that after the fix, Recon (1) starts cleanly when its local OM DB is missing and fetches a fresh one instead of crashing, and (2) creates a reinitialization checkpoint and **deletes it** afterward (no leak).

## Method
1. Stopped Recon.
2. Deleted the local OM snapshot DB from Recon's metadata directory (`/data/metadata/om.snapshot.db_*`).
3. Restarted Recon.
4. Inspected the Recon log for startup, full-snapshot fetch, checkpoint creation, and checkpoint cleanup.

## Results — PASS

**1. Clean startup, no NPE, datanode service up:**
```
05:55:49,205 INFO recovery.ReconOmMetadataManagerImpl: Starting ReconOMMetadataManagerImpl
05:55:49,214 INFO impl.OzoneManagerServiceProviderImpl: Ozone Manager Service Provider is started.
05:55:49,355 INFO server.SCMDatanodeProtocolServer: ScmDatanodeProtocol RPC server for DataNodes is listening at /0.0.0.0:9891
```
No `getStore() is null` NPE; Recon started fully and datanodes re-registered.

**2. Fresh OM DB downloaded (seq 0 → full snapshot):**
```
05:56:09,213 INFO impl.OzoneManagerServiceProviderImpl: Seq number of Recon's OM DB : 0
05:56:09,214 INFO impl.OzoneManagerServiceProviderImpl: Obtaining full snapshot from Ozone Manager
05:56:09,627 INFO recon.TarExtractor: Tar extraction completed and moved from staging to: /data/metadata/om.snapshot.db_1785909369257
05:56:09,756 INFO impl.OzoneManagerServiceProviderImpl: Successfully updated Recon OM DB with new snapshot.
```

**3. Checkpoint created for the synced OM DB:**
```
05:56:09,766 INFO tasks.ReconTaskControllerImpl: Queueing task reinitialization event due to: MANUAL_TRIGGER (retry attempt count: 0)
05:56:09,776 INFO db.RDBCheckpointManager: Created checkpoint in rocksDB at /data/metadata/temp-recon-reinit-checkpoint_17c3cd76-f185-4c2b-a682-bff0f50d924c/om.snapshot.db_1785909369257_checkpoint_1785909369767 in 9 milliseconds
05:56:09,819 INFO tasks.ReconTaskControllerImpl: Checkpoint creation succeeded
```

**4. Tasks reinitialized, then checkpoint deleted (the fix):**
```
05:56:10,333 INFO tasks.ReconTaskControllerImpl: Re-initialization of tasks completed successfully.
05:56:10,334 INFO tasks.ReconTaskControllerImpl: Completed processing reinitialization event: MANUAL_TRIGGER
05:56:10,336 INFO tasks.ReconTaskControllerImpl: Cleaned up checkpoint directory: /data/metadata/temp-recon-reinit-checkpoint_17c3cd76-f185-4c2b-a682-bff0f50d924c
```
The same checkpoint directory that was created (`..._17c3cd76-...`) is deleted at the end of the reinitialization — confirming the leak is fixed. (Pre-fix, this directory would have been left on disk.)

## Conclusion
Both behaviors are confirmed on the patched build:
- **NPE / fresh-start fix:** missing OM DB → Recon downloads a fresh snapshot and starts normally (no crash, datanode RPC service comes up).
- **Checkpoint-cleanup fix:** the reinitialization checkpoint is created, used, and **removed** — no orphaned `temp-recon-reinit-checkpoint_*` directory remains.

