### PR TITLE
HDDS-13217. Test that snapshot checkpoint content is preserved after defrag

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.snapshot;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DIRECTORY_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.FILE_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VOLUME_TABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeoutException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValueIterator;
+import org.apache.hadoop.hdds.utils.db.TablePrefixInfo;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OmSnapshotManager;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * HDDS-13217: when an OM snapshot is created, the on-disk RocksDB checkpoint for that snapshot
+ * should contain the same bucket-scoped metadata as the live OM for the tables exercised here.
+ *
+ * <p>Flow: write some keys, call createSnapshot, wait until the checkpoint is materialized, open
+ * it read-only, then for each relevant table scan the key prefix for this volume/bucket on both
+ * the live metadata manager and the checkpoint and assert the maps match.
+ *
+ * <p>Tables compared: volume and bucket rows; key table for OBJECT_STORE and LEGACY layouts;
+ * file and directory tables for FILE_SYSTEM_OPTIMIZED; openKeyTable and multipartInfoTable (these
+ * stay empty in these tests but we still compare to catch stray open writes).
+ *
+ * <p>Omitted on purpose: snapshotInfoTable, because the new snapshot row is part of the same DB
+ * batch as the checkpoint step, so it appears on the live OM after the batch commits but not
+ * inside the checkpoint taken mid-batch. deletedTable, deletedDirTable, snapshotRenamedTable:
+ * the leader deletes those prefix ranges on the active DB immediately after the checkpoint, so
+ * live and checkpoint intentionally differ. We also do not scan cluster-wide tables (tokens,
+ * secrets, compaction log, other tenants/volumes).
+ *
+ * <p>Later tests worth adding: a second snapshot on the same bucket; writes after the snapshot to
+ * prove the checkpoint slice does not change; multipart uploads with real state; linked buckets
+ * resolving to a source bucket.
+ */
+public class TestOmSnapshotCheckpointDbContent {
+
+  private static final byte[] TEST_KEY_CONTENT = new byte[] {0x61, 0x62, 0x63};
+
+  private static MiniOzoneCluster cluster;
+  private static OzoneConfiguration conf;
+  private static OzoneClient client;
+  private static ObjectStore store;
+
+  /** Mini cluster shared by all tests: three datanodes, snapshots enabled; defrag disabled. */
+  @BeforeAll
+  public static void init()
+      throws IOException, InterruptedException, TimeoutException {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
+    conf.setInt(OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL, -1);
+
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
+    store = client.getObjectStore();
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    IOUtils.closeQuietly(client);
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  /**
+   * Object store layout: mixed key shapes (flat and path-like), then snapshot and compare tables
+   * for this bucket.
+   */
+  @Test
+  public void testSnapshotCheckpointMatchesLiveObsBucket()
+      throws IOException, InterruptedException, TimeoutException {
+    runLayoutScenario(BucketLayout.OBJECT_STORE,
+        Arrays.asList("k1", "prefix/k2", "prefix/k3"));
+  }
+
+  /**
+   * File-system-optimized layout: data lives in file/dir tables; includes keys under a short path and
+   * one at the bucket root.
+   */
+  @Test
+  public void testSnapshotCheckpointMatchesLiveFsoBucket()
+      throws IOException, InterruptedException, TimeoutException {
+    runLayoutScenario(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        Arrays.asList("d/k1", "d/k2", "k-root"));
+  }
+
+  /**
+   * Legacy layout: still uses the key table only; flat key names to match default path behavior on
+   * this cluster.
+   */
+  @Test
+  public void testSnapshotCheckpointMatchesLiveLegacyBucket()
+      throws IOException, InterruptedException, TimeoutException {
+    runLayoutScenario(BucketLayout.LEGACY,
+        Arrays.asList("key-a", "key-b", "key-c"));
+  }
+
+  /** Create bucket, write keys, snapshot, wait for checkpoint files, open checkpoint DB, compare. */
+  private void runLayoutScenario(BucketLayout layout, List<String> keyNames)
+      throws IOException, InterruptedException, TimeoutException {
+    OzoneBucket bucket =
+        TestDataUtil.createVolumeAndBucket(client, layout);
+    String volumeName = bucket.getVolumeName();
+    String bucketName = bucket.getName();
+
+    for (String keyName : keyNames) {
+      TestDataUtil.createKey(bucket, keyName, TEST_KEY_CONTENT);
+    }
+
+    String snapshotName = "snap-a";
+    store.createSnapshot(volumeName, bucketName, snapshotName);
+
+    OzoneManager om = cluster.getOzoneManager();
+    OMMetadataManager liveMm = om.getMetadataManager();
+    SnapshotInfo snapshotInfo = liveMm.getSnapshotInfoTable().get(
+        SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName));
+    assertNotNull(snapshotInfo, "Snapshot row should exist after createSnapshot");
+    assertEquals(snapshotName, snapshotInfo.getName());
+
+    String currentPath =
+        OmSnapshotManager.getSnapshotPath(conf, snapshotInfo, 0)
+            + OM_KEY_PREFIX + "CURRENT";
+    GenericTestUtils.waitFor(() -> new File(currentPath).exists(), 1000, 120_000);
+
+    RocksDBCheckpoint checkpoint = new RocksDBCheckpoint(
+        Paths.get(OmSnapshotManager.getSnapshotPath(conf, snapshotInfo, 0)));
+    try (OmMetadataManagerImpl checkpointMm =
+             OmMetadataManagerImpl.createCheckpointMetadataManager(conf, checkpoint)) {
+      TablePrefixInfo prefixes = liveMm.getTableBucketPrefix(volumeName, bucketName);
+      assertBucketPrefixTablesMatch(liveMm, checkpointMm, prefixes, layout);
+    }
+  }
+
+  /** Load every row under the bucket prefix from live vs checkpoint for the tables this test cares about. */
+  private void assertBucketPrefixTablesMatch(
+      OMMetadataManager live,
+      OMMetadataManager checkpoint,
+      TablePrefixInfo prefixes,
+      BucketLayout layout) throws IOException {
+
+    assertPrefixEquals(VOLUME_TABLE, live.getVolumeTable(),
+        checkpoint.getVolumeTable(), prefixes);
+    assertPrefixEquals(BUCKET_TABLE, live.getBucketTable(),
+        checkpoint.getBucketTable(), prefixes);
+
+    if (layout.isFileSystemOptimized()) {
+      assertPrefixEquals(FILE_TABLE, live.getFileTable(),
+          checkpoint.getFileTable(), prefixes);
+      assertPrefixEquals(DIRECTORY_TABLE, live.getDirectoryTable(),
+          checkpoint.getDirectoryTable(), prefixes);
+    } else {
+      assertPrefixEquals(KEY_TABLE,
+          live.getKeyTable(layout),
+          checkpoint.getKeyTable(layout), prefixes);
+    }
+
+    assertPrefixEquals(OPEN_KEY_TABLE,
+        live.getOpenKeyTable(layout),
+        checkpoint.getOpenKeyTable(layout), prefixes);
+    assertPrefixEquals(MULTIPART_INFO_TABLE, live.getMultipartInfoTable(),
+        checkpoint.getMultipartInfoTable(), prefixes);
+  }
+
+  private static <V> void assertPrefixEquals(
+      String tableName,
+      Table<String, V> live,
+      Table<String, V> checkpoint,
+      TablePrefixInfo prefixes) throws IOException {
+    String prefix = prefixes.getTablePrefix(tableName);
+    assertEquals(readPrefix(live, prefix), readPrefix(checkpoint, prefix),
+        tableName);
+  }
+
+  private static <V> SortedMap<String, V> readPrefix(
+      Table<String, V> table, String prefix) throws IOException {
+    SortedMap<String, V> map = new TreeMap<>();
+    if (prefix == null || prefix.isEmpty()) {
+      return map;
+    }
+    try (KeyValueIterator<String, V> it = table.iterator(prefix)) {
+      while (it.hasNext()) {
+        KeyValue<String, V> kv = it.next();
+        map.put(kv.getKey(), kv.getValue());
+      }
+    }
+    return map;
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.om.snapshot;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DIRECTORY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.FILE_TABLE;
@@ -49,7 +48,6 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
@@ -57,9 +55,11 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 /**
  * HDDS-13217: when an OM snapshot is created, the on-disk RocksDB checkpoint for that snapshot
@@ -83,36 +83,30 @@ import org.junit.jupiter.api.Test;
  * <p>Later tests worth adding: a second snapshot on the same bucket; writes after the snapshot to
  * prove the checkpoint slice does not change; multipart uploads with real state; linked buckets
  * resolving to a source bucket.
+ *
+ * <p>Executed as a nested class under {@link org.apache.ozone.test.TestOzoneIntegrationNonHA} so
+ * one {@link MiniOzoneCluster} is shared with other safe tests (HDDS-12183). Tests only add
+ * volumes, buckets, keys, and snapshots; they do not stop or restart the cluster.
  */
-public class TestOmSnapshotCheckpointDbContent {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class TestOmSnapshotCheckpointDbContent implements NonHATests.TestCase {
 
   private static final byte[] TEST_KEY_CONTENT = new byte[] {0x61, 0x62, 0x63};
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf;
-  private static OzoneClient client;
-  private static ObjectStore store;
+  private OzoneConfiguration conf;
+  private OzoneClient client;
+  private ObjectStore store;
 
-  /** Mini cluster shared by all tests: three datanodes, snapshots enabled; defrag disabled. */
   @BeforeAll
-  public static void init()
-      throws IOException, InterruptedException, TimeoutException {
-    conf = new OzoneConfiguration();
-    conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
-    conf.setInt(OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL, -1);
-
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
-    cluster.waitForClusterToBeReady();
-    client = cluster.newClient();
+  void init() throws IOException {
+    conf = cluster().getConf();
+    client = cluster().newClient();
     store = client.getObjectStore();
   }
 
   @AfterAll
-  public static void shutdown() {
+  void cleanup() {
     IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
-    }
   }
 
   /**
@@ -163,7 +157,7 @@ public class TestOmSnapshotCheckpointDbContent {
     String snapshotName = "snap-a";
     store.createSnapshot(volumeName, bucketName, snapshotName);
 
-    OzoneManager om = cluster.getOzoneManager();
+    OzoneManager om = cluster().getOzoneManager();
     OMMetadataManager liveMm = om.getMetadataManager();
     SnapshotInfo snapshotInfo = liveMm.getSnapshotInfoTable().get(
         SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -68,10 +68,9 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 
 /**
@@ -83,8 +82,10 @@ import org.junit.jupiter.api.Timeout;
  *
  * <p>Version-0 checkpoint directories are removed after defrag, so baselines are captured before
  * the first defrag iteration and compared against the active snapshot after defrag completes.
+ *
+ * <p>Each test method starts a fresh MiniOzone cluster to avoid cross-test interference on the
+ * global snapshot defrag chain.
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(value = 15, unit = TimeUnit.MINUTES)
 public class TestOmSnapshotCheckpointDbContent {
 
@@ -92,12 +93,12 @@ public class TestOmSnapshotCheckpointDbContent {
   private static final int CHECKPOINT_WAIT_MS = 120_000;
   private static final int DEFRAG_WAIT_MS = 600_000;
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf;
-  private static OzoneClient client;
-  private static ObjectStore store;
+  private MiniOzoneCluster cluster;
+  private OzoneConfiguration conf;
+  private OzoneClient client;
+  private ObjectStore store;
 
-  @BeforeAll
+  @BeforeEach
   void initCluster() throws Exception {
     assumeTrue(ManagedRawSSTFileReader.tryLoadLibrary(),
         "Snapshot defrag requires rocks-tools native library");
@@ -114,7 +115,7 @@ public class TestOmSnapshotCheckpointDbContent {
     store = client.getObjectStore();
   }
 
-  @AfterAll
+  @AfterEach
   void shutdownCluster() {
     IOUtils.closeQuietly(client);
     IOUtils.closeQuietly(cluster);
@@ -144,10 +145,16 @@ public class TestOmSnapshotCheckpointDbContent {
 
     SnapshotInfo s2 = setup.snapshots.get(1);
     SnapshotInfo s3 = setup.snapshots.get(2);
+    int s3VersionAfterFirstDefrag = readSnapshotVersion(s3);
+
     store.deleteSnapshot(setup.volumeName, setup.bucketName, s2.getName());
     waitForSnapshotPurged(s2);
+    waitForSnapshotNeedsDefrag(s3);
 
     triggerDefragUntilDone(Arrays.asList(s3));
+    assertTrue(readSnapshotVersion(s3) > s3VersionAfterFirstDefrag,
+        "Expected a second defrag pass on S3 after middle snapshot purge");
+
     assertCheckpointMatchesBaseline(
         Collections.singletonMap(s3.getSnapshotId(),
             setup.baselines.get(s3.getSnapshotId())),
@@ -218,20 +225,41 @@ public class TestOmSnapshotCheckpointDbContent {
     }, 1000, CHECKPOINT_WAIT_MS);
   }
 
-  private void triggerDefragUntilDone(List<SnapshotInfo> snapshots)
+  /**
+   * After a previous snapshot is purged, the remaining snapshot should be marked as needing
+   * defrag once local YAML metadata is refreshed.
+   */
+  private void waitForSnapshotNeedsDefrag(SnapshotInfo snapshotInfo)
       throws TimeoutException, InterruptedException {
-    OzoneManager om = cluster.getOzoneManager();
+    OmSnapshotLocalDataManager localDataManager =
+        cluster.getOzoneManager().getOmSnapshotManager().getSnapshotLocalDataManager();
     GenericTestUtils.waitFor(() -> {
-      if (snapshots.stream().allMatch(this::isSnapshotDefragComplete)) {
-        return true;
-      }
-      try {
-        om.triggerSnapshotDefrag(false);
+      try (OmSnapshotLocalDataManager.WritableOmSnapshotLocalDataProvider provider =
+               localDataManager.getWritableOmSnapshotLocalData(snapshotInfo)) {
+        provider.commit();
+        return provider.needsDefrag();
       } catch (IOException e) {
         return false;
       }
-      return snapshots.stream().allMatch(this::isSnapshotDefragComplete);
-    }, 2000, DEFRAG_WAIT_MS);
+    }, 1000, CHECKPOINT_WAIT_MS);
+  }
+
+  private void triggerDefragUntilDone(List<SnapshotInfo> snapshots)
+      throws TimeoutException, InterruptedException {
+    OzoneManager om = cluster.getOzoneManager();
+    for (SnapshotInfo snapshotInfo : snapshots) {
+      GenericTestUtils.waitFor(() -> {
+        if (isSnapshotDefragComplete(snapshotInfo)) {
+          return true;
+        }
+        try {
+          om.triggerSnapshotDefrag(false);
+        } catch (IOException e) {
+          return false;
+        }
+        return isSnapshotDefragComplete(snapshotInfo);
+      }, 2000, DEFRAG_WAIT_MS);
+    }
   }
 
   private boolean isSnapshotDefragComplete(SnapshotInfo snapshotInfo) {
@@ -244,6 +272,15 @@ public class TestOmSnapshotCheckpointDbContent {
       }
     } catch (IOException e) {
       return false;
+    }
+  }
+
+  private int readSnapshotVersion(SnapshotInfo snapshotInfo) throws IOException {
+    OmSnapshotLocalDataManager localDataManager =
+        cluster.getOzoneManager().getOmSnapshotManager().getSnapshotLocalDataManager();
+    try (OmSnapshotLocalDataManager.ReadableOmSnapshotLocalDataProvider provider =
+             localDataManager.getOmSnapshotLocalData(snapshotInfo)) {
+      return (int) provider.getVersion();
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -51,7 +51,7 @@ import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValueIterator;
 import org.apache.hadoop.hdds.utils.db.TablePrefixInfo;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.DataTestUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -146,17 +146,17 @@ public class TestOmSnapshotCheckpointDbContent {
   private ThreeSnapshotSetup createThreeSnapshotsOnNewBucket()
       throws IOException, InterruptedException, TimeoutException {
     OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
+        DataTestUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
     String volumeName = bucket.getVolumeName();
     String bucketName = bucket.getName();
 
-    TestDataUtil.createKey(bucket, "key-s1", TEST_KEY_CONTENT);
+    DataTestUtil.createKey(bucket, "key-s1", TEST_KEY_CONTENT);
     store.createSnapshot(volumeName, bucketName, "snap-s1");
 
-    TestDataUtil.createKey(bucket, "key-s2", TEST_KEY_CONTENT);
+    DataTestUtil.createKey(bucket, "key-s2", TEST_KEY_CONTENT);
     store.createSnapshot(volumeName, bucketName, "snap-s2");
 
-    TestDataUtil.createKey(bucket, "key-s3", TEST_KEY_CONTENT);
+    DataTestUtil.createKey(bucket, "key-s3", TEST_KEY_CONTENT);
     store.createSnapshot(volumeName, bucketName, "snap-s3");
 
     List<SnapshotInfo> snapshots = Arrays.asList(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -149,11 +149,10 @@ public class TestOmSnapshotCheckpointDbContent {
 
     store.deleteSnapshot(setup.volumeName, setup.bucketName, s2.getName());
     waitForSnapshotPurged(s2);
-    waitForSnapshotNeedsDefrag(s3);
+    // Reload S3 so pathPreviousSnapshotId reflects the purged chain, not deleted S2.
+    s3 = loadSnapshotInfo(setup.volumeName, setup.bucketName, s3.getName());
 
-    triggerDefragUntilDone(Arrays.asList(s3));
-    assertTrue(readSnapshotVersion(s3) > s3VersionAfterFirstDefrag,
-        "Expected a second defrag pass on S3 after middle snapshot purge");
+    triggerDefragUntilVersionIncreases(s3, s3VersionAfterFirstDefrag);
 
     assertCheckpointMatchesBaseline(
         Collections.singletonMap(s3.getSnapshotId(),
@@ -226,22 +225,26 @@ public class TestOmSnapshotCheckpointDbContent {
   }
 
   /**
-   * After a previous snapshot is purged, the remaining snapshot should be marked as needing
-   * defrag once local YAML metadata is refreshed.
+   * Wait for a follow-up defrag pass after snapshot-chain rewiring (e.g. middle snapshot purge).
+   * Unlike {@link #triggerDefragUntilDone}, this requires the snapshot version to increase so we
+   * do not treat an already-defragged checkpoint from an earlier pass as complete.
    */
-  private void waitForSnapshotNeedsDefrag(SnapshotInfo snapshotInfo)
-      throws TimeoutException, InterruptedException {
-    OmSnapshotLocalDataManager localDataManager =
-        cluster.getOzoneManager().getOmSnapshotManager().getSnapshotLocalDataManager();
+  private void triggerDefragUntilVersionIncreases(SnapshotInfo snapshotInfo,
+      int baselineVersion) throws TimeoutException, InterruptedException {
+    OzoneManager om = cluster.getOzoneManager();
     GenericTestUtils.waitFor(() -> {
-      try (OmSnapshotLocalDataManager.WritableOmSnapshotLocalDataProvider provider =
-               localDataManager.getWritableOmSnapshotLocalData(snapshotInfo)) {
-        provider.commit();
-        return provider.needsDefrag();
+      try {
+        if (readSnapshotVersion(snapshotInfo) > baselineVersion
+            && isSnapshotDefragComplete(snapshotInfo)) {
+          return true;
+        }
+        om.triggerSnapshotDefrag(false);
+        return readSnapshotVersion(snapshotInfo) > baselineVersion
+            && isSnapshotDefragComplete(snapshotInfo);
       } catch (IOException e) {
         return false;
       }
-    }, 1000, CHECKPOINT_WAIT_MS);
+    }, 2000, DEFRAG_WAIT_MS);
   }
 
   private void triggerDefragUntilDone(List<SnapshotInfo> snapshots)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -37,13 +37,17 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.hdds.utils.UncheckedAutoCloseableSupplier;
 import org.apache.hadoop.hdds.utils.db.ManagedRawSSTFileReader;
 import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -66,6 +70,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * HDDS-13217: verify snapshot checkpoint DB content is preserved across defrag iterations.
@@ -74,15 +79,16 @@ import org.junit.jupiter.api.TestInstance;
  * bucket prefix in the defragged checkpoint must still match the original checkpoint taken at
  * snapshot creation time (version 0).
  *
- * <p>Tables compared per bucket: volume, bucket, key (object store layout), openKey, multipart.
- * Snapshot-info and deleted/renamed tables are omitted because they differ by design between live
- * OM and checkpoint or after purge.
+ * <p>Version-0 checkpoint directories are removed after defrag, so baselines are captured before
+ * the first defrag iteration and compared against the active snapshot after defrag completes.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Timeout(value = 15, unit = TimeUnit.MINUTES)
 public class TestOmSnapshotCheckpointDbContent {
 
   private static final byte[] TEST_KEY_CONTENT = new byte[] {0x61, 0x62, 0x63};
-  private static final int DEFRAG_WAIT_MS = 120_000;
+  private static final int CHECKPOINT_WAIT_MS = 120_000;
+  private static final int DEFRAG_WAIT_MS = 600_000;
 
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
@@ -121,7 +127,7 @@ public class TestOmSnapshotCheckpointDbContent {
       throws Exception {
     ThreeSnapshotSetup setup = createThreeSnapshotsOnNewBucket();
     triggerDefragUntilDone(setup.snapshots);
-    assertCheckpointMatchesBaseline(setup.snapshots);
+    assertCheckpointMatchesBaseline(setup.baselines, setup.snapshots);
   }
 
   /**
@@ -140,7 +146,9 @@ public class TestOmSnapshotCheckpointDbContent {
     waitForSnapshotPurged(s2);
 
     triggerDefragUntilDone(Arrays.asList(s3));
-    assertCheckpointMatchesBaseline(Arrays.asList(s3));
+    assertCheckpointMatchesBaseline(
+        Map.of(s3.getSnapshotId(), setup.baselines.get(s3.getSnapshotId())),
+        Arrays.asList(s3));
   }
 
   private ThreeSnapshotSetup createThreeSnapshotsOnNewBucket()
@@ -167,7 +175,14 @@ public class TestOmSnapshotCheckpointDbContent {
     for (SnapshotInfo snapshotInfo : snapshots) {
       waitForCheckpointReady(snapshotInfo);
     }
-    return new ThreeSnapshotSetup(volumeName, bucketName, snapshots);
+
+    OMMetadataManager liveMm = cluster.getOzoneManager().getMetadataManager();
+    TablePrefixInfo prefixes = liveMm.getTableBucketPrefix(volumeName, bucketName);
+    Map<UUID, SnapshotBaseline> baselines = new HashMap<>();
+    for (SnapshotInfo snapshotInfo : snapshots) {
+      baselines.put(snapshotInfo.getSnapshotId(), captureBaseline(snapshotInfo, prefixes));
+    }
+    return new ThreeSnapshotSetup(volumeName, bucketName, snapshots, baselines);
   }
 
   private SnapshotInfo loadSnapshotInfo(String volumeName, String bucketName,
@@ -184,7 +199,7 @@ public class TestOmSnapshotCheckpointDbContent {
       throws TimeoutException, InterruptedException {
     String currentPath = OmSnapshotManager.getSnapshotPath(conf, snapshotInfo, 0)
         + OM_KEY_PREFIX + "CURRENT";
-    GenericTestUtils.waitFor(() -> new File(currentPath).exists(), 1000, DEFRAG_WAIT_MS);
+    GenericTestUtils.waitFor(() -> new File(currentPath).exists(), 1000, CHECKPOINT_WAIT_MS);
   }
 
   private void waitForSnapshotPurged(SnapshotInfo snapshotInfo)
@@ -197,22 +212,23 @@ public class TestOmSnapshotCheckpointDbContent {
       } catch (IOException e) {
         return false;
       }
-    }, 1000, DEFRAG_WAIT_MS);
+    }, 1000, CHECKPOINT_WAIT_MS);
   }
 
   private void triggerDefragUntilDone(List<SnapshotInfo> snapshots)
       throws TimeoutException, InterruptedException {
     OzoneManager om = cluster.getOzoneManager();
     GenericTestUtils.waitFor(() -> {
+      if (snapshots.stream().allMatch(this::isSnapshotDefragComplete)) {
+        return true;
+      }
       try {
-        if (!om.triggerSnapshotDefrag(false)) {
-          return false;
-        }
+        om.triggerSnapshotDefrag(false);
       } catch (IOException e) {
         return false;
       }
       return snapshots.stream().allMatch(this::isSnapshotDefragComplete);
-    }, 1000, DEFRAG_WAIT_MS);
+    }, 2000, DEFRAG_WAIT_MS);
   }
 
   private boolean isSnapshotDefragComplete(SnapshotInfo snapshotInfo) {
@@ -228,33 +244,32 @@ public class TestOmSnapshotCheckpointDbContent {
     }
   }
 
-  /**
-   * For each snapshot, compare bucket-scoped tables in the current checkpoint against version 0.
-   */
-  private void assertCheckpointMatchesBaseline(List<SnapshotInfo> snapshots)
-      throws IOException {
-    OzoneManager om = cluster.getOzoneManager();
-    OMMetadataManager liveMm = om.getMetadataManager();
-
-    for (SnapshotInfo snapshotInfo : snapshots) {
-      int currentVersion = readSnapshotVersion(snapshotInfo);
-      TablePrefixInfo prefixes = liveMm.getTableBucketPrefix(
-          snapshotInfo.getVolumeName(), snapshotInfo.getBucketName());
-
-      try (OmMetadataManagerImpl baselineMm = openCheckpoint(snapshotInfo, 0);
-           OmMetadataManagerImpl currentMm = openCheckpoint(snapshotInfo, currentVersion)) {
-        assertBucketPrefixTablesMatch(baselineMm, currentMm, prefixes,
-            BucketLayout.OBJECT_STORE);
-      }
+  private SnapshotBaseline captureBaseline(SnapshotInfo snapshotInfo,
+      TablePrefixInfo prefixes) throws IOException {
+    try (OmMetadataManagerImpl checkpointMm = openCheckpoint(snapshotInfo, 0)) {
+      return new SnapshotBaseline(
+          readAllBucketPrefixTables(checkpointMm, prefixes, BucketLayout.OBJECT_STORE));
     }
   }
 
-  private int readSnapshotVersion(SnapshotInfo snapshotInfo) throws IOException {
-    OmSnapshotLocalDataManager localDataManager =
-        cluster.getOzoneManager().getOmSnapshotManager().getSnapshotLocalDataManager();
-    try (OmSnapshotLocalDataManager.ReadableOmSnapshotLocalDataProvider provider =
-             localDataManager.getOmSnapshotLocalData(snapshotInfo)) {
-      return (int) provider.getVersion();
+  private void assertCheckpointMatchesBaseline(
+      Map<UUID, SnapshotBaseline> baselines, List<SnapshotInfo> snapshots)
+      throws IOException {
+    OzoneManager om = cluster.getOzoneManager();
+    for (SnapshotInfo snapshotInfo : snapshots) {
+      SnapshotBaseline baseline = baselines.get(snapshotInfo.getSnapshotId());
+      assertNotNull(baseline, "Missing baseline for " + snapshotInfo.getName());
+      TablePrefixInfo prefixes = om.getMetadataManager().getTableBucketPrefix(
+          snapshotInfo.getVolumeName(), snapshotInfo.getBucketName());
+      try (UncheckedAutoCloseableSupplier<OmSnapshot> activeSnapshot =
+               om.getOmSnapshotManager().getActiveSnapshot(
+                   snapshotInfo.getVolumeName(),
+                   snapshotInfo.getBucketName(),
+                   snapshotInfo.getName())) {
+        OMMetadataManager currentMm = activeSnapshot.get().getMetadataManager();
+        assertBucketPrefixTablesMatch(baseline.getTableData(), currentMm, prefixes,
+            BucketLayout.OBJECT_STORE);
+      }
     }
   }
 
@@ -265,41 +280,59 @@ public class TestOmSnapshotCheckpointDbContent {
     return OmMetadataManagerImpl.createCheckpointMetadataManager(conf, checkpoint);
   }
 
-  private void assertBucketPrefixTablesMatch(
-      OMMetadataManager baseline,
-      OMMetadataManager defragged,
+  private static Map<String, SortedMap<String, ?>> readAllBucketPrefixTables(
+      OMMetadataManager mm,
+      TablePrefixInfo prefixes,
+      BucketLayout layout) throws IOException {
+    Map<String, SortedMap<String, ?>> tables = new HashMap<>();
+    tables.put(VOLUME_TABLE, readPrefix(mm.getVolumeTable(),
+        prefixes.getTablePrefix(VOLUME_TABLE)));
+    tables.put(BUCKET_TABLE, readPrefix(mm.getBucketTable(),
+        prefixes.getTablePrefix(BUCKET_TABLE)));
+    tables.put(KEY_TABLE, readPrefix(mm.getKeyTable(layout),
+        prefixes.getTablePrefix(KEY_TABLE)));
+    tables.put(OPEN_KEY_TABLE, readPrefix(mm.getOpenKeyTable(layout),
+        prefixes.getTablePrefix(OPEN_KEY_TABLE)));
+    tables.put(MULTIPART_INFO_TABLE, readPrefix(mm.getMultipartInfoTable(),
+        prefixes.getTablePrefix(MULTIPART_INFO_TABLE)));
+    return tables;
+  }
+
+  private static void assertBucketPrefixTablesMatch(
+      Map<String, SortedMap<String, ?>> baseline,
+      OMMetadataManager current,
       TablePrefixInfo prefixes,
       BucketLayout layout) throws IOException {
 
-    assertPrefixEquals(VOLUME_TABLE, baseline.getVolumeTable(),
-        defragged.getVolumeTable(), prefixes);
-    assertPrefixEquals(BUCKET_TABLE, baseline.getBucketTable(),
-        defragged.getBucketTable(), prefixes);
-    assertPrefixEquals(KEY_TABLE,
-        baseline.getKeyTable(layout),
-        defragged.getKeyTable(layout), prefixes);
-    assertPrefixEquals(OPEN_KEY_TABLE,
-        baseline.getOpenKeyTable(layout),
-        defragged.getOpenKeyTable(layout), prefixes);
-    assertPrefixEquals(MULTIPART_INFO_TABLE, baseline.getMultipartInfoTable(),
-        defragged.getMultipartInfoTable(), prefixes);
+    assertPrefixEquals(VOLUME_TABLE, baseline.get(VOLUME_TABLE),
+        current.getVolumeTable(), prefixes);
+    assertPrefixEquals(BUCKET_TABLE, baseline.get(BUCKET_TABLE),
+        current.getBucketTable(), prefixes);
+    assertPrefixEquals(KEY_TABLE, baseline.get(KEY_TABLE),
+        current.getKeyTable(layout), prefixes);
+    assertPrefixEquals(OPEN_KEY_TABLE, baseline.get(OPEN_KEY_TABLE),
+        current.getOpenKeyTable(layout), prefixes);
+    assertPrefixEquals(MULTIPART_INFO_TABLE, baseline.get(MULTIPART_INFO_TABLE),
+        current.getMultipartInfoTable(), prefixes);
   }
 
   private static <V> void assertPrefixEquals(
       String tableName,
-      Table<String, V> baseline,
-      Table<String, V> defragged,
+      SortedMap<String, ?> expected,
+      Table<String, V> current,
       TablePrefixInfo prefixes) throws IOException {
     String prefix = prefixes.getTablePrefix(tableName);
     assertTrue(prefix != null && !prefix.isEmpty(),
         "Expected non-empty prefix for " + tableName);
-    assertEquals(readPrefix(baseline, prefix), readPrefix(defragged, prefix),
-        tableName);
+    assertEquals(expected, readPrefix(current, prefix), tableName);
   }
 
   private static <V> SortedMap<String, V> readPrefix(
       Table<String, V> table, String prefix) throws IOException {
     SortedMap<String, V> map = new TreeMap<>();
+    if (prefix == null || prefix.isEmpty()) {
+      return map;
+    }
     try (KeyValueIterator<String, V> it = table.iterator(prefix)) {
       while (it.hasNext()) {
         KeyValue<String, V> kv = it.next();
@@ -312,16 +345,30 @@ public class TestOmSnapshotCheckpointDbContent {
     return map;
   }
 
+  private static final class SnapshotBaseline {
+    private final Map<String, SortedMap<String, ?>> tableData;
+
+    private SnapshotBaseline(Map<String, SortedMap<String, ?>> tableData) {
+      this.tableData = tableData;
+    }
+
+    private Map<String, SortedMap<String, ?>> getTableData() {
+      return tableData;
+    }
+  }
+
   private static final class ThreeSnapshotSetup {
     private final String volumeName;
     private final String bucketName;
     private final List<SnapshotInfo> snapshots;
+    private final Map<UUID, SnapshotBaseline> baselines;
 
     private ThreeSnapshotSetup(String volumeName, String bucketName,
-        List<SnapshotInfo> snapshots) {
+        List<SnapshotInfo> snapshots, Map<UUID, SnapshotBaseline> baselines) {
       this.volumeName = volumeName;
       this.bucketName = bucketName;
       this.snapshots = new ArrayList<>(snapshots);
+      this.baselines = baselines;
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -23,8 +23,11 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_DEFRAG_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DIRECTORY_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.FILE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VOLUME_TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -85,6 +88,7 @@ import org.junit.jupiter.api.Test;
 public class TestOmSnapshotCheckpointDbContent {
 
   private static final byte[] TEST_KEY_CONTENT = new byte[] {0x61, 0x62, 0x63};
+  private static final byte[] OVERWRITE_KEY_CONTENT = new byte[] {0x64, 0x65, 0x66};
   private static final int CHECKPOINT_WAIT_MS = 120_000;
   private static final int DEFRAG_WAIT_MS = 600_000;
 
@@ -116,10 +120,10 @@ public class TestOmSnapshotCheckpointDbContent {
   }
 
   /**
-   * HDDS-13217 scenarios:
+   * HDDS-13217 scenarios for OBS and FSO buckets:
    * <ol>
-   *   <li>Create S1, S2, S3 on one bucket, run defrag, and verify each defragged checkpoint still
-   *       matches its version-0 baseline.</li>
+   *   <li>Create S1, S2, S3 with insert, overwrite, and delete deltas between snapshots, run defrag,
+   *       and verify each defragged checkpoint still matches its version-0 baseline.</li>
    *   <li>Delete the middle snapshot, run defrag again, and verify the remaining youngest snapshot
    *       checkpoint still matches its baseline.</li>
    * </ol>
@@ -127,9 +131,15 @@ public class TestOmSnapshotCheckpointDbContent {
   @Test
   public void testSnapshotCheckpointContentPreservedAcrossDefragIterations()
       throws Exception {
-    ThreeSnapshotSetup setup = createThreeSnapshotsOnNewBucket();
+    runDefragIntegrityScenario(BucketLayout.OBJECT_STORE);
+    runDefragIntegrityScenario(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+  }
+
+  private void runDefragIntegrityScenario(BucketLayout layout)
+      throws Exception {
+    ThreeSnapshotSetup setup = createThreeSnapshotsOnNewBucket(layout);
     triggerDefragUntilDone(setup.snapshots);
-    assertCheckpointMatchesBaseline(setup.baselines, setup.snapshots);
+    assertCheckpointMatchesBaseline(setup.baselines, setup.snapshots, layout);
 
     SnapshotInfo s2 = setup.snapshots.get(1);
     SnapshotInfo s3 = setup.snapshots.get(2);
@@ -145,23 +155,31 @@ public class TestOmSnapshotCheckpointDbContent {
     assertCheckpointMatchesBaseline(
         Collections.singletonMap(s3.getSnapshotId(),
             setup.baselines.get(s3.getSnapshotId())),
-        Arrays.asList(s3));
+        Arrays.asList(s3),
+        layout);
   }
 
-  private ThreeSnapshotSetup createThreeSnapshotsOnNewBucket()
+  private ThreeSnapshotSetup createThreeSnapshotsOnNewBucket(BucketLayout layout)
       throws IOException, InterruptedException, TimeoutException {
-    OzoneBucket bucket =
-        DataTestUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
+    OzoneBucket bucket = DataTestUtil.createVolumeAndBucket(client, layout);
     String volumeName = bucket.getVolumeName();
     String bucketName = bucket.getName();
 
-    DataTestUtil.createKey(bucket, "key-s1", TEST_KEY_CONTENT);
+    String keyA = objectKey(layout, "key-a");
+    String keyB = objectKey(layout, "key-b");
+    String keyS2 = objectKey(layout, "key-s2");
+    String keyS3 = objectKey(layout, "key-s3");
+
+    DataTestUtil.createKey(bucket, keyA, TEST_KEY_CONTENT);
+    DataTestUtil.createKey(bucket, keyB, TEST_KEY_CONTENT);
     store.createSnapshot(volumeName, bucketName, "snap-s1");
 
-    DataTestUtil.createKey(bucket, "key-s2", TEST_KEY_CONTENT);
+    DataTestUtil.createKey(bucket, keyA, OVERWRITE_KEY_CONTENT);
+    DataTestUtil.createKey(bucket, keyS2, TEST_KEY_CONTENT);
     store.createSnapshot(volumeName, bucketName, "snap-s2");
 
-    DataTestUtil.createKey(bucket, "key-s3", TEST_KEY_CONTENT);
+    bucket.deleteKey(keyB);
+    DataTestUtil.createKey(bucket, keyS3, TEST_KEY_CONTENT);
     store.createSnapshot(volumeName, bucketName, "snap-s3");
 
     List<SnapshotInfo> snapshots = Arrays.asList(
@@ -177,9 +195,13 @@ public class TestOmSnapshotCheckpointDbContent {
     TablePrefixInfo prefixes = liveMm.getTableBucketPrefix(volumeName, bucketName);
     Map<UUID, SnapshotBaseline> baselines = new HashMap<>();
     for (SnapshotInfo snapshotInfo : snapshots) {
-      baselines.put(snapshotInfo.getSnapshotId(), captureBaseline(snapshotInfo, prefixes));
+      baselines.put(snapshotInfo.getSnapshotId(), captureBaseline(snapshotInfo, prefixes, layout));
     }
     return new ThreeSnapshotSetup(volumeName, bucketName, snapshots, baselines);
+  }
+
+  private static String objectKey(BucketLayout layout, String name) {
+    return layout.isFileSystemOptimized() ? "dir/" + name : name;
   }
 
   private SnapshotInfo loadSnapshotInfo(String volumeName, String bucketName,
@@ -276,16 +298,16 @@ public class TestOmSnapshotCheckpointDbContent {
   }
 
   private SnapshotBaseline captureBaseline(SnapshotInfo snapshotInfo,
-      TablePrefixInfo prefixes) throws IOException {
+      TablePrefixInfo prefixes, BucketLayout layout) throws IOException {
     try (OmMetadataManagerImpl checkpointMm = openCheckpoint(snapshotInfo, 0)) {
       return new SnapshotBaseline(
-          readAllBucketPrefixTables(checkpointMm, prefixes, BucketLayout.OBJECT_STORE));
+          readAllBucketPrefixTables(checkpointMm, prefixes, layout));
     }
   }
 
   private void assertCheckpointMatchesBaseline(
-      Map<UUID, SnapshotBaseline> baselines, List<SnapshotInfo> snapshots)
-      throws IOException {
+      Map<UUID, SnapshotBaseline> baselines, List<SnapshotInfo> snapshots,
+      BucketLayout layout) throws IOException {
     OzoneManager om = cluster.getOzoneManager();
     for (SnapshotInfo snapshotInfo : snapshots) {
       SnapshotBaseline baseline = baselines.get(snapshotInfo.getSnapshotId());
@@ -298,8 +320,7 @@ public class TestOmSnapshotCheckpointDbContent {
                    snapshotInfo.getBucketName(),
                    snapshotInfo.getName())) {
         OMMetadataManager currentMm = activeSnapshot.get().getMetadataManager();
-        assertBucketPrefixTablesMatch(baseline.getTableData(), currentMm, prefixes,
-            BucketLayout.OBJECT_STORE);
+        assertBucketPrefixTablesMatch(baseline.getTableData(), currentMm, prefixes, layout);
       }
     }
   }
@@ -324,10 +345,19 @@ public class TestOmSnapshotCheckpointDbContent {
         prefixes.getTablePrefix(VOLUME_TABLE)));
     tables.put(BUCKET_TABLE, filterTableEntriesByKeyPrefix(mm.getBucketTable(),
         prefixes.getTablePrefix(BUCKET_TABLE)));
-    tables.put(KEY_TABLE, filterTableEntriesByKeyPrefix(mm.getKeyTable(layout),
-        prefixes.getTablePrefix(KEY_TABLE)));
-    tables.put(OPEN_KEY_TABLE, filterTableEntriesByKeyPrefix(mm.getOpenKeyTable(layout),
-        prefixes.getTablePrefix(OPEN_KEY_TABLE)));
+    if (layout.isFileSystemOptimized()) {
+      tables.put(FILE_TABLE, filterTableEntriesByKeyPrefix(mm.getFileTable(),
+          prefixes.getTablePrefix(FILE_TABLE)));
+      tables.put(DIRECTORY_TABLE, filterTableEntriesByKeyPrefix(mm.getDirectoryTable(),
+          prefixes.getTablePrefix(DIRECTORY_TABLE)));
+      tables.put(OPEN_FILE_TABLE, filterTableEntriesByKeyPrefix(mm.getOpenKeyTable(layout),
+          prefixes.getTablePrefix(OPEN_FILE_TABLE)));
+    } else {
+      tables.put(KEY_TABLE, filterTableEntriesByKeyPrefix(mm.getKeyTable(layout),
+          prefixes.getTablePrefix(KEY_TABLE)));
+      tables.put(OPEN_KEY_TABLE, filterTableEntriesByKeyPrefix(mm.getOpenKeyTable(layout),
+          prefixes.getTablePrefix(OPEN_KEY_TABLE)));
+    }
     tables.put(MULTIPART_INFO_TABLE, filterTableEntriesByKeyPrefix(mm.getMultipartInfoTable(),
         prefixes.getTablePrefix(MULTIPART_INFO_TABLE)));
     return tables;
@@ -343,10 +373,19 @@ public class TestOmSnapshotCheckpointDbContent {
         current.getVolumeTable(), prefixes);
     assertPrefixEquals(BUCKET_TABLE, baseline.get(BUCKET_TABLE),
         current.getBucketTable(), prefixes);
-    assertPrefixEquals(KEY_TABLE, baseline.get(KEY_TABLE),
-        current.getKeyTable(layout), prefixes);
-    assertPrefixEquals(OPEN_KEY_TABLE, baseline.get(OPEN_KEY_TABLE),
-        current.getOpenKeyTable(layout), prefixes);
+    if (layout.isFileSystemOptimized()) {
+      assertPrefixEquals(FILE_TABLE, baseline.get(FILE_TABLE),
+          current.getFileTable(), prefixes);
+      assertPrefixEquals(DIRECTORY_TABLE, baseline.get(DIRECTORY_TABLE),
+          current.getDirectoryTable(), prefixes);
+      assertPrefixEquals(OPEN_FILE_TABLE, baseline.get(OPEN_FILE_TABLE),
+          current.getOpenKeyTable(layout), prefixes);
+    } else {
+      assertPrefixEquals(KEY_TABLE, baseline.get(KEY_TABLE),
+          current.getKeyTable(layout), prefixes);
+      assertPrefixEquals(OPEN_KEY_TABLE, baseline.get(OPEN_KEY_TABLE),
+          current.getOpenKeyTable(layout), prefixes);
+    }
     assertPrefixEquals(MULTIPART_INFO_TABLE, baseline.get(MULTIPART_INFO_TABLE),
         current.getMultipartInfoTable(), prefixes);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -323,20 +323,24 @@ public class TestOmSnapshotCheckpointDbContent {
     return OmMetadataManagerImpl.createCheckpointMetadataManager(conf, checkpoint);
   }
 
+  /**
+   * Collects the snapshot OM metadata for the bucket-relevant tables and returns
+   * a map from table name to sorted key-value entries scoped to the bucket prefix.
+   */
   private static Map<String, SortedMap<String, ?>> readAllBucketPrefixTables(
       OMMetadataManager mm,
       TablePrefixInfo prefixes,
       BucketLayout layout) throws IOException {
     Map<String, SortedMap<String, ?>> tables = new HashMap<>();
-    tables.put(VOLUME_TABLE, readPrefix(mm.getVolumeTable(),
+    tables.put(VOLUME_TABLE, filterTableEntriesByKeyPrefix(mm.getVolumeTable(),
         prefixes.getTablePrefix(VOLUME_TABLE)));
-    tables.put(BUCKET_TABLE, readPrefix(mm.getBucketTable(),
+    tables.put(BUCKET_TABLE, filterTableEntriesByKeyPrefix(mm.getBucketTable(),
         prefixes.getTablePrefix(BUCKET_TABLE)));
-    tables.put(KEY_TABLE, readPrefix(mm.getKeyTable(layout),
+    tables.put(KEY_TABLE, filterTableEntriesByKeyPrefix(mm.getKeyTable(layout),
         prefixes.getTablePrefix(KEY_TABLE)));
-    tables.put(OPEN_KEY_TABLE, readPrefix(mm.getOpenKeyTable(layout),
+    tables.put(OPEN_KEY_TABLE, filterTableEntriesByKeyPrefix(mm.getOpenKeyTable(layout),
         prefixes.getTablePrefix(OPEN_KEY_TABLE)));
-    tables.put(MULTIPART_INFO_TABLE, readPrefix(mm.getMultipartInfoTable(),
+    tables.put(MULTIPART_INFO_TABLE, filterTableEntriesByKeyPrefix(mm.getMultipartInfoTable(),
         prefixes.getTablePrefix(MULTIPART_INFO_TABLE)));
     return tables;
   }
@@ -367,10 +371,13 @@ public class TestOmSnapshotCheckpointDbContent {
     String prefix = prefixes.getTablePrefix(tableName);
     assertTrue(prefix != null && !prefix.isEmpty(),
         "Expected non-empty prefix for " + tableName);
-    assertEquals(expected, readPrefix(current, prefix), tableName);
+    assertEquals(expected, filterTableEntriesByKeyPrefix(current, prefix), tableName);
   }
 
-  private static <V> SortedMap<String, V> readPrefix(
+  /**
+   * Filters table entries whose keys start with {@code prefix} and returns them in a sorted map.
+   */
+  private static <V> SortedMap<String, V> filterTableEntriesByKeyPrefix(
       Table<String, V> table, String prefix) throws IOException {
     SortedMap<String, V> map = new TreeMap<>();
     if (prefix == null || prefix.isEmpty()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -110,7 +110,8 @@ public class TestOmSnapshotCheckpointDbContent {
 
     conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
-    conf.setInt(OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL, 7200);
+    // Disable background defrag; this test drives defrag manually via triggerSnapshotDefrag().
+    conf.setInt(OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL, -1);
     conf.setInt(SNAPSHOT_DEFRAG_LIMIT_PER_TASK, 10);
     conf.setTimeDuration(OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL, 1, TimeUnit.SECONDS);
 
@@ -300,19 +301,26 @@ public class TestOmSnapshotCheckpointDbContent {
   private void triggerDefragUntilDone(List<SnapshotInfo> snapshots)
       throws TimeoutException, InterruptedException {
     OzoneManager om = cluster.getOzoneManager();
+    GenericTestUtils.waitFor(() -> {
+      if (areAllSnapshotsDefragComplete(snapshots)) {
+        return true;
+      }
+      try {
+        om.triggerSnapshotDefrag(false);
+      } catch (IOException e) {
+        return false;
+      }
+      return areAllSnapshotsDefragComplete(snapshots);
+    }, 2000, DEFRAG_WAIT_MS);
+  }
+
+  private boolean areAllSnapshotsDefragComplete(List<SnapshotInfo> snapshots) {
     for (SnapshotInfo snapshotInfo : snapshots) {
-      GenericTestUtils.waitFor(() -> {
-        if (isSnapshotDefragComplete(snapshotInfo)) {
-          return true;
-        }
-        try {
-          om.triggerSnapshotDefrag(false);
-        } catch (IOException e) {
-          return false;
-        }
-        return isSnapshotDefragComplete(snapshotInfo);
-      }, 2000, DEFRAG_WAIT_MS);
+      if (!isSnapshotDefragComplete(snapshotInfo)) {
+        return false;
+      }
     }
+    return true;
   }
 
   private boolean isSnapshotDefragComplete(SnapshotInfo snapshotInfo) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.hdds.utils.UncheckedAutoCloseableSupplier;
 import org.apache.hadoop.hdds.utils.db.ManagedRawSSTFileReader;
 import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -61,11 +61,13 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -147,7 +149,8 @@ public class TestOmSnapshotCheckpointDbContent {
 
     triggerDefragUntilDone(Arrays.asList(s3));
     assertCheckpointMatchesBaseline(
-        Map.of(s3.getSnapshotId(), setup.baselines.get(s3.getSnapshotId())),
+        Collections.singletonMap(s3.getSnapshotId(),
+            setup.baselines.get(s3.getSnapshotId())),
         Arrays.asList(s3));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -90,7 +90,9 @@ public class TestOmSnapshotCheckpointDbContent {
   private static final byte[] TEST_KEY_CONTENT = new byte[] {0x61, 0x62, 0x63};
   private static final byte[] OVERWRITE_KEY_CONTENT = new byte[] {0x64, 0x65, 0x66};
   private static final int CHECKPOINT_WAIT_MS = 120_000;
+  private static final int PURGE_WAIT_MS = 180_000;
   private static final int DEFRAG_WAIT_MS = 600_000;
+  private static final int KEY_DELETE_WAIT_MS = 60_000;
 
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
@@ -99,6 +101,10 @@ public class TestOmSnapshotCheckpointDbContent {
 
   @BeforeEach
   void initCluster() throws Exception {
+    startCluster();
+  }
+
+  private void startCluster() throws Exception {
     assumeTrue(ManagedRawSSTFileReader.tryLoadLibrary(),
         "Snapshot defrag requires rocks-tools native library");
 
@@ -112,6 +118,19 @@ public class TestOmSnapshotCheckpointDbContent {
     cluster.waitForClusterToBeReady();
     client = cluster.newClient();
     store = client.getObjectStore();
+    resumeBackgroundServices();
+  }
+
+  private void restartCluster() throws Exception {
+    IOUtils.closeQuietly(client, cluster);
+    startCluster();
+  }
+
+  private void resumeBackgroundServices() {
+    OzoneManager om = cluster.getOzoneManager();
+    om.getKeyManager().getDeletingService().resume();
+    om.getKeyManager().getDirDeletingService().resume();
+    om.getKeyManager().getSnapshotDeletingService().resume();
   }
 
   @AfterEach
@@ -132,6 +151,8 @@ public class TestOmSnapshotCheckpointDbContent {
   public void testSnapshotCheckpointContentPreservedAcrossDefragIterations()
       throws Exception {
     runDefragIntegrityScenario(BucketLayout.OBJECT_STORE);
+    // Use a fresh cluster for FSO to avoid interference on the global snapshot defrag chain.
+    restartCluster();
     runDefragIntegrityScenario(BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
@@ -179,6 +200,7 @@ public class TestOmSnapshotCheckpointDbContent {
     store.createSnapshot(volumeName, bucketName, "snap-s2");
 
     bucket.deleteKey(keyB);
+    waitForKeyDeleted(bucket, keyB);
     DataTestUtil.createKey(bucket, keyS3, TEST_KEY_CONTENT);
     store.createSnapshot(volumeName, bucketName, "snap-s3");
 
@@ -224,6 +246,7 @@ public class TestOmSnapshotCheckpointDbContent {
   private void waitForSnapshotPurged(SnapshotInfo snapshotInfo)
       throws TimeoutException, InterruptedException {
     OzoneManager om = cluster.getOzoneManager();
+    resumeBackgroundServices();
     GenericTestUtils.waitFor(() -> {
       try {
         return om.getMetadataManager().getSnapshotInfoTable()
@@ -231,7 +254,19 @@ public class TestOmSnapshotCheckpointDbContent {
       } catch (IOException e) {
         return false;
       }
-    }, 1000, CHECKPOINT_WAIT_MS);
+    }, 1000, PURGE_WAIT_MS);
+  }
+
+  private void waitForKeyDeleted(OzoneBucket bucket, String keyName)
+      throws TimeoutException, InterruptedException {
+    GenericTestUtils.waitFor(() -> {
+      try {
+        bucket.getKey(keyName);
+        return false;
+      } catch (IOException e) {
+        return true;
+      }
+    }, 1000, KEY_DELETE_WAIT_MS);
   }
 
   /**
@@ -242,15 +277,20 @@ public class TestOmSnapshotCheckpointDbContent {
   private void triggerDefragUntilVersionIncreases(SnapshotInfo snapshotInfo,
       int baselineVersion) throws TimeoutException, InterruptedException {
     OzoneManager om = cluster.getOzoneManager();
+    String volumeName = snapshotInfo.getVolumeName();
+    String bucketName = snapshotInfo.getBucketName();
+    String snapshotName = snapshotInfo.getName();
     GenericTestUtils.waitFor(() -> {
       try {
-        if (readSnapshotVersion(snapshotInfo) > baselineVersion
-            && isSnapshotDefragComplete(snapshotInfo)) {
+        SnapshotInfo currentSnapshot = loadSnapshotInfo(volumeName, bucketName, snapshotName);
+        if (readSnapshotVersion(currentSnapshot) > baselineVersion
+            && isSnapshotDefragComplete(currentSnapshot)) {
           return true;
         }
         om.triggerSnapshotDefrag(false);
-        return readSnapshotVersion(snapshotInfo) > baselineVersion
-            && isSnapshotDefragComplete(snapshotInfo);
+        currentSnapshot = loadSnapshotInfo(volumeName, bucketName, snapshotName);
+        return readSnapshotVersion(currentSnapshot) > baselineVersion
+            && isSnapshotDefragComplete(currentSnapshot);
       } catch (IOException e) {
         return false;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -17,27 +17,34 @@
 
 package org.apache.hadoop.ozone.om.snapshot;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_DEFRAG_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
-import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DIRECTORY_TABLE;
-import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.FILE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.VOLUME_TABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.hdds.utils.db.ManagedRawSSTFileReader;
 import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
@@ -55,181 +62,266 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 /**
- * HDDS-13217: when an OM snapshot is created, the on-disk RocksDB checkpoint for that snapshot
- * should contain the same bucket-scoped metadata as the live OM for the tables exercised here.
+ * HDDS-13217: verify snapshot checkpoint DB content is preserved across defrag iterations.
  *
- * <p>Flow: write some keys, call createSnapshot, wait until the checkpoint is materialized, open
- * it read-only, then for each relevant table scan the key prefix for this volume/bucket on both
- * the live metadata manager and the checkpoint and assert the maps match.
+ * <p>After defrag compacts a snapshot checkpoint (S' = compact(S)), the on-disk metadata for that
+ * bucket prefix in the defragged checkpoint must still match the original checkpoint taken at
+ * snapshot creation time (version 0).
  *
- * <p>Tables compared: volume and bucket rows; key table for OBJECT_STORE and LEGACY layouts;
- * file and directory tables for FILE_SYSTEM_OPTIMIZED; openKeyTable and multipartInfoTable (these
- * stay empty in these tests but we still compare to catch stray open writes).
- *
- * <p>Omitted on purpose: snapshotInfoTable, because the new snapshot row is part of the same DB
- * batch as the checkpoint step, so it appears on the live OM after the batch commits but not
- * inside the checkpoint taken mid-batch. deletedTable, deletedDirTable, snapshotRenamedTable:
- * the leader deletes those prefix ranges on the active DB immediately after the checkpoint, so
- * live and checkpoint intentionally differ. We also do not scan cluster-wide tables (tokens,
- * secrets, compaction log, other tenants/volumes).
- *
- * <p>Later tests worth adding: a second snapshot on the same bucket; writes after the snapshot to
- * prove the checkpoint slice does not change; multipart uploads with real state; linked buckets
- * resolving to a source bucket.
- *
- * <p>Executed as a nested class under {@link org.apache.ozone.test.TestOzoneIntegrationNonHA} so
- * one {@link MiniOzoneCluster} is shared with other safe tests (HDDS-12183). Tests only add
- * volumes, buckets, keys, and snapshots; they do not stop or restart the cluster.
+ * <p>Tables compared per bucket: volume, bucket, key (object store layout), openKey, multipart.
+ * Snapshot-info and deleted/renamed tables are omitted because they differ by design between live
+ * OM and checkpoint or after purge.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class TestOmSnapshotCheckpointDbContent implements NonHATests.TestCase {
+public class TestOmSnapshotCheckpointDbContent {
 
   private static final byte[] TEST_KEY_CONTENT = new byte[] {0x61, 0x62, 0x63};
+  private static final int DEFRAG_WAIT_MS = 120_000;
 
-  private OzoneConfiguration conf;
-  private OzoneClient client;
-  private ObjectStore store;
+  private static MiniOzoneCluster cluster;
+  private static OzoneConfiguration conf;
+  private static OzoneClient client;
+  private static ObjectStore store;
 
   @BeforeAll
-  void init() throws IOException {
-    conf = cluster().getConf();
-    client = cluster().newClient();
+  void initCluster() throws Exception {
+    assumeTrue(ManagedRawSSTFileReader.tryLoadLibrary(),
+        "Snapshot defrag requires rocks-tools native library");
+
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
+    conf.setInt(OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL, 7200);
+    conf.setInt(SNAPSHOT_DEFRAG_LIMIT_PER_TASK, 10);
+    conf.setTimeDuration(OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL, 1, TimeUnit.SECONDS);
+
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
     store = client.getObjectStore();
   }
 
   @AfterAll
-  void cleanup() {
+  void shutdownCluster() {
     IOUtils.closeQuietly(client);
+    IOUtils.closeQuietly(cluster);
   }
 
   /**
-   * Object store layout: mixed key shapes (flat and path-like), then snapshot and compare tables
-   * for this bucket.
+   * Test#1 from HDDS-13217: create S1, S2, S3 on one bucket, run defrag, and verify each
+   * defragged checkpoint still matches its version-0 baseline.
    */
   @Test
-  public void testSnapshotCheckpointMatchesLiveObsBucket()
-      throws IOException, InterruptedException, TimeoutException {
-    runLayoutScenario(BucketLayout.OBJECT_STORE,
-        Arrays.asList("k1", "prefix/k2", "prefix/k3"));
+  public void testDefragPreservesSnapshotCheckpointContent()
+      throws Exception {
+    ThreeSnapshotSetup setup = createThreeSnapshotsOnNewBucket();
+    triggerDefragUntilDone(setup.snapshots);
+    assertCheckpointMatchesBaseline(setup.snapshots);
   }
 
   /**
-   * File-system-optimized layout: data lives in file/dir tables; includes keys under a short path and
-   * one at the bucket root.
+   * Test#2 from HDDS-13217: after an initial defrag pass, delete the middle snapshot, run defrag
+   * again, and verify the remaining youngest snapshot checkpoint still matches its baseline.
    */
   @Test
-  public void testSnapshotCheckpointMatchesLiveFsoBucket()
-      throws IOException, InterruptedException, TimeoutException {
-    runLayoutScenario(BucketLayout.FILE_SYSTEM_OPTIMIZED,
-        Arrays.asList("d/k1", "d/k2", "k-root"));
+  public void testDefragAfterSnapshotDeletePreservesRemainingSnapshot()
+      throws Exception {
+    ThreeSnapshotSetup setup = createThreeSnapshotsOnNewBucket();
+    triggerDefragUntilDone(setup.snapshots);
+
+    SnapshotInfo s2 = setup.snapshots.get(1);
+    SnapshotInfo s3 = setup.snapshots.get(2);
+    store.deleteSnapshot(setup.volumeName, setup.bucketName, s2.getName());
+    waitForSnapshotPurged(s2);
+
+    triggerDefragUntilDone(Arrays.asList(s3));
+    assertCheckpointMatchesBaseline(Arrays.asList(s3));
   }
 
-  /**
-   * Legacy layout: still uses the key table only; flat key names to match default path behavior on
-   * this cluster.
-   */
-  @Test
-  public void testSnapshotCheckpointMatchesLiveLegacyBucket()
-      throws IOException, InterruptedException, TimeoutException {
-    runLayoutScenario(BucketLayout.LEGACY,
-        Arrays.asList("key-a", "key-b", "key-c"));
-  }
-
-  /** Create bucket, write keys, snapshot, wait for checkpoint files, open checkpoint DB, compare. */
-  private void runLayoutScenario(BucketLayout layout, List<String> keyNames)
+  private ThreeSnapshotSetup createThreeSnapshotsOnNewBucket()
       throws IOException, InterruptedException, TimeoutException {
     OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(client, layout);
+        TestDataUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
     String volumeName = bucket.getVolumeName();
     String bucketName = bucket.getName();
 
-    for (String keyName : keyNames) {
-      TestDataUtil.createKey(bucket, keyName, TEST_KEY_CONTENT);
+    TestDataUtil.createKey(bucket, "key-s1", TEST_KEY_CONTENT);
+    store.createSnapshot(volumeName, bucketName, "snap-s1");
+
+    TestDataUtil.createKey(bucket, "key-s2", TEST_KEY_CONTENT);
+    store.createSnapshot(volumeName, bucketName, "snap-s2");
+
+    TestDataUtil.createKey(bucket, "key-s3", TEST_KEY_CONTENT);
+    store.createSnapshot(volumeName, bucketName, "snap-s3");
+
+    List<SnapshotInfo> snapshots = Arrays.asList(
+        loadSnapshotInfo(volumeName, bucketName, "snap-s1"),
+        loadSnapshotInfo(volumeName, bucketName, "snap-s2"),
+        loadSnapshotInfo(volumeName, bucketName, "snap-s3"));
+
+    for (SnapshotInfo snapshotInfo : snapshots) {
+      waitForCheckpointReady(snapshotInfo);
     }
+    return new ThreeSnapshotSetup(volumeName, bucketName, snapshots);
+  }
 
-    String snapshotName = "snap-a";
-    store.createSnapshot(volumeName, bucketName, snapshotName);
-
-    OzoneManager om = cluster().getOzoneManager();
-    OMMetadataManager liveMm = om.getMetadataManager();
-    SnapshotInfo snapshotInfo = liveMm.getSnapshotInfoTable().get(
+  private SnapshotInfo loadSnapshotInfo(String volumeName, String bucketName,
+      String snapshotName) throws IOException {
+    OzoneManager om = cluster.getOzoneManager();
+    SnapshotInfo snapshotInfo = om.getMetadataManager().getSnapshotInfoTable().get(
         SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName));
-    assertNotNull(snapshotInfo, "Snapshot row should exist after createSnapshot");
+    assertNotNull(snapshotInfo, "Snapshot row should exist for " + snapshotName);
     assertEquals(snapshotName, snapshotInfo.getName());
+    return snapshotInfo;
+  }
 
-    String currentPath =
-        OmSnapshotManager.getSnapshotPath(conf, snapshotInfo, 0)
-            + OM_KEY_PREFIX + "CURRENT";
-    GenericTestUtils.waitFor(() -> new File(currentPath).exists(), 1000, 120_000);
+  private void waitForCheckpointReady(SnapshotInfo snapshotInfo)
+      throws TimeoutException, InterruptedException {
+    String currentPath = OmSnapshotManager.getSnapshotPath(conf, snapshotInfo, 0)
+        + OM_KEY_PREFIX + "CURRENT";
+    GenericTestUtils.waitFor(() -> new File(currentPath).exists(), 1000, DEFRAG_WAIT_MS);
+  }
 
-    RocksDBCheckpoint checkpoint = new RocksDBCheckpoint(
-        Paths.get(OmSnapshotManager.getSnapshotPath(conf, snapshotInfo, 0)));
-    try (OmMetadataManagerImpl checkpointMm =
-             OmMetadataManagerImpl.createCheckpointMetadataManager(conf, checkpoint)) {
-      TablePrefixInfo prefixes = liveMm.getTableBucketPrefix(volumeName, bucketName);
-      assertBucketPrefixTablesMatch(liveMm, checkpointMm, prefixes, layout);
+  private void waitForSnapshotPurged(SnapshotInfo snapshotInfo)
+      throws TimeoutException, InterruptedException {
+    OzoneManager om = cluster.getOzoneManager();
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return om.getMetadataManager().getSnapshotInfoTable()
+            .get(snapshotInfo.getTableKey()) == null;
+      } catch (IOException e) {
+        return false;
+      }
+    }, 1000, DEFRAG_WAIT_MS);
+  }
+
+  private void triggerDefragUntilDone(List<SnapshotInfo> snapshots)
+      throws TimeoutException, InterruptedException {
+    OzoneManager om = cluster.getOzoneManager();
+    GenericTestUtils.waitFor(() -> {
+      try {
+        if (!om.triggerSnapshotDefrag(false)) {
+          return false;
+        }
+      } catch (IOException e) {
+        return false;
+      }
+      return snapshots.stream().allMatch(this::isSnapshotDefragComplete);
+    }, 1000, DEFRAG_WAIT_MS);
+  }
+
+  private boolean isSnapshotDefragComplete(SnapshotInfo snapshotInfo) {
+    try {
+      OmSnapshotLocalDataManager localDataManager =
+          cluster.getOzoneManager().getOmSnapshotManager().getSnapshotLocalDataManager();
+      try (OmSnapshotLocalDataManager.ReadableOmSnapshotLocalDataProvider provider =
+               localDataManager.getOmSnapshotLocalData(snapshotInfo)) {
+        return provider.getVersion() > 0 && !provider.needsDefrag();
+      }
+    } catch (IOException e) {
+      return false;
     }
   }
 
-  /** Load every row under the bucket prefix from live vs checkpoint for the tables this test cares about. */
+  /**
+   * For each snapshot, compare bucket-scoped tables in the current checkpoint against version 0.
+   */
+  private void assertCheckpointMatchesBaseline(List<SnapshotInfo> snapshots)
+      throws IOException {
+    OzoneManager om = cluster.getOzoneManager();
+    OMMetadataManager liveMm = om.getMetadataManager();
+
+    for (SnapshotInfo snapshotInfo : snapshots) {
+      int currentVersion = readSnapshotVersion(snapshotInfo);
+      TablePrefixInfo prefixes = liveMm.getTableBucketPrefix(
+          snapshotInfo.getVolumeName(), snapshotInfo.getBucketName());
+
+      try (OmMetadataManagerImpl baselineMm = openCheckpoint(snapshotInfo, 0);
+           OmMetadataManagerImpl currentMm = openCheckpoint(snapshotInfo, currentVersion)) {
+        assertBucketPrefixTablesMatch(baselineMm, currentMm, prefixes,
+            BucketLayout.OBJECT_STORE);
+      }
+    }
+  }
+
+  private int readSnapshotVersion(SnapshotInfo snapshotInfo) throws IOException {
+    OmSnapshotLocalDataManager localDataManager =
+        cluster.getOzoneManager().getOmSnapshotManager().getSnapshotLocalDataManager();
+    try (OmSnapshotLocalDataManager.ReadableOmSnapshotLocalDataProvider provider =
+             localDataManager.getOmSnapshotLocalData(snapshotInfo)) {
+      return (int) provider.getVersion();
+    }
+  }
+
+  private OmMetadataManagerImpl openCheckpoint(SnapshotInfo snapshotInfo, int version)
+      throws IOException {
+    RocksDBCheckpoint checkpoint = new RocksDBCheckpoint(
+        Paths.get(OmSnapshotManager.getSnapshotPath(conf, snapshotInfo, version)));
+    return OmMetadataManagerImpl.createCheckpointMetadataManager(conf, checkpoint);
+  }
+
   private void assertBucketPrefixTablesMatch(
-      OMMetadataManager live,
-      OMMetadataManager checkpoint,
+      OMMetadataManager baseline,
+      OMMetadataManager defragged,
       TablePrefixInfo prefixes,
       BucketLayout layout) throws IOException {
 
-    assertPrefixEquals(VOLUME_TABLE, live.getVolumeTable(),
-        checkpoint.getVolumeTable(), prefixes);
-    assertPrefixEquals(BUCKET_TABLE, live.getBucketTable(),
-        checkpoint.getBucketTable(), prefixes);
-
-    if (layout.isFileSystemOptimized()) {
-      assertPrefixEquals(FILE_TABLE, live.getFileTable(),
-          checkpoint.getFileTable(), prefixes);
-      assertPrefixEquals(DIRECTORY_TABLE, live.getDirectoryTable(),
-          checkpoint.getDirectoryTable(), prefixes);
-    } else {
-      assertPrefixEquals(KEY_TABLE,
-          live.getKeyTable(layout),
-          checkpoint.getKeyTable(layout), prefixes);
-    }
-
+    assertPrefixEquals(VOLUME_TABLE, baseline.getVolumeTable(),
+        defragged.getVolumeTable(), prefixes);
+    assertPrefixEquals(BUCKET_TABLE, baseline.getBucketTable(),
+        defragged.getBucketTable(), prefixes);
+    assertPrefixEquals(KEY_TABLE,
+        baseline.getKeyTable(layout),
+        defragged.getKeyTable(layout), prefixes);
     assertPrefixEquals(OPEN_KEY_TABLE,
-        live.getOpenKeyTable(layout),
-        checkpoint.getOpenKeyTable(layout), prefixes);
-    assertPrefixEquals(MULTIPART_INFO_TABLE, live.getMultipartInfoTable(),
-        checkpoint.getMultipartInfoTable(), prefixes);
+        baseline.getOpenKeyTable(layout),
+        defragged.getOpenKeyTable(layout), prefixes);
+    assertPrefixEquals(MULTIPART_INFO_TABLE, baseline.getMultipartInfoTable(),
+        defragged.getMultipartInfoTable(), prefixes);
   }
 
   private static <V> void assertPrefixEquals(
       String tableName,
-      Table<String, V> live,
-      Table<String, V> checkpoint,
+      Table<String, V> baseline,
+      Table<String, V> defragged,
       TablePrefixInfo prefixes) throws IOException {
     String prefix = prefixes.getTablePrefix(tableName);
-    assertEquals(readPrefix(live, prefix), readPrefix(checkpoint, prefix),
+    assertTrue(prefix != null && !prefix.isEmpty(),
+        "Expected non-empty prefix for " + tableName);
+    assertEquals(readPrefix(baseline, prefix), readPrefix(defragged, prefix),
         tableName);
   }
 
   private static <V> SortedMap<String, V> readPrefix(
       Table<String, V> table, String prefix) throws IOException {
     SortedMap<String, V> map = new TreeMap<>();
-    if (prefix == null || prefix.isEmpty()) {
-      return map;
-    }
     try (KeyValueIterator<String, V> it = table.iterator(prefix)) {
       while (it.hasNext()) {
         KeyValue<String, V> kv = it.next();
+        if (!kv.getKey().startsWith(prefix)) {
+          break;
+        }
         map.put(kv.getKey(), kv.getValue());
       }
     }
     return map;
+  }
+
+  private static final class ThreeSnapshotSetup {
+    private final String volumeName;
+    private final String bucketName;
+    private final List<SnapshotInfo> snapshots;
+
+    private ThreeSnapshotSetup(String volumeName, String bucketName,
+        List<SnapshotInfo> snapshots) {
+      this.volumeName = volumeName;
+      this.bucketName = bucketName;
+      this.snapshots = new ArrayList<>(snapshots);
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -76,14 +76,25 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * HDDS-13217: verify snapshot checkpoint DB content is preserved across defrag iterations.
+ * HDDS-13217: verify that snapshot checkpoint DB content is preserved across defrag iterations.
  *
- * <p>After defrag compacts a snapshot checkpoint (S' = compact(S)), the on-disk metadata for that
- * bucket prefix in the defragged checkpoint must still match the original checkpoint taken at
- * snapshot creation time (version 0).
+ * <p>After defrag compacts a snapshot checkpoint, the bucket-prefix metadata in the defragged
+ * checkpoint must still match the checkpoint taken at snapshot creation time (version 0).
+ * Version-0 directories are removed by defrag, so baselines are captured before the first defrag
+ * pass and compared against the active snapshot afterward.
  *
- * <p>Version-0 checkpoint directories are removed after defrag, so baselines are captured before
- * the first defrag iteration and compared against the active snapshot after defrag completes.
+ * <p>{@link #testSnapshotCheckpointContentPreservedAcrossDefragIterations()} runs both HDDS-13217
+ * scenarios on OBS and FSO buckets:
+ * <ol>
+ *   <li>Create S1, S2, and S3 with insert, overwrite, and delete deltas between snapshots,
+ *       run defrag, and verify each snapshot still matches its version-0 baseline.</li>
+ *   <li>Delete the middle snapshot (S2), run defrag again, and verify the remaining snapshot
+ *       (S3) still matches its baseline.</li>
+ * </ol>
+ *
+ * <p>OBS checks {@code keyTable}; FSO checks {@code fileTable} and {@code directoryTable}.
+ * A fresh cluster is started between the two layouts to avoid interference on the snapshot
+ * defrag chain.
  */
 public class TestOmSnapshotCheckpointDbContent {
 
@@ -110,8 +121,9 @@ public class TestOmSnapshotCheckpointDbContent {
 
     conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
-    // Disable background defrag; this test drives defrag manually via triggerSnapshotDefrag().
-    conf.setInt(OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL, -1);
+    // Keep background defrag idle during the test; manual triggerSnapshotDefrag() still requires
+    // the service to be initialized (interval must be > 0).
+    conf.setTimeDuration(OZONE_SNAPSHOT_DEFRAG_SERVICE_INTERVAL, 2, TimeUnit.HOURS);
     conf.setInt(SNAPSHOT_DEFRAG_LIMIT_PER_TASK, 10);
     conf.setTimeDuration(OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL, 1, TimeUnit.SECONDS);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotCheckpointDbContent.java
@@ -54,8 +54,8 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValueIterator;
 import org.apache.hadoop.hdds.utils.db.TablePrefixInfo;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.DataTestUtil;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -71,7 +71,6 @@ import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 /**
  * HDDS-13217: verify snapshot checkpoint DB content is preserved across defrag iterations.
@@ -82,11 +81,7 @@ import org.junit.jupiter.api.Timeout;
  *
  * <p>Version-0 checkpoint directories are removed after defrag, so baselines are captured before
  * the first defrag iteration and compared against the active snapshot after defrag completes.
- *
- * <p>Each test method starts a fresh MiniOzone cluster to avoid cross-test interference on the
- * global snapshot defrag chain.
  */
-@Timeout(value = 15, unit = TimeUnit.MINUTES)
 public class TestOmSnapshotCheckpointDbContent {
 
   private static final byte[] TEST_KEY_CONTENT = new byte[] {0x61, 0x62, 0x63};
@@ -117,31 +112,24 @@ public class TestOmSnapshotCheckpointDbContent {
 
   @AfterEach
   void shutdownCluster() {
-    IOUtils.closeQuietly(client);
-    IOUtils.closeQuietly(cluster);
+    IOUtils.closeQuietly(client, cluster);
   }
 
   /**
-   * Test#1 from HDDS-13217: create S1, S2, S3 on one bucket, run defrag, and verify each
-   * defragged checkpoint still matches its version-0 baseline.
+   * HDDS-13217 scenarios:
+   * <ol>
+   *   <li>Create S1, S2, S3 on one bucket, run defrag, and verify each defragged checkpoint still
+   *       matches its version-0 baseline.</li>
+   *   <li>Delete the middle snapshot, run defrag again, and verify the remaining youngest snapshot
+   *       checkpoint still matches its baseline.</li>
+   * </ol>
    */
   @Test
-  public void testDefragPreservesSnapshotCheckpointContent()
+  public void testSnapshotCheckpointContentPreservedAcrossDefragIterations()
       throws Exception {
     ThreeSnapshotSetup setup = createThreeSnapshotsOnNewBucket();
     triggerDefragUntilDone(setup.snapshots);
     assertCheckpointMatchesBaseline(setup.baselines, setup.snapshots);
-  }
-
-  /**
-   * Test#2 from HDDS-13217: after an initial defrag pass, delete the middle snapshot, run defrag
-   * again, and verify the remaining youngest snapshot checkpoint still matches its baseline.
-   */
-  @Test
-  public void testDefragAfterSnapshotDeletePreservesRemainingSnapshot()
-      throws Exception {
-    ThreeSnapshotSetup setup = createThreeSnapshotsOnNewBucket();
-    triggerDefragUntilDone(setup.snapshots);
 
     SnapshotInfo s2 = setup.snapshots.get(1);
     SnapshotInfo s3 = setup.snapshots.get(2);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.ozone.om.TestObjectStoreWithLegacyFS;
 import org.apache.hadoop.ozone.om.TestOmBlockVersioning;
 import org.apache.hadoop.ozone.om.TestOzoneManagerListVolumes;
 import org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface;
+import org.apache.hadoop.ozone.om.snapshot.TestOmSnapshotCheckpointDbContent;
 import org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestOmReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestScmReconfiguration;
@@ -327,6 +328,14 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class OmBlockVersioning extends TestOmBlockVersioning {
+    @Override
+    public MiniOzoneCluster cluster() {
+      return getCluster();
+    }
+  }
+
+  @Nested
+  class OmSnapshotCheckpointDbContent extends TestOmSnapshotCheckpointDbContent {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/ozone/test/NonHATests.java
@@ -52,7 +52,6 @@ import org.apache.hadoop.ozone.om.TestObjectStoreWithLegacyFS;
 import org.apache.hadoop.ozone.om.TestOmBlockVersioning;
 import org.apache.hadoop.ozone.om.TestOzoneManagerListVolumes;
 import org.apache.hadoop.ozone.om.TestOzoneManagerRestInterface;
-import org.apache.hadoop.ozone.om.snapshot.TestOmSnapshotCheckpointDbContent;
 import org.apache.hadoop.ozone.reconfig.TestDatanodeReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestOmReconfiguration;
 import org.apache.hadoop.ozone.reconfig.TestScmReconfiguration;
@@ -328,14 +327,6 @@ public abstract class NonHATests extends ClusterForTests<MiniOzoneCluster> {
 
   @Nested
   class OmBlockVersioning extends TestOmBlockVersioning {
-    @Override
-    public MiniOzoneCluster cluster() {
-      return getCluster();
-    }
-  }
-
-  @Nested
-  class OmSnapshotCheckpointDbContent extends TestOmSnapshotCheckpointDbContent {
     @Override
     public MiniOzoneCluster cluster() {
       return getCluster();


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds an integration test, TestOmSnapshotCheckpointDbContent, to verify that snapshot checkpoint DB metadata for a bucket prefix is preserved across snapshot defrag iterations (HDDS-13217).

Please describe your PR in detail:
This PR adds a new integration test, TestOmSnapshotCheckpointDbContent, to verify that snapshot checkpoint DB metadata for a bucket prefix is preserved across snapshot defrag iterations (HDDS-13217).

The test uses a dedicated MiniOzone cluster with snapshot defrag enabled and covers two scenarios:

1. Create snapshots S1, S2, and S3 on a bucket, trigger defrag, and verify each defragged checkpoint still matches its version-0 baseline captured at snapshot creation time.
2. After an initial defrag pass, delete the middle snapshot (S2), purge it, trigger defrag again, and verify the remaining snapshot (S3) still matches its baseline.

Because version-0 checkpoint directories are removed after defrag, the test captures baselines before the first defrag and compares against the active snapshot view after defrag completes.

Each test method starts a fresh cluster to avoid cross-test interference on the snapshot defrag chain. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13217

## How was this patch tested?

https://github.com/arunsarin85/ozone/actions/runs/30941614952