### PR TITLE
HDDS-15787. Log OM block deletion ack at INFO in SCMBlockProtocolServer

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -268,10 +268,8 @@ public class SCMBlockProtocolServer implements
     for (BlockGroup bg : keyBlocksInfoList) {
       totalBlocks += bg.getDeletedBlocks().size();
     }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("SCM is informed by OM to delete {} keys. Total blocks to deleted {}.",
+    LOG.info("SCM is informed by OM to delete {} keys. Total blocks to deleted {}.",
           keyBlocksInfoList.size(), totalBlocks);
-    }
     List<DeleteBlockGroupResult> results = new ArrayList<>();
     Map<String, String> auditMap = Maps.newHashMap();
     ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result resultCode;
@@ -283,9 +281,8 @@ public class SCMBlockProtocolServer implements
       perfMetrics.updateDeleteKeySuccessStats(keyBlocksInfoList.size(), startNanos);
       resultCode = ScmBlockLocationProtocolProtos.
           DeleteScmBlockResult.Result.success;
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Total number of blocks ACK by SCM in this cycle: " + totalBlocks);
-      }
+      LOG.info("Total number of blocks ACK by SCM in this cycle: " + totalBlocks);
+
     } catch (IOException ioe) {
       e = ioe;
       perfMetrics.updateDeleteKeyFailedBlocks(totalBlocks);


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-15787: The SCM log message for acknowledging block deletions sent from OM is changed from DEBUG to INFO. 

Please describe your PR in detail:
* At present there are INFO level log traces of deletes sent from OM to SCM, sent from SCM to DN, and received/ack'd on DN from SCM. The logging of reception/acknowledgement on SCM of the deletes sent from OM is the only gap. We already have these logs, they are just DEBUG by default.
* The solution is to promote the visibility to the INFO level, making the entire delete chain visible by default.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15787

## How was this patch tested?

Verified output in docker cluster, using ozone freon rk command with --clean-objects option to trigger writes and deletes:

ozone freon rk --num-of-volumes=1 --num-of-buckets=3 --num-of-keys=1024 --validate-writes --clean-objects --num-of-threads=3

In the logs we see:

2026-08-04 19:12:53,428 [IPC Server handler 54 on default port 9863] INFO server.SCMBlockProtocolServer: SCM is informed by OM to delete 3072 keys. Total blocks to deleted 3072.
2026-08-04 19:12:53,431 [IPC Server handler 54 on default port 9863] INFO ha.SequenceIdGenerator: Allocate a batch for delTxnId, change lastId from 0 to 1000.
2026-08-04 19:12:53,440 [IPC Server handler 54 on default port 9863] INFO server.SCMBlockProtocolServer: Total number of blocks ACK by SCM in this cycle: 3072


