### PR TITLE
HDDS-16080. TestClientRetryContainerStateMachineFailures takes 12 minutes due to a 30s heartbeat override

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestClientRetryContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestClientRetryContainerStateMachineFailures.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.client.rpc;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
@@ -34,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.IOUtils;
@@ -87,7 +85,6 @@ public class TestClientRetryContainerStateMachineFailures {
     conf.setLong(OZONE_DATANODE_PIPELINE_LIMIT, 1);
     conf.setLong(OZONE_SCM_PIPELINE_PER_METADATA_VOLUME, 1);
     conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "150s");
-    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 30, TimeUnit.SECONDS);
 
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
     clientConfig.setStreamBufferFlushDelay(false);


### PR DESCRIPTION
## What changes were proposed in this pull request?
TestClientRetryContainerStateMachineFailures takes 12 minutes due to a 30s heartbeat override
I'm not sure whether it was intentional, but setting the heartbeat to 30 seconds resulted in over 10 minutes of execution time for this test, which is really slowing down the CI. Dropping it to the default 1 sec makes it 2x+ faster. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16080

## How was this patch tested?
The test was executed in a loop more than 50 times. No failures
