### PR TITLE
HDDS-16081. TestOMRatisSnapshots fails due to leader applied index taken before flush

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -288,10 +288,6 @@ public class TestOMRatisSnapshots {
     });
     List<String> newKeys = writeFuture.get();
 
-    // A write is acked once queued in the double buffer, but the applied index
-    // advances only after the buffer commits. Flush so it covers all newKeys.
-    leaderOM.awaitDoubleBufferFlush();
-
     // All newKeys writes have completed (writeFuture.get() above), so the
     // leader must already contain them.
     OMMetadataManager leaderOmMetaMgr = leaderOM.getMetadataManager();
@@ -314,14 +310,16 @@ public class TestOMRatisSnapshots {
     assertLogCapture(logCapture, msg);
     assertLogCapture(logCapture, "Install Checkpoint is finished");
 
-    // Wait for the follower to apply everything the leader has applied; all
+    // Wait for the follower to apply everything the leader has committed; all
     // writes have completed on the leader, so after this no further snapshot
     // install (and DB reload) can occur and the follower DB reads below are
     // safe from "Rocks Database is closed" races.
-    long leaderApplied = leaderOM.getOmRatisServer()
-        .getLastAppliedTermIndex().getIndex();
+    // The applied index only advances on double buffer flush, so it can lag
+    // acked writes; the commit index covers them all.
+    long leaderCommitted = leaderRatisServer.getServerDivision().getRaftLog()
+        .getLastCommittedIndex();
     GenericTestUtils.waitFor(() -> followerOM.getOmRatisServer()
-        .getLastAppliedTermIndex().getIndex() >= leaderApplied, 100, 30_000);
+        .getLastAppliedTermIndex().getIndex() >= leaderCommitted, 100, 30_000);
 
     long followerOMLastAppliedIndex =
         followerOM.getOmRatisServer().getLastAppliedTermIndex().getIndex();
@@ -377,11 +375,6 @@ public class TestOMRatisSnapshots {
     // Do some transactions so that the log index increases
     List<String> keys = writeKeysToIncreaseLogIndex(leaderRatisServer, 200);
 
-    // A write is acked once queued in the double buffer, but the applied index
-    // advances only after the buffer commits. Flush so the transaction info
-    // read below covers all keys.
-    leaderOM.awaitDoubleBufferFlush();
-
     // Get transaction Index
     TransactionInfo transactionInfo =
         TransactionInfo.readTransactionInfo(leaderOM.getMetadataManager());
@@ -390,6 +383,12 @@ public class TestOMRatisSnapshots {
             transactionInfo.getTransactionIndex());
     long leaderOMSnapshotIndex = leaderOMTermIndex.getIndex();
     long leaderOMSnapshotTermIndex = leaderOMTermIndex.getTerm();
+
+    // The snapshot index above only advances on double buffer flush, so it can
+    // lag the keys written above; the commit index covers them all. Read after
+    // the snapshot index, so it is never behind it.
+    long leaderCommitted = leaderRatisServer.getServerDivision().getRaftLog()
+        .getLastCommittedIndex();
 
     // Start the inactive OM. Checkpoint installation will happen spontaneously.
     OzoneManager.setTestInstallSnapshot(true);
@@ -413,12 +412,11 @@ public class TestOMRatisSnapshots {
     });
     readFuture.get();
 
-    // The recently started OM should be lagging behind the leader OM.
-    // Wait & for follower to update transactions to leader snapshot index.
-    // Timeout error if follower does not load update within 3s
+    // The recently started OM should be lagging behind the leader OM. Wait for
+    // it to catch up, which covers the snapshot index and all the keys.
     GenericTestUtils.waitFor(() -> {
       return followerOM.getOmRatisServer().getLastAppliedTermIndex().getIndex()
-          >= leaderOMSnapshotIndex - 1;
+          >= leaderCommitted;
     }, 100, 30_000);
 
     long followerOMLastAppliedIndex =
@@ -487,10 +485,12 @@ public class TestOMRatisSnapshots {
 
     // Wait for the follower to finish applying in-flight transactions, so
     // that the TermIndex read below matches what installCheckpoint observes.
-    long leaderAppliedIndex = leaderOM.getOmRatisServer()
-        .getLastAppliedTermIndex().getIndex();
+    // The applied index only advances on double buffer flush, so it can lag
+    // acked writes; the commit index covers them all.
+    long leaderCommitted = leaderOM.getOmRatisServer().getServerDivision()
+        .getRaftLog().getLastCommittedIndex();
     GenericTestUtils.waitFor(() -> followerRatisServer
-        .getLastAppliedTermIndex().getIndex() >= leaderAppliedIndex, 100, 10_000);
+        .getLastAppliedTermIndex().getIndex() >= leaderCommitted, 100, 10_000);
 
     // Install the old checkpoint on the follower OM. This should fail as the
     // followerOM is already ahead of that transactionLogIndex and the OM

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -288,6 +288,10 @@ public class TestOMRatisSnapshots {
     });
     List<String> newKeys = writeFuture.get();
 
+    // A write is acked once queued in the double buffer, but the applied index
+    // advances only after the buffer commits. Flush so it covers all newKeys.
+    leaderOM.awaitDoubleBufferFlush();
+
     // All newKeys writes have completed (writeFuture.get() above), so the
     // leader must already contain them.
     OMMetadataManager leaderOmMetaMgr = leaderOM.getMetadataManager();
@@ -372,6 +376,11 @@ public class TestOMRatisSnapshots {
 
     // Do some transactions so that the log index increases
     List<String> keys = writeKeysToIncreaseLogIndex(leaderRatisServer, 200);
+
+    // A write is acked once queued in the double buffer, but the applied index
+    // advances only after the buffer commits. Flush so the transaction info
+    // read below covers all keys.
+    leaderOM.awaitDoubleBufferFlush();
 
     // Get transaction Index
     TransactionInfo transactionInfo =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Flaky TestOMRatisSnapshots#testInstallSnapshotWithClientWrite: follower may not have all keys when the leader's last applied index is reached

The test starts a stopped follower OM, writes 200 keys while it catches up, waits for the follower to reach the leader, then reads the follower's RocksDB directly to confirm every key arrived. Sometimes the last few keys aren't there yet. That happens because there is a small gap in which a write has already been acked to the client (and committed to the Ratis log) but not yet flushed to RocksDB. The test relies on the leader's lastAppliedTermIndex, which only advances on flush, so the target it hands the follower can sit behind writes that already returned. Previously, a 5-second sleep made the flush all but certain by the time that index was read. HDDS-10310 replaced it with an index-based wait and dropped the per-key sleeps from the write loop, so the writes now outrun the flush and nothing closes the gap, leaving the test to check the follower's DB for keys that are still queued. 
 The waits now target the leader's Ratis commit index, which covers every acked write. Three tests change:

  - testInstallSnapshotWithClientWrite: target was the leader's applied index.
  - testInstallSnapshotWithClientRead: target was the persisted snapshot index. The commit index is captured after the TransactionInfo read, so it is never behind it, and the existing wait can simply be retargeted. leaderOMSnapshotIndex stays in the checkpoint assertions, which is what it is actually for.
  - testInstallOldCheckpointFailure: same wrong target on a wait whose stated goal is "no in-flight transactions left".


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16081

## How was this patch tested?
To reproduce it for sure, a small delay (1 ms) has been added to OzoneManagerDoubleBuffer#flush. The testInstallSnapshotWithClientWrite test fails often in this case.