### PR TITLE
HDDS-11620. Log SCM finalization completion

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
@@ -118,6 +118,7 @@ public class SCMUpgradeFinalizer extends
       createPipelinesAfterFinalization(context);
       stateManager.removeFinalizingMark();
     }
+    logCheckpointCrossed(FinalizationCheckpoint.FINALIZATION_COMPLETE);
   }
 
   private void closePipelinesBeforeFinalization(PipelineManager pipelineManager)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
@@ -53,6 +53,8 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
+import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -231,8 +233,19 @@ public class TestScmFinalization {
 
     // Execute upgrade finalization, then check that events happened in the
     // correct order.
-    StatusAndMessages status =
-        manager.finalizeUpgrade(UUID.randomUUID().toString());
+    LogCapturer logCapturer =
+        LogCapturer.captureLogs(UpgradeFinalizer.class);
+    StatusAndMessages status;
+    try {
+      status = manager.finalizeUpgrade(UUID.randomUUID().toString());
+      String finalizationCompleteLog =
+          "SCM Finalization has crossed checkpoint FINALIZATION_COMPLETE";
+      assertEquals(
+          initialCheckpoint != FinalizationCheckpoint.FINALIZATION_COMPLETE,
+          logCapturer.getOutput().contains(finalizationCompleteLog));
+    } finally {
+      logCapturer.stopCapturing();
+    }
     assertEquals(getStatusFromCheckpoint(initialCheckpoint).status(),
         status.status());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
@@ -19,9 +19,11 @@ package org.apache.hadoop.hdds.scm.upgrade;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.matches;
@@ -31,6 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -67,6 +70,8 @@ import org.slf4j.LoggerFactory;
  * Tests SCM finalization operations on mocked upgrade state.
  */
 public class TestScmFinalization {
+  private static final String FINALIZATION_COMPLETE_LOG =
+      "SCM Finalization has crossed checkpoint FINALIZATION_COMPLETE";
   private static final Logger LOG =
       LoggerFactory.getLogger(TestScmFinalization.class);
 
@@ -238,11 +243,9 @@ public class TestScmFinalization {
     StatusAndMessages status;
     try {
       status = manager.finalizeUpgrade(UUID.randomUUID().toString());
-      String finalizationCompleteLog =
-          "SCM Finalization has crossed checkpoint FINALIZATION_COMPLETE";
       assertEquals(
           initialCheckpoint != FinalizationCheckpoint.FINALIZATION_COMPLETE,
-          logCapturer.getOutput().contains(finalizationCompleteLog));
+          logCapturer.getOutput().contains(FINALIZATION_COMPLETE_LOG));
     } finally {
       logCapturer.stopCapturing();
     }
@@ -307,6 +310,36 @@ public class TestScmFinalization {
 
     // If the initial checkpoint was FINALIZATION_COMPLETE, no mocks should
     // have been invoked.
+  }
+
+  @Test
+  public void testFinalizationCompleteNotLoggedWhenRemovingMarkFails()
+      throws Exception {
+    FinalizationStateManager stateManager = mock(FinalizationStateManager.class);
+    when(stateManager.crossedCheckpoint(
+        FinalizationCheckpoint.FINALIZATION_COMPLETE)).thenReturn(false);
+    doThrow(new IOException("Failed to remove finalizing mark"))
+        .when(stateManager).removeFinalizingMark();
+
+    SCMUpgradeFinalizationContext context =
+        mock(SCMUpgradeFinalizationContext.class);
+    PipelineManager pipelineManager = getMockPipelineManager(
+        FinalizationCheckpoint.MLV_EQUALS_SLV);
+    when(context.getFinalizationStateManager()).thenReturn(stateManager);
+    when(context.getPipelineManager()).thenReturn(pipelineManager);
+    when(context.getSCMContext()).thenReturn(SCMContext.emptyContext());
+
+    SCMUpgradeFinalizer finalizer =
+        new SCMUpgradeFinalizer(mock(HDDSLayoutVersionManager.class));
+    LogCapturer logCapturer = LogCapturer.captureLogs(UpgradeFinalizer.class);
+    try {
+      IOException exception = assertThrows(IOException.class,
+          () -> finalizer.postFinalizeUpgrade(context));
+      assertEquals("Failed to remove finalizing mark", exception.getMessage());
+      assertFalse(logCapturer.getOutput().contains(FINALIZATION_COMPLETE_LOG));
+    } finally {
+      logCapturer.stopCapturing();
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM logs when upgrade finalization crosses the `FINALIZATION_STARTED` and
`MLV_EQUALS_SLV` checkpoints, but it did not log after crossing
`FINALIZATION_COMPLETE`. This made it difficult for operators to determine
from the SCM log whether finalization completed successfully.

This change logs the `FINALIZATION_COMPLETE` checkpoint after the finalizing
marker is removed successfully. It also extends the SCM finalization test to
verify that the completion message is emitted when finalization advances to
the completed state, but not when SCM is already finalized.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11620

## How was this patch tested?

```shell
mvn -pl hadoop-hdds/server-scm -am -Dtest=TestScmFinalization \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipShade -DskipRecon \
  -DskipDocs test
mvn -pl hadoop-hdds/server-scm -DskipTests -DskipShade -DskipRecon \
  -DskipDocs checkstyle:check
```

CI: https://github.com/F64116045/ozone/actions/runs/31136447694
