### PR TITLE
HDDS-16114. Avoid misleading Ozone mount warning in acceptance test results

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/testlib.sh
+++ b/hadoop-ozone/dist/src/main/smoketest/testlib.sh
@@ -30,8 +30,9 @@ run_rebot() {
   #Should be writeable from the docker containers where user is different.
   chmod a+wx "${tempdir}"
   if docker run --rm -v "${input_dir}":/rebot-input -v "${tempdir}":/rebot-output -w /rebot-input \
+      --entrypoint bash \
       $(get_runner_image_spec) \
-      bash -c "rebot --nostatusrc -d /rebot-output $@"; then
+      -c "rebot --nostatusrc -d /rebot-output $@"; then
     mv -v "${tempdir}"/* "${output_dir}"/
   fi
   rmdir "${tempdir}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The acceptance test helper uses the Ozone runner image to combine Robot Framework results with `rebot`.

The runner image's default entrypoint expects Ozone to be mounted at `/opt/hadoop`. Report aggregation does not need that mount, but the entrypoint still emits:

> To use Ozone please mount ozone folder to /opt/hadoop

This change overrides the container entrypoint with `bash` and passes the existing `rebot` command through `-c`. This bypasses the irrelevant mount check while preserving the existing volumes, working directory, command, and output handling.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16114

## How was this patch tested?

Fork CI was run at commit `026dd7ce2ab029da87c023bae532d014a364a51a`:

https://github.com/smengcl/hadoop-ozone/actions/runs/31296676320/attempts/2

All acceptance jobs passed after retry, including:

* [acceptance (tools)](https://github.com/smengcl/hadoop-ozone/actions/runs/31296676320/job/93205423096)
* [acceptance (misc)](https://github.com/smengcl/hadoop-ozone/actions/runs/31296676320/job/93214380319)
* [acceptance (EC)](https://github.com/smengcl/hadoop-ozone/actions/runs/31296676320/job/93214380357)

The complete logs for these jobs confirm that `rebot` generated the combined XML files and final `log.html` and `report.html`. None of the logs contains the `/opt/hadoop` mount warning.

The first attempt had SCM safe-mode startup timeouts in the EC and misc acceptance jobs. Both jobs passed on retry, confirming that those failures were transient and unrelated to this change.

The rerun recorded 42 successful and 2 skipped jobs. The remaining non-green jobs were unrelated integration-test results:

* `integration (om)` failed in `TestOMRatisSnapshots.testInstallSnapshotWithClientWrite` because an expected snapshot was null.
* `integration (flaky)` was cancelled after hanging in `TestBlockOutputStreamWithFailures`.

Generated-by: Codex (GPT-5)
