### PR TITLE
HDDS-16115. Reject invalid lifecycle rule Status values

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneLifecycleConfiguration;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -44,6 +45,9 @@ import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 @XmlRootElement(name = "LifecycleConfiguration",
     namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class S3LifecycleConfiguration {
+  private static final String STATUS_ENABLED = "Enabled";
+  private static final String STATUS_DISABLED = "Disabled";
+
   @XmlElement(name = "Rule")
   private List<Rule> rules = new ArrayList<>();
 
@@ -313,16 +317,16 @@ public class S3LifecycleConfiguration {
    */
   private OmLCRule convertToOmRule(Rule rule) throws OMException, OS3Exception {
     String status = rule.getStatus();
-    if (status == null || status.isEmpty()) {
+    if (StringUtils.isEmpty(status)) {
       throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML,
           "The Status element is required in LifecycleConfiguration");
     }
-    if (!"Enabled".equals(status) && !"Disabled".equals(status)) {
+    if (!STATUS_ENABLED.equals(status) && !STATUS_DISABLED.equals(status)) {
       throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML);
     }
 
     OmLCRule.Builder builder = new OmLCRule.Builder()
-        .setEnabled("Enabled".equals(status))
+        .setEnabled(STATUS_ENABLED.equals(status))
         .setId(rule.getId())
         .setPrefix(rule.getPrefix());
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
@@ -312,13 +312,17 @@ public class S3LifecycleConfiguration {
    * @return OmLCRule internal rule representation
    */
   private OmLCRule convertToOmRule(Rule rule) throws OMException, OS3Exception {
-    if (rule.getStatus() == null || rule.getStatus().isEmpty()) {
+    String status = rule.getStatus();
+    if (status == null || status.isEmpty()) {
       throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML,
           "The Status element is required in LifecycleConfiguration");
     }
+    if (!"Enabled".equals(status) && !"Disabled".equals(status)) {
+      throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML);
+    }
 
     OmLCRule.Builder builder = new OmLCRule.Builder()
-        .setEnabled("Enabled".equals(rule.getStatus()))
+        .setEnabled("Enabled".equals(status))
         .setId(rule.getId())
         .setPrefix(rule.getPrefix());
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
@@ -182,7 +182,7 @@ public class TestS3LifecycleConfigurationPut {
 
   @Test
   public void testPutValidLifecycleConfiguration() throws Exception {
-    assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", onePrefix()).getStatus());
+    assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", withStatus("Enabled")).getStatus());
     assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", withStatus("Disabled")).getStatus());
     assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", emptyPrefix()).getStatus());
     assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", oneTag()).getStatus());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
@@ -56,6 +56,8 @@ import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 /**
@@ -137,6 +139,16 @@ public class TestS3LifecycleConfigurationPut {
     }
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"enabled", "disabled", "invalid"})
+  public void testPutLifecycleConfigurationWithInvalidStatus(String status)
+      throws Exception {
+    OS3Exception ex = assertThrows(OS3Exception.class,
+        () -> bucketEndpoint.put("bucket1", withStatus(status)));
+    assertEquals(HTTP_BAD_REQUEST, ex.getHttpCode());
+    assertEquals(MALFORMED_XML.getCode(), ex.getCode());
+  }
+
   private void testInvalidLifecycleConfiguration(Supplier<InputStream> inputStream,
       int expectedHttpCode, String expectedErrorCode) throws Exception {
     try {
@@ -171,6 +183,7 @@ public class TestS3LifecycleConfigurationPut {
   @Test
   public void testPutValidLifecycleConfiguration() throws Exception {
     assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", onePrefix()).getStatus());
+    assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", withStatus("Disabled")).getStatus());
     assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", emptyPrefix()).getStatus());
     assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", oneTag()).getStatus());
     assertEquals(HTTP_OK, bucketEndpoint.put("bucket1", twoTagsInAndOperator()).getStatus());
@@ -301,6 +314,19 @@ public class TestS3LifecycleConfigurationPut {
         "<Expiration><Days>30</Days></Expiration>" +
         "</Rule>" +
         "</LifecycleConfiguration>");
+    return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static InputStream withStatus(String status) {
+    String xml =
+        "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+            "<Rule>" +
+            "<ID>remove logs after 30 days</ID>" +
+            "<Prefix>prefix/</Prefix>" +
+            "<Status>" + status + "</Status>" +
+            "<Expiration><Days>30</Days></Expiration>" +
+            "</Rule>" +
+            "</LifecycleConfiguration>";
     return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

According to the [Amazon S3 LifecycleRule API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html), lifecycle rule `Status` is required and only accepts the exact values `Enabled` or `Disabled`. This behavior is covered by [`test_lifecycle_invalid_status`](https://github.com/ceph/s3-tests/blob/fb8b73092bb1dd8db829f1205a9e52e73bf9a232/s3tests/functional/test_s3.py#L9013-L9038) in ceph/s3-tests.

S3 Gateway previously checked only whether `Status` was missing or empty. It then converted the value using `"Enabled".equals(status)`, causing every other non-empty value, including `enabled`, `disabled`, and `invalid`, to be accepted and interpreted as a disabled rule.

This pull request validates `Status` against the two values defined by Amazon S3 before converting the lifecycle rule. Parameterized tests cover invalid values, while the valid path explicitly verifies both `Enabled` and `Disabled`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16115

## How was this patch tested?

```shell
mvn -pl hadoop-ozone/s3gateway -DskipDocs=true -DskipShade \
  -Dtest=TestS3LifecycleConfigurationPut test
```
```shell
mvn -pl hadoop-ozone/s3gateway -DskipDocs=true -DskipShade test
```
Ceph S3 compatibility test against a locally built packaged Ozone cluster:
```shell
S3TEST_CONF=<path-to-s3tests.conf> python -m pytest -v \
  s3tests/functional/test_s3.py::test_lifecycle_invalid_status
```
CI: https://github.com/F64116045/ozone/actions/runs/31442942005