### PR TITLE
HDDS-16088. Reject lifecycle AbortIncompleteMultipartUpload rules whose daysAfterInitiation exceeds the MPU cleanup threshold

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1553,7 +1553,7 @@
 
       Interaction with S3 lifecycle AbortIncompleteMultipartUpload rules:
       When a bucket lifecycle rule specifies an AbortIncompleteMultipartUpload action, its
-      daysAfterInitiation value must be strictly not greater than this threshold (in days). If
+      daysAfterInitiation value must be strictly less than this threshold. If
       daysAfterInitiation is greater than or equal to this threshold, MultipartUploadCleanupService
       will abort the upload before the lifecycle rule fires, silently making the rule ineffective.
       Ozone enforces this constraint at lifecycle configuration creation time and will reject

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1553,7 +1553,7 @@
 
       Interaction with S3 lifecycle AbortIncompleteMultipartUpload rules:
       When a bucket lifecycle rule specifies an AbortIncompleteMultipartUpload action, its
-      daysAfterInitiation value must be strictly less than this threshold (in days). If
+      daysAfterInitiation value must be strictly not greater than this threshold (in days). If
       daysAfterInitiation is greater than or equal to this threshold, MultipartUploadCleanupService
       will abort the upload before the lifecycle rule fires, silently making the rule ineffective.
       Ozone enforces this constraint at lifecycle configuration creation time and will reject

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1546,9 +1546,19 @@
     <value>30d</value>
     <tag>OZONE, OM, PERFORMANCE</tag>
     <description>
-      Controls how long multipart upload is considered active. Specifically, if a multipart info
-      has been ongoing longer than the value of this config entry, that multipart info is considered as
-      expired (e.g. due to client crash). Unit could be defined with postfix (ns,ms,s,m,h,d)
+      Controls how long a multipart upload is considered active before MultipartUploadCleanupService
+      treats it as stale and aborts it. If a multipart upload has been ongoing longer than this
+      threshold (e.g. due to a client crash), it will be cleaned up automatically.
+      Unit can be specified with a postfix (ns, ms, s, m, h, d).
+
+      Interaction with S3 lifecycle AbortIncompleteMultipartUpload rules:
+      When a bucket lifecycle rule specifies an AbortIncompleteMultipartUpload action, its
+      daysAfterInitiation value must be strictly less than this threshold (in days). If
+      daysAfterInitiation is greater than or equal to this threshold, MultipartUploadCleanupService
+      will abort the upload before the lifecycle rule fires, silently making the rule ineffective.
+      Ozone enforces this constraint at lifecycle configuration creation time and will reject
+      configurations that violate it. To use a longer daysAfterInitiation value, increase this
+      threshold accordingly.
     </description>
   </property>
 

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -2281,7 +2281,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
         .withPrefix("")
         .withStatus(BucketLifecycleConfiguration.ENABLED);
     rule3.setAbortIncompleteMultipartUpload(
-        new AbortIncompleteMultipartUpload().withDaysAfterInitiation(30));
+        new AbortIncompleteMultipartUpload().withDaysAfterInitiation(29));
 
     rules.add(rule1);
     rules.add(rule2);
@@ -2313,7 +2313,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     assertEquals("abort-incomplete-mpu-no-prefix", retrievedRule3.getId());
     assertEquals("", retrievedRule3.getPrefix());
     assertEquals(BucketLifecycleConfiguration.ENABLED, retrievedRule3.getStatus());
-    assertEquals(30, retrievedRule3.getAbortIncompleteMultipartUpload().getDaysAfterInitiation());
+    assertEquals(29, retrievedRule3.getAbortIncompleteMultipartUpload().getDaysAfterInitiation());
   }
 
   /**

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -2393,7 +2393,7 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
         .prefix("")
         .status(ExpirationStatus.ENABLED)
         .abortIncompleteMultipartUpload(AbortIncompleteMultipartUpload.builder()
-            .daysAfterInitiation(30)
+            .daysAfterInitiation(29)
             .build())
         .build();
 
@@ -2438,7 +2438,7 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     assertEquals("abort-incomplete-mpu-no-filter", retrievedRule4.id());
     assertEquals("", retrievedRule4.prefix());
     assertEquals(ExpirationStatus.ENABLED, retrievedRule4.status());
-    assertEquals(30, retrievedRule4.abortIncompleteMultipartUpload().daysAfterInitiation());
+    assertEquals(29, retrievedRule4.abortIncompleteMultipartUpload().daysAfterInitiation());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleConfigurationSetRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleConfigurationSetRequest.java
@@ -222,13 +222,17 @@ public class OMLifecycleConfigurationSetRequest extends OMClientRequest {
         OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD,
         OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT,
         TimeUnit.MILLISECONDS);
-    long expireThresholdDays = TimeUnit.MILLISECONDS.toDays(expireThresholdMillis);
 
     for (LifecycleRule rule : config.getRulesList()) {
+      if (!rule.getEnabled()) {
+        continue;
+      }
       for (LifecycleAction action : rule.getActionList()) {
         if (action.hasAbortIncompleteMultipartUpload()) {
           int daysAfterInitiation = action.getAbortIncompleteMultipartUpload().getDaysAfterInitiation();
-          if (daysAfterInitiation >= expireThresholdDays) {
+          long daysAfterInitiationMillis = TimeUnit.DAYS.toMillis(daysAfterInitiation);
+          if (daysAfterInitiationMillis >= expireThresholdMillis) {
+            long expireThresholdDays = TimeUnit.MILLISECONDS.toDays(expireThresholdMillis);
             throw new OMException(
                 "Invalid lifecycle configuration: rule '" + rule.getId() + "' has an " +
                 "AbortIncompleteMultipartUpload action with daysAfterInitiation=" + daysAfterInitiation +
@@ -238,7 +242,7 @@ public class OMLifecycleConfigurationSetRequest extends OMClientRequest {
                 ozoneManager.getConfiguration().get(
                     OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD,
                     OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT) +
-                "). The MultipartUploadCleanupService will abort the upload before the " +
+                "). The MultipartUploadCleanupService will clean up the upload before the " +
                 "lifecycle rule fires, making the rule ineffective. " +
                 "Set daysAfterInitiation to a value less than " + expireThresholdDays +
                 " day(s), or increase " + OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD + ".",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleConfigurationSetRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleConfigurationSetRequest.java
@@ -232,20 +232,18 @@ public class OMLifecycleConfigurationSetRequest extends OMClientRequest {
           int daysAfterInitiation = action.getAbortIncompleteMultipartUpload().getDaysAfterInitiation();
           long daysAfterInitiationMillis = TimeUnit.DAYS.toMillis(daysAfterInitiation);
           if (daysAfterInitiationMillis >= expireThresholdMillis) {
-            long expireThresholdDays = TimeUnit.MILLISECONDS.toDays(expireThresholdMillis);
+            String expireThresholdConfig = ozoneManager.getConfiguration().get(
+                OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD,
+                OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT);
             throw new OMException(
                 "Invalid lifecycle configuration: rule '" + rule.getId() + "' has an " +
                 "AbortIncompleteMultipartUpload action with daysAfterInitiation=" + daysAfterInitiation +
-                " day(s), which is greater than or equal to the cluster MPU expire threshold " +
-                expireThresholdDays + " day(s) (" +
-                OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD + "=" +
-                ozoneManager.getConfiguration().get(
-                    OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD,
-                    OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT) +
+                " day(s), which is not less than the cluster MPU expire threshold (" +
+                OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD + "=" + expireThresholdConfig +
                 "). The MultipartUploadCleanupService will clean up the upload before the " +
                 "lifecycle rule fires, making the rule ineffective. " +
-                "Set daysAfterInitiation to a value less than " + expireThresholdDays +
-                " day(s), or increase " + OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD + ".",
+                "Set daysAfterInitiation to a value less than " + expireThresholdConfig +
+                ", or increase " + OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD + ".",
                 OMException.ResultCodes.INVALID_REQUEST);
           }
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleConfigurationSetRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleConfigurationSetRequest.java
@@ -23,12 +23,14 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.B
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
@@ -44,7 +46,9 @@ import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.lifecycle.OMLifecycleConfigurationSetResponse;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LifecycleAction;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LifecycleConfiguration;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LifecycleRule;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetLifecycleConfigurationRequest;
@@ -92,10 +96,12 @@ public class OMLifecycleConfigurationSetRequest extends OMClientRequest {
 
     if (resolvedBucket.bucketLayout().toProto() != request.getLifecycleConfiguration().getBucketLayout()) {
       throw new OMException("Bucket layout mismatch: requested lifecycle configuration " +
-          "has bucket layout " + request.getLifecycleConfiguration().getBucketLayout() + 
+          "has bucket layout " + request.getLifecycleConfiguration().getBucketLayout() +
           " but the actual bucket has layout " + resolvedBucket.bucketLayout().toProto(),
           OMException.ResultCodes.INVALID_REQUEST);
     }
+
+    validateAbortMpuDaysAgainstCleanupThreshold(ozoneManager, lifecycleConfiguration);
 
     SetLifecycleConfigurationRequest.Builder newCreateRequest =
         request.toBuilder();
@@ -200,6 +206,46 @@ public class OMLifecycleConfigurationSetRequest extends OMClientRequest {
       LOG.error("Lifecycle configuration creation failed for bucket:{} " +
           "in volume:{}", bucketName, volumeName, exception);
       return omClientResponse;
+    }
+  }
+
+  /**
+   * Rejects lifecycle configurations where an AbortIncompleteMultipartUpload rule's
+   * daysAfterInitiation is greater than or equal to the cluster-wide MPU expire threshold
+   * (ozone.om.open.mpu.expire.threshold). When that happens, MultipartUploadCleanupService
+   * will reap the upload before the lifecycle rule ever fires, silently making the rule
+   * ineffective. Failing fast here surfaces the misconfiguration to the operator.
+   */
+  private static void validateAbortMpuDaysAgainstCleanupThreshold(
+      OzoneManager ozoneManager, LifecycleConfiguration config) throws OMException {
+    long expireThresholdMillis = ozoneManager.getConfiguration().getTimeDuration(
+        OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD,
+        OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT,
+        TimeUnit.MILLISECONDS);
+    long expireThresholdDays = TimeUnit.MILLISECONDS.toDays(expireThresholdMillis);
+
+    for (LifecycleRule rule : config.getRulesList()) {
+      for (LifecycleAction action : rule.getActionList()) {
+        if (action.hasAbortIncompleteMultipartUpload()) {
+          int daysAfterInitiation = action.getAbortIncompleteMultipartUpload().getDaysAfterInitiation();
+          if (daysAfterInitiation >= expireThresholdDays) {
+            throw new OMException(
+                "Invalid lifecycle configuration: rule '" + rule.getId() + "' has an " +
+                "AbortIncompleteMultipartUpload action with daysAfterInitiation=" + daysAfterInitiation +
+                " day(s), which is greater than or equal to the cluster MPU expire threshold " +
+                expireThresholdDays + " day(s) (" +
+                OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD + "=" +
+                ozoneManager.getConfiguration().get(
+                    OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD,
+                    OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT) +
+                "). The MultipartUploadCleanupService will abort the upload before the " +
+                "lifecycle rule fires, making the rule ineffective. " +
+                "Set daysAfterInitiation to a value less than " + expireThresholdDays +
+                " day(s), or increase " + OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD + ".",
+                OMException.ResultCodes.INVALID_REQUEST);
+          }
+        }
+      }
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleConfigurationRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleConfigurationRequest.java
@@ -159,6 +159,15 @@ public class TestOMLifecycleConfigurationRequest {
    */
   public OMRequest setLifecycleConfigurationRequestWithAbortMpu(
       String volumeName, String bucketName, int daysAfterInitiation) {
+    return setLifecycleConfigurationRequestWithAbortMpu(volumeName, bucketName, daysAfterInitiation, true);
+  }
+
+  /**
+   * Builds a SetLifecycleConfiguration request with a single AbortIncompleteMultipartUpload rule,
+   * with configurable enabled state.
+   */
+  public OMRequest setLifecycleConfigurationRequestWithAbortMpu(
+      String volumeName, String bucketName, int daysAfterInitiation, boolean enabled) {
     LifecycleConfiguration lcc = LifecycleConfiguration.newBuilder()
         .setBucketLayout(BucketLayoutProto.OBJECT_STORE)
         .setCreationTime(System.currentTimeMillis())
@@ -166,7 +175,7 @@ public class TestOMLifecycleConfigurationRequest {
         .setBucket(bucketName)
         .addRules(LifecycleRule.newBuilder()
             .setId(RandomStringUtils.randomAlphabetic(32))
-            .setEnabled(true)
+            .setEnabled(enabled)
             .addAction(LifecycleAction.newBuilder()
                 .setAbortIncompleteMultipartUpload(
                     AbortIncompleteMultipartUpload.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleConfigurationRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleConfigurationRequest.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AbortIncompleteMultipartUpload;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketLayoutProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteLifecycleConfigurationRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LifecycleAction;
@@ -66,14 +67,16 @@ public class TestOMLifecycleConfigurationRequest {
   protected OMMetrics omMetrics;
   protected OMMetadataManager omMetadataManager;
   protected AuditLogger auditLogger;
+  protected OzoneConfiguration ozoneConfiguration;
 
   @BeforeEach
   public void setup() throws Exception {
     ozoneManager = mock(OzoneManager.class);
-    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration = new OzoneConfiguration();
     omMetrics = OMMetrics.create(ozoneConfiguration);
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS, tempDir.getAbsolutePath());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, ozoneManager);
+    when(ozoneManager.getConfiguration()).thenReturn(ozoneConfiguration);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     when(ozoneManager.getMaxUserVolumeCount()).thenReturn(10L);
@@ -146,6 +149,37 @@ public class TestOMLifecycleConfigurationRequest {
 
     return OMRequest.newBuilder().setSetLifecycleConfigurationRequest(
             setLifecycleConfigurationRequest)
+        .setCmdType(Type.SetLifecycleConfiguration)
+        .setClientId(UUID.randomUUID().toString())
+        .build();
+  }
+
+  /**
+   * Builds a SetLifecycleConfiguration request with a single AbortIncompleteMultipartUpload rule.
+   */
+  public OMRequest setLifecycleConfigurationRequestWithAbortMpu(
+      String volumeName, String bucketName, int daysAfterInitiation) {
+    LifecycleConfiguration lcc = LifecycleConfiguration.newBuilder()
+        .setBucketLayout(BucketLayoutProto.OBJECT_STORE)
+        .setCreationTime(System.currentTimeMillis())
+        .setVolume(volumeName)
+        .setBucket(bucketName)
+        .addRules(LifecycleRule.newBuilder()
+            .setId(RandomStringUtils.randomAlphabetic(32))
+            .setEnabled(true)
+            .addAction(LifecycleAction.newBuilder()
+                .setAbortIncompleteMultipartUpload(
+                    AbortIncompleteMultipartUpload.newBuilder()
+                        .setDaysAfterInitiation(daysAfterInitiation)
+                        .build()))
+            .setFilter(LifecycleFilter.newBuilder().setPrefix("prefix/")))
+        .build();
+
+    return OMRequest.newBuilder()
+        .setSetLifecycleConfigurationRequest(
+            SetLifecycleConfigurationRequest.newBuilder()
+                .setLifecycleConfiguration(lcc)
+                .build())
         .setCmdType(Type.SetLifecycleConfiguration)
         .setClientId(UUID.randomUUID().toString())
         .build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleConfigurationSetRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleConfigurationSetRequest.java
@@ -436,4 +436,18 @@ public class TestOMLifecycleConfigurationSetRequest extends
     OMRequest result = setRequest.preExecute(ozoneManager);
     assertNotNull(result);
   }
+
+  @Test
+  public void testPreExecuteSkipsDisabledAbortMpuRule() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    // daysAfterInitiation == 60 would normally be rejected, but the rule is disabled.
+    OMRequest request = setLifecycleConfigurationRequestWithAbortMpu(volumeName, bucketName, 60, false);
+    OMLifecycleConfigurationSetRequest setRequest =
+        new OMLifecycleConfigurationSetRequest(request);
+
+    // Disabled rules must not trigger the threshold check.
+    OMRequest result = setRequest.preExecute(ozoneManager);
+    assertNotNull(result);
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleConfigurationSetRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleConfigurationSetRequest.java
@@ -34,7 +34,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -386,5 +388,52 @@ public class TestOMLifecycleConfigurationSetRequest extends
         .disallowSetLifecycleConfigurationBeforeFinalization(request, ctx);
 
     assertEquals(request, result);
+  }
+
+  @Test
+  public void testPreExecuteRejectsAbortMpuDaysEqualToExpireThreshold() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    // Default threshold is 30d; requesting daysAfterInitiation == 30 must be rejected.
+    long thresholdDays = TimeUnit.MILLISECONDS.toDays(
+        ozoneConfiguration.getTimeDuration(
+            OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD,
+            OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT,
+            TimeUnit.MILLISECONDS));
+
+    OMRequest request = setLifecycleConfigurationRequestWithAbortMpu(
+        volumeName, bucketName, (int) thresholdDays);
+    OMLifecycleConfigurationSetRequest setRequest =
+        new OMLifecycleConfigurationSetRequest(request);
+
+    OMException ex = assertThrows(OMException.class, () -> setRequest.preExecute(ozoneManager));
+    assertEquals(OMException.ResultCodes.INVALID_REQUEST, ex.getResult());
+  }
+
+  @Test
+  public void testPreExecuteRejectsAbortMpuDaysGreaterThanExpireThreshold() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    // Default threshold is 30d; requesting daysAfterInitiation == 60 must be rejected.
+    OMRequest request = setLifecycleConfigurationRequestWithAbortMpu(volumeName, bucketName, 60);
+    OMLifecycleConfigurationSetRequest setRequest =
+        new OMLifecycleConfigurationSetRequest(request);
+
+    OMException ex = assertThrows(OMException.class, () -> setRequest.preExecute(ozoneManager));
+    assertEquals(OMException.ResultCodes.INVALID_REQUEST, ex.getResult());
+  }
+
+  @Test
+  public void testPreExecuteAcceptsAbortMpuDaysLessThanExpireThreshold() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    // Default threshold is 30d; requesting daysAfterInitiation == 7 must be accepted.
+    OMRequest request = setLifecycleConfigurationRequestWithAbortMpu(volumeName, bucketName, 7);
+    OMLifecycleConfigurationSetRequest setRequest =
+        new OMLifecycleConfigurationSetRequest(request);
+
+    // preExecute must succeed without throwing.
+    OMRequest result = setRequest.preExecute(ozoneManager);
+    assertNotNull(result);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ozone's `MultipartUploadCleanupService` periodically reaps multipart uploads that have been active longer than `ozone.om.open.mpu.expire.threshold` (default: 30 days). When a bucket lifecycle rule sets an
`AbortIncompleteMultipartUpload` action with a `daysAfterInitiation` value **greater than or equal to** that threshold, the cleanup service will abort the upload first, silently making the lifecycle rule ineffective. The operator receives no feedback that the configured rule can never fire.

This patch adds eager validation in `OMLifecycleConfigurationSetRequest.preExecute` that rejects any `AbortIncompleteMultipartUpload` lifecycle rule whose `daysAfterInitiation >= ozone.om.open.mpu.expire.threshold` (converted to days) with an `INVALID_REQUEST` error.

## What is the link to the Apache JIRA
HDDS-16088

## How was this patch tested?
Tested via integration tests.