### PR TITLE
HDDS-16119. Fix DatanodeStorageMetrics metrics-system deadlock and mini-cluster source leak

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DatanodeStorageMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DatanodeStorageMetrics.java
@@ -34,6 +34,9 @@ import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
  * This is the same scope as the {@code storageReport} entries produced by
  * {@code OzoneContainer.getNodeReport()}; meta and DB volumes are excluded.
  * Registered as {@code Hadoop:service=HddsDatanode,name=DatanodeStorageMetrics}.
+ * In mini-cluster mode, where many datanodes share one metrics system, the name
+ * is suffixed with the datanode UUID ({@code DatanodeStorageMetrics-<uuid>}) so
+ * registration and unregistration stay unique per datanode.
  */
 @Metrics(about = "Ozone DataNode node-level storage totals",
     context = OzoneConsts.OZONE)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DatanodeStorageMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DatanodeStorageMetrics.java
@@ -58,19 +58,9 @@ public final class DatanodeStorageMetrics implements MetricsSource {
   private final MutableVolumeSet volumeSet;
   private final String sourceName;
 
-  private DatanodeStorageMetrics(MutableVolumeSet volumeSet) {
+  private DatanodeStorageMetrics(MutableVolumeSet volumeSet, String sourceName) {
     this.volumeSet = volumeSet;
-    // In mini-cluster mode many datanodes share one metrics system, so the
-    // metrics system uniquifies the constant source name on registration
-    // (DatanodeStorageMetrics-1, -2, ...). Unregistering by the constant base
-    // name would then leak every source past the first, and each leaked source
-    // pins a shut-down datanode's MutableVolumeSet. Make the name unique per
-    // datanode up front so register and unregister stay symmetric. In
-    // production there is one instance per JVM, so keep the plain name for
-    // stable JMX and Prometheus metric names.
-    this.sourceName = DefaultMetricsSystem.inMiniClusterMode()
-        ? SOURCE_NAME + '-' + volumeSet.getDatanodeUuid()
-        : SOURCE_NAME;
+    this.sourceName = sourceName;
     this.registry = new MetricsRegistry(sourceName);
   }
 
@@ -79,8 +69,19 @@ public final class DatanodeStorageMetrics implements MetricsSource {
    * with the default Metrics2 system.
    */
   public static DatanodeStorageMetrics create(MutableVolumeSet volumeSet) {
-    DatanodeStorageMetrics datanodeStorageMetrics = new DatanodeStorageMetrics(volumeSet);
-    DefaultMetricsSystem.instance().register(datanodeStorageMetrics.sourceName,
+    // In mini-cluster mode many datanodes share one metrics system, so the
+    // metrics system uniquifies the constant source name on registration
+    // (DatanodeStorageMetrics-1, -2, ...). Unregistering by the constant base
+    // name would then leak every source past the first, and each leaked source
+    // pins a shut-down datanode's MutableVolumeSet. Make the name unique per
+    // datanode up front so register and unregister stay symmetric. In
+    // production there is one instance per JVM, so keep the plain name for
+    // stable JMX and Prometheus metric names.
+    String sourceName = DefaultMetricsSystem.inMiniClusterMode()
+        ? SOURCE_NAME + '-' + volumeSet.getDatanodeUuid()
+        : SOURCE_NAME;
+    DatanodeStorageMetrics datanodeStorageMetrics = new DatanodeStorageMetrics(volumeSet, sourceName);
+    DefaultMetricsSystem.instance().register(sourceName,
         "DataNode node-level storage totals", datanodeStorageMetrics);
     return datanodeStorageMetrics;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DatanodeStorageMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DatanodeStorageMetrics.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
 
 /**
  * Node-level storage totals for a DataNode, aggregated over its HDDS data volumes only
- * ({@code VolumeType.DATA_VOLUME}) via {@link MutableVolumeSet#getStorageReport()}.
+ * ({@code VolumeType.DATA_VOLUME}) via {@link MutableVolumeSet#getStorageReportSnapshot()}.
  * This is the same scope as the {@code storageReport} entries produced by
  * {@code OzoneContainer.getNodeReport()}; meta and DB volumes are excluded.
  * Registered as {@code Hadoop:service=HddsDatanode,name=DatanodeStorageMetrics}.
@@ -53,10 +53,22 @@ public final class DatanodeStorageMetrics implements MetricsSource {
 
   private final MetricsRegistry registry;
   private final MutableVolumeSet volumeSet;
+  private final String sourceName;
 
   private DatanodeStorageMetrics(MutableVolumeSet volumeSet) {
     this.volumeSet = volumeSet;
-    this.registry = new MetricsRegistry(SOURCE_NAME);
+    // In mini-cluster mode many datanodes share one metrics system, so the
+    // metrics system uniquifies the constant source name on registration
+    // (DatanodeStorageMetrics-1, -2, ...). Unregistering by the constant base
+    // name would then leak every source past the first, and each leaked source
+    // pins a shut-down datanode's MutableVolumeSet. Make the name unique per
+    // datanode up front so register and unregister stay symmetric. In
+    // production there is one instance per JVM, so keep the plain name for
+    // stable JMX and Prometheus metric names.
+    this.sourceName = DefaultMetricsSystem.inMiniClusterMode()
+        ? SOURCE_NAME + '-' + volumeSet.getDatanodeUuid()
+        : SOURCE_NAME;
+    this.registry = new MetricsRegistry(sourceName);
   }
 
   /**
@@ -65,8 +77,8 @@ public final class DatanodeStorageMetrics implements MetricsSource {
    */
   public static DatanodeStorageMetrics create(MutableVolumeSet volumeSet) {
     DatanodeStorageMetrics datanodeStorageMetrics = new DatanodeStorageMetrics(volumeSet);
-    DefaultMetricsSystem.instance().register(
-        SOURCE_NAME, "DataNode node-level storage totals", datanodeStorageMetrics);
+    DefaultMetricsSystem.instance().register(datanodeStorageMetrics.sourceName,
+        "DataNode node-level storage totals", datanodeStorageMetrics);
     return datanodeStorageMetrics;
   }
 
@@ -74,7 +86,7 @@ public final class DatanodeStorageMetrics implements MetricsSource {
    * Unregisters this source from the Metrics2 system.
    */
   public void unregister() {
-    DefaultMetricsSystem.instance().unregisterSource(SOURCE_NAME);
+    DefaultMetricsSystem.instance().unregisterSource(sourceName);
   }
 
   /**
@@ -83,12 +95,17 @@ public final class DatanodeStorageMetrics implements MetricsSource {
    */
   @Override
   public void getMetrics(MetricsCollector collector, boolean all) {
-    MetricsRecordBuilder builder = collector.addRecord(SOURCE_NAME);
+    MetricsRecordBuilder builder = collector.addRecord(sourceName);
     registry.snapshot(builder, all);
 
     long capacity = 0L;
     long used = 0L;
-    for (StorageLocationReport report : volumeSet.getStorageReport()) {
+    // getMetrics() runs while the DefaultMetricsSystem monitor is held. Read a
+    // lock-free snapshot instead of getStorageReport(), which takes the
+    // volume-set lock: a volume-failure handler holds that lock while
+    // unregistering volume metrics (which needs the same monitor), so locking
+    // here can deadlock the metrics system.
+    for (StorageLocationReport report : volumeSet.getStorageReportSnapshot()) {
       capacity = Math.addExact(capacity, report.getCapacity());
       used = Math.addExact(used, report.getScmUsed());
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -21,7 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -446,16 +446,12 @@ public class MutableVolumeSet implements VolumeSet {
    * deadlock the whole metrics system.
    */
   public StorageLocationReport[] getStorageReportSnapshot() {
-    // No lock is held, so the map sizes can change concurrently; collect into a
-    // list instead of indexing into a pre-sized array.
-    List<StorageLocationReport> reports = new ArrayList<>(volumeMap.size() + failedVolumeMap.size());
-    for (StorageVolume volume : volumeMap.values()) {
-      reports.add(volume.getReport());
-    }
-    for (StorageVolume volume : failedVolumeMap.values()) {
-      reports.add(volume.getReport());
-    }
-    return reports.toArray(new StorageLocationReport[0]);
+    // volumeMap and failedVolumeMap are ConcurrentHashMaps; their value streams
+    // are weakly consistent, so no lock is needed here (same guarantee as
+    // getVolumesList()).
+    return Stream.concat(volumeMap.values().stream(), failedVolumeMap.values().stream())
+        .map(StorageVolume::getReport)
+        .toArray(StorageLocationReport[]::new);
   }
 
   public String getDatanodeUuid() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -407,18 +408,42 @@ public class MutableVolumeSet implements VolumeSet {
   public StorageLocationReport[] getStorageReport() {
     this.readLock();
     try {
-      StorageLocationReport[] reports = new StorageLocationReport[volumeMap.size() + failedVolumeMap.size()];
-      int counter = 0;
-      for (StorageVolume volume : volumeMap.values()) {
-        reports[counter++] = volume.getReport();
-      }
-      for (StorageVolume volume : failedVolumeMap.values()) {
-        reports[counter++] = volume.getReport();
-      }
-      return reports;
+      return buildStorageReport();
     } finally {
       this.readUnlock();
     }
+  }
+
+  /**
+   * Lock-free variant of {@link #getStorageReport()}. Both {@code volumeMap}
+   * and {@code failedVolumeMap} are {@link ConcurrentHashMap}s, so this returns
+   * a weakly-consistent snapshot (mirroring {@link #getVolumesList()}) without
+   * acquiring the volume-set lock.
+   *
+   * <p>Use this from callers that must not block on the volume-set lock. In
+   * particular, metrics sampling runs while the {@code DefaultMetricsSystem}
+   * monitor is held, and a volume-failure handler holds the volume-set write
+   * lock while unregistering volume metrics (which needs that same monitor);
+   * acquiring the volume-set lock from the sampling thread can therefore
+   * deadlock the whole metrics system.
+   */
+  public StorageLocationReport[] getStorageReportSnapshot() {
+    return buildStorageReport();
+  }
+
+  private StorageLocationReport[] buildStorageReport() {
+    List<StorageLocationReport> reports = new ArrayList<>(volumeMap.size() + failedVolumeMap.size());
+    for (StorageVolume volume : volumeMap.values()) {
+      reports.add(volume.getReport());
+    }
+    for (StorageVolume volume : failedVolumeMap.values()) {
+      reports.add(volume.getReport());
+    }
+    return reports.toArray(new StorageLocationReport[0]);
+  }
+
+  public String getDatanodeUuid() {
+    return datanodeUuid;
   }
 
   public StorageVolume.VolumeType getVolumeType() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -408,7 +408,15 @@ public class MutableVolumeSet implements VolumeSet {
   public StorageLocationReport[] getStorageReport() {
     this.readLock();
     try {
-      return buildStorageReport();
+      StorageLocationReport[] reports = new StorageLocationReport[volumeMap.size() + failedVolumeMap.size()];
+      int counter = 0;
+      for (StorageVolume volume : volumeMap.values()) {
+        reports[counter++] = volume.getReport();
+      }
+      for (StorageVolume volume : failedVolumeMap.values()) {
+        reports[counter++] = volume.getReport();
+      }
+      return reports;
     } finally {
       this.readUnlock();
     }
@@ -428,10 +436,8 @@ public class MutableVolumeSet implements VolumeSet {
    * deadlock the whole metrics system.
    */
   public StorageLocationReport[] getStorageReportSnapshot() {
-    return buildStorageReport();
-  }
-
-  private StorageLocationReport[] buildStorageReport() {
+    // No lock is held, so the map sizes can change concurrently; collect into a
+    // list instead of indexing into a pre-sized array.
     List<StorageLocationReport> reports = new ArrayList<>(volumeMap.size() + failedVolumeMap.size());
     for (StorageVolume volume : volumeMap.values()) {
       reports.add(volume.getReport());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -405,6 +405,16 @@ public class MutableVolumeSet implements VolumeSet {
     return hasEnoughVolumes;
   }
 
+  /**
+   * Returns a consistent snapshot of the storage reports under the volume-set
+   * read lock.
+   *
+   * <p>Do not call this from metrics collection (or any caller that may hold the
+   * {@code DefaultMetricsSystem} monitor): a volume-failure handler holds the
+   * volume-set write lock while unregistering volume metrics under that same
+   * monitor, so taking the read lock here can deadlock the metrics system. Use
+   * {@link #getStorageReportSnapshot()} from those paths instead.
+   */
   public StorageLocationReport[] getStorageReport() {
     this.readLock();
     try {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDatanodeStorageMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDatanodeStorageMetrics.java
@@ -21,9 +21,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.UUID;
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.metrics2.impl.MetricsRecordImpl;
+import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +54,7 @@ class TestDatanodeStorageMetrics {
         .build();
 
     MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
-    when(volumeSet.getStorageReport())
+    when(volumeSet.getStorageReportSnapshot())
         .thenReturn(new StorageLocationReport[]{vol1, vol2});
 
     DatanodeStorageMetrics metrics = DatanodeStorageMetrics.create(volumeSet);
@@ -78,7 +81,7 @@ class TestDatanodeStorageMetrics {
   void testZeroCapacityReturnsZeroPercentage() {
     // No volumes → capacity=0, used=0; OzoneUsedPercentage must be 0.0, not NaN.
     MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
-    when(volumeSet.getStorageReport()).thenReturn(new StorageLocationReport[0]);
+    when(volumeSet.getStorageReportSnapshot()).thenReturn(new StorageLocationReport[0]);
 
     DatanodeStorageMetrics metrics = DatanodeStorageMetrics.create(volumeSet);
     try {
@@ -92,6 +95,42 @@ class TestDatanodeStorageMetrics {
     } finally {
       metrics.unregister();
     }
+  }
+
+  @Test
+  void testNoSourceLeakInMiniClusterMode() {
+    // In mini-cluster mode many datanodes share one metrics system. Register
+    // and unregister must be symmetric so no source (and its pinned volume set)
+    // leaks. The pre-fix code registered a constant name (uniquified to -N) but
+    // unregistered the base name, leaking every datanode past the first.
+    boolean prev = DefaultMetricsSystem.inMiniClusterMode();
+    DefaultMetricsSystem.setMiniClusterMode(true);
+    try {
+      MetricsSystemImpl ms = (MetricsSystemImpl) DefaultMetricsSystem.instance();
+      String uuidA = "dn-" + UUID.randomUUID();
+      String uuidB = "dn-" + UUID.randomUUID();
+      String nameA = DatanodeStorageMetrics.SOURCE_NAME + '-' + uuidA;
+      String nameB = DatanodeStorageMetrics.SOURCE_NAME + '-' + uuidB;
+
+      DatanodeStorageMetrics a = DatanodeStorageMetrics.create(mockVolumeSet(uuidA));
+      DatanodeStorageMetrics b = DatanodeStorageMetrics.create(mockVolumeSet(uuidB));
+      assertThat(ms.getSource(nameA)).isNotNull();
+      assertThat(ms.getSource(nameB)).isNotNull();
+
+      a.unregister();
+      b.unregister();
+      assertThat(ms.getSource(nameA)).isNull();
+      assertThat(ms.getSource(nameB)).isNull();
+    } finally {
+      DefaultMetricsSystem.setMiniClusterMode(prev);
+    }
+  }
+
+  private static MutableVolumeSet mockVolumeSet(String datanodeUuid) {
+    MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
+    when(volumeSet.getDatanodeUuid()).thenReturn(datanodeUuid);
+    when(volumeSet.getStorageReportSnapshot()).thenReturn(new StorageLocationReport[0]);
+    return volumeSet;
   }
 
   private static long findLong(Iterable<AbstractMetric> metrics, String name) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDatanodeStorageMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDatanodeStorageMetrics.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 import org.apache.hadoop.metrics2.AbstractMetric;
+import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.metrics2.impl.MetricsRecordImpl;
-import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
 import org.junit.jupiter.api.Test;
@@ -105,15 +105,16 @@ class TestDatanodeStorageMetrics {
     // unregistered the base name, leaking every datanode past the first.
     boolean prev = DefaultMetricsSystem.inMiniClusterMode();
     DefaultMetricsSystem.setMiniClusterMode(true);
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    String uuidA = "dn-" + UUID.randomUUID();
+    String uuidB = "dn-" + UUID.randomUUID();
+    String nameA = DatanodeStorageMetrics.SOURCE_NAME + '-' + uuidA;
+    String nameB = DatanodeStorageMetrics.SOURCE_NAME + '-' + uuidB;
+    DatanodeStorageMetrics a = null;
+    DatanodeStorageMetrics b = null;
     try {
-      MetricsSystemImpl ms = (MetricsSystemImpl) DefaultMetricsSystem.instance();
-      String uuidA = "dn-" + UUID.randomUUID();
-      String uuidB = "dn-" + UUID.randomUUID();
-      String nameA = DatanodeStorageMetrics.SOURCE_NAME + '-' + uuidA;
-      String nameB = DatanodeStorageMetrics.SOURCE_NAME + '-' + uuidB;
-
-      DatanodeStorageMetrics a = DatanodeStorageMetrics.create(mockVolumeSet(uuidA));
-      DatanodeStorageMetrics b = DatanodeStorageMetrics.create(mockVolumeSet(uuidB));
+      a = DatanodeStorageMetrics.create(mockVolumeSet(uuidA));
+      b = DatanodeStorageMetrics.create(mockVolumeSet(uuidB));
       assertThat(ms.getSource(nameA)).isNotNull();
       assertThat(ms.getSource(nameB)).isNotNull();
 
@@ -122,6 +123,14 @@ class TestDatanodeStorageMetrics {
       assertThat(ms.getSource(nameA)).isNull();
       assertThat(ms.getSource(nameB)).isNull();
     } finally {
+      // Do not leak sources into other tests if an assertion above fails.
+      // unregister() is idempotent, so a repeat after the happy path is a no-op.
+      if (a != null) {
+        a.unregister();
+      }
+      if (b != null) {
+        b.unregister();
+      }
       DefaultMetricsSystem.setMiniClusterMode(prev);
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -34,6 +35,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -192,6 +196,29 @@ public class TestVolumeSet {
         .getStorageDir());
     assertNumVolumes(volSet, 1, 1);
     volSet.shutdown();
+  }
+
+  @Test
+  public void testStorageReportSnapshotDoesNotBlockOnWriteLock() throws Exception {
+    // Regression test: DatanodeStorageMetrics.getMetrics() samples the volume
+    // set while the DefaultMetricsSystem monitor is held. It must not block on
+    // the volume-set lock, otherwise it deadlocks with a volume-failure handler
+    // that holds the write lock while unregistering volume metrics.
+    volumeSet.writeLock();
+    try {
+      CompletableFuture<Integer> snapshot = CompletableFuture.supplyAsync(
+          () -> volumeSet.getStorageReportSnapshot().length);
+      // The snapshot must return without waiting for the write lock.
+      assertEquals(2, snapshot.get(10, TimeUnit.SECONDS));
+
+      // Sanity check that the lock is genuinely held: the locking variant does
+      // block behind the write lock (it must time out here).
+      CompletableFuture<Integer> locked = CompletableFuture.supplyAsync(
+          () -> volumeSet.getStorageReport().length);
+      assertThrows(TimeoutException.class, () -> locked.get(2, TimeUnit.SECONDS));
+    } finally {
+      volumeSet.writeUnlock();
+    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/TestDatanodeStorageMetricsIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/TestDatanodeStorageMetricsIntegration.java
@@ -123,7 +123,12 @@ public class TestDatanodeStorageMetricsIntegration {
    * Each call re-reads the underlying storage reports — do not mix values
    * from different calls when checking invariants across gauges.
    */
-  private static MetricsRecordBuilder storageMetrics() {
-    return getMetrics(DatanodeStorageMetrics.SOURCE_NAME);
+  private MetricsRecordBuilder storageMetrics() {
+    // In mini-cluster mode the source name is made unique per datanode (to keep
+    // metrics registration and unregistration symmetric and avoid the
+    // shared-JVM source leak), so look it up by the per-datanode name.
+    MutableVolumeSet volumeSet = cluster.getHddsDatanodes().get(0)
+        .getDatanodeStateMachine().getContainer().getVolumeSet();
+    return getMetrics(DatanodeStorageMetrics.SOURCE_NAME + '-' + volumeSet.getDatanodeUuid());
   }
 }


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.8)

## What changes were proposed in this pull request?

`DatanodeStorageMetrics` (added in HDDS-13128) has two defects, both fixed here.

**Defect 1 (deadlock).** `getMetrics()` reads storage totals via `MutableVolumeSet.getStorageReport()`, which takes the volume-set read lock. The metrics sampler timer calls `getMetrics()` while holding the global `DefaultMetricsSystem` monitor (every HDDS service registers `PrometheusMetricsSink` by default, so the timer samples all sources). Meanwhile a volume-failure handler (`MutableVolumeSet.failVolume()`) holds the volume-set write lock and then calls `VolumeIOStats.unregister()`, which needs the same monitor. The two lock orders are opposite, so when a sample tick lands inside a `failVolume` critical section the two threads deadlock. The sampler then holds the metrics monitor forever and every metrics register, unregister, or sample across the process blocks. On a datanode this hangs the metrics thread and the Prometheus endpoint when a data volume fails; in a mini-cluster (where SCM, OM, and datanodes share one metrics system per JVM) it freezes the whole cluster.

The fix adds `MutableVolumeSet.getStorageReportSnapshot()`, a lock-free read from the existing `ConcurrentHashMap`s (the same weakly-consistent guarantee that `getVolumesList()` already provides), and `getMetrics()` uses it. The locking `getStorageReport()` is unchanged for the node-report path. `DatanodeStorageMetrics` was the only sampled metrics source that reached into the shared volume-set lock (`VolumeInfoMetrics.getMetrics()` reads only its own volume), so removing this edge breaks the cycle.

**Defect 2 (source leak, mini-cluster and test scope).** The source was registered under a constant name (uniquified to `-N` in mini-cluster mode) but unregistered by the base name, so every datanode past the first leaked its source and pinned a shut-down datanode's `MutableVolumeSet`. In mini-cluster mode the source is now registered and unregistered under a per-datanode name so the two are symmetric. Production keeps the plain `DatanodeStorageMetrics` name (one instance per JVM) so JMX and Prometheus metric names are unchanged.

This deadlock is also the root cause of the recent master integration-job 90 minute timeouts: an intermittent, silent hang of a long-running test with a random cross-subsystem victim, no slowdown on runs that miss the race, and a sharp onset at the first integration coverage of HDDS-13128.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16119

## How was this patch tested?

New and updated unit and integration tests, all run locally:

* `TestVolumeSet#testStorageReportSnapshotDoesNotBlockOnWriteLock`: holds the volume-set write lock and asserts the snapshot returns promptly from another thread while the locking `getStorageReport()` times out.
* `TestDatanodeStorageMetrics#testNoSourceLeakInMiniClusterMode`: in mini-cluster mode, asserts create then unregister leaves no residual source.
* `TestDatanodeStorageMetricsIntegration`: updated to look up the per-datanode source name; passes on a real single-datanode `MiniOzoneCluster`.

`mvn -pl :hdds-container-service test -Dtest=TestDatanodeStorageMetrics,TestVolumeSet` and the integration test pass, and `checkstyle.sh` is clean on both changed modules.

And tests are not timing out anymore: https://github.com/smengcl/hadoop-ozone/actions/runs/31443047833