### PR TITLE
HDDS-16120. A single MiniOzoneCluster build timeout cascades into whole-suite failures in MiniOzoneClusterProvider

### DIFF
--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
@@ -125,7 +125,7 @@ public class MiniOzoneClusterProvider {
   private final Thread reapThread;
 
   private final Set<MiniOzoneCluster> createdClusters = new HashSet<>();
-  private final BlockingQueue<MiniOzoneCluster> clusters
+  private final BlockingQueue<ClusterCreationResult> clusterResults
       = new ArrayBlockingQueue<>(PRE_CREATE_LIMIT);
   private final BlockingQueue<MiniOzoneCluster> expiredClusters
       = new ArrayBlockingQueue<>(EXPIRED_LIMIT);
@@ -152,10 +152,14 @@ public class MiniOzoneClusterProvider {
           + "been reached for this provider. Please increase the value set "
           + "in the constructor");
     }
-    MiniOzoneCluster cluster = clusters.poll(100, SECONDS);
-    if (cluster == null) {
+    ClusterCreationResult result = clusterResults.poll(100, SECONDS);
+    if (result == null) {
       throw new IOException("Failed to obtain available cluster in time");
     }
+    if (result.getFailure() != null) {
+      throw result.getFailure();
+    }
+    MiniOzoneCluster cluster = result.getCluster();
     createdClusters.add(cluster);
     consumedClusterCount++;
     return cluster;
@@ -215,14 +219,22 @@ public class MiniOzoneClusterProvider {
           cluster = builder.build();
           cluster.waitForClusterToBeReady();
           createdCount++;
-          clusters.put(cluster);
+          clusterResults.put(ClusterCreationResult.success(cluster));
         } catch (InterruptedException e) {
           if (cluster != null) {
             cluster.shutdown();
           }
           break;
         } catch (IOException | TimeoutException e) {
-          throw new RuntimeException("Unable to build cluster", e);
+          LOG.warn("Unable to build cluster", e);
+          if (cluster != null) {
+            cluster.shutdown();
+          }
+          try {
+            clusterResults.put(ClusterCreationResult.failure(e));
+          } catch (InterruptedException interrupted) {
+            break;
+          }
         }
       }
     });
@@ -232,9 +244,10 @@ public class MiniOzoneClusterProvider {
   }
 
   private void destroyRemainingClusters() {
-    while (!clusters.isEmpty()) {
+    while (!clusterResults.isEmpty()) {
       try {
-        MiniOzoneCluster cluster = clusters.poll();
+        ClusterCreationResult result = clusterResults.poll();
+        MiniOzoneCluster cluster = result == null ? null : result.getCluster();
         if (cluster != null) {
           destroy(cluster);
         }
@@ -256,6 +269,34 @@ public class MiniOzoneClusterProvider {
       }
     }
     createdClusters.clear();
+  }
+
+  private static final class ClusterCreationResult {
+    private final MiniOzoneCluster cluster;
+    private final IOException failure;
+
+    private ClusterCreationResult(MiniOzoneCluster cluster,
+        IOException failure) {
+      this.cluster = cluster;
+      this.failure = failure;
+    }
+
+    private static ClusterCreationResult success(MiniOzoneCluster cluster) {
+      return new ClusterCreationResult(cluster, null);
+    }
+
+    private static ClusterCreationResult failure(Exception failure) {
+      return new ClusterCreationResult(null,
+          new IOException("Unable to build cluster", failure));
+    }
+
+    private MiniOzoneCluster getCluster() {
+      return cluster;
+    }
+
+    private IOException getFailure() {
+      return failure;
+    }
   }
 
 }

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
@@ -117,6 +117,7 @@ public class MiniOzoneClusterProvider {
   private static final int PRE_CREATE_LIMIT = 1;
   private static final int EXPIRED_LIMIT = 4;
   private volatile boolean shutdown = false;
+  private volatile boolean shutdownRequested = false;
   private final int clusterLimit;
   private int consumedClusterCount = 0;
 
@@ -173,6 +174,7 @@ public class MiniOzoneClusterProvider {
   }
 
   public synchronized void shutdown() throws InterruptedException {
+    shutdownRequested = true;
     createThread.interrupt();
     createThread.join();
     destroyRemainingClusters();
@@ -219,7 +221,10 @@ public class MiniOzoneClusterProvider {
           cluster = builder.build();
           cluster.waitForClusterToBeReady();
           createdCount++;
-          clusterResults.put(ClusterCreationResult.success(cluster));
+          if (!addClusterResult(ClusterCreationResult.success(cluster))) {
+            cluster.shutdown();
+            break;
+          }
         } catch (InterruptedException e) {
           if (cluster != null) {
             cluster.shutdown();
@@ -231,7 +236,9 @@ public class MiniOzoneClusterProvider {
             cluster.shutdown();
           }
           try {
-            clusterResults.put(ClusterCreationResult.failure(e));
+            if (!addClusterResult(ClusterCreationResult.failure(e))) {
+              break;
+            }
           } catch (InterruptedException interrupted) {
             break;
           }
@@ -241,6 +248,16 @@ public class MiniOzoneClusterProvider {
     t.setName("Mini-Cluster-Provider-Create");
     t.start();
     return t;
+  }
+
+  private boolean addClusterResult(ClusterCreationResult result)
+      throws InterruptedException {
+    while (!shutdownRequested) {
+      if (clusterResults.offer(result, 1, SECONDS)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private void destroyRemainingClusters() {

--- a/hadoop-ozone/mini-cluster/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneClusterProvider.java
+++ b/hadoop-ozone/mini-cluster/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneClusterProvider.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+
+class TestMiniOzoneClusterProvider {
+
+  @Test
+  void retriesAfterBuildFailure() throws Exception {
+    IOException failure = new IOException("failed");
+    MiniOzoneCluster first = mock(MiniOzoneCluster.class);
+    MiniOzoneCluster second = mock(MiniOzoneCluster.class);
+    TestBuilder builder = new TestBuilder(failure, first, second);
+    MiniOzoneClusterProvider provider = new MiniOzoneClusterProvider(builder,
+        2);
+
+    try {
+      IOException exception = assertThrows(IOException.class,
+          provider::provide);
+      assertSame(failure, exception.getCause());
+      assertSame(first, provider.provide());
+      assertSame(second, provider.provide());
+      assertEquals(3, builder.getBuildCount());
+    } finally {
+      provider.shutdown();
+    }
+  }
+
+  @Test
+  void retriesAfterReadinessTimeoutAndShutsDownCluster() throws Exception {
+    TimeoutException failure = new TimeoutException("failed");
+    MiniOzoneCluster failed = mock(MiniOzoneCluster.class);
+    doThrow(failure).when(failed).waitForClusterToBeReady();
+    MiniOzoneCluster first = mock(MiniOzoneCluster.class);
+    MiniOzoneCluster second = mock(MiniOzoneCluster.class);
+    TestBuilder builder = new TestBuilder(failed, first, second);
+    MiniOzoneClusterProvider provider = new MiniOzoneClusterProvider(builder,
+        2);
+
+    try {
+      IOException exception = assertThrows(IOException.class,
+          provider::provide);
+      assertSame(failure, exception.getCause());
+      assertSame(first, provider.provide());
+      assertSame(second, provider.provide());
+      assertEquals(3, builder.getBuildCount());
+      verify(failed).shutdown();
+    } finally {
+      provider.shutdown();
+    }
+  }
+
+  private static final class TestBuilder extends MiniOzoneCluster.Builder {
+    private final Queue<Object> results;
+    private final AtomicInteger buildCount = new AtomicInteger();
+
+    private TestBuilder(Object... results) {
+      super(new OzoneConfiguration());
+      this.results = new ArrayDeque<>(Arrays.asList(results));
+    }
+
+    @Override
+    public MiniOzoneCluster build() throws IOException {
+      buildCount.incrementAndGet();
+      Object result = results.remove();
+      if (result instanceof IOException) {
+        throw (IOException) result;
+      }
+      return (MiniOzoneCluster) result;
+    }
+
+    private int getBuildCount() {
+      return buildCount.get();
+    }
+  }
+}

--- a/hadoop-ozone/mini-cluster/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneClusterProvider.java
+++ b/hadoop-ozone/mini-cluster/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneClusterProvider.java
@@ -20,14 +20,20 @@ package org.apache.hadoop.ozone;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -78,6 +84,29 @@ class TestMiniOzoneClusterProvider {
     } finally {
       provider.shutdown();
     }
+  }
+
+  @Test
+  void shutdownDoesNotBlockWhenClusterCreationConsumesInterrupt()
+      throws Exception {
+    IOException failure = new IOException("failed");
+    MiniOzoneCluster cluster = mock(MiniOzoneCluster.class);
+    CountDownLatch readinessStarted = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      readinessStarted.countDown();
+      try {
+        new CountDownLatch(1).await();
+      } catch (InterruptedException ignored) {
+        // Simulate cluster creation consuming the shutdown interrupt.
+      }
+      return null;
+    }).when(cluster).waitForClusterToBeReady();
+    MiniOzoneClusterProvider provider = new MiniOzoneClusterProvider(
+        new TestBuilder(failure, cluster), 1);
+
+    assertTrue(readinessStarted.await(5, TimeUnit.SECONDS));
+    assertTimeoutPreemptively(Duration.ofSeconds(5), provider::shutdown);
+    verify(cluster).shutdown();
   }
 
   private static final class TestBuilder extends MiniOzoneCluster.Builder {


### PR DESCRIPTION
## What changes were proposed in this pull request?
`MiniOzoneClusterProvider` creates clusters on a background thread and passes them to consumers through a bounded blocking queue. Previously, an `IOException` or `TimeoutException` during cluster creation terminated the background thread. The queue was then never refilled, causing every subsequent `provide()` call to wait for 100 seconds and fail with the misleading `Failed to obtain available cluster in time` message.

This change passes both successful clusters and build failures through the existing bounded queue:
- A failed build is surfaced immediately from the affected `provide()` call, with the original exception preserved as its cause.
- The background create thread continues building clusters after a failure.
- A partially created cluster is shut down before the failure is published.
- Subsequent `provide()` calls can receive successfully created clusters.
- Failed builds do not count toward the configured cluster limit.

The queue capacity remains one and `put()` is blocking, providing natural backpressure when builds fail persistently. This prevents the create thread from processing failures in an unbounded tight loop without introducing a retry limit, backoff duration, or polling interval.

The change limits the blast radius of an individual cluster startup failure. It does not attempt to address the underlying cause of slow cluster startup.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16120

## How was this patch tested?

Local Test
```shell
mvn -pl :ozone-mini-cluster test \
    -Dtest=TestMiniOzoneClusterProvider \
    -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/31478614848

Generated-by: Codex (GPT-5)