### PR TITLE
HDDS-16148. Bump com.fasterxml.jackson:jackson-bom from 2.21.5 to 2.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <httpcore.version>4.4.16</httpcore.version>
     <iceberg.version>1.10.2</iceberg.version>
     <io.grpc.version>1.77.1</io.grpc.version>
-    <jackson2-bom.version>2.21.5</jackson2-bom.version>
+    <jackson2-bom.version>2.22.1</jackson2-bom.version>
     <jacoco.version>0.8.15</jacoco.version>
     <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
     <jakarta.inject.version>2.6.1</jakarta.inject.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Bump com.fasterxml.jackson:jackson-bom from 2.21.5 to 2.22.1

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16148

## How was this patch tested?

https://github.com/krvikash/ozone/actions/runs/31513310557