### PR TITLE
HDDS-16130. Remove Pair usage from Safe-mode APIs and callers.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -32,6 +31,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerResponseProto;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -279,8 +279,7 @@ public interface ScmClient extends Closeable {
    * @return map of rule statuses.
    * @throws IOException
    */
-  Map<String, Pair<Boolean, String>> getSafeModeRuleStatuses()
-      throws IOException;
+  List<SafeModeRuleStatusProto> getSafeModeRuleStatuses() throws IOException;
 
   /**
    * Force SCM out of safe mode.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -276,7 +276,7 @@ public interface ScmClient extends Closeable {
   /**
    * Get the safe mode status of all rules.
    *
-   * @return map of rule statuses.
+   * @return list of rule statuses.
    * @throws IOException
    */
   List<SafeModeRuleStatusProto> getSafeModeRuleStatuses() throws IOException;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -35,6 +34,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransaction
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.Type;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
@@ -411,8 +411,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
    */
   boolean inSafeMode() throws IOException;
 
-  Map<String, Pair<Boolean, String>> getSafeModeRuleStatuses()
-      throws IOException;
+  List<SafeModeRuleStatusProto> getSafeModeRuleStatuses() throws IOException;
 
   /**
    * Force SCM out of Safe mode.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicatedReplicationConfig;
@@ -881,29 +880,11 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   }
 
   @Override
-  public Map<String, Pair<Boolean, String>> getSafeModeRuleStatuses()
-      throws IOException {
-    GetSafeModeRuleStatusesRequestProto request =
-        GetSafeModeRuleStatusesRequestProto.getDefaultInstance();
-    GetSafeModeRuleStatusesResponseProto response =
-        submitRequest(Type.GetSafeModeRuleStatuses,
-            builder -> builder.setGetSafeModeRuleStatusesRequest(request))
-            .getGetSafeModeRuleStatusesResponse();
-    return buildSafeModeRuleStatusesMap(response);
-  }
-
-  /**
-   * Helper method to build a map from GetSafeModeRuleStatusesResponseProto.
-   * Extracts rule names and their status information.
-   */
-  private Map<String, Pair<Boolean, String>> buildSafeModeRuleStatusesMap(
-      GetSafeModeRuleStatusesResponseProto response) {
-    Map<String, Pair<Boolean, String>> ruleStatuses = new HashMap<>();
-    for (SafeModeRuleStatusProto statusProto : response.getSafeModeRuleStatusesProtoList()) {
-      ruleStatuses.put(statusProto.getRuleName(),
-          Pair.of(statusProto.getValidate(), statusProto.getStatusText()));
-    }
-    return ruleStatuses;
+  public List<SafeModeRuleStatusProto> getSafeModeRuleStatuses() throws IOException {
+    GetSafeModeRuleStatusesRequestProto request = GetSafeModeRuleStatusesRequestProto.getDefaultInstance();
+    GetSafeModeRuleStatusesResponseProto response = submitRequest(Type.GetSafeModeRuleStatuses,
+        builder -> builder.setGetSafeModeRuleStatusesRequest(request)).getGetSafeModeRuleStatusesResponse();
+    return response.getSafeModeRuleStatusesProtoList();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -119,7 +119,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SCMListContainerIDsResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SCMListContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SCMListContainerResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ScmContainerLocationRequest;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ScmContainerLocationResponse;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ScmContainerLocationResponse.Status;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -93,7 +92,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetMetricsResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.InSafeModeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.InSafeModeResponseProto;
@@ -628,10 +626,12 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
                 request.getGetPipelineRequest(), request.getVersion()))
             .build();
       case GetSafeModeRuleStatuses:
+        final GetSafeModeRuleStatusesResponseProto proto = GetSafeModeRuleStatusesResponseProto.newBuilder()
+            .addAllSafeModeRuleStatusesProto(impl.getSafeModeRuleStatuses())
+            .build();
         return ScmContainerLocationResponse.newBuilder()
             .setCmdType(request.getCmdType()).setStatus(Status.OK)
-            .setGetSafeModeRuleStatusesResponse(getSafeModeRuleStatues(
-                request.getGetSafeModeRuleStatusesRequest()))
+            .setGetSafeModeRuleStatusesResponse(proto)
             .build();
       case DecommissionNodes:
         return ScmContainerLocationResponse.newBuilder()
@@ -1053,21 +1053,6 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
     return InSafeModeResponseProto.newBuilder()
         .setInSafeMode(impl.inSafeMode()).build();
 
-  }
-
-  public GetSafeModeRuleStatusesResponseProto getSafeModeRuleStatues(
-      GetSafeModeRuleStatusesRequestProto request) throws IOException {
-    Map<String, Pair<Boolean, String>>
-        map = impl.getSafeModeRuleStatuses();
-    List<SafeModeRuleStatusProto> proto = new ArrayList();
-    for (Map.Entry<String, Pair<Boolean, String>> entry : map.entrySet()) {
-      proto.add(SafeModeRuleStatusProto.newBuilder().setRuleName(entry.getKey())
-          .setValidate(entry.getValue().getLeft())
-          .setStatusText(entry.getValue().getRight())
-          .build());
-    }
-    return GetSafeModeRuleStatusesResponseProto.newBuilder()
-        .addAllSafeModeRuleStatusesProto(proto).build();
   }
 
   public FinalizeScmUpgradeResponseProto getFinalizeScmUpgrade(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -23,8 +23,11 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_RULE_REFRE
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_RULE_REFRESH_INTERVAL_DEFAULT;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -32,9 +35,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMService.Event;
@@ -271,13 +274,16 @@ public class SCMSafeModeManager implements SafeModeManager {
   }
 
   /** Get the safe mode status of all rules. */
-  public Map<String, Pair<Boolean, String>> getRuleStatus() {
-    Map<String, Pair<Boolean, String>> map = new HashMap<>();
+  public List<SafeModeRuleStatusProto> getRuleStatus() {
+    final List<SafeModeRuleStatusProto> protos = new ArrayList<>(exitRules.size());
     for (SafeModeExitRule<?> exitRule : exitRules.values()) {
-      map.put(exitRule.getRuleName(),
-          Pair.of(exitRule.validate(), exitRule.getStatusText()));
+      protos.add(SafeModeRuleStatusProto.newBuilder()
+          .setRuleName(exitRule.getRuleName())
+          .setValidate(exitRule.validate())
+          .setStatusText(exitRule.getStatusText())
+          .build());
     }
-    return map;
+    return protos;
   }
 
   public boolean getPreCheckComplete() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -23,7 +23,6 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_RULE_REFRE
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_RULE_REFRESH_INTERVAL_DEFAULT;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -277,11 +276,8 @@ public class SCMSafeModeManager implements SafeModeManager {
   public List<SafeModeRuleStatusProto> getRuleStatus() {
     final List<SafeModeRuleStatusProto> protos = new ArrayList<>(exitRules.size());
     for (SafeModeExitRule<?> exitRule : exitRules.values()) {
-      protos.add(SafeModeRuleStatusProto.newBuilder()
-          .setRuleName(exitRule.getRuleName())
-          .setValidate(exitRule.validate())
-          .setStatusText(exitRule.getStatusText())
-          .build());
+      protos.add(SafeModeRuleStatusProto.newBuilder().setRuleName(exitRule.getRuleName())
+          .setValidate(exitRule.validate()).setStatusText(exitRule.getStatusText()).build());
     }
     return protos;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -49,7 +49,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -65,6 +64,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto.Builder;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerResponseProto;
 import org.apache.hadoop.hdds.protocolPB.ReconfigureProtocolPB;
 import org.apache.hadoop.hdds.protocolPB.ReconfigureProtocolServerSideTranslatorPB;
@@ -1064,16 +1064,13 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
-  public Map<String, Pair<Boolean, String>> getSafeModeRuleStatuses()
-      throws IOException {
+  public List<SafeModeRuleStatusProto> getSafeModeRuleStatuses() {
     try {
-      Map<String, Pair<Boolean, String>> result = scm.getRuleStatus();
-      AUDIT.logReadSuccess(buildAuditMessageForSuccess(
-          SCMAction.GET_SAFE_MODE_RULE_STATUSES, null));
+      final List<SafeModeRuleStatusProto> result = scm.getRuleStatus();
+      AUDIT.logReadSuccess(buildAuditMessageForSuccess(SCMAction.GET_SAFE_MODE_RULE_STATUSES, null));
       return result;
     } catch (Exception ex) {
-      AUDIT.logReadFailure(buildAuditMessageForFailure(
-          SCMAction.GET_SAFE_MODE_RULE_STATUSES, null, ex));
+      AUDIT.logReadFailure(buildAuditMessageForFailure(SCMAction.GET_SAFE_MODE_RULE_STATUSES, null, ex));
       throw ex;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -2095,7 +2095,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   /**
    * Get the safe mode status of all rules.
    *
-   * @return map of rule statuses.
+   * @return list of rule statuses.
    */
   public List<SafeModeRuleStatusProto> getRuleStatus() {
     return scmSafeModeManager.getRuleStatus();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -55,7 +55,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.management.ObjectName;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
@@ -67,6 +66,7 @@ import org.apache.hadoop.hdds.conf.TracingReconfigurationCallback;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
@@ -2097,18 +2097,16 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    *
    * @return map of rule statuses.
    */
-  public Map<String, Pair<Boolean, String>> getRuleStatus() {
+  public List<SafeModeRuleStatusProto> getRuleStatus() {
     return scmSafeModeManager.getRuleStatus();
   }
 
   @Override
   public Map<String, String[]> getSafeModeRuleStatus() {
     Map<String, String[]> map = new HashMap<>();
-    for (Map.Entry<String, Pair<Boolean, String>> entry :
-        scmSafeModeManager.getRuleStatus().entrySet()) {
-      String[] status =
-          {entry.getValue().getRight(), entry.getValue().getLeft().toString()};
-      map.put(entry.getKey(), status);
+    for (SafeModeRuleStatusProto entry : scmSafeModeManager.getRuleStatus()) {
+      String[] status = {entry.getStatusText(), Boolean.toString(entry.getValidate())};
+      map.put(entry.getRuleName(), status);
     }
     return map;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -36,9 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -47,6 +45,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -86,7 +85,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/** Test class for SCMSafeModeManager.
+/**
+ * Test class for SCMSafeModeManager.
  */
 public class TestSCMSafeModeManager {
 
@@ -478,13 +478,11 @@ public class TestSCMSafeModeManager {
    * @param stringToMatch string to match in the rule status.
    */
   private void validateRuleStatus(String safeModeRule, String stringToMatch) {
-    Set<Map.Entry<String, Pair<Boolean, String>>> ruleStatuses =
-        scmSafeModeManager.getRuleStatus().entrySet();
-    for (Map.Entry<String, Pair<Boolean, String>> entry : ruleStatuses) {
-      if (entry.getKey().equals(safeModeRule)) {
-        Pair<Boolean, String> value = entry.getValue();
-        assertEquals(false, value.getLeft());
-        assertThat(value.getRight()).containsIgnoringCase(stringToMatch);
+    List<SafeModeRuleStatusProto> ruleStatuses = scmSafeModeManager.getRuleStatus();
+    for (SafeModeRuleStatusProto proto : ruleStatuses) {
+      if (proto.getRuleName().equals(safeModeRule)) {
+        assertFalse(proto.getValidate());
+        assertThat(proto.getStatusText()).containsIgnoringCase(stringToMatch);
       }
     }
   }
@@ -1108,7 +1106,7 @@ public class TestSCMSafeModeManager {
    */
   private void verifyPeriodicLoggingActive(GenericTestUtils.LogCapturer logCapturer)
       throws InterruptedException {
-    Map<String, Pair<Boolean, String>> ruleStatuses = scmSafeModeManager.getRuleStatus();
+    List<SafeModeRuleStatusProto> ruleStatuses = scmSafeModeManager.getRuleStatus();
     for (int i = 0; i < 2; i++) {
       logCapturer.clearOutput();
       // Wait for configured interval (500ms + small buffer) for next log message
@@ -1116,8 +1114,8 @@ public class TestSCMSafeModeManager {
       String logOutput = logCapturer.getOutput();
 
       assertThat(logOutput).contains("SCM SafeMode Status | state=");
-      for (String ruleName : ruleStatuses.keySet()) {
-        assertThat(logOutput).contains("SCM SafeMode Status | " + ruleName);
+      for (SafeModeRuleStatusProto proto: ruleStatuses) {
+        assertThat(logOutput).contains("SCM SafeMode Status | " + proto.getRuleName());
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -35,7 +35,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -37,6 +36,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionSummary;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerResponseProto;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -375,8 +375,7 @@ public class ContainerOperationClient implements ScmClient {
   }
 
   @Override
-  public Map<String, Pair<Boolean, String>> getSafeModeRuleStatuses()
-      throws IOException {
+  public List<SafeModeRuleStatusProto> getSafeModeRuleStatuses() throws IOException {
     return storageContainerLocationClient.getSafeModeRuleStatuses();
   }
 

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCheckSubcommand.java
@@ -20,16 +20,15 @@ package org.apache.hadoop.hdds.scm.cli;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalInt;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.cli.AbstractSubcommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB.ScmNodeTarget;
@@ -172,9 +171,11 @@ public class SafeModeCheckSubcommand extends AbstractSubcommand implements Calla
       }
 
       if (isVerbose()) {
-        Map<String, Pair<Boolean, String>> rules = scmClient.getSafeModeRuleStatuses();
+        List<SafeModeRuleStatusProto> rules = scmClient.getSafeModeRuleStatuses();
         if (rules != null && !rules.isEmpty()) {
-          printSafeModeRules(rules);
+          for (SafeModeRuleStatusProto r : rules) {
+            System.out.printf("validated:%s, %s, %s%n", r.getValidate(), r.getRuleName(), r.getStatusText());
+          }
         }
       }
     } catch (Exception e) {
@@ -215,14 +216,6 @@ public class SafeModeCheckSubcommand extends AbstractSubcommand implements Calla
     } catch (Exception e) {
       // If address resolution fails, no match
       return false;
-    }
-  }
-  
-  private void printSafeModeRules(Map<String, Pair<Boolean, String>> rules) {
-    for (Map.Entry<String, Pair<Boolean, String>> entry : rules.entrySet()) {
-      Pair<Boolean, String> value = entry.getValue();
-      System.out.printf("validated:%s, %s, %s%n",
-          value.getLeft(), entry.getKey(), value.getRight());
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR splits out the safe-mode API and caller updates from the larger HDDS-15942 change set in PR #10962 into a separate subtask.
## Why are the changes needed?

It replaces the old `Pair<Boolean, String>` based safe-mode status contract with the new `SafeModeRuleStatus` type across the SCM protocol, SCM server, and `cli-admin`. Replacing it with SafeModeRuleStatus gives the fields a clear meaning, self-describing and easier to maintain.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16130

## How was this patch tested?

Updated the respective Test cases and validated locally.
Successful CI : https://github.com/navinko/ozone/actions/runs/31507651933