### PR TITLE
HDDS-16158. Fix sendDeleteKeysRequestAndClearList Authorization and FSO Trash Handling

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
@@ -1443,7 +1443,6 @@ public class KeyLifecycleService extends BackgroundService {
           LOG.debug("request size {} for {} keys", deleteKeysRequest.getSerializedSize(), keyCount);
 
           if (deleteKeysRequest.getSerializedSize() < ratisByteLimit) {
-            // perform preExecute as ratis submit does not perform preExecute
             OMRequest omRequestRaw = OMRequest.newBuilder()
                 .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKeys)
                 .setVersion(ClientVersion.CURRENT_VERSION)
@@ -1458,6 +1457,7 @@ public class KeyLifecycleService extends BackgroundService {
               response = ugi.doAs(new PrivilegedExceptionAction<OzoneManagerProtocolProtos.OMResponse>() {
                 @Override
                 public OzoneManagerProtocolProtos.OMResponse run() throws Exception {
+                  // perform preExecute as ratis submit does not perform preExecute
                   OMRequest omRequest = omClientRequest.preExecute(getOzoneManager());
                   return OzoneManagerRatisUtils.submitRequest(
                       getOzoneManager(), omRequest, clientId, callId.getAndIncrement());
@@ -1695,6 +1695,7 @@ public class KeyLifecycleService extends BackgroundService {
     return ozoneTrash != null ? ozoneTrash : ozoneManager.getOzoneTrash();
   }
 
+  @VisibleForTesting
   public void setOzoneTrash(OzoneTrash ozoneTrash) {
     this.ozoneTrash = ozoneTrash;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
@@ -190,7 +190,6 @@ public class KeyLifecycleService extends BackgroundService {
         StorageUnit.BYTES);
     // always go to 90% of max limit for request as other header will be added
     this.ratisByteLimit = (int) (limit * 0.9);
-    this.ozoneTrash = ozoneManager.getOzoneTrash();
   }
 
   @Override
@@ -447,8 +446,8 @@ public class KeyLifecycleService extends BackgroundService {
               // If trash is enabled, move files to trash, instead of send delete requests.
               // OBS bucket doesn't support trash.
               if (bucket.getBucketLayout() == OBJECT_STORE) {
-                sendDeleteKeysRequestAndClearList(bucket.getVolumeName(), bucket.getBucketName(), expiredKeyList,
-                    false, scanStateBuilder, true);
+                sendDeleteKeysRequestAndClearList(bucket.getVolumeName(), bucket.getBucketName(),
+                    bucket.getOwner(), expiredKeyList, false, scanStateBuilder, true);
               } else {
                 // handle keys first, then directories
                 handleAndClearFullList(bucket, expiredKeyList, false, scanStateBuilder, true);
@@ -987,8 +986,8 @@ public class KeyLifecycleService extends BackgroundService {
       boolean saved = false;
       if (expiredKeyList != null && !expiredKeyList.isEmpty()) {
         if (bucket.getBucketLayout() == OBJECT_STORE) {
-          sendDeleteKeysRequestAndClearList(bucket.getVolumeName(), bucket.getBucketName(), expiredKeyList,
-              false, scanStateBuilder, false);
+          sendDeleteKeysRequestAndClearList(bucket.getVolumeName(), bucket.getBucketName(),
+              bucket.getOwner(), expiredKeyList, false, scanStateBuilder, false);
         } else {
           handleAndClearFullList(bucket, expiredKeyList, false, scanStateBuilder, false);
         }
@@ -1348,12 +1347,12 @@ public class KeyLifecycleService extends BackgroundService {
 
     private void handleAndClearFullList(OmBucketInfo bucket, LimitedExpiredObjectList keysList,
         boolean dir, OmLifecycleScanState.Builder scanStateBuilder, boolean scanFinished) {
-      if (moveToTrashEnabled.get() && bucket.getBucketLayout() != OBJECT_STORE && ozoneTrash != null) {
+      if (moveToTrashEnabled.get() && bucket.getBucketLayout() != OBJECT_STORE && getEffectiveOzoneTrash() != null) {
         moveToTrash(bucket, keysList, dir);
         sendSaveScanStateRequest(scanStateBuilder, scanFinished);
       } else {
-        sendDeleteKeysRequestAndClearList(bucket.getVolumeName(), bucket.getBucketName(), keysList, dir,
-            scanStateBuilder, scanFinished);
+        sendDeleteKeysRequestAndClearList(bucket.getVolumeName(), bucket.getBucketName(),
+            bucket.getOwner(), keysList, dir, scanStateBuilder, scanFinished);
       }
     }
 
@@ -1393,8 +1392,9 @@ public class KeyLifecycleService extends BackgroundService {
       }
     }
 
-    private void sendDeleteKeysRequestAndClearList(String volume, String bucket, LimitedExpiredObjectList keysList,
-        boolean dir, OmLifecycleScanState.Builder scanStateBuilder, boolean scanFinished) {
+    private void sendDeleteKeysRequestAndClearList(String volume, String bucket, String bucketOwner,
+        LimitedExpiredObjectList keysList, boolean dir,
+        OmLifecycleScanState.Builder scanStateBuilder, boolean scanFinished) {
       try {
         if (getInjector(1) != null) {
           try {
@@ -1404,6 +1404,7 @@ public class KeyLifecycleService extends BackgroundService {
           }
         }
 
+        UserGroupInformation ugi = UserGroupInformation.createRemoteUser(bucketOwner);
         int batchSize = keyDeleteBatchSize;
         int startIndex = 0;
         for (int i = 0; i < keysList.size();) {
@@ -1442,16 +1443,32 @@ public class KeyLifecycleService extends BackgroundService {
           LOG.debug("request size {} for {} keys", deleteKeysRequest.getSerializedSize(), keyCount);
 
           if (deleteKeysRequest.getSerializedSize() < ratisByteLimit) {
-            // send request out
-            OMRequest omRequest = OMRequest.newBuilder()
+            // perform preExecute as ratis submit does not perform preExecute
+            OMRequest omRequestRaw = OMRequest.newBuilder()
                 .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKeys)
                 .setVersion(ClientVersion.CURRENT_VERSION)
                 .setClientId(clientId.toString())
                 .setDeleteKeysRequest(deleteKeysRequest)
                 .build();
             long startTime = System.nanoTime();
-            final OzoneManagerProtocolProtos.OMResponse response = OzoneManagerRatisUtils.submitRequest(
-                getOzoneManager(), omRequest, clientId, callId.getAndIncrement());
+            final OzoneManagerProtocolProtos.OMResponse response;
+            try {
+              final OMClientRequest omClientRequest = OzoneManagerRatisUtils.createClientRequest(
+                  omRequestRaw, getOzoneManager());
+              response = ugi.doAs(new PrivilegedExceptionAction<OzoneManagerProtocolProtos.OMResponse>() {
+                @Override
+                public OzoneManagerProtocolProtos.OMResponse run() throws Exception {
+                  OMRequest omRequest = omClientRequest.preExecute(getOzoneManager());
+                  return OzoneManagerRatisUtils.submitRequest(
+                      getOzoneManager(), omRequest, clientId, callId.getAndIncrement());
+                }
+              });
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new ServiceException(e);
+            } catch (IOException e) {
+              throw new ServiceException(e);
+            }
             long endTime = System.nanoTime();
             LOG.debug("DeleteKeys request with {} keys cost {} ns", keyCount, endTime - startTime);
             long deletedCount = keyCount;
@@ -1670,12 +1687,14 @@ public class KeyLifecycleService extends BackgroundService {
     this.listMaxSize = size;
   }
 
-  @VisibleForTesting
-  public void setMpuAbortLimitPerTask(int limit) {
-    this.mpuAbortLimitPerTask = limit;
+  // Returns the test-injected OzoneTrash if set, otherwise the live instance
+  // from OzoneManager. This is needed because startTrashEmptier() runs after
+  // keyManager.start() in all OzoneManager startup paths, so the field cannot
+  // be populated eagerly in the constructor.
+  private OzoneTrash getEffectiveOzoneTrash() {
+    return ozoneTrash != null ? ozoneTrash : ozoneManager.getOzoneTrash();
   }
 
-  @VisibleForTesting
   public void setOzoneTrash(OzoneTrash ozoneTrash) {
     this.ozoneTrash = ozoneTrash;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -3447,11 +3447,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
   }
 
   /**
-   * Regression test: KeyLifecycleService must delete keys even when ozone.acl.enabled=true.
-   * Before the fix, sendDeleteKeysRequestAndClearList submitted DeleteKeys requests without
-   * userInfo (missing preExecute / ugi.doAs), causing UNAUTHORIZED when resolveBucketLink
-   * called createUGIForApi() on the blank-userName request. Uses OBJECT_STORE layout because
-   * that path calls sendDeleteKeysRequestAndClearList directly (not via moveToTrash).
+   * Tests when security is enabled.
    */
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -3502,6 +3498,30 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertEquals(0, getKeyCount(OBJECT_STORE) - initialKeyCount,
           "Keys should be deleted by lifecycle service but were not — "
               + "possible UNAUTHORIZED from missing userInfo in DeleteKeys request");
+    }
+
+    @Test
+    void testMoveToTrashWithAclsEnabled()
+        throws IOException, TimeoutException, InterruptedException {
+      final String volumeName = getTestName();
+      final String bucketName = uniqueObjectName("bucket");
+      long initialRenamedKeyCount = metrics.getNumKeyRenamed().value();
+      long initialDeletedKeyCount = getDeletedKeyCount();
+      String bucketOwner = UserGroupInformation.getCurrentUser().getShortUserName() + "-test";
+      List<OmKeyArgs> keyList =
+          createKeys(volumeName, bucketName, FILE_SYSTEM_OPTIMIZED, bucketOwner, KEY_COUNT, 1, "key", null);
+      assertEquals(KEY_COUNT, keyList.size());
+      final float trashInterval = 0.5f;
+      conf.setFloat(FS_TRASH_INTERVAL_KEY, trashInterval);
+      FileSystem fs = SecurityUtil.doAsLoginUser(
+          (PrivilegedExceptionAction<FileSystem>) () -> new TrashOzoneFileSystem(om));
+      keyLifecycleService.setOzoneTrash(new OzoneTrash(fs, conf, om));
+      ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(EXPIRE_SECONDS);
+      createLifecyclePolicy(volumeName, bucketName, FILE_SYSTEM_OPTIMIZED, "", null, date.toString(), true);
+      GenericTestUtils.waitFor(
+          () -> (metrics.getNumKeyRenamed().value() - initialRenamedKeyCount) == KEY_COUNT,
+          WAIT_CHECK_INTERVAL, 10000);
+      assertEquals(0, getDeletedKeyCount() - initialDeletedKeyCount);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -22,7 +22,13 @@ import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.fs.ozone.OzoneTrashPolicy.CURRENT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.security.SecurityConfig.OZONE_TEST_AUTHORIZATION_ENABLED;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE;
@@ -3438,6 +3444,65 @@ class TestKeyLifecycleService extends OzoneTestBase {
     assertFalse(overList.isFull());
     assertEquals(0, overList.size());
     assertEquals(0, overList.getPartCount());
+  }
+
+  /**
+   * Regression test: KeyLifecycleService must delete keys even when ozone.acl.enabled=true.
+   * Before the fix, sendDeleteKeysRequestAndClearList submitted DeleteKeys requests without
+   * userInfo (missing preExecute / ugi.doAs), causing UNAUTHORIZED when resolveBucketLink
+   * called createUGIForApi() on the blank-userName request. Uses OBJECT_STORE layout because
+   * that path calls sendDeleteKeysRequestAndClearList directly (not via moveToTrash).
+   */
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class WithAclsEnabled {
+
+    @BeforeAll
+    void setup(@TempDir File testDir) throws Exception {
+      scmBlockTestingClient = new ScmBlockLocationTestingClient(null, null, 0);
+      createConfig(testDir);
+      conf.setBoolean(OZONE_TEST_AUTHORIZATION_ENABLED, true);
+      conf.setBoolean(OZONE_ACL_ENABLED, true);
+      conf.set(OZONE_ACL_AUTHORIZER_CLASS, OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
+      conf.setStrings(OZONE_ADMINISTRATORS, OZONE_ADMINISTRATORS_WILDCARD);
+      createSubject();
+      keyDeletingService.suspend();
+      directoryDeletingService.suspend();
+    }
+
+    @AfterAll
+    void cleanup() {
+      if (om != null) {
+        om.stop();
+        om.join();
+      }
+    }
+
+    @Test
+    void testLifecycleDeleteSucceedsWithAclsEnabled()
+        throws IOException, TimeoutException, InterruptedException {
+      final String volumeName = getTestName();
+      final String bucketName = uniqueObjectName("bucket");
+      long initialDeletedKeyCount = getDeletedKeyCount();
+      long initialKeyCount = getKeyCount(OBJECT_STORE);
+
+      List<OmKeyArgs> keyList = createKeys(volumeName, bucketName, OBJECT_STORE,
+          KEY_COUNT, 1, "key", null);
+      assertEquals(KEY_COUNT, keyList.size());
+      GenericTestUtils.waitFor(
+          () -> getKeyCount(OBJECT_STORE) - initialKeyCount == KEY_COUNT,
+          WAIT_CHECK_INTERVAL, 1000);
+
+      ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(EXPIRE_SECONDS);
+      createLifecyclePolicy(volumeName, bucketName, OBJECT_STORE, "key", null, date.toString(), true);
+
+      GenericTestUtils.waitFor(
+          () -> (getDeletedKeyCount() - initialDeletedKeyCount) == KEY_COUNT,
+          WAIT_CHECK_INTERVAL, 10000);
+      assertEquals(0, getKeyCount(OBJECT_STORE) - initialKeyCount,
+          "Keys should be deleted by lifecycle service but were not — "
+              + "possible UNAUTHORIZED from missing userInfo in DeleteKeys request");
+    }
   }
 
   private static void addSplitSchemaPart(OMMetadataManager omMetadataManager,


### PR DESCRIPTION
## What changes were proposed in this pull request?

`sendDeleteKeysRequestAndClearList` has two related issues that prevent delete-key requests from being handled correctly in production, particularly when ACLs are enabled and when FSO trash handling is configured.

First, `sendDeleteKeysRequestAndClearList` submits the Ratis request without executing `preExecute` under the appropriate UGI context. As a result, `userInfo.userName` remains blank. When ACLs are enabled, `resolveBucketLink` attempts to create a UGI from the blank user information and fails with `UNAUTHORIZED`.

Second, `ozoneTrash` is captured during `KeyManager` construction, before `OzoneManager.startTrashEmptier()` is invoked. Since all `OzoneManager` startup paths call `keyManager.start()` before starting the trash emptier, `ozoneManager.getOzoneTrash()` is `null` when the constructor runs. The field is never updated afterward, causing the FSO `moveToTrash` path in `handleAndClearFullList` to remain unreachable in production.

**Fix**

* Wrap `createClientRequest`, `preExecute`, and `submitRequest` inside:
  `ugi.doAs(UserGroupInformation.createRemoteUser(bucketOwner))`, following the existing `moveToTrash` pattern.
* Handle `IOException` from `ugi.doAs()` and `createClientRequest()` by converting it to `ServiceException`, alongside the existing `InterruptedException` handling.
* Remove the constructor-time assignment of `ozoneTrash`.
* Add `getEffectiveOzoneTrash()`, which returns the test-injected `ozoneTrash` when present, otherwise retrieves `ozoneManager.getOzoneTrash()` at call time after the trash emptier has started.
* Update `handleAndClearFullList` to use `getEffectiveOzoneTrash()`.
* Preserve existing test behavior through `setOzoneTrash(...)`.

This ensures the request is executed with the correct user context and that the FSO trash `moveToTrash` path is correctly reached in production.


## What is the link to the Apache JIRA

HDDS-16158

## How was this patch tested?

Tested manually in cluster with security and acl enabled.  Also verified using integration test created using claude.
