### PR TITLE
HDDS-16156. Create HTTP base dir under java.io.tmpdir instead of the working directory

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -37,7 +37,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1800,7 +1799,8 @@ public final class HttpServer2 implements FilterContainer {
 
   /**
    * Utility method to initialize config key ozone.http.basedir and create a
-   * temporary directory under the current working directory if not set.
+   * temporary directory under the system temporary directory
+   * ({@code java.io.tmpdir}) if not set.
    *
    * @param ozoneConfiguration current configuration.
    * @throws IOException if unable to create a temp directory.
@@ -1809,9 +1809,10 @@ public final class HttpServer2 implements FilterContainer {
           throws IOException {
     if (org.apache.commons.lang3.StringUtils.isEmpty(ozoneConfiguration.get(
             OzoneConfigKeys.OZONE_HTTP_BASEDIR))) {
-      // Setting ozone.http.basedir to cwd if not set so that server setup
-      // doesn't fail.
-      File tmpMetaDir = Files.createTempDirectory(Paths.get(""),
+      // Create the base dir under java.io.tmpdir (not the process working
+      // directory) so server setup does not fail when the CWD is not
+      // writable, e.g. S3 Gateway running in a Kubernetes container.
+      File tmpMetaDir = Files.createTempDirectory(
               "ozone_http_tmp_base_dir").toFile();
       ShutdownHookManager.get().addShutdownHook(() -> {
         try {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
@@ -17,10 +17,14 @@
 
 package org.apache.hadoop.hdds.server.http;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.jupiter.api.Test;
 
@@ -49,5 +53,26 @@ public class TestHttpServer2 {
       // Check default value in ozone-default.xml
       assertEquals(60000, server.getIdleTimeout());
     }
+  }
+
+  /**
+   * When ozone.http.basedir is not set, the base dir must be created under the
+   * system temporary directory (java.io.tmpdir), not the process working
+   * directory, so startup does not fail when the CWD is not writable.
+   */
+  @Test
+  public void testSetHttpBaseDirUsesSystemTempDir() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.unset(OzoneConfigKeys.OZONE_HTTP_BASEDIR);
+
+    HttpServer2.setHttpBaseDir(conf);
+
+    String baseDir = conf.get(OzoneConfigKeys.OZONE_HTTP_BASEDIR);
+    assertThat(baseDir).isNotEmpty();
+    Path baseDirPath = Paths.get(baseDir).toAbsolutePath().normalize();
+    assertThat(baseDirPath).exists();
+    Path systemTmpDir = Paths.get(System.getProperty("java.io.tmpdir"))
+        .toAbsolutePath().normalize();
+    assertThat(baseDirPath.startsWith(systemTmpDir)).isTrue();
   }
 }


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.8)

## What changes were proposed in this pull request?

`HttpServer2.setHttpBaseDir()` creates the temporary HTTP base directory under the process current working directory when `ozone.http.basedir` is unset:

```java
File tmpMetaDir = Files.createTempDirectory(Paths.get(""), "ozone_http_tmp_base_dir").toFile();
```

`Paths.get("")` resolves to the process working directory. When that directory is not writable by the running uid, `Files.createTempDirectory` throws `AccessDeniedException`, which `GenericCli` reports as `Access denied: ...` and the process exits.

S3 Gateway is the service that hits this: `Gateway.call()` invokes the static `setHttpBaseDir()` at startup, before its HTTP servers are constructed. In the `kubernetes` acceptance check the s3g statefulset sets no `workingDir` and no `runAsUser`, so the working directory is the runner image working directory; when it is not writable the s3g pod CrashLoopBackOffs at startup, before serving anything. SCM, OM, Recon and Datanode are not affected: they do not call the static helper, and `BaseHttpServer` resolves an unset `ozone.http.basedir` to `${ozone.metadata.dirs}/webserver` on a writable volume. The docker-compose environments are not affected because they set `ozone.http.basedir=/tmp/ozone_http` explicitly.

This changes `setHttpBaseDir()` to create the temporary base directory under `java.io.tmpdir` (`Files.createTempDirectory("ozone_http_tmp_base_dir")`), which is writable by contract, so startup no longer depends on the working directory being writable. Freon uses the same helper and benefits from the same fix.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16156

## How was this patch tested?

Added `TestHttpServer2#testSetHttpBaseDirUsesSystemTempDir`, which asserts that the resolved base directory exists and is located under `java.io.tmpdir`. Ran the new test and `checkstyle` on the `framework` module locally; both pass.
