### PR TITLE
HDDS-16132. Retry follower SCM DN server start after catch-up

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -87,10 +87,11 @@ public class SCMStateMachine extends BaseStateMachine {
   // Interval for the fallback retry that starts the deferred datanode-server on
   // a follower (see retryStartDNServerUntilReady).
   private static final long DN_SERVER_START_RETRY_INTERVAL_MS = 1000L;
+  private final long dnServerStartRetryIntervalMs;
 
   // Periodically retries the deferred datanode-server start on a follower so an
   // idle cluster (no new transactions, only Ratis heartbeats) still exits safe
-  // mode once catch-up becomes observable. Self-cancels after the server starts.
+  // mode once catch-up becomes observable.
   private ScheduledExecutorService dnServerStartRetryExecutor;
   private ScheduledFuture<?> dnServerStartRetryFuture;
 
@@ -107,10 +108,17 @@ public class SCMStateMachine extends BaseStateMachine {
 
   public SCMStateMachine(final StorageContainerManager scm,
       SCMHADBTransactionBuffer buffer) {
+    this(scm, buffer, DN_SERVER_START_RETRY_INTERVAL_MS);
+  }
+
+  @VisibleForTesting
+  SCMStateMachine(final StorageContainerManager scm,
+      SCMHADBTransactionBuffer buffer, long retryIntervalMs) {
     this.scm = scm;
     this.invokers = new EnumMap<>(RequestType.class);
     this.transactionBuffer = buffer;
     this.metrics = scm.getMetrics();
+    this.dnServerStartRetryIntervalMs = retryIntervalMs;
     TransactionInfo latestTrxInfo = this.transactionBuffer.getLatestTrxInfo();
     if (!latestTrxInfo.isDefault()) {
       updateLastAppliedTermIndex(latestTrxInfo.getTerm(),
@@ -128,15 +136,13 @@ public class SCMStateMachine extends BaseStateMachine {
             .setNameFormat(scm.threadNamePrefix() + "SCMDNServerStartRetry-%d")
             .setDaemon(true)
             .build());
-    this.dnServerStartRetryFuture = dnServerStartRetryExecutor.scheduleWithFixedDelay(
-        this::retryStartDNServerUntilReady, DN_SERVER_START_RETRY_INTERVAL_MS,
-        DN_SERVER_START_RETRY_INTERVAL_MS, TimeUnit.MILLISECONDS);
     isInitialized = true;
   }
 
   public SCMStateMachine() {
     isInitialized = false;
     this.metrics = null;
+    this.dnServerStartRetryIntervalMs = DN_SERVER_START_RETRY_INTERVAL_MS;
   }
 
   private void addRatisEvent(String message) {
@@ -321,6 +327,7 @@ public class SCMStateMachine extends BaseStateMachine {
         leaderCommitIndexOnStart = getLeaderCommitIndex();
       }
       tryStartDNServerAndRefreshSafeMode();
+      scheduleDNServerStartRetry();
       String message = "Leader changed to " + newLeaderId +
           ", current SCM " + scm.getScmId() + " is still follower.";
       LOG.info(message);
@@ -434,12 +441,15 @@ public class SCMStateMachine extends BaseStateMachine {
    * container reports are processed against the up-to-date container/pipeline
    * state rather than a stale, mid-replay snapshot.
    */
-  private void tryStartDNServerAndRefreshSafeMode() {
-    if (isStateMachineReady.get()) {
+  private synchronized void tryStartDNServerAndRefreshSafeMode() {
+    if (scm.isStopped() || isStateMachineReady.get()) {
       return;
     }
     if (scm.getScmContext().isLeader() || isFollowerCaughtUp()) {
       if (isStateMachineReady.compareAndSet(false, true)) {
+        // No further retry is needed. shutdown() lets the current retry, if
+        // this method was called by it, finish normally without cancellation.
+        dnServerStartRetryExecutor.shutdown();
         scm.getDatanodeProtocolServer().start();
         scm.getScmSafeModeManager().refreshAndValidate();
       }
@@ -453,33 +463,52 @@ public class SCMStateMachine extends BaseStateMachine {
    * cluster a restarted follower can miss the moment the leader's committed
    * index becomes observable (it is not yet known when {@code notifyLeaderChanged}
    * fires) and never start its datanode server, leaving it stuck in safe mode.
-   * This re-checks until the server starts, then cancels itself. Starting stays
+   * This re-checks until the server starts. Starting stays
    * gated by the same {@link #tryStartDNServerAndRefreshSafeMode()} predicate, so
    * it cannot start the server before genuine catch-up.
    */
   private void retryStartDNServerUntilReady() {
-    if (isStateMachineReady.get()) {
-      cancelDNServerStartRetry();
-      return;
-    }
     try {
-      tryStartDNServerAndRefreshSafeMode();
+      if (!scm.isStopped() && !isStateMachineReady.get()) {
+        tryStartDNServerAndRefreshSafeMode();
+      }
     } catch (Exception e) {
-      // Never let a transient failure (e.g. SCM not fully wired up yet during
-      // startup) kill the scheduled task; log and retry on the next tick.
-      LOG.warn("Retry of deferred datanode-server start failed; will retry", e);
-      return;
-    }
-    if (isStateMachineReady.get()) {
-      cancelDNServerStartRetry();
+      // Do not let a failed readiness check terminate the fallback. The
+      // finally block only schedules another attempt if startup is pending.
+      LOG.warn("Deferred datanode-server start retry failed", e);
+    } finally {
+      synchronized (this) {
+        dnServerStartRetryFuture = null;
+        scheduleDNServerStartRetry();
+      }
     }
   }
 
-  private void cancelDNServerStartRetry() {
-    ScheduledFuture<?> future = dnServerStartRetryFuture;
-    if (future != null) {
-      future.cancel(false);
+  private synchronized void scheduleDNServerStartRetry() {
+    if (scm.isStopped() || isStateMachineReady.get() ||
+        dnServerStartRetryExecutor.isShutdown() || dnServerStartRetryFuture != null) {
+      return;
     }
+    dnServerStartRetryFuture = dnServerStartRetryExecutor.schedule(
+        this::retryStartDNServerUntilReady, dnServerStartRetryIntervalMs, TimeUnit.MILLISECONDS);
+  }
+
+  public void stopDNServerStartRetry() {
+    synchronized (this) {
+      dnServerStartRetryExecutor.shutdownNow();
+      dnServerStartRetryFuture = null;
+    }
+    HadoopExecutors.shutdown(dnServerStartRetryExecutor, LOG, 5, TimeUnit.SECONDS);
+  }
+
+  @VisibleForTesting
+  boolean isDNServerStartRetryStopped() {
+    return dnServerStartRetryExecutor.isShutdown();
+  }
+
+  @VisibleForTesting
+  boolean isDNServerStartRetryTerminated() {
+    return dnServerStartRetryExecutor.isTerminated();
   }
 
   /**
@@ -625,8 +654,7 @@ public class SCMStateMachine extends BaseStateMachine {
       transactionBuffer.close();
       HadoopExecutors.
           shutdown(installSnapshotExecutor, LOG, 5, TimeUnit.SECONDS);
-      HadoopExecutors.
-          shutdown(dnServerStartRetryExecutor, LOG, 5, TimeUnit.SECONDS);
+      stopDNServerStartRetry();
     } else if (!scm.isStopped()) {
       scm.shutDown("scm statemachine is closed by ratis, terminate SCM");
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
@@ -86,8 +87,9 @@ public class SCMStateMachine extends BaseStateMachine {
 
   // Interval for the fallback retry that starts the deferred datanode-server on
   // a follower (see retryStartDNServerUntilReady).
-  private static final long DN_SERVER_START_RETRY_INTERVAL_MS = 1000L;
-  private final long dnServerStartRetryIntervalMs;
+  private static final Duration DN_SERVER_START_RETRY_INTERVAL =
+      Duration.ofSeconds(1);
+  private final Duration dnServerStartRetryInterval;
 
   // Periodically retries the deferred datanode-server start on a follower so an
   // idle cluster (no new transactions, only Ratis heartbeats) still exits safe
@@ -108,17 +110,17 @@ public class SCMStateMachine extends BaseStateMachine {
 
   public SCMStateMachine(final StorageContainerManager scm,
       SCMHADBTransactionBuffer buffer) {
-    this(scm, buffer, DN_SERVER_START_RETRY_INTERVAL_MS);
+    this(scm, buffer, DN_SERVER_START_RETRY_INTERVAL);
   }
 
   @VisibleForTesting
   SCMStateMachine(final StorageContainerManager scm,
-      SCMHADBTransactionBuffer buffer, long retryIntervalMs) {
+      SCMHADBTransactionBuffer buffer, Duration retryInterval) {
     this.scm = scm;
     this.invokers = new EnumMap<>(RequestType.class);
     this.transactionBuffer = buffer;
     this.metrics = scm.getMetrics();
-    this.dnServerStartRetryIntervalMs = retryIntervalMs;
+    this.dnServerStartRetryInterval = retryInterval;
     TransactionInfo latestTrxInfo = this.transactionBuffer.getLatestTrxInfo();
     if (!latestTrxInfo.isDefault()) {
       updateLastAppliedTermIndex(latestTrxInfo.getTerm(),
@@ -142,7 +144,7 @@ public class SCMStateMachine extends BaseStateMachine {
   public SCMStateMachine() {
     isInitialized = false;
     this.metrics = null;
-    this.dnServerStartRetryIntervalMs = DN_SERVER_START_RETRY_INTERVAL_MS;
+    this.dnServerStartRetryInterval = DN_SERVER_START_RETRY_INTERVAL;
   }
 
   private void addRatisEvent(String message) {
@@ -490,7 +492,8 @@ public class SCMStateMachine extends BaseStateMachine {
       return;
     }
     dnServerStartRetryFuture = dnServerStartRetryExecutor.schedule(
-        this::retryStartDNServerUntilReady, dnServerStartRetryIntervalMs, TimeUnit.MILLISECONDS);
+        this::retryStartDNServerUntilReady,
+        dnServerStartRetryInterval.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   public void stopDNServerStartRetry() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
@@ -82,6 +84,16 @@ public class SCMStateMachine extends BaseStateMachine {
   private final boolean isInitialized;
   private ExecutorService installSnapshotExecutor;
 
+  // Interval for the fallback retry that starts the deferred datanode-server on
+  // a follower (see retryStartDNServerUntilReady).
+  private static final long DN_SERVER_START_RETRY_INTERVAL_MS = 1000L;
+
+  // Periodically retries the deferred datanode-server start on a follower so an
+  // idle cluster (no new transactions, only Ratis heartbeats) still exits safe
+  // mode once catch-up becomes observable. Self-cancels after the server starts.
+  private ScheduledExecutorService dnServerStartRetryExecutor;
+  private ScheduledFuture<?> dnServerStartRetryFuture;
+
   private DBCheckpoint installingDBCheckpoint = null;
   private List<ManagedSecretKey> installingSecretKeys = null;
 
@@ -111,6 +123,14 @@ public class SCMStateMachine extends BaseStateMachine {
             .setNameFormat(scm.threadNamePrefix() + "SCMInstallSnapshot-%d")
             .build()
     );
+    this.dnServerStartRetryExecutor = HadoopExecutors.newScheduledThreadPool(1,
+        new ThreadFactoryBuilder()
+            .setNameFormat(scm.threadNamePrefix() + "SCMDNServerStartRetry-%d")
+            .setDaemon(true)
+            .build());
+    this.dnServerStartRetryFuture = dnServerStartRetryExecutor.scheduleWithFixedDelay(
+        this::retryStartDNServerUntilReady, DN_SERVER_START_RETRY_INTERVAL_MS,
+        DN_SERVER_START_RETRY_INTERVAL_MS, TimeUnit.MILLISECONDS);
     isInitialized = true;
   }
 
@@ -427,6 +447,42 @@ public class SCMStateMachine extends BaseStateMachine {
   }
 
   /**
+   * Periodic fallback for the deferred datanode-server start on a follower. The
+   * Ratis callbacks ({@code applyTransaction}, {@code notifyTermIndexUpdated},
+   * {@code notifyLeaderChanged}) only fire on new activity, so on an idle
+   * cluster a restarted follower can miss the moment the leader's committed
+   * index becomes observable (it is not yet known when {@code notifyLeaderChanged}
+   * fires) and never start its datanode server, leaving it stuck in safe mode.
+   * This re-checks until the server starts, then cancels itself. Starting stays
+   * gated by the same {@link #tryStartDNServerAndRefreshSafeMode()} predicate, so
+   * it cannot start the server before genuine catch-up.
+   */
+  private void retryStartDNServerUntilReady() {
+    if (isStateMachineReady.get()) {
+      cancelDNServerStartRetry();
+      return;
+    }
+    try {
+      tryStartDNServerAndRefreshSafeMode();
+    } catch (Exception e) {
+      // Never let a transient failure (e.g. SCM not fully wired up yet during
+      // startup) kill the scheduled task; log and retry on the next tick.
+      LOG.warn("Retry of deferred datanode-server start failed; will retry", e);
+      return;
+    }
+    if (isStateMachineReady.get()) {
+      cancelDNServerStartRetry();
+    }
+  }
+
+  private void cancelDNServerStartRetry() {
+    ScheduledFuture<?> future = dnServerStartRetryFuture;
+    if (future != null) {
+      future.cancel(false);
+    }
+  }
+
+  /**
    * @return true if this follower's last applied index has reached the leader's
    * committed index captured when it (re)joined, i.e. all transactions the
    * leader had committed at that point have been replayed. Comparing against a
@@ -569,6 +625,8 @@ public class SCMStateMachine extends BaseStateMachine {
       transactionBuffer.close();
       HadoopExecutors.
           shutdown(installSnapshotExecutor, LOG, 5, TimeUnit.SECONDS);
+      HadoopExecutors.
+          shutdown(dnServerStartRetryExecutor, LOG, 5, TimeUnit.SECONDS);
     } else if (!scm.isStopped()) {
       scm.shutDown("scm statemachine is closed by ratis, terminate SCM");
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -117,6 +117,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceException;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
+import org.apache.hadoop.hdds.scm.ha.SCMStateMachine;
 import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator;
 import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManager;
 import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManagerImpl;
@@ -1664,6 +1665,12 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       IOUtils.close(LOG, reconfigurationHandler, scmHAManager);
       stopReplicationManager(); // started eagerly
       return;
+    }
+
+    SCMStateMachine stateMachine = getScmHAManager().getRatisServer()
+        .getSCMStateMachine();
+    if (stateMachine != null) {
+      stateMachine.stopDNServerStartRetry();
     }
     try {
       if (containerBalancer.isBalancerRunning()) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMStateMachine.java
@@ -17,36 +17,194 @@
 
 package org.apache.hadoop.hdds.scm.ha;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMMetrics;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.util.concurrent.ExecutorHelper;
+import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.DivisionInfo;
+import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.protocol.TermIndex;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test SCMStateMachine events recording.
+ * Tests SCMStateMachine events and deferred datanode-server startup.
  */
 public class TestSCMStateMachine {
+  private static final long RETRY_INTERVAL_MS = 100L;
+
+  private final AtomicBoolean commitIndexAvailable = new AtomicBoolean();
+  private final AtomicBoolean scmStopped = new AtomicBoolean();
+  private final AtomicLong lastAppliedIndex = new AtomicLong(5L);
+  private final RaftPeerId followerId = RaftPeerId.valueOf("follower");
+  private final RaftPeerId leaderId = RaftPeerId.valueOf("leader");
+
+  private StorageContainerManager scm;
+  private SCMMetrics metrics;
+  private SCMHADBTransactionBuffer buffer;
+  private SCMDatanodeProtocolServer datanodeProtocolServer;
+  private SCMSafeModeManager safeModeManager;
+  private SCMStateMachine stateMachine;
+
+  @BeforeEach
+  void setUp() {
+    scm = mock(StorageContainerManager.class);
+    metrics = SCMMetrics.create();
+    buffer = mock(SCMHADBTransactionBuffer.class);
+    datanodeProtocolServer = mock(SCMDatanodeProtocolServer.class);
+    safeModeManager = mock(SCMSafeModeManager.class);
+
+    SCMContext scmContext = mock(SCMContext.class);
+    SCMHAManager haManager = mock(SCMHAManager.class);
+    SCMRatisServer ratisServer = mock(SCMRatisServer.class);
+    RaftServer.Division division = mock(RaftServer.Division.class);
+    DivisionInfo divisionInfo = mock(DivisionInfo.class);
+
+    when(scm.getMetrics()).thenReturn(metrics);
+    when(scm.isStopped()).thenAnswer(invocation -> scmStopped.get());
+    when(scm.getScmContext()).thenReturn(scmContext);
+    when(scm.getScmHAManager()).thenReturn(haManager);
+    when(scm.getDatanodeProtocolServer()).thenReturn(datanodeProtocolServer);
+    when(scm.getScmSafeModeManager()).thenReturn(safeModeManager);
+    when(haManager.getRatisServer()).thenReturn(ratisServer);
+    when(ratisServer.getDivision()).thenReturn(division);
+    when(division.getInfo()).thenReturn(divisionInfo);
+    when(divisionInfo.getLeaderId()).thenReturn(leaderId);
+    when(divisionInfo.getLastAppliedIndex()).thenAnswer(invocation -> lastAppliedIndex.get());
+    when(division.getCommitInfos()).thenAnswer(invocation -> commitIndexAvailable.get()
+        ? Collections.singletonList(RaftProtos.CommitInfoProto.newBuilder()
+            .setServer(RaftProtos.RaftPeerProto.newBuilder().setId(leaderId.toByteString()))
+            .setCommitIndex(5L)
+            .build())
+        : Collections.emptyList());
+    when(buffer.getLatestTrxInfo()).thenReturn(
+        TransactionInfo.valueOf(TermIndex.valueOf(0, 0)));
+
+    stateMachine = new SCMStateMachine(scm, buffer, RETRY_INTERVAL_MS);
+  }
+
+  @AfterEach
+  void tearDown() {
+    stateMachine.stopDNServerStartRetry();
+    metrics.unRegister();
+  }
 
   @Test
-  public void testRatisEventsRecording() throws Exception {
-    StorageContainerManager scm = mock(StorageContainerManager.class);
-    SCMMetrics metrics = SCMMetrics.create();
-    when(scm.getMetrics()).thenReturn(metrics);
-
-    SCMHADBTransactionBuffer buffer = mock(SCMHADBTransactionBuffer.class);
-    when(buffer.getLatestTrxInfo()).thenReturn(TransactionInfo.valueOf(TermIndex.valueOf(0, 0)));
-
-    SCMStateMachine stateMachine = new SCMStateMachine(scm, buffer);
-
+  void testRatisEventsRecording() {
     stateMachine.notifyConfigurationChanged(1, 1, RaftProtos.RaftConfigurationProto.getDefaultInstance());
     assertTrue(metrics.getRatisEvents().contains("Configuration changed at term index"));
+  }
 
-    metrics.unRegister();
+  @Test
+  void testRetryStartsDNServerWhenLeaderCommitIndexBecomesAvailable() throws Exception {
+    LogCapturer executorLogs = LogCapturer.captureLogs(ExecutorHelper.class);
+    try {
+      stateMachine.notifyLeaderChanged(memberId(), leaderId);
+      verify(datanodeProtocolServer, never()).start();
+
+      commitIndexAvailable.set(true);
+
+      verify(datanodeProtocolServer, timeout(2000)).start();
+      verify(safeModeManager, timeout(2000)).refreshAndValidate();
+      assertThat(stateMachine.getIsStateMachineReady()).isTrue();
+      assertThat(stateMachine.isDNServerStartRetryStopped()).isTrue();
+      GenericTestUtils.waitFor(stateMachine::isDNServerStartRetryTerminated, 10, 2000);
+      assertThat(executorLogs.getOutput()).doesNotContain("CancellationException");
+    } finally {
+      executorLogs.stopCapturing();
+    }
+  }
+
+  @Test
+  void testRetryWaitsUntilFollowerCatchesUp() {
+    commitIndexAvailable.set(true);
+    lastAppliedIndex.set(4L);
+
+    stateMachine.notifyLeaderChanged(memberId(), leaderId);
+
+    verify(datanodeProtocolServer, after(RETRY_INTERVAL_MS * 3).never()).start();
+    lastAppliedIndex.set(5L);
+    verify(datanodeProtocolServer, timeout(2000)).start();
+    verify(safeModeManager, timeout(2000)).refreshAndValidate();
+  }
+
+  @Test
+  void testAlreadyCaughtUpStartsDNServerExactlyOnce() throws Exception {
+    commitIndexAvailable.set(true);
+
+    stateMachine.notifyLeaderChanged(memberId(), leaderId);
+    stateMachine.notifyLeaderChanged(memberId(), leaderId);
+
+    verify(datanodeProtocolServer, times(1)).start();
+    verify(safeModeManager, times(1)).refreshAndValidate();
+    assertThat(stateMachine.getIsStateMachineReady()).isTrue();
+    GenericTestUtils.waitFor(stateMachine::isDNServerStartRetryTerminated, 10, 2000);
+  }
+
+  @Test
+  void testStopPreventsPendingRetryFromStartingDNServer() {
+    stateMachine.notifyLeaderChanged(memberId(), leaderId);
+    scmStopped.set(true);
+
+    stateMachine.stopDNServerStartRetry();
+
+    assertThat(stateMachine.isDNServerStartRetryStopped()).isTrue();
+    commitIndexAvailable.set(true);
+    verify(datanodeProtocolServer, after(RETRY_INTERVAL_MS * 2).never()).start();
+  }
+
+  @Test
+  void testStopWaitsForRunningRetry() throws Exception {
+    CountDownLatch startEntered = new CountDownLatch(1);
+    CountDownLatch allowStart = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      startEntered.countDown();
+      assertTrue(allowStart.await(2, TimeUnit.SECONDS));
+      return null;
+    }).when(datanodeProtocolServer).start();
+    stateMachine.notifyLeaderChanged(memberId(), leaderId);
+    commitIndexAvailable.set(true);
+    assertTrue(startEntered.await(2, TimeUnit.SECONDS));
+
+    scmStopped.set(true);
+    CompletableFuture<Void> stopFuture = CompletableFuture.runAsync(stateMachine::stopDNServerStartRetry);
+    assertThrows(TimeoutException.class, () -> stopFuture.get(100, TimeUnit.MILLISECONDS));
+
+    allowStart.countDown();
+    stopFuture.get(2, TimeUnit.SECONDS);
+    assertThat(stateMachine.isDNServerStartRetryTerminated()).isTrue();
+    verify(datanodeProtocolServer, times(1)).start();
+  }
+
+  private RaftGroupMemberId memberId() {
+    return RaftGroupMemberId.valueOf(followerId, RaftGroupId.randomId());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMStateMachine.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -59,7 +60,7 @@ import org.junit.jupiter.api.Test;
  * Tests SCMStateMachine events and deferred datanode-server startup.
  */
 public class TestSCMStateMachine {
-  private static final long RETRY_INTERVAL_MS = 100L;
+  private static final Duration RETRY_INTERVAL = Duration.ofMillis(100);
 
   private final AtomicBoolean commitIndexAvailable = new AtomicBoolean();
   private final AtomicBoolean scmStopped = new AtomicBoolean();
@@ -108,7 +109,7 @@ public class TestSCMStateMachine {
     when(buffer.getLatestTrxInfo()).thenReturn(
         TransactionInfo.valueOf(TermIndex.valueOf(0, 0)));
 
-    stateMachine = new SCMStateMachine(scm, buffer, RETRY_INTERVAL_MS);
+    stateMachine = new SCMStateMachine(scm, buffer, RETRY_INTERVAL);
   }
 
   @AfterEach
@@ -150,7 +151,7 @@ public class TestSCMStateMachine {
 
     stateMachine.notifyLeaderChanged(memberId(), leaderId);
 
-    verify(datanodeProtocolServer, after(RETRY_INTERVAL_MS * 3).never()).start();
+    verify(datanodeProtocolServer, after(RETRY_INTERVAL.toMillis() * 3).never()).start();
     lastAppliedIndex.set(5L);
     verify(datanodeProtocolServer, timeout(2000)).start();
     verify(safeModeManager, timeout(2000)).refreshAndValidate();
@@ -178,7 +179,7 @@ public class TestSCMStateMachine {
 
     assertThat(stateMachine.isDNServerStartRetryStopped()).isTrue();
     commitIndexAvailable.set(true);
-    verify(datanodeProtocolServer, after(RETRY_INTERVAL_MS * 2).never()).start();
+    verify(datanodeProtocolServer, after(RETRY_INTERVAL.toMillis() * 2).never()).start();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMFollowerCatchupWithContainerReport.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMFollowerCatchupWithContainerReport.java
@@ -223,10 +223,10 @@ public class TestSCMFollowerCatchupWithContainerReport {
   }
 
   /**
-   * Edge case for removing the background polling loop: on an otherwise idle
+   * Edge case for the fallback retry: on an otherwise idle
    * cluster a restarted follower must still start its datanode server (exit safe
-   * mode) and serve replicas after promotion, driven by Ratis heartbeats /
-   * notifyLeaderChanged rather than a steady stream of new transactions.
+   * mode) and serve replicas after promotion without a steady stream of new
+   * transactions.
    */
   @Test
   void testFollowerCatchupOnIdleCluster() throws Exception {


### PR DESCRIPTION
Generated-by: Codex (GPT-5.6 Sol)

## What changes were proposed in this pull request?

This fixes a production liveness issue in SCM HA, not only a flaky test.

A follower SCM restarted in an otherwise idle cluster can remain in safe mode indefinitely. The initial Ratis `notifyLeaderChanged` callback may run before the leader commit index is visible, so the existing catch-up check cannot yet start the deferred datanode protocol server. Ratis 3.2.1 can learn the leader commit index from a later heartbeat, but it does not expose a state-machine callback when that heartbeat updates the commit information. If no new transaction is applied, Ozone receives no later callback that would re-run the catch-up check.

The ideal long-term fix is an event-driven Ratis callback or future for this progress update. With the current Ratis API, Ozone must recheck the condition. This patch uses a dedicated single-thread scheduled executor to retry the existing `tryStartDNServerAndRefreshSafeMode()` path. The existing readiness predicate remains the authority for startup, so the datanode protocol server cannot start until the follower has genuinely caught up. The retry stops after readiness, and the executor is explicitly shut down with the SCM state machine; making its thread a daemon is only an additional process-shutdown safeguard.

The change introduces no RPC, wire-format, storage-format, or configuration compatibility changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16132

## How was this patch tested?

- `mvn -pl hadoop-ozone/integration-test -am test -Dtest=TestSCMFollowerCatchupWithContainerReport -DskipShade -DskipRecon -DskipDocs` (3 tests passed)
- `mvn -o -pl hadoop-hdds/server-scm checkstyle:check`