### PR TITLE
HDDS-10788. Fix intermittent failure in TestWatchForCommit.testWatchForCommitForRetryfailure

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.OutputStream;
@@ -255,32 +256,49 @@ public class TestWatchForCommit {
                 xceiverClient.getPipeline()));
         reply.getResponse().get();
         long index = reply.getLogIndex();
-        cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
-        cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
+        // Shut down the Ratis leader and one follower so that no reachable
+        // leader remains to answer the watch with NotReplicatedException, which
+        // would let an ALL_COMMITTED watch degrade to a normal (majority) reply.
+        shutdownRatisLeaderAndOneFollower(pipeline);
         // emulate closing pipeline when SCM detects DEAD datanodes
         cluster.getStorageContainerManager()
             .getPipelineManager().closePipeline(pipeline.getId());
-        // again write data with more than max buffer limit. This wi
-        // just watch for a log index which in not updated in the commitInfo Map
-        // as well as there is no logIndex generate in Ratis.
-        // The basic idea here is just to test if its throws an exception.
+        // Watch for a log index which is neither present in the commitInfo map
+        // nor generated in Ratis. With no reachable leader this must fail.
+        // The basic idea here is just to test that it throws an exception.
         ExecutionException e = assertThrows(ExecutionException.class,
             () -> xceiverClient.watchForCommit(index + RandomUtils.secure().randomInt(0, 100) + 10)
                 .get());
-        // since the timeout value is quite long, the watch request will either
-        // fail with NotReplicated exceptio, RetryFailureException or
-        // RuntimeException
+        // The watch fails via retry/replication (or group mismatch) failure,
+        // not a bare timeout.
         assertFalse(HddsClientUtils
             .checkForException(e) instanceof TimeoutException);
-        // client should not attempt to watch with
-        // MAJORITY_COMMITTED replication level, except the grpc IO issue
-        if (!logCapturer.getOutput().contains("Connection refused")) {
-          assertThat(e.getMessage()).doesNotContain("Watch-MAJORITY_COMMITTED");
-        }
+        // The client attempts the watch at the requested replication level.
+        assertThat(logCapturer.getOutput()).contains(watchType + " way commit failed");
       } finally {
         clientManager.releaseClient(xceiverClient, false);
       }
     }
+  }
+
+  private void shutdownRatisLeaderAndOneFollower(Pipeline pipeline) throws Exception {
+    DatanodeDetails leader = null;
+    DatanodeDetails follower = null;
+    for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
+      DatanodeDetails details = dn.getDatanodeDetails();
+      if (!pipeline.getNodes().contains(details)) {
+        continue;
+      }
+      if (RatisTestHelper.isRatisLeader(dn, pipeline)) {
+        leader = details;
+      } else if (follower == null && RatisTestHelper.isRatisFollower(dn, pipeline)) {
+        follower = details;
+      }
+    }
+    assertNotNull(leader, "No Ratis leader found in pipeline " + pipeline.getId());
+    assertNotNull(follower, "No Ratis follower found in pipeline " + pipeline.getId());
+    cluster.shutdownHddsDatanode(leader);
+    cluster.shutdownHddsDatanode(follower);
   }
 
   @ParameterizedTest

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
@@ -294,6 +294,9 @@ public class TestWatchForCommit {
       } else if (follower == null && RatisTestHelper.isRatisFollower(dn, pipeline)) {
         follower = details;
       }
+      if (leader != null && follower != null) {
+        break;
+      }
     }
     assertNotNull(leader, "No Ratis leader found in pipeline " + pipeline.getId());
     assertNotNull(follower, "No Ratis follower found in pipeline " + pipeline.getId());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestWatchForCommit.java
@@ -282,6 +282,11 @@ public class TestWatchForCommit {
   }
 
   private void shutdownRatisLeaderAndOneFollower(Pipeline pipeline) throws Exception {
+    // Leader detection and shutdown happen in two steps. This assumes the leader
+    // stays stable in between, which holds here because the pipeline is freshly
+    // formed and idle (no writes in flight), so no Ratis re-election is expected
+    // during the scan. If one did occur, a stale leader could be shut down while
+    // the real leader survives.
     DatanodeDetails leader = null;
     DatanodeDetails follower = null;
     for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.8)

## What changes were proposed in this pull request?

`TestWatchForCommit.testWatchForCommitForRetryfailure` is intermittently failing (it is tagged `@Flaky("HDDS-5818")` and surfaces in the `integration (flaky)` check). The most common failure is:

```
org.opentest4j.AssertionFailedError: Expected java.util.concurrent.ExecutionException to be thrown, but nothing was thrown.
  at ...TestWatchForCommit.testWatchForCommitForRetryfailure(TestWatchForCommit.java:267)
```

Root cause: the test shuts down two of three datanodes and expects `watchForCommit` for a not-yet-committed index to always throw. For the `ALL_COMMITTED` watch type this is not guaranteed. When the surviving node happens to be the Ratis leader, it answers the watch with `NotReplicatedException`, which `XceiverClientRatis.watchForCommit` handles by degrading to a majority reply and completing the future normally. In that case nothing is thrown and the assertion fails, so the outcome depends on leader placement.

This change shuts down the Ratis leader plus one follower, so that no reachable leader remains. With no leader there is no `NotReplicatedException` to degrade an `ALL_COMMITTED` watch, so the watch fails deterministically for both watch types.

It also replaces the previous `doesNotContain("Watch-MAJORITY_COMMITTED")` assertion with a deterministic replication-level check that asserts the client logged that the watch at the requested replication level failed. The old assertion was unsatisfiable in general: an `ALL_COMMITTED` watch intentionally falls back to a majority watch, and a `MAJORITY_COMMITTED` watch request itself contains that string, so it only passed via the `"Connection refused"` escape hatch. That assertion was itself a source of flakiness (the symptom originally reported on this Jira).

The `closePipeline` step and the rest of the scenario are unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10788

## How was this patch tested?

Ran `TestWatchForCommit#testWatchForCommitForRetryfailure` (both `MAJORITY_COMMITTED` and `ALL_COMMITTED` parameters) locally: `Tests run: 2, Failures: 0` across repeated runs, and the new replication-level assertion held for both watch types. `checkstyle` on the `ozone-integration-test` module passes. A single green run cannot fully prove non-flakiness, but the fix is deterministic by construction: with no reachable leader the graceful-degrade path is unreachable, so the watch always completes exceptionally.

Run 10x10: https://github.com/smengcl/hadoop-ozone/actions/runs/32388474883
