### PR TITLE
HDDS-16150. Fix error code for invalid S3 Lifecycle Expiration Days from InvalidRequest to InvalidArgument

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
@@ -140,9 +140,10 @@ public class BucketLifecycleHandler extends BucketOperationHandler {
     } catch (WebApplicationException ex) {
       throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML, bucketName);
     } catch (OMException ex) {
-      // OM reports lifecycle validation failures as INVALID_REQUEST, which the shared translation maps to InvalidRequest.
-      // AWS S3 uses InvalidArgument for rejected lifecycle configurations, so remap INVALID_REQUEST -> InvalidArgument for
-      // this endpoint. This also applies to OM-only checks (e.g. bucket layout mismatch), even though there is no AWS equivalent.
+      // OM reports lifecycle validation failures as INVALID_REQUEST, which the shared translation maps to
+      // InvalidRequest. AWS S3 uses InvalidArgument for rejected lifecycle configurations, so remap
+      // INVALID_REQUEST -> InvalidArgument for this endpoint. This also applies to OM-only checks
+      // (e.g. bucket layout mismatch), even though there is no AWS equivalent.
       if (ex.getResult() == OMException.ResultCodes.INVALID_REQUEST) {
         throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, bucketName, ex);
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
@@ -140,11 +140,9 @@ public class BucketLifecycleHandler extends BucketOperationHandler {
     } catch (WebApplicationException ex) {
       throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML, bucketName);
     } catch (OMException ex) {
-      // Both the rule validation in toOmLifecycleConfiguration and OM's own checks in
-      // setLifecycleConfiguration reject with INVALID_REQUEST, which the shared translation reports
-      // as InvalidRequest. S3 expects InvalidArgument for a rejected lifecycle configuration, so the
-      // whole path is remapped. This also covers OM-only checks such as bucket layout mismatch, which
-      // has no AWS equivalent.
+      // OM reports lifecycle validation failures as INVALID_REQUEST, which the shared translation maps to InvalidRequest.
+      // AWS S3 uses InvalidArgument for rejected lifecycle configurations, so remap INVALID_REQUEST -> InvalidArgument for
+      // this endpoint. This also applies to OM-only checks (e.g. bucket layout mismatch), even though there is no AWS equivalent.
       if (ex.getResult() == OMException.ResultCodes.INVALID_REQUEST) {
         throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, bucketName, ex);
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
@@ -131,22 +131,28 @@ public class BucketLifecycleHandler extends BucketOperationHandler {
     verifyBucketOwner(context, bucketName);
     S3LifecycleConfiguration s3LifecycleConfiguration;
     OzoneBucket ozoneBucket = context.getVolume().getBucket(bucketName);
+    OmLifecycleConfiguration lcc;
     try {
       s3LifecycleConfiguration = new PutBucketLifecycleConfigurationUnmarshaller().readFrom(null,
           null, null, null, null, body);
-      OmLifecycleConfiguration lcc =
-          s3LifecycleConfiguration.toOmLifecycleConfiguration(ozoneBucket);
-      ozoneBucket.setLifecycleConfiguration(lcc);
+      lcc = s3LifecycleConfiguration.toOmLifecycleConfiguration(ozoneBucket);
     } catch (WebApplicationException ex) {
       throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML, bucketName);
     } catch (OMException ex) {
-      // OM reports lifecycle validation failures as INVALID_REQUEST, which the shared translation maps to
-      // InvalidRequest. AWS S3 uses InvalidArgument for rejected lifecycle configurations, so remap
-      // INVALID_REQUEST -> InvalidArgument for this endpoint. This also applies to OM-only checks
-      // (e.g. bucket layout mismatch), even though there is no AWS equivalent.
+      // Rule validation rejects client-supplied values with INVALID_REQUEST, which the shared
+      // translation maps to InvalidRequest. AWS S3 uses InvalidArgument for a rejected lifecycle
+      // configuration, so only this validation step is remapped.
       if (ex.getResult() == OMException.ResultCodes.INVALID_REQUEST) {
         throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, bucketName, ex);
       }
+      throw S3ErrorTable.newError(bucketName, ex);
+    }
+
+    try {
+      ozoneBucket.setLifecycleConfiguration(lcc);
+    } catch (OMException ex) {
+      // OM raises INVALID_REQUEST for server-side conditions as well, such as a bucket layout
+      // mismatch, so its result codes keep the shared translation instead of being remapped.
       throw S3ErrorTable.newError(bucketName, ex);
     }
     return Response.ok().build();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
@@ -140,6 +140,14 @@ public class BucketLifecycleHandler extends BucketOperationHandler {
     } catch (WebApplicationException ex) {
       throw S3ErrorTable.newError(S3ErrorTable.MALFORMED_XML, bucketName);
     } catch (OMException ex) {
+      // Both the rule validation in toOmLifecycleConfiguration and OM's own checks in
+      // setLifecycleConfiguration reject with INVALID_REQUEST, which the shared translation reports
+      // as InvalidRequest. S3 expects InvalidArgument for a rejected lifecycle configuration, so the
+      // whole path is remapped. This also covers OM-only checks such as bucket layout mismatch, which
+      // has no AWS equivalent.
+      if (ex.getResult() == OMException.ResultCodes.INVALID_REQUEST) {
+        throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, bucketName, ex);
+      }
       throw S3ErrorTable.newError(bucketName, ex);
     }
     return Response.ok().build();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/S3LifecycleConfiguration.java
@@ -299,9 +299,9 @@ public class S3LifecycleConfiguration {
       if (ex.getCause() instanceof OMException) {
         throw (OMException) ex.getCause();
       }
-      throw S3ErrorTable.newError(S3ErrorTable.INVALID_REQUEST, ozoneBucket.getName(), ex);
+      throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, ozoneBucket.getName(), ex);
     } catch (IllegalStateException ex) {
-      throw S3ErrorTable.newError(S3ErrorTable.INVALID_REQUEST, ozoneBucket.getName(), ex);
+      throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, ozoneBucket.getName(), ex);
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
@@ -25,6 +25,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ACCESS_DENIED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_XML;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_BUCKET;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.QUOTA_EXCEEDED;
@@ -130,6 +131,17 @@ public class TestS3LifecycleConfigurationPut {
         HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(TestS3LifecycleConfigurationPut::withEmptyFilterAndInvalidDate,
         HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
+  }
+
+  @Test
+  public void testPutLifecycleConfigurationPropagatesOmInvalidRequest()
+      throws Exception {
+    // OM also raises INVALID_REQUEST for conditions that are not rejected rule values, such as the
+    // bucket layout mismatch in OMLifecycleConfigurationSetRequest. Those keep reporting
+    // InvalidRequest instead of being remapped to InvalidArgument.
+    assertUnhandledOMExceptionPropagated(
+        new OMException("Bucket layout mismatch", OMException.ResultCodes.INVALID_REQUEST),
+        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
@@ -24,7 +24,7 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ACCESS_DENIED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_XML;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_BUCKET;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.QUOTA_EXCEEDED;
@@ -107,23 +107,29 @@ public class TestS3LifecycleConfigurationPut {
   @Test
   public void testPutInvalidLifecycleConfiguration() throws Exception {
     testInvalidLifecycleConfiguration(TestS3LifecycleConfigurationPut::withoutAction,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(TestS3LifecycleConfigurationPut::withoutFilter,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(this::useDuplicateTagInAndOperator,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(this::usePrefixTagWithoutAndOperatorInFilter,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(this::usePrefixAndOperatorCoExistInFilter,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(this::usePrefixFilterCoExist,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(this::useAndOperatorOnlyOnePrefix,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(this::useAndOperatorOnlyOneTag,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
     testInvalidLifecycleConfiguration(this::useEmptyAndOperator,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
+    testInvalidLifecycleConfiguration(TestS3LifecycleConfigurationPut::withExpirationZeroDays,
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
+    testInvalidLifecycleConfiguration(TestS3LifecycleConfigurationPut::withExpirationDaysAndDate,
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
+    testInvalidLifecycleConfiguration(TestS3LifecycleConfigurationPut::withEmptyFilterAndInvalidDate,
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
   }
 
   @Test
@@ -164,7 +170,7 @@ public class TestS3LifecycleConfigurationPut {
       fail();
     } catch (OS3Exception ex) {
       assertEquals(HTTP_BAD_REQUEST, ex.getHttpCode());
-      assertEquals(INVALID_REQUEST.getCode(), ex.getCode());
+      assertEquals(INVALID_ARGUMENT.getCode(), ex.getCode());
     }
   }
 
@@ -256,12 +262,12 @@ public class TestS3LifecycleConfigurationPut {
     // Test with zero days - should fail
     testInvalidLifecycleConfiguration(
         TestS3LifecycleConfigurationPut::withAbortZeroDays,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
 
     // Test with negative days - should fail
     testInvalidLifecycleConfiguration(
         TestS3LifecycleConfigurationPut::withAbortNegativeDays,
-        HTTP_BAD_REQUEST, INVALID_REQUEST.getCode());
+        HTTP_BAD_REQUEST, INVALID_ARGUMENT.getCode());
   }
 
   private static InputStream onePrefix() {
@@ -286,6 +292,48 @@ public class TestS3LifecycleConfigurationPut {
         "<ID>remove logs after 30 days</ID>" +
         "<Prefix>prefix/</Prefix>" +
         "<Status>Enabled</Status>" +
+        "</Rule>" +
+        "</LifecycleConfiguration>");
+    return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static InputStream withExpirationZeroDays() {
+    String xml = (
+        "<LifecycleConfiguration xmlns=\"http://s3.amazonaws" +
+        ".com/doc/2006-03-01/\">" +
+        "<Rule>" +
+        "<ID>zero-days</ID>" +
+        "<Prefix>prefix/</Prefix>" +
+        "<Status>Enabled</Status>" +
+        "<Expiration><Days>0</Days></Expiration>" +
+        "</Rule>" +
+        "</LifecycleConfiguration>");
+    return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static InputStream withExpirationDaysAndDate() {
+    String xml = (
+        "<LifecycleConfiguration xmlns=\"http://s3.amazonaws" +
+        ".com/doc/2006-03-01/\">" +
+        "<Rule>" +
+        "<ID>days-and-date</ID>" +
+        "<Prefix>prefix/</Prefix>" +
+        "<Status>Enabled</Status>" +
+        "<Expiration><Days>30</Days><Date>2044-01-19T00:00:00+00:00</Date></Expiration>" +
+        "</Rule>" +
+        "</LifecycleConfiguration>");
+    return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static InputStream withEmptyFilterAndInvalidDate() {
+    String xml = (
+        "<LifecycleConfiguration xmlns=\"http://s3.amazonaws" +
+        ".com/doc/2006-03-01/\">" +
+        "<Rule>" +
+        "<ID>empty-filter-invalid-date</ID>" +
+        "<Filter></Filter>" +
+        "<Status>Enabled</Status>" +
+        "<Expiration><Date>2023-03-03</Date></Expiration>" +
         "</Rule>" +
         "</LifecycleConfiguration>");
     return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## What changes were proposed in this pull request?

`PutBucketLifecycleConfiguration` returns the S3 error code `InvalidRequest` when a lifecycle rule is
rejected, for example `Days: 0` or a `Date` that is not valid. AWS S3 returns `InvalidArgument` for
these, and s3-tests asserts on that exact code string.

OM raises every lifecycle validation failure as `OMException.ResultCodes.INVALID_REQUEST`, and
`S3ErrorTable.translateResultCode()` maps it to the same-named S3 code. That table is shared by all
S3 endpoints, so it is left untouched; the remapping is applied on the lifecycle PUT path only, in
`BucketLifecycleHandler.putBucketLifecycleConfiguration()` and
`S3LifecycleConfiguration.toOmLifecycleConfiguration()`. Other result codes keep the shared
translation. The HTTP status stays 400; only the error code string changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16150

## How was this patch tested?

`TestS3LifecycleConfigurationPut`: existing assertions updated to `InvalidArgument`, plus new cases
for `Days: 0` and for an empty `<Filter>` with an invalid `Date`.

`mvn -pl :ozone-s3gateway test` — 723 tests, 0 failures. `mvn -pl :ozone-s3gateway checkstyle:check`
passes.