### PR TITLE
HDDS-8096. Redirect S3G Jersey logs to log file

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -488,6 +488,7 @@ MIT
    org.bouncycastle:bcutil-jdk18on
    org.codehaus.mojo:animal-sniffer-annotations
    org.slf4j:jcl-over-slf4j
+   org.slf4j:jul-to-slf4j
    org.slf4j:slf4j-api
    org.slf4j:slf4j-reload4j
 

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -166,6 +166,7 @@ share/ozone/lib/jsp-api.jar
 share/ozone/lib/jspecify.jar
 share/ozone/lib/jsr311-api.jar
 share/ozone/lib/jts-core.jar
+share/ozone/lib/jul-to-slf4j.jar
 share/ozone/lib/jtokkit.jar
 share/ozone/lib/kerb-core.jar
 share/ozone/lib/kerb-crypto.jar

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -244,6 +244,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-client</artifactId>
       <type>test-jar</type>
       <scope>test</scope>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -181,6 +181,10 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ratis.util.JvmPauseMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import picocli.CommandLine.Command;
 
 /**
@@ -68,9 +69,16 @@ public class Gateway extends GenericCli implements Callable<Void> {
   private final JvmPauseMonitor jvmPauseMonitor = newJvmPauseMonitor("S3G");
 
   public static void main(String[] args) throws Exception {
+    redirectJulToSlf4j();
     OzoneNetUtils.disableJvmNetworkAddressCacheIfRequired(
             new OzoneConfiguration());
     new Gateway().run(args);
+  }
+
+  @VisibleForTesting
+  static void redirectJulToSlf4j() {
+    SLF4JBridgeHandler.removeHandlersForRootLogger();
+    SLF4JBridgeHandler.install();
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestGateway.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestGateway.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import org.apache.log4j.Level;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.WriterAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+/**
+ * Tests S3 Gateway startup behavior.
+ */
+public class TestGateway {
+
+  private final Logger rootLogger = LogManager.getLogManager().getLogger("");
+  private Handler[] originalHandlers;
+
+  @BeforeEach
+  void saveRootLoggerHandlers() {
+    originalHandlers = rootLogger.getHandlers();
+    removeRootLoggerHandlers();
+  }
+
+  @AfterEach
+  void restoreRootLoggerHandlers() {
+    removeRootLoggerHandlers();
+    for (Handler handler : originalHandlers) {
+      rootLogger.addHandler(handler);
+    }
+  }
+
+  @Test
+  void redirectsJulLogsToSlf4j() {
+    String loggerName = TestGateway.class.getName();
+    Logger julLogger = Logger.getLogger(loggerName);
+    org.apache.log4j.Logger log4jLogger =
+        org.apache.log4j.Logger.getLogger(loggerName);
+    Level originalLevel = log4jLogger.getLevel();
+    boolean originalAdditivity = log4jLogger.getAdditivity();
+    StringWriter output = new StringWriter();
+    WriterAppender appender = new WriterAppender(
+        new PatternLayout("%m%n"), output);
+    log4jLogger.setLevel(Level.WARN);
+    log4jLogger.setAdditivity(false);
+    log4jLogger.addAppender(appender);
+    rootLogger.addHandler(new ConsoleHandler());
+
+    try {
+      Gateway.redirectJulToSlf4j();
+
+      assertThat(rootLogger.getHandlers())
+          .singleElement()
+          .isInstanceOf(SLF4JBridgeHandler.class);
+
+      String message = "JUL warning redirected to the S3 Gateway log";
+      julLogger.warning(message);
+
+      assertThat(output.toString()).contains(message);
+    } finally {
+      log4jLogger.removeAppender(appender);
+      appender.close();
+      log4jLogger.setLevel(originalLevel);
+      log4jLogger.setAdditivity(originalAdditivity);
+    }
+  }
+
+  private void removeRootLoggerHandlers() {
+    for (Handler handler : rootLogger.getHandlers()) {
+      rootLogger.removeHandler(handler);
+    }
+  }
+}

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestGateway.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestGateway.java
@@ -19,14 +19,11 @@ package org.apache.hadoop.ozone.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.StringWriter;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
-import org.apache.log4j.Level;
-import org.apache.log4j.PatternLayout;
-import org.apache.log4j.WriterAppender;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,18 +53,8 @@ public class TestGateway {
 
   @Test
   void redirectsJulLogsToSlf4j() {
-    String loggerName = TestGateway.class.getName();
-    Logger julLogger = Logger.getLogger(loggerName);
-    org.apache.log4j.Logger log4jLogger =
-        org.apache.log4j.Logger.getLogger(loggerName);
-    Level originalLevel = log4jLogger.getLevel();
-    boolean originalAdditivity = log4jLogger.getAdditivity();
-    StringWriter output = new StringWriter();
-    WriterAppender appender = new WriterAppender(
-        new PatternLayout("%m%n"), output);
-    log4jLogger.setLevel(Level.WARN);
-    log4jLogger.setAdditivity(false);
-    log4jLogger.addAppender(appender);
+    Logger julLogger = Logger.getLogger(TestGateway.class.getName());
+    LogCapturer logCapturer = LogCapturer.captureLogs(TestGateway.class);
     rootLogger.addHandler(new ConsoleHandler());
 
     try {
@@ -80,12 +67,9 @@ public class TestGateway {
       String message = "JUL warning redirected to the S3 Gateway log";
       julLogger.warning(message);
 
-      assertThat(output.toString()).contains(message);
+      assertThat(logCapturer.getOutput()).contains(message);
     } finally {
-      log4jLogger.removeAppender(appender);
-      appender.close();
-      log4jLogger.setLevel(originalLevel);
-      log4jLogger.setAdditivity(originalAdditivity);
+      logCapturer.stopCapturing();
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3 Gateway now redirects Java Util Logging (JUL) records to SLF4J before initializing Jersey.

Jersey logs through JUL, whose default `ConsoleHandler` writes to stderr. As a result, Jersey warnings were written to the S3 Gateway daemon's stderr output instead of the configured S3 Gateway log file.

This change adds the SLF4J JUL bridge to the S3 Gateway module, removes the JUL root logger's existing handlers during S3 Gateway startup, and installs `SLF4JBridgeHandler`. JUL records are then handled by the existing SLF4J/reload4j configuration and written to the regular S3 Gateway log.

A unit test verifies that a JUL warning reaches a reload4j appender through the bridge and that the JUL console handler is replaced.

Reference: https://www.slf4j.org/api/org/slf4j/bridge/SLF4JBridgeHandler.html
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8096

## How was this patch tested?

- `mvn -pl :ozone-s3gateway -Dtest=TestGateway -DskipShade -DskipRecon -DskipDocs test`
- `mvn -pl :ozone-s3gateway -DskipShade -DskipRecon -DskipDocs test`

CI: https://github.com/F64116045/ozone/actions/runs/31610030872

