### PR TITLE
HDDS-15356. Addendum: Make multi-buffer chunk checksum allocation-free

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -259,6 +259,8 @@ public class Checksum {
   /**
    * The default implementation of computeChecksum(ChunkBuffer) that does not use cache, even if cache is initialized.
    * This is a stop-gap solution before the protocol change.
+   * The input must be prepared for reading as described by
+   * {@link #computeChecksum(ChunkBuffer, boolean)}.
    * @param data ChunkBuffer
    * @return ChecksumData
    * @throws OzoneChecksumException
@@ -269,6 +271,10 @@ public class Checksum {
   }
 
   /**
+   * The input must be prepared for reading. For each buffer returned by
+   * {@link ChunkBuffer#asByteBufferList()}, the bytes in
+   * {@code [position(), limit())} must be the logical checksum data.
+   *
    * This method does not advance the positions of {@code data}'s underlying
    * buffers. Both the no-cache and cache paths slice via
    * {@link ByteBuffer#duplicate()}.
@@ -305,6 +311,7 @@ public class Checksum {
     final int checksumCount = dataLength == 0 ? 0 : 1 + (dataLength - 1) / bytesPerChecksum;
     final List<ByteString> result = new ArrayList<>(checksumCount);
     int windowRemaining = bytesPerChecksum;
+    long processed = 0;
     algo.reset();
 
     for (ByteBuffer src : data.asByteBufferList()) {
@@ -314,6 +321,7 @@ public class Checksum {
         final int n = Math.min(srcLim - srcPos, windowRemaining);
         algo.update(BufferUtils.slice(src, srcPos, n));
         srcPos += n;
+        processed += n;
         windowRemaining -= n;
         if (windowRemaining == 0) {
           result.add(algo.finish());
@@ -321,6 +329,10 @@ public class Checksum {
           windowRemaining = bytesPerChecksum;
         }
       }
+    }
+    if (processed != dataLength) {
+      throw new IllegalStateException("ChunkBuffer remaining byte count is " + dataLength
+          + ", but its underlying buffers expose " + processed + " bytes");
     }
     if (windowRemaining < bytesPerChecksum) {
       // Unaligned trailing window.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
@@ -87,6 +87,14 @@ public class ChecksumCache {
           + bytesPerChecksum + " call=" + chksumSize);
     }
     final int currChunkLength = data.remaining();
+    final List<ByteBuffer> buffers = data.asByteBufferList();
+    long readableByteCount = 0;
+    for (ByteBuffer buffer : buffers) {
+      readableByteCount += buffer.remaining();
+    }
+    Preconditions.checkState(readableByteCount == currChunkLength,
+        "ChunkBuffer remaining byte count is %s, but its underlying buffers expose %s bytes",
+        currChunkLength, readableByteCount);
 
     if (currChunkLength == prevChunkLength) {
       LOG.debug("ChunkBuffer data length same as last time ({}). "
@@ -111,7 +119,7 @@ public class ChecksumCache {
     algo.reset();
     long position = 0;
 
-    for (ByteBuffer src : data.asByteBufferList()) {
+    for (ByteBuffer src : buffers) {
       int srcPos = src.position();
       final int srcLim = src.limit();
       final int srcLen = srcLim - srcPos;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.common;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -116,5 +117,20 @@ public class TestChecksum {
 
     final Checksum checksum = getChecksum(null, false);
     assertEquals(1, checksum.computeChecksum(data).getChecksums().size());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRejectsIncrementalBufferInWriteMode(boolean useChecksumCache) {
+    try (ChunkBuffer data = ChunkBuffer.allocate(32, 8)) {
+      data.put(new byte[10]);
+
+      final Checksum checksum = getChecksum(null, useChecksumCache);
+      final IllegalStateException exception = assertThrows(
+          IllegalStateException.class,
+          () -> checksum.computeChecksum(data, useChecksumCache));
+      assertEquals("ChunkBuffer remaining byte count is 22, but its underlying buffers expose 6 bytes",
+          exception.getMessage());
+    }
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.common.Checksum.Algorithm;
 import org.apache.hadoop.ozone.common.Checksum.StreamingChecksum;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -109,6 +110,38 @@ class TestChecksumCache {
     final ChecksumData actual = cached.computeChecksum(partiallyPositioned(data), true);
 
     Assertions.assertEquals(expected.getChecksums(), actual.getChecksums());
+  }
+
+  @Test
+  void testRejectsInvalidBufferWhenLengthMatchesCache() throws Exception {
+    final Checksum checksum = new Checksum(ChecksumType.SHA256, 10, true);
+    checksum.computeChecksum(ByteBuffer.wrap(new byte[10]), true);
+
+    try (ChunkBuffer data = ChunkBuffer.allocate(20, 10)) {
+      data.put(new byte[10]);
+      final IllegalStateException exception = Assertions.assertThrows(
+          IllegalStateException.class,
+          () -> checksum.computeChecksum(data, true));
+      Assertions.assertEquals(
+          "ChunkBuffer remaining byte count is 10, but its underlying buffers expose 0 bytes",
+          exception.getMessage());
+    }
+  }
+
+  @Test
+  void testRejectedBufferDoesNotModifyCache() throws Exception {
+    final Checksum cached = new Checksum(ChecksumType.SHA256, 10, true);
+    try (ChunkBuffer data = ChunkBuffer.allocate(80, 32)) {
+      data.put(new byte[33]);
+      Assertions.assertThrows(IllegalStateException.class,
+          () -> cached.computeChecksum(data, true));
+    }
+
+    final ByteBuffer valid = ByteBuffer.wrap(new byte[10]);
+    final ChecksumData expected = new Checksum(ChecksumType.SHA256, 10)
+        .computeChecksum(valid.duplicate());
+    final ChecksumData actual = cached.computeChecksum(valid, true);
+    Assertions.assertEquals(expected, actual);
   }
 
   private static ChunkBuffer split(byte[] data, int length, int bufferSize) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up to #10350.

The checksum walkers process each underlying `ByteBuffer` from its current position to its limit. Therefore, the input `ChunkBuffer` must be prepared for reading, and these ranges must represent the logical checksum data.

This change:

- documents the read-ready `ChunkBuffer` requirement;
- validates that the underlying readable ranges match `ChunkBuffer.remaining()`;
- validates cached input before an early return or cache mutation;
- prevents invalid input from returning stale cached checksums or corrupting reusable cache state; and
- adds regression tests for direct and cached checksum calculation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15356

## How was this patch tested?

- 31 checksum unit tests passed: `TestChecksum`, `TestChecksumCache`, and `TestChecksumMultiBuffer`.
- Checkstyle passed all 58 goals.
- The `-Pdist` Javadoc lifecycle passed all 148 goals with warnings treated as errors and source release 25.
- SpotBugs completed with zero findings.
- `git diff --check` passed.

Generated-by: Codex (GPT-5.6 Sol)
