### PR TITLE
HDDS-16164. DirectoryDeletingService could deadlock snapshot purge while retaining snapshot DB handles

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingServiceWithFSO.java
@@ -626,7 +626,7 @@ public class TestDirectoryDeletingServiceWithFSO {
     }).when(service).optimizeDirDeletesAndSubmitRequest(anyLong(), anyLong(),
         anyLong(), anyList(), anyList(), eq(null), anyLong(), any(),
         any(ReclaimableDirFilter.class), any(ReclaimableKeyFilter.class), anyMap(), any(),
-        anyLong(), any(AtomicInteger.class));
+        anyLong(), any(AtomicInteger.class), any());
 
     Mockito.doAnswer(i -> {
       store.createSnapshot(testVolumeName, testBucketName, snap2);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -676,26 +677,34 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         CompletableFuture<Boolean> workersCompleted = CompletableFuture.completedFuture(true);
         for (int i = 0; i < parallelThreads; i++) {
           AtomicBoolean workerReady = new AtomicBoolean();
-          CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
-            try {
-              return processDeletedDirectories(currentSnapshotInfo, keyManager, dirSupplier,
-                  expectedPreviousSnapshotId, exclusiveSizeMap, rnCnt, remainNum, () -> {
-                    if (snapshotDbHandlesClosed != null) {
-                      signalWorkerReady(workerReady, snapshotDbHandlesClosed);
-                      if (awaitUninterruptibly(submitSnapshotRequests)) {
-                        Thread.currentThread().interrupt();
+          try {
+            CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
+              try {
+                return processDeletedDirectories(currentSnapshotInfo, keyManager, dirSupplier,
+                    expectedPreviousSnapshotId, exclusiveSizeMap, rnCnt, remainNum, () -> {
+                      if (snapshotDbHandlesClosed != null) {
+                        signalWorkerReady(workerReady, snapshotDbHandlesClosed);
+                        if (awaitUninterruptibly(submitSnapshotRequests)) {
+                          Thread.currentThread().interrupt();
+                        }
                       }
-                    }
-                  });
-            } catch (Throwable e) {
-              return false;
-            } finally {
-              if (snapshotDbHandlesClosed != null) {
-                signalWorkerReady(workerReady, snapshotDbHandlesClosed);
+                    });
+              } catch (Throwable e) {
+                return false;
+              } finally {
+                if (snapshotDbHandlesClosed != null) {
+                  signalWorkerReady(workerReady, snapshotDbHandlesClosed);
+                }
               }
+            }, isThreadPoolActive(deletionThreadPool) ? deletionThreadPool : ForkJoinPool.commonPool());
+            workersCompleted = workersCompleted.thenCombine(future, (a, b) -> a && b);
+          } catch (RejectedExecutionException e) {
+            if (snapshotDbHandlesClosed != null) {
+              countDown(snapshotDbHandlesClosed, parallelThreads - i);
             }
-          }, isThreadPoolActive(deletionThreadPool) ? deletionThreadPool : ForkJoinPool.commonPool());
-          workersCompleted = workersCompleted.thenCombine(future, (a, b) -> a && b);
+            workersCompleted = workersCompleted.thenApply(ignored -> false);
+            break;
+          }
         }
 
         boolean interrupted = false;
@@ -703,9 +712,12 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
           interrupted = awaitUninterruptibly(snapshotDbHandlesClosed);
           // Workers have released their previous-snapshot DB handles and stopped using the iterator and current
           // snapshot. Close the task-owned resources before allowing synchronous OM requests to be submitted.
-          dirSupplier.close();
-          currentSnapshot.close();
-          submitSnapshotRequests.countDown();
+          try {
+            dirSupplier.close();
+            currentSnapshot.close();
+          } finally {
+            submitSnapshotRequests.countDown();
+          }
         }
 
         while (true) {
@@ -857,6 +869,12 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
     private void signalWorkerReady(AtomicBoolean workerReady, CountDownLatch snapshotDbHandlesClosed) {
       if (workerReady.compareAndSet(false, true)) {
         snapshotDbHandlesClosed.countDown();
+      }
+    }
+
+    private void countDown(CountDownLatch latch, int count) {
+      for (int i = 0; i < count; i++) {
+        latch.countDown();
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -40,14 +40,17 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
@@ -127,7 +130,8 @@ import org.slf4j.LoggerFactory;
  *
  * <h2>Threading and Parallelism</h2>
  * <ul>
- *   <li>Uses a configurable thread pool for parallel deletion tasks within each store/snapshot.</li>
+ *   <li>Uses a configurable thread pool for parallel deletion tasks within each store or snapshot.</li>
+ *   <li>Coordinates snapshot workers so each thread closes its own snapshot DB handles before submitting requests.</li>
  *   <li>Each snapshot and AOS get a separate background task for deletion.</li>
  * </ul>
  *
@@ -159,6 +163,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   private final SnapshotChainManager snapshotChainManager;
   private final boolean deepCleanSnapshots;
   private ExecutorService deletionThreadPool;
+  private final ReentrantLock snapshotProcessingLock = new ReentrantLock();
   private final AtomicInteger numberOfParallelThreadsPerStore;
   private final AtomicLong deletedDirsCount;
   private final AtomicLong movedDirsCount;
@@ -330,7 +335,8 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
       CheckedFunction<KeyValue<String, OmKeyInfo>, Boolean, IOException> reclaimableDirChecker,
       CheckedFunction<KeyValue<String, OmKeyInfo>, Boolean, IOException> reclaimableFileChecker,
       Map<VolumeBucketId, BucketNameInfo> bucketNameInfoMap,
-      UUID expectedPreviousSnapshotId, long rnCnt, AtomicInteger remainNum) {
+      UUID expectedPreviousSnapshotId, long rnCnt, AtomicInteger remainNum,
+      Runnable beforeSubmit) {
 
     // Optimization to handle delete sub-dir and keys to remove quickly
     // This case will be useful to handle when depth of directory is high
@@ -361,6 +367,8 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         break;
       }
     }
+    beforeSubmit.run();
+
     if (!purgePathRequestList.isEmpty()) {
       submitPurgePathsWithBatching(purgePathRequestList, snapTableKey, expectedPreviousSnapshotId, bucketNameInfoMap);
     }
@@ -639,7 +647,8 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
      * @param keyManager KeyManager of the underlying store.
      */
     @VisibleForTesting
-    void processDeletedDirsForStore(SnapshotInfo currentSnapshotInfo, KeyManager keyManager, long rnCnt, int remainNum)
+    void processDeletedDirsForStore(SnapshotInfo currentSnapshotInfo, KeyManager keyManager,
+        UncheckedAutoCloseableSupplier<OmSnapshot> currentSnapshot, long rnCnt, int remainNum)
         throws IOException, ExecutionException, InterruptedException {
       String volume, bucket; String snapshotTableKey;
       if (currentSnapshotInfo != null) {
@@ -650,6 +659,8 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         volume = null; bucket = null; snapshotTableKey = null;
       }
 
+      Map<UUID, Pair<Long, Long>> exclusiveSizeMap = Maps.newConcurrentMap();
+      boolean processedAllDeletedDirs;
       try (DeletedDirSupplier dirSupplier = new DeletedDirSupplier(currentSnapshotInfo == null ?
           keyManager.getDeletedDirEntries() : keyManager.getDeletedDirEntries(volume, bucket))) {
         // This is to avoid race condition b/w purge request and snapshot chain update. For AOS taking the global
@@ -658,43 +669,83 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         UUID expectedPreviousSnapshotId = currentSnapshotInfo == null ?
             snapshotChainManager.getLatestGlobalSnapshotId() :
             SnapshotUtils.getPreviousSnapshotId(currentSnapshotInfo, snapshotChainManager);
-        Map<UUID, Pair<Long, Long>> exclusiveSizeMap = Maps.newConcurrentMap();
-
-        CompletableFuture<Boolean> processedAllDeletedDirs = CompletableFuture.completedFuture(true);
         final int parallelThreads = numberOfParallelThreadsPerStore.get();
+        CountDownLatch snapshotDbHandlesClosed = currentSnapshotInfo == null ? null :
+            new CountDownLatch(parallelThreads);
+        CountDownLatch submitSnapshotRequests = currentSnapshotInfo == null ? null : new CountDownLatch(1);
+        CompletableFuture<Boolean> workersCompleted = CompletableFuture.completedFuture(true);
         for (int i = 0; i < parallelThreads; i++) {
+          AtomicBoolean workerReady = new AtomicBoolean();
           CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
             try {
               return processDeletedDirectories(currentSnapshotInfo, keyManager, dirSupplier,
-                  expectedPreviousSnapshotId, exclusiveSizeMap, rnCnt, remainNum);
+                  expectedPreviousSnapshotId, exclusiveSizeMap, rnCnt, remainNum, () -> {
+                    if (snapshotDbHandlesClosed != null) {
+                      signalWorkerReady(workerReady, snapshotDbHandlesClosed);
+                      if (awaitUninterruptibly(submitSnapshotRequests)) {
+                        Thread.currentThread().interrupt();
+                      }
+                    }
+                  });
             } catch (Throwable e) {
               return false;
+            } finally {
+              if (snapshotDbHandlesClosed != null) {
+                signalWorkerReady(workerReady, snapshotDbHandlesClosed);
+              }
             }
           }, isThreadPoolActive(deletionThreadPool) ? deletionThreadPool : ForkJoinPool.commonPool());
-          processedAllDeletedDirs = processedAllDeletedDirs.thenCombine(future, (a, b) -> a && b);
+          workersCompleted = workersCompleted.thenCombine(future, (a, b) -> a && b);
         }
-        // If AOS or all directories have been processed for snapshot, update snapshot size delta and deep clean flag
-        // if it is a snapshot.
-        if (processedAllDeletedDirs.get()) {
-          List<OzoneManagerProtocolProtos.SetSnapshotPropertyRequest> setSnapshotPropertyRequests = new ArrayList<>();
 
-          for (Map.Entry<UUID, Pair<Long, Long>> entry : exclusiveSizeMap.entrySet()) {
-            UUID snapshotID = entry.getKey();
-            long exclusiveSize = entry.getValue().getLeft();
-            long exclusiveReplicatedSize = entry.getValue().getRight();
-            setSnapshotPropertyRequests.add(getSetSnapshotRequestUpdatingExclusiveSize(
-                exclusiveSize, exclusiveReplicatedSize, snapshotID));
-          }
-
-          // Updating directory deep clean flag of snapshot.
-          if (currentSnapshotInfo != null) {
-            setSnapshotPropertyRequests.add(OzoneManagerProtocolProtos.SetSnapshotPropertyRequest.newBuilder()
-                .setSnapshotKey(snapshotTableKey)
-                .setDeepCleanedDeletedDir(true)
-                .build());
-          }
-          submitSetSnapshotRequests(setSnapshotPropertyRequests);
+        boolean interrupted = false;
+        if (currentSnapshotInfo != null) {
+          interrupted = awaitUninterruptibly(snapshotDbHandlesClosed);
+          // Workers have released their previous-snapshot DB handles and stopped using the iterator and current
+          // snapshot. Close the task-owned resources before allowing synchronous OM requests to be submitted.
+          dirSupplier.close();
+          currentSnapshot.close();
+          submitSnapshotRequests.countDown();
         }
+
+        while (true) {
+          try {
+            processedAllDeletedDirs = workersCompleted.get();
+            break;
+          } catch (InterruptedException e) {
+            if (currentSnapshotInfo == null) {
+              throw e;
+            }
+            interrupted = true;
+          }
+        }
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+          throw new InterruptedException();
+        }
+      }
+
+      // If AOS or all directories have been processed for snapshot, update snapshot size delta and deep clean flag
+      // if it is a snapshot. All snapshot DB iterators and handles have been closed before this synchronous request.
+      if (processedAllDeletedDirs) {
+        List<OzoneManagerProtocolProtos.SetSnapshotPropertyRequest> setSnapshotPropertyRequests = new ArrayList<>();
+
+        for (Map.Entry<UUID, Pair<Long, Long>> entry : exclusiveSizeMap.entrySet()) {
+          UUID snapshotID = entry.getKey();
+          long exclusiveSize = entry.getValue().getLeft();
+          long exclusiveReplicatedSize = entry.getValue().getRight();
+          setSnapshotPropertyRequests.add(getSetSnapshotRequestUpdatingExclusiveSize(
+              exclusiveSize, exclusiveReplicatedSize, snapshotID));
+        }
+
+        // Updating directory deep clean flag of snapshot.
+        if (currentSnapshotInfo != null) {
+          setSnapshotPropertyRequests.add(OzoneManagerProtocolProtos.SetSnapshotPropertyRequest.newBuilder()
+              .setSnapshotKey(snapshotTableKey)
+              .setDeepCleanedDeletedDir(true)
+              .build());
+        }
+        submitSetSnapshotRequests(setSnapshotPropertyRequests);
       }
     }
 
@@ -713,9 +764,11 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
      * @param remaining Number of dirs to be processed.
      * @return A boolean indicating whether the processed directory list is empty.
      */
+    @SuppressWarnings("checkstyle:ParameterNumber")
     private boolean processDeletedDirectories(SnapshotInfo currentSnapshotInfo, KeyManager keyManager,
         DeletedDirSupplier dirSupplier, UUID expectedPreviousSnapshotId,
-        Map<UUID, Pair<Long, Long>> totalExclusiveSizeMap, long runCount, int remaining) {
+        Map<UUID, Pair<Long, Long>> totalExclusiveSizeMap, long runCount, int remaining,
+        Runnable afterSnapshotDbHandlesClosed) {
       OmSnapshotManager omSnapshotManager = getOzoneManager().getOmSnapshotManager();
       IOzoneManagerLock lock = getOzoneManager().getMetadataManager().getLock();
       String snapshotTableKey = currentSnapshotInfo == null ? null : currentSnapshotInfo.getTableKey();
@@ -769,7 +822,14 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
             subFileNum, allSubDirList, purgePathRequestList, snapshotTableKey,
             startTime, getOzoneManager().getKeyManager(),
             reclaimableDirFilter, reclaimableFileFilter, bucketNameInfos, expectedPreviousSnapshotId,
-            runCount, remainNum);
+            runCount, remainNum, () -> {
+              // Keep the snapshot GC locks until the purge requests complete, but release all snapshot DB read
+              // locks first. Otherwise a synchronous request can wait for the double buffer while the double
+              // buffer waits for a colliding snapshot DB write lock.
+              reclaimableDirFilter.closeSnapshotDbHandles();
+              reclaimableFileFilter.closeSnapshotDbHandles();
+              afterSnapshotDbHandlesClosed.run();
+            });
         Map<UUID, Long> exclusiveReplicatedSizeMap = reclaimableFileFilter.getExclusiveReplicatedSizeMap();
         Map<UUID, Long> exclusiveSizeMap = reclaimableFileFilter.getExclusiveSizeMap();
         List<UUID> previousPathSnapshotsInChain =
@@ -791,6 +851,24 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
         LOG.error("Error while running delete directories for store : {} and files background task. " +
                 "Will retry at next run. ", snapshotTableKey, e);
         return false;
+      }
+    }
+
+    private void signalWorkerReady(AtomicBoolean workerReady, CountDownLatch snapshotDbHandlesClosed) {
+      if (workerReady.compareAndSet(false, true)) {
+        snapshotDbHandlesClosed.countDown();
+      }
+    }
+
+    private boolean awaitUninterruptibly(CountDownLatch latch) {
+      boolean interrupted = false;
+      while (true) {
+        try {
+          latch.await();
+          return interrupted;
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
       }
     }
 
@@ -824,12 +902,25 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
           } else if (!isPreviousPurgeTransactionFlushed()) {
             return BackgroundTaskResult.EmptyTaskResult.newResult();
           }
-          try (UncheckedAutoCloseableSupplier<OmSnapshot> omSnapshot = snapInfo == null ? null :
-              omSnapshotManager.getActiveSnapshot(snapInfo.getVolumeName(), snapInfo.getBucketName(),
-                  snapInfo.getName())) {
-            KeyManager keyManager = snapInfo == null ? getOzoneManager().getKeyManager()
-                : omSnapshot.get().getKeyManager();
-            processDeletedDirsForStore(snapInfo, keyManager, run, pathLimitPerTask);
+          boolean snapshotProcessingLockAcquired = false;
+          try {
+            if (snapInfo != null) {
+              // Serialize snapshot setup before opening the snapshot DB. Workers still process each snapshot in
+              // parallel, but another snapshot task cannot wait here while retaining a task-owned DB handle.
+              snapshotProcessingLock.lockInterruptibly();
+              snapshotProcessingLockAcquired = true;
+            }
+            try (UncheckedAutoCloseableSupplier<OmSnapshot> omSnapshot = snapInfo == null ? null :
+                omSnapshotManager.getActiveSnapshot(snapInfo.getVolumeName(), snapInfo.getBucketName(),
+                    snapInfo.getName())) {
+              KeyManager keyManager = snapInfo == null ? getOzoneManager().getKeyManager()
+                  : omSnapshot.get().getKeyManager();
+              processDeletedDirsForStore(snapInfo, keyManager, omSnapshot, run, pathLimitPerTask);
+            }
+          } finally {
+            if (snapshotProcessingLockAcquired) {
+              snapshotProcessingLock.unlock();
+            }
           }
         } catch (IOException | ExecutionException e) {
           LOG.error("Error while running delete files background task for store {}. Will retry at next run.",

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -18,11 +18,17 @@
 package org.apache.hadoop.ozone.om.service;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_MANAGER_STRIPED_LOCK_SIZE_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_THREAD_NUMBER_DIR_DELETION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import com.google.protobuf.ServiceException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -37,17 +43,26 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.utils.db.DBConfigFromFile;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OmTestManagers;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -55,11 +70,16 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.util.ExitUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -223,7 +243,7 @@ public class TestDirectoryDeletingService {
       assertThat(threadPoolExecutor.isShutdown()).as(
           "deletion thread pool should be active when processing deleted dirs").isFalse();
       long completedTaskCountBefore = threadPoolExecutor.getCompletedTaskCount();
-      dirDeletingTask.processDeletedDirsForStore(null, ozoneManager.getKeyManager(), 1, 1);
+      dirDeletingTask.processDeletedDirsForStore(null, ozoneManager.getKeyManager(), null, 1, 1);
       GenericTestUtils.waitFor(
           () -> threadPoolExecutor.getCompletedTaskCount() >= completedTaskCountBefore + threadCount, 100, 5000);
     } finally {
@@ -311,7 +331,7 @@ public class TestDirectoryDeletingService {
     bucketNameInfoMap.put(vbId, bni);
 
     dds.optimizeDirDeletesAndSubmitRequest(0L, 0L, 0L, new ArrayList<>(), purgeList, null, Time.monotonicNow(), km,
-        kv -> true, kv -> true, bucketNameInfoMap, null, 1L, new AtomicInteger(Integer.MAX_VALUE));
+        kv -> true, kv -> true, bucketNameInfoMap, null, 1L, new AtomicInteger(Integer.MAX_VALUE), () -> { });
 
     assertThat(captured.size())
         .as("Expect batching to respect Ratis byte limit")
@@ -329,6 +349,146 @@ public class TestDirectoryDeletingService {
     }
 
     org.apache.commons.io.FileUtils.deleteDirectory(testDir);
+  }
+
+  /**
+   * Regression test for HDDS-16164. DDS must release its current snapshot DB handle before submitting a
+   * synchronous OM request. Otherwise a snapshot purge can hold the only allowed unflushed transaction while its
+   * double-buffer flush waits for the colliding snapshot DB write lock, and DDS waits indefinitely for capacity to
+   * apply its request.
+   */
+  @Test
+  @DisplayName("DirectoryDeletingService must not deadlock at the unflushed transaction limit")
+  void testNoUnflushedTransactionDeadlock() throws Exception {
+    int threadCount = 3;
+    OzoneConfiguration conf = createConfAndInitValues(threadCount);
+    conf.setInt(OMConfigKeys.OZONE_OM_UNFLUSHED_TRANSACTION_MAX_COUNT, 1);
+    conf.setInt(OZONE_MANAGER_STRIPED_LOCK_SIZE_PREFIX + "snapshot_db_lock", 1);
+    conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 1, TimeUnit.HOURS);
+    conf.setTimeDuration(OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL, 1, TimeUnit.HOURS);
+    conf.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL, 1, TimeUnit.HOURS);
+
+    OmTestManagers managers = new OmTestManagers(conf);
+    om = managers.getOzoneManager();
+    KeyManager keyManager = managers.getKeyManager();
+    OMMetadataManager metadataManager = managers.getMetadataManager();
+    OzoneManagerProtocol writeClient = managers.getWriteClient();
+    keyManager.getDirDeletingService().shutdown();
+
+    OMRequestTestUtils.addVolumeToOM(metadataManager,
+        OmVolumeArgs.newBuilder().setOwnerName("o").setAdminName("a").setVolume(volumeName).build());
+    OMRequestTestUtils.addBucketToOM(metadataManager,
+        OmBucketInfo.newBuilder().setVolumeName(volumeName).setBucketName(bucketName)
+            .setObjectID(1).setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED).build());
+
+    String previousSnapshotName = "previous";
+    writeClient.createSnapshot(volumeName, bucketName, previousSnapshotName);
+    om.awaitDoubleBufferFlush();
+
+    OmBucketInfo bucketInfo = metadataManager.getBucketTable()
+        .get(metadataManager.getBucketKey(volumeName, bucketName));
+    OmDirectoryInfo deletedDir = OmDirectoryInfo.newBuilder()
+        .setName("deleted-dir")
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setObjectID(2)
+        .setParentObjectID(bucketInfo.getObjectID())
+        .setUpdateID(0)
+        .build();
+    String deletedDirKey = OMRequestTestUtils.addDirKeyToDirTable(
+        false, deletedDir, volumeName, bucketName, 1L, metadataManager);
+    OMRequestTestUtils.deleteDir(deletedDirKey, volumeName, bucketName, metadataManager);
+
+    String deepCleanSnapshotName = "deep-clean";
+    writeClient.createSnapshot(volumeName, bucketName, deepCleanSnapshotName);
+    String purgeSnapshotName = "purge";
+    writeClient.createSnapshot(volumeName, bucketName, purgeSnapshotName);
+    om.awaitDoubleBufferFlush();
+
+    String deepCleanKey = SnapshotInfo.getTableKey(volumeName, bucketName, deepCleanSnapshotName);
+    SnapshotInfo deepCleanInfo = metadataManager.getSnapshotInfoTable().get(deepCleanKey);
+    assertNotNull(deepCleanInfo);
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return OmSnapshotManager.areSnapshotChangesFlushedToDB(metadataManager, deepCleanInfo);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 100, 10000);
+
+    writeClient.deleteSnapshot(volumeName, bucketName, purgeSnapshotName);
+    om.awaitDoubleBufferFlush();
+    String purgeKey = SnapshotInfo.getTableKey(volumeName, bucketName, purgeSnapshotName);
+    assertNotNull(metadataManager.getSnapshotInfoTable().get(purgeKey));
+
+    CountDownLatch ddsAtSubmit = new CountDownLatch(1);
+    CountDownLatch ddsMayProceed = new CountDownLatch(1);
+    AtomicBoolean paused = new AtomicBoolean();
+    DirectoryDeletingService service = new DirectoryDeletingService(1, TimeUnit.HOURS, 1,
+        om, conf, threadCount, true) {
+      @Override
+      protected OzoneManagerProtocolProtos.OMResponse submitRequest(
+          OzoneManagerProtocolProtos.OMRequest omRequest) throws ServiceException {
+        assertThat(omRequest.getCmdType()).isIn(
+            OzoneManagerProtocolProtos.Type.PurgeDirectories,
+            OzoneManagerProtocolProtos.Type.SetSnapshotProperty);
+        if (paused.compareAndSet(false, true)) {
+          assertThat(omRequest.getCmdType()).isEqualTo(OzoneManagerProtocolProtos.Type.PurgeDirectories);
+          ddsAtSubmit.countDown();
+          try {
+            ddsMayProceed.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ServiceException(e);
+          }
+        }
+        return super.submitRequest(omRequest);
+      }
+    };
+
+    OzoneManagerDoubleBuffer doubleBuffer =
+        om.getOmRatisServer().getOmStateMachine().getOzoneManagerDoubleBuffer();
+    Semaphore unflushedTransactions =
+        (Semaphore) HddsWhiteboxTestUtils.getInternalState(doubleBuffer, "unFlushedTransactions");
+    ThreadPoolExecutor deletionThreadPool = service.getDeletionThreadPool();
+    long completedTaskCountBefore = deletionThreadPool.getCompletedTaskCount();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> ddsFuture = executor.submit(
+          () -> service.new DirDeletingTask(deepCleanInfo.getSnapshotId()).call());
+      assertTrue(ddsAtSubmit.await(30, TimeUnit.SECONDS), "DirDeletingTask never reached submitRequest");
+
+      AtomicBoolean purgeDone = new AtomicBoolean();
+      OzoneManagerProtocolProtos.OMRequest purgeRequest = OzoneManagerProtocolProtos.OMRequest.newBuilder()
+          .setCmdType(OzoneManagerProtocolProtos.Type.SnapshotPurge)
+          .setSnapshotPurgeRequest(OzoneManagerProtocolProtos.SnapshotPurgeRequest.newBuilder()
+              .addSnapshotDBKeys(purgeKey))
+          .setClientId(ClientId.randomId().toString())
+          .build();
+      Future<?> purgeFuture = executor.submit(() -> {
+        OzoneManagerRatisUtils.submitRequest(om, purgeRequest, ClientId.randomId(), 1L);
+        purgeDone.set(true);
+        return null;
+      });
+      GenericTestUtils.waitFor(
+          () -> unflushedTransactions.availablePermits() == 0 || purgeDone.get(), 50, 30000);
+
+      ddsMayProceed.countDown();
+      try {
+        ddsFuture.get(60, TimeUnit.SECONDS);
+      } catch (TimeoutException e) {
+        fail("DirectoryDeletingService retained a snapshot DB read lock across its synchronous OM request");
+      }
+      purgeFuture.get(60, TimeUnit.SECONDS);
+      assertThat(deletionThreadPool.getCompletedTaskCount() - completedTaskCountBefore)
+          .as("snapshot processing should use all configured deletion workers")
+          .isEqualTo(threadCount);
+    } finally {
+      ddsMayProceed.countDown();
+      executor.shutdownNow();
+      service.shutdown();
+    }
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -46,6 +46,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +64,7 @@ import org.apache.hadoop.hdds.utils.db.DBConfigFromFile;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OmTestManagers;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -81,6 +84,7 @@ import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.util.ExitUtils;
+import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -488,6 +492,76 @@ public class TestDirectoryDeletingService {
       ddsMayProceed.countDown();
       executor.shutdownNow();
       service.shutdown();
+    }
+  }
+
+  @Test
+  @DisplayName("DirectoryDeletingService releases snapshot workers when submission is rejected")
+  void testRejectedSnapshotWorkerSubmission() throws Exception {
+    OzoneConfiguration conf = createConfAndInitValues(2);
+    OmTestManagers managers = new OmTestManagers(conf);
+    om = managers.getOzoneManager();
+    KeyManager keyManager = managers.getKeyManager();
+    OMMetadataManager metadataManager = managers.getMetadataManager();
+    OzoneManagerProtocol writeClient = managers.getWriteClient();
+    keyManager.getDirDeletingService().shutdown();
+
+    OMRequestTestUtils.addVolumeToOM(metadataManager,
+        OmVolumeArgs.newBuilder().setOwnerName("o").setAdminName("a").setVolume(volumeName).build());
+    OMRequestTestUtils.addBucketToOM(metadataManager,
+        OmBucketInfo.newBuilder().setVolumeName(volumeName).setBucketName(bucketName)
+            .setObjectID(1).setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED).build());
+    String snapshotName = "snapshot";
+    writeClient.createSnapshot(volumeName, bucketName, snapshotName);
+    om.awaitDoubleBufferFlush();
+
+    String snapshotKey = SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName);
+    SnapshotInfo snapshotInfo = metadataManager.getSnapshotInfoTable().get(snapshotKey);
+    assertNotNull(snapshotInfo);
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return OmSnapshotManager.areSnapshotChangesFlushedToDB(metadataManager, snapshotInfo);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 100, 10000);
+
+    DirectoryDeletingService service = new DirectoryDeletingService(1, TimeUnit.HOURS, 1,
+        om, conf, 2, true);
+    RejectAfterFirstExecutor rejectionExecutor = new RejectAfterFirstExecutor();
+    HddsWhiteboxTestUtils.setInternalState(service, "deletionThreadPool", rejectionExecutor);
+    ExecutorService taskExecutor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> processFuture = taskExecutor.submit(() -> {
+        try (UncheckedAutoCloseableSupplier<OmSnapshot> snapshot = om.getOmSnapshotManager().getActiveSnapshot(
+            volumeName, bucketName, snapshotName)) {
+          service.new DirDeletingTask(snapshotInfo.getSnapshotId()).processDeletedDirsForStore(snapshotInfo,
+              snapshot.get().getKeyManager(), snapshot, 1, 1);
+        }
+        return null;
+      });
+      processFuture.get(10, TimeUnit.SECONDS);
+      assertThat(rejectionExecutor.getCompletedTaskCount()).isEqualTo(1);
+    } finally {
+      taskExecutor.shutdownNow();
+      service.shutdown();
+    }
+  }
+
+  private static final class RejectAfterFirstExecutor extends ThreadPoolExecutor {
+    private final AtomicInteger submittedTaskCount = new AtomicInteger();
+
+    private RejectAfterFirstExecutor() {
+      super(1, 1, 0, TimeUnit.MILLISECONDS, new LinkedBlockingDeque<>());
+    }
+
+    @Override
+    public void execute(Runnable task) {
+      if (submittedTaskCount.getAndIncrement() == 0) {
+        super.execute(task);
+      } else {
+        throw new RejectedExecutionException("Rejected by test executor");
+      }
     }
   }
 


### PR DESCRIPTION
Generated-by: Codex (GPT-5.6 Sol)

## What changes were proposed in this pull request?

DirectoryDeletingService (DDS) processes snapshots with parallel directory workers. The task thread retains the current snapshot DB handle, while each worker can retain previous-snapshot handles through reclaimable filters. Those handles hold striped `SNAPSHOT_DB_LOCK` read locks.

Before this change, a worker could synchronously submit `PurgeDirectories` while retaining its previous-snapshot handles, or DDS could submit its final snapshot-property request while retaining the task-owned current handle. If `OMDoubleBufferFlushThread` was applying an earlier snapshot purge that needed the colliding write-lock stripe and the unflushed transaction limit was reached, both sides could wait indefinitely.

This patch preserves per-snapshot worker parallelism while enforcing this order:

1. Each worker closes its previous-snapshot DB handles after it finishes reading.
2. DDS waits for every worker to reach that point, closes its current snapshot handle and iterator, then releases workers to submit requests.
3. Workers retain their snapshot-GC locks until their requests complete.

Snapshot task setup is serialized before the task-owned current handle is opened, preventing a second snapshot task from waiting while retaining such a handle. The worker barrier also handles a rejected executor submission during reconfiguration: DDS accounts for unscheduled workers, releases workers that already started, and retries the work in a later run.

The patch adds a deterministic circular-wait regression with one snapshot DB lock stripe and one unflushed transaction. It also verifies that snapshot work retains the configured worker parallelism and that a rejected worker submission does not strand an accepted worker.

## What is the link to the Apache JIRA

[HDDS-16164](https://issues.apache.org/jira/browse/HDDS-16164)

## How was this patch tested?

- `mvn -pl :ozone-manager test -Dtest=TestDirectoryDeletingService -DskipShade -DskipRecon -DskipDocs` (6 tests passed)
- `mvn -pl :ozone-manager -am install -DskipTests -DskipShade -DskipRecon -DskipDocs` (27-module reactor, 497 goals)
- `mvn -pl :ozone-integration-test test -Dtest=TestDirectoryDeletingServiceWithFSO#testAOSKeyDeletingWithSnapshotCreateParallelExecution -DskipShade -DskipRecon -DskipDocs` (1 test passed)
- `mvn -pl :ozone-manager checkstyle:check -DskipTests -DskipShade -DskipRecon -DskipDocs` (0 violations)
- `git diff --check`