### PR TITLE
HDDS-11128. Isolate maintenance and decommission test invocations

### DIFF
--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -114,14 +114,6 @@ class TestReconAndAdminContainerCLI {
    * are still drifting past each other (HDDS-15223).
    */
   private static final int RM_RECON_COMPARE_STABLE_POLLS = 2;
-  /**
-   * Max wait for a decommission/maintenance triggered replica copy to be reflected in SCM. The
-   * default {@link OzoneTestHelper#waitForReplicaCount(long, int, MiniOzoneCluster)} budget (30s)
-   * is occasionally not enough on a loaded CI runner (the recurring flake tracked in HDDS-11128,
-   * see also HDDS-10582), so give these waits double the headroom. The happy path returns as soon
-   * as the copy lands.
-   */
-  private static final int REPLICA_COPY_WAIT_MS = 60_000;
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
   private static ScmClient scmClient;
@@ -280,7 +272,7 @@ class TestReconAndAdminContainerCLI {
     // a new replica-copy is made to another node.
     // For maintenance, there is no replica-copy in this case.
     if (!isMaintenance) {
-      OzoneTestHelper.waitForReplicaCount(containerIdR3, 4, cluster, REPLICA_COPY_WAIT_MS);
+      OzoneTestHelper.waitForStableReplicaCount(containerIdR3, 4, cluster);
     }
 
     compareRMReportToReconResponse(underReplicatedState);
@@ -307,7 +299,7 @@ class TestReconAndAdminContainerCLI {
     // There will be a replica copy for both maintenance and decommission.
     // maintenance 3 -> 4, decommission 4 -> 5.
     int expectedReplicaNum = isMaintenance ? 4 : 5;
-    OzoneTestHelper.waitForReplicaCount(containerIdR3, expectedReplicaNum, cluster, REPLICA_COPY_WAIT_MS);
+    OzoneTestHelper.waitForStableReplicaCount(containerIdR3, expectedReplicaNum, cluster);
 
     compareRMReportToReconResponse(underReplicatedState);
     compareRMReportToReconResponse(overReplicatedState);

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -114,6 +114,12 @@ class TestReconAndAdminContainerCLI {
    * are still drifting past each other (HDDS-15223).
    */
   private static final int RM_RECON_COMPARE_STABLE_POLLS = 2;
+  /**
+   * Max wait for a decommission/maintenance triggered replica copy to be reflected in SCM. The
+   * default {@link OzoneTestHelper#waitForReplicaCount} budget (30s) is not always enough on a
+   * loaded CI runner, which is the recurring flake tracked in HDDS-11128 (see also HDDS-10582).
+   */
+  private static final int REPLICA_COPY_WAIT_MS = 120_000;
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
   private static ScmClient scmClient;
@@ -272,7 +278,7 @@ class TestReconAndAdminContainerCLI {
     // a new replica-copy is made to another node.
     // For maintenance, there is no replica-copy in this case.
     if (!isMaintenance) {
-      OzoneTestHelper.waitForReplicaCount(containerIdR3, 4, cluster);
+      OzoneTestHelper.waitForReplicaCount(containerIdR3, 4, cluster, REPLICA_COPY_WAIT_MS);
     }
 
     compareRMReportToReconResponse(underReplicatedState);
@@ -299,7 +305,7 @@ class TestReconAndAdminContainerCLI {
     // There will be a replica copy for both maintenance and decommission.
     // maintenance 3 -> 4, decommission 4 -> 5.
     int expectedReplicaNum = isMaintenance ? 4 : 5;
-    OzoneTestHelper.waitForReplicaCount(containerIdR3, expectedReplicaNum, cluster);
+    OzoneTestHelper.waitForReplicaCount(containerIdR3, expectedReplicaNum, cluster, REPLICA_COPY_WAIT_MS);
 
     compareRMReportToReconResponse(underReplicatedState);
     compareRMReportToReconResponse(overReplicatedState);

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -116,10 +116,12 @@ class TestReconAndAdminContainerCLI {
   private static final int RM_RECON_COMPARE_STABLE_POLLS = 2;
   /**
    * Max wait for a decommission/maintenance triggered replica copy to be reflected in SCM. The
-   * default {@link OzoneTestHelper#waitForReplicaCount} budget (30s) is not always enough on a
-   * loaded CI runner, which is the recurring flake tracked in HDDS-11128 (see also HDDS-10582).
+   * default {@link OzoneTestHelper#waitForReplicaCount(long, int, MiniOzoneCluster)} budget (30s)
+   * is occasionally not enough on a loaded CI runner (the recurring flake tracked in HDDS-11128,
+   * see also HDDS-10582), so give these waits double the headroom. The happy path returns as soon
+   * as the copy lands.
    */
-  private static final int REPLICA_COPY_WAIT_MS = 120_000;
+  private static final int REPLICA_COPY_WAIT_MS = 60_000;
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
   private static ScmClient scmClient;

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.ContainerHealthState;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -235,11 +236,11 @@ class TestReconAndAdminContainerCLI {
   void testNodesInDecommissionOrMaintenance(
       NodeOperationalState initialState, NodeOperationalState finalState,
       boolean isMaintenance) throws Exception {
-    Pipeline pipeline =
-        scmClient.getContainerWithPipeline(containerIdR3).getPipeline();
+    OzoneTestHelper.waitForStableReplicaCount(containerIdR3, 3, cluster);
 
     List<DatanodeDetails> details =
-        pipeline.getNodes().stream()
+        scmContainerManager.getContainerReplicas(ContainerID.valueOf(containerIdR3)).stream()
+            .map(ContainerReplica::getDatanodeDetails)
             .filter(d -> d.getPersistedOpState().equals(IN_SERVICE))
             .collect(Collectors.toList());
 
@@ -315,6 +316,8 @@ class TestReconAndAdminContainerCLI {
 
     NodeTestUtil.waitForDnToReachPersistedOpState(nodeToGoOffline1, IN_SERVICE);
     NodeTestUtil.waitForDnToReachPersistedOpState(nodeToGoOffline2, IN_SERVICE);
+
+    OzoneTestHelper.waitForStableReplicaCount(containerIdR3, 3, cluster);
 
     compareRMReportToReconResponse(underReplicatedState);
     compareRMReportToReconResponse(overReplicatedState);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/OzoneTestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/OzoneTestHelper.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
@@ -461,12 +462,24 @@ public final class OzoneTestHelper {
 
   public static void waitForReplicaCount(long containerID, int count,
       MiniOzoneCluster cluster) throws TimeoutException, InterruptedException {
-    waitForReplicaCount(containerID, count, cluster, 30000);
+    GenericTestUtils.waitFor(() -> countReplicas(containerID, cluster) == count,
+        200, 30000);
   }
 
-  public static void waitForReplicaCount(long containerID, int count, MiniOzoneCluster cluster, int timeoutMillis)
+  /**
+   * Like {@link #waitForReplicaCount(long, int, MiniOzoneCluster)}, but only returns once
+   * replication has quiesced: no pending add or delete ops remain for the container, so the count
+   * has settled at {@code count} instead of being observed transiently while SCM is still adding or
+   * removing replicas. This removes the race where the count passes through {@code count} between
+   * polls under a loaded runner (HDDS-10582, HDDS-11128).
+   */
+  public static void waitForStableReplicaCount(long containerID, int count, MiniOzoneCluster cluster)
       throws TimeoutException, InterruptedException {
-    GenericTestUtils.waitFor(() -> countReplicas(containerID, cluster) == count, 200, timeoutMillis);
+    ReplicationManager replicationManager = cluster.getStorageContainerManager().getReplicationManager();
+    ContainerID cid = ContainerID.valueOf(containerID);
+    GenericTestUtils.waitFor(() ->
+        replicationManager.getPendingReplicationOps(cid).isEmpty() && countReplicas(containerID, cluster) == count,
+        200, 30000);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/OzoneTestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/OzoneTestHelper.java
@@ -461,8 +461,12 @@ public final class OzoneTestHelper {
 
   public static void waitForReplicaCount(long containerID, int count,
       MiniOzoneCluster cluster) throws TimeoutException, InterruptedException {
-    GenericTestUtils.waitFor(() -> countReplicas(containerID, cluster) == count,
-        200, 30000);
+    waitForReplicaCount(containerID, count, cluster, 30000);
+  }
+
+  public static void waitForReplicaCount(long containerID, int count, MiniOzoneCluster cluster, int timeoutMillis)
+      throws TimeoutException, InterruptedException {
+    GenericTestUtils.waitFor(() -> countReplicas(containerID, cluster) == count, 200, timeoutMillis);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/OzoneTestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/OzoneTestHelper.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -468,18 +469,28 @@ public final class OzoneTestHelper {
 
   /**
    * Like {@link #waitForReplicaCount(long, int, MiniOzoneCluster)}, but only returns once
-   * replication has quiesced: no pending add or delete ops remain for the container, so the count
-   * has settled at {@code count} instead of being observed transiently while SCM is still adding or
-   * removing replicas. This removes the race where the count passes through {@code count} between
-   * polls under a loaded runner (HDDS-10582, HDDS-11128).
+   * replication has quiesced: the container is healthy with {@code count} replicas and no pending
+   * add or delete ops. Checking the current replication health avoids treating an empty pending-op
+   * list as settled before ReplicationManager has evaluated the latest replica or node state.
    */
   public static void waitForStableReplicaCount(long containerID, int count, MiniOzoneCluster cluster)
       throws TimeoutException, InterruptedException {
-    ReplicationManager replicationManager = cluster.getStorageContainerManager().getReplicationManager();
+    ContainerManager containerManager = cluster.getStorageContainerManager().getContainerManager();
+    ReplicationManager replicationManager = cluster.getStorageContainerManager()
+        .getReplicationManager();
     ContainerID cid = ContainerID.valueOf(containerID);
-    GenericTestUtils.waitFor(() ->
-        replicationManager.getPendingReplicationOps(cid).isEmpty() && countReplicas(containerID, cluster) == count,
-        200, 30000);
+    GenericTestUtils.waitFor(() -> {
+      try {
+        ContainerInfo container = containerManager.getContainer(cid);
+        Set<ContainerReplica> replicas = containerManager.getContainerReplicas(cid);
+        return replicas.size() == count
+            && replicationManager.getPendingReplicationOps(cid).isEmpty()
+            && replicationManager.getContainerReplicationHealth(container, replicas).getHealthState()
+            == ContainerHealthResult.HealthState.HEALTHY;
+      } catch (ContainerNotFoundException e) {
+        return false;
+      }
+    }, 200, 30000);
   }
 
   /**


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.8)
Generated-by: Codex (GPT-5)

## What changes were proposed in this pull request?

`TestReconAndAdminContainerCLI#testNodesInDecommissionOrMaintenance` intermittently timed out after
a decommission or maintenance step (HDDS-11128).

The original patch assumed that the test observed a transient replica count while SCM was still
processing replication. A 10 by 10 stress run of that patch showed a different race. The maintenance
invocation recommissions its nodes but can return while its fourth replica still exists. The following
decommission invocation then selects a node from the original pipeline while SCM is still removing the
excess replica. If SCM deletes the replica on the node that just started decommissioning, decommission
correctly completes without creating another copy, and the test waits for a replica count that SCM does
not need to reach.

This change isolates the two parameterized invocations:

- It waits for a healthy three replica baseline before each invocation.
- It selects nodes from SCM's current container replicas instead of the original pipeline.
- After recommission, it waits for SCM to restore the healthy three replica baseline.
- `waitForStableReplicaCount` now requires the exact count, no pending operations, and current
  `ReplicationManager` health `HEALTHY`. An empty pending operation list alone does not prove that
  `ReplicationManager` has evaluated the latest replica and node state.

The test remains tagged `@Flaky("HDDS-11128")` while the fix is validated under repeated CI runs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11128

## How was this patch tested?

The pre fix 10 by 10 run had 23 failed iterations. Twenty two failures were timeouts in parameter
invocation `[2]`, the decommission case. The remaining failure occurred during setup when Recon briefly
closed its container metadata DB during asynchronous task reinitialization. That setup failure is
independent and is not addressed by this patch.

- Pre fix stress run: https://github.com/smengcl/hadoop-ozone/actions/runs/32388474599
- `mvn -pl :ozone-integration-test-recon -am install -DskipTests -DskipShade -DskipDocs`: all 42
  required modules passed with JDK 21.
- `./hadoop-ozone/dev-support/checks/checkstyle.sh`: all 58 modules passed with zero violations.
- The affected parameterized method completed 11 consecutive local class lifecycles, 22 parameter
  invocations, without a failure.

- Post fix 10 by 10 stress run: https://github.com/smengcl/hadoop-ozone/actions/runs/32427117512
  All 10 split jobs passed, for 100 repeated test executions.
