### PR TITLE
HDDS-15333. Expose volume quota and namespace usage metrics in OM Prometheus endpoint.

### DIFF
--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -589,7 +589,7 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
       getBucketIterator();
 
   Iterator<Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>>>
-  getVolumeIterator();
+      getVolumeIterator();
 
   TableIterator<String, Table.KeyValue<String, OmKeyInfo>> getKeyIterator() throws IOException;
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -585,11 +585,11 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
    */
   Set<String> listTableNames();
 
-  Iterator<Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>>>
-      getBucketIterator();
-
   Iterator<Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>>>
       getVolumeIterator();
+
+  Iterator<Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>>>
+      getBucketIterator();
 
   TableIterator<String, Table.KeyValue<String, OmKeyInfo>> getKeyIterator() throws IOException;
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -588,6 +588,9 @@ public interface OMMetadataManager extends DBStoreHAManager, AutoCloseable {
   Iterator<Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>>>
       getBucketIterator();
 
+  Iterator<Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>>>
+  getVolumeIterator();
+
   TableIterator<String, Table.KeyValue<String, OmKeyInfo>> getKeyIterator() throws IOException;
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketUtilizationMetrics.java
@@ -37,10 +37,10 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
  * Available metrics:
  * <ul>
  *   <li>Bytes used in bucket.
- *   <li>Bucket quote in bytes.
+ *   <li>Bucket quota in bytes.
  *   <li>Bucket quota in namespace.
  *   <li>Bucket available space. Calculated from difference between used bytes in bucket and bucket quota.
- *   If bucket quote is not set then this metric show -1 as value.
+ *   If bucket quota is not set then this metric shows -1 as value.
  * </ul>
  */
 @InterfaceAudience.Private
@@ -87,6 +87,7 @@ public class BucketUtilizationMetrics implements MetricsSource {
           .addGauge(BucketMetricsInfo.BucketSnapshotUsedBytes, bucketInfo.getSnapshotUsedBytes())
           .addGauge(BucketMetricsInfo.BucketQuotaBytes, bucketInfo.getQuotaInBytes())
           .addGauge(BucketMetricsInfo.BucketQuotaNamespace, bucketInfo.getQuotaInNamespace())
+          .addGauge(BucketMetricsInfo.BucketUsedNamespace, bucketInfo.getUsedNamespace())
           .addGauge(BucketMetricsInfo.BucketAvailableBytes, availableSpace);
     }
   }
@@ -101,6 +102,7 @@ public class BucketUtilizationMetrics implements MetricsSource {
     BucketName("Bucket Metrics."),
     BucketUsedBytes("Bytes used by bucket in AOS."),
     BucketQuotaBytes("Bucket quota in bytes"),
+    BucketUsedNamespace("Bucket used namespace."),
     BucketSnapshotUsedBytes("Bucket quota bytes held in snapshots"),
     BucketQuotaNamespace("Bucket quota in namespace."),
     BucketAvailableBytes("Bucket available space.");

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketUtilizationMetrics.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
  * <ul>
  *   <li>Bytes used in bucket.
  *   <li>Bucket quota bytes held in snapshots.
- *   <li>Bucket quota in bytes. If bucket quota is not set then this metric shows -1 as value.
- *   <li>Bucket quota in namespace. If bucket quota is not set then this metric shows -1 as value.
+ *   <li>Bucket quota in bytes.
+ *   <li>Bucket quota in namespace.
  *   <li>Bucket used namespace (number of keys/directories in bucket).
  *   <li>Bucket available space. Calculated from difference between used bytes in bucket and bucket quota.
  *   If bucket quota is not set then this metric shows -1 as value.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketUtilizationMetrics.java
@@ -37,8 +37,10 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
  * Available metrics:
  * <ul>
  *   <li>Bytes used in bucket.
- *   <li>Bucket quota in bytes.
- *   <li>Bucket quota in namespace.
+ *   <li>Bucket quota bytes held in snapshots.
+ *   <li>Bucket quota in bytes. If bucket quota is not set then this metric shows -1 as value.
+ *   <li>Bucket quota in namespace. If bucket quota is not set then this metric shows -1 as value.
+ *   <li>Bucket used namespace (number of keys/directories in bucket).
  *   <li>Bucket available space. Calculated from difference between used bytes in bucket and bucket quota.
  *   If bucket quota is not set then this metric shows -1 as value.
  * </ul>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1000,7 +1000,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   @Override
   public Iterator<Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>>>
-  getVolumeIterator() {
+      getVolumeIterator() {
     return volumeTable.cacheIterator();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -999,6 +999,12 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   @Override
+  public Iterator<Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>>>
+  getVolumeIterator() {
+    return volumeTable.cacheIterator();
+  }
+
+  @Override
   public TableIterator<String, KeyValue<String, OmKeyInfo>>
       getKeyIterator() throws IOException {
     return keyTable.iterator();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -993,15 +993,15 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   @Override
-  public Iterator<Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>>>
-      getBucketIterator() {
-    return bucketTable.cacheIterator();
-  }
-
-  @Override
   public Iterator<Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>>>
       getVolumeIterator() {
     return volumeTable.cacheIterator();
+  }
+
+  @Override
+  public Iterator<Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>>>
+      getBucketIterator() {
+    return bucketTable.cacheIterator();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -508,8 +508,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private final OzoneLockProvider ozoneLockProvider;
   private final OMPerformanceMetrics perfMetrics;
-  private final BucketUtilizationMetrics bucketUtilizationMetrics;
   private final VolumeUtilizationMetrics volumeUtilizationMetrics;
+  private final BucketUtilizationMetrics bucketUtilizationMetrics;
 
   private boolean fsSnapshotEnabled;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -509,6 +509,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private final OzoneLockProvider ozoneLockProvider;
   private final OMPerformanceMetrics perfMetrics;
   private final BucketUtilizationMetrics bucketUtilizationMetrics;
+  private final VolumeUtilizationMetrics volumeUtilizationMetrics;
 
   private boolean fsSnapshotEnabled;
 
@@ -774,6 +775,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       omState = State.INITIALIZED;
     }
 
+    volumeUtilizationMetrics = VolumeUtilizationMetrics.create(metadataManager);
     bucketUtilizationMetrics = BucketUtilizationMetrics.create(metadataManager);
     omHostName = HddsUtils.getHostName(conf);
   }
@@ -2502,6 +2504,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OMHAMetrics.unRegister();
       }
       omRatisServer = null;
+
+      if (volumeUtilizationMetrics != null) {
+        volumeUtilizationMetrics.unRegister();
+      }
 
       if (bucketUtilizationMetrics != null) {
         bucketUtilizationMetrics.unRegister();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeUtilizationMetrics.java
@@ -33,11 +33,14 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 
 /**
  * A class for collecting and reporting volume utilization metrics.
+ * <p>
  * Available metrics:
- *   Volume quota in bytes.
- *   Volume quota in namespace (maximum number of buckets).
- *   Volume used namespace (current number of buckets).
- *
+ * <ul>
+ *   <li>Volume quota in bytes. If volume quota is not set then this metric shows -1 as value.
+ *   <li>Volume quota in namespace (maximum number of buckets). If volume quota is not set then this
+ *   metric shows -1 as value.
+ *   <li>Volume used namespace (current number of buckets).
+ * </ul>
  */
 @InterfaceAudience.Private
 @Metrics(about = "Ozone Volume Utilization Metrics", context = OzoneConsts.OZONE)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeUtilizationMetrics.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+
+/**
+ * A class for collecting and reporting volume utilization metrics.
+ * Available metrics:
+ *   Volume quota in bytes.
+ *   Volume quota in namespace (maximum number of buckets).
+ *   Volume used namespace (current number of buckets).
+ *
+ */
+@InterfaceAudience.Private
+@Metrics(about = "Ozone Volume Utilization Metrics", context = OzoneConsts.OZONE)
+public class VolumeUtilizationMetrics implements MetricsSource {
+
+  private static final String SOURCE = VolumeUtilizationMetrics.class.getSimpleName();
+
+  private final OMMetadataManager metadataManager;
+
+  public VolumeUtilizationMetrics(OMMetadataManager metadataManager) {
+    this.metadataManager = metadataManager;
+  }
+
+  public static VolumeUtilizationMetrics create(OMMetadataManager metadataManager) {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    return ms.register(SOURCE, "Volume Utilization Metrics", new VolumeUtilizationMetrics(metadataManager));
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    Iterator<Entry<CacheKey<String>, CacheValue<OmVolumeArgs>>> volumeIterator =
+        metadataManager.getVolumeIterator();
+
+    while (volumeIterator.hasNext()) {
+      Entry<CacheKey<String>, CacheValue<OmVolumeArgs>> entry = volumeIterator.next();
+      OmVolumeArgs volumeArgs = entry.getValue().getCacheValue();
+      if (volumeArgs == null) {
+        continue;
+      }
+
+      collector.addRecord(SOURCE)
+          .setContext("Volume metrics")
+          .tag(VolumeMetricsInfo.VolumeName, volumeArgs.getVolume())
+          .addGauge(VolumeMetricsInfo.VolumeQuotaBytes, volumeArgs.getQuotaInBytes())
+          .addGauge(VolumeMetricsInfo.VolumeQuotaNamespace, volumeArgs.getQuotaInNamespace())
+          .addGauge(VolumeMetricsInfo.VolumeUsedNamespace, volumeArgs.getUsedNamespace());
+    }
+  }
+
+  public void unRegister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(SOURCE);
+  }
+
+  enum VolumeMetricsInfo implements MetricsInfo {
+    VolumeName("Volume name."),
+    VolumeQuotaBytes("Volume quota in bytes."),
+    VolumeQuotaNamespace("Volume quota in namespace."),
+    VolumeUsedNamespace("Volume used namespace.");
+
+    private final String desc;
+
+    VolumeMetricsInfo(String desc) {
+      this.desc = desc;
+    }
+
+    @Override
+    public String description() {
+      return desc;
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketUtilizationMetrics.java
@@ -55,8 +55,8 @@ public class TestBucketUtilizationMetrics {
   private static final long QUOTA_IN_BYTES_2 = QUOTA_RESET;
   private static final long QUOTA_IN_NAMESPACE_1 = 1;
   private static final long QUOTA_IN_NAMESPACE_2 = 2;
-  private static final long USED_NAMESPACE_1 = 5;
-  private static final long USED_NAMESPACE_2 = 3;
+  private static final long USED_NAMESPACE_1 = 3;
+  private static final long USED_NAMESPACE_2 = 4;
 
   @Test
   void testBucketUtilizationMetrics() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketUtilizationMetrics.java
@@ -113,7 +113,8 @@ public class TestBucketUtilizationMetrics {
   }
 
   private static Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>> createMockEntry(String volumeName,
-      String bucketName, long usedBytes, long snapshotUsedBytes, long quotaInBytes, long quotaInNamespace, long usedNamespace) {
+      String bucketName, long usedBytes, long snapshotUsedBytes, long quotaInBytes, long quotaInNamespace,
+      long usedNamespace) {
     Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>> entry = mock(Map.Entry.class);
     CacheValue<OmBucketInfo> cacheValue = mock(CacheValue.class);
     OmBucketInfo bucketInfo = mock(OmBucketInfo.class);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketUtilizationMetrics.java
@@ -55,15 +55,17 @@ public class TestBucketUtilizationMetrics {
   private static final long QUOTA_IN_BYTES_2 = QUOTA_RESET;
   private static final long QUOTA_IN_NAMESPACE_1 = 1;
   private static final long QUOTA_IN_NAMESPACE_2 = 2;
+  private static final long USED_NAMESPACE_1 = 5;
+  private static final long USED_NAMESPACE_2 = 3;
 
   @Test
   void testBucketUtilizationMetrics() {
     OMMetadataManager omMetadataManager = mock(OMMetadataManager.class);
 
     Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>> entry1 = createMockEntry(VOLUME_NAME_1, BUCKET_NAME_1,
-        USED_BYTES_1, SNAPSHOT_USED_BYTES_1, QUOTA_IN_BYTES_1, QUOTA_IN_NAMESPACE_1);
+        USED_BYTES_1, SNAPSHOT_USED_BYTES_1, QUOTA_IN_BYTES_1, QUOTA_IN_NAMESPACE_1, USED_NAMESPACE_1);
     Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>> entry2 = createMockEntry(VOLUME_NAME_2, BUCKET_NAME_2,
-        USED_BYTES_2, SNAPSHOT_USED_BYTES_2, QUOTA_IN_BYTES_2, QUOTA_IN_NAMESPACE_2);
+        USED_BYTES_2, SNAPSHOT_USED_BYTES_2, QUOTA_IN_BYTES_2, QUOTA_IN_NAMESPACE_2, USED_NAMESPACE_2);
 
     Iterator<Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>>> bucketIterator = mock(Iterator.class);
     when(bucketIterator.hasNext())
@@ -94,6 +96,7 @@ public class TestBucketUtilizationMetrics {
     verify(mb, times(1)).tag(BucketMetricsInfo.BucketName, BUCKET_NAME_1);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketUsedBytes, USED_BYTES_1);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketSnapshotUsedBytes, SNAPSHOT_USED_BYTES_1);
+    verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketUsedNamespace, USED_NAMESPACE_1);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketQuotaBytes, QUOTA_IN_BYTES_1);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketQuotaNamespace, QUOTA_IN_NAMESPACE_1);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketAvailableBytes,
@@ -102,6 +105,7 @@ public class TestBucketUtilizationMetrics {
     verify(mb, times(1)).tag(BucketMetricsInfo.VolumeName, VOLUME_NAME_2);
     verify(mb, times(1)).tag(BucketMetricsInfo.BucketName, BUCKET_NAME_2);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketUsedBytes, USED_BYTES_2);
+    verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketUsedNamespace, USED_NAMESPACE_2);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketSnapshotUsedBytes, SNAPSHOT_USED_BYTES_2);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketQuotaBytes, QUOTA_IN_BYTES_2);
     verify(mb, times(1)).addGauge(BucketMetricsInfo.BucketQuotaNamespace, QUOTA_IN_NAMESPACE_2);
@@ -109,13 +113,14 @@ public class TestBucketUtilizationMetrics {
   }
 
   private static Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>> createMockEntry(String volumeName,
-      String bucketName, long usedBytes, long snapshotUsedBytes, long quotaInBytes, long quotaInNamespace) {
+      String bucketName, long usedBytes, long snapshotUsedBytes, long quotaInBytes, long quotaInNamespace, long usedNamespace) {
     Map.Entry<CacheKey<String>, CacheValue<OmBucketInfo>> entry = mock(Map.Entry.class);
     CacheValue<OmBucketInfo> cacheValue = mock(CacheValue.class);
     OmBucketInfo bucketInfo = mock(OmBucketInfo.class);
 
     when(bucketInfo.getVolumeName()).thenReturn(volumeName);
     when(bucketInfo.getBucketName()).thenReturn(bucketName);
+    when(bucketInfo.getUsedNamespace()).thenReturn(usedNamespace);
     when(bucketInfo.getUsedBytes()).thenReturn(usedBytes);
     when(bucketInfo.getSnapshotUsedBytes()).thenReturn(snapshotUsedBytes);
     when(bucketInfo.getQuotaInBytes()).thenReturn(quotaInBytes);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVolumeUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVolumeUtilizationMetrics.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.VolumeUtilizationMetrics.VolumeMetricsInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for VolumeUtilizationMetrics.
+ */
+public class TestVolumeUtilizationMetrics {
+
+  private static final String VOLUME_NAME_1 = "volume1";
+  private static final String VOLUME_NAME_2 = "volume2";
+  private static final long QUOTA_IN_BYTES_1 = OzoneConsts.TB;
+  private static final long QUOTA_IN_BYTES_2 = -1;
+  private static final long QUOTA_IN_NAMESPACE_1 = 10;
+  private static final long QUOTA_IN_NAMESPACE_2 = -1;
+  private static final long USED_NAMESPACE_1 = 4;
+  private static final long USED_NAMESPACE_2 = 0;
+
+  @Test
+  void testVolumeUtilizationMetrics() {
+    OMMetadataManager omMetadataManager = mock(OMMetadataManager.class);
+
+    Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>> entry1 =
+        createMockEntry(VOLUME_NAME_1, QUOTA_IN_BYTES_1, QUOTA_IN_NAMESPACE_1, USED_NAMESPACE_1);
+    Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>> entry2 =
+        createMockEntry(VOLUME_NAME_2, QUOTA_IN_BYTES_2, QUOTA_IN_NAMESPACE_2, USED_NAMESPACE_2);
+
+    Iterator<Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>>> volumeIterator = mock(Iterator.class);
+    when(volumeIterator.hasNext())
+        .thenReturn(true)
+        .thenReturn(true)
+        .thenReturn(false);
+
+    when(volumeIterator.next())
+        .thenReturn(entry1)
+        .thenReturn(entry2);
+
+    when(omMetadataManager.getVolumeIterator()).thenReturn(volumeIterator);
+
+    MetricsRecordBuilder mb = mock(MetricsRecordBuilder.class);
+    when(mb.setContext(anyString())).thenReturn(mb);
+    when(mb.tag(any(MetricsInfo.class), anyString())).thenReturn(mb);
+    when(mb.addGauge(any(MetricsInfo.class), anyInt())).thenReturn(mb);
+    when(mb.addGauge(any(MetricsInfo.class), anyLong())).thenReturn(mb);
+
+    MetricsCollector metricsCollector = mock(MetricsCollector.class);
+    when(metricsCollector.addRecord(anyString())).thenReturn(mb);
+
+    VolumeUtilizationMetrics volumeMetrics = new VolumeUtilizationMetrics(omMetadataManager);
+    volumeMetrics.getMetrics(metricsCollector, true);
+
+    verify(mb, times(1)).tag(VolumeMetricsInfo.VolumeName, VOLUME_NAME_1);
+    verify(mb, times(1)).addGauge(VolumeMetricsInfo.VolumeQuotaBytes, QUOTA_IN_BYTES_1);
+    verify(mb, times(1)).addGauge(VolumeMetricsInfo.VolumeQuotaNamespace, QUOTA_IN_NAMESPACE_1);
+    verify(mb, times(1)).addGauge(VolumeMetricsInfo.VolumeUsedNamespace, USED_NAMESPACE_1);
+
+    verify(mb, times(1)).tag(VolumeMetricsInfo.VolumeName, VOLUME_NAME_2);
+    verify(mb, times(1)).addGauge(VolumeMetricsInfo.VolumeQuotaBytes, QUOTA_IN_BYTES_2);
+    verify(mb, times(1)).addGauge(VolumeMetricsInfo.VolumeQuotaNamespace, QUOTA_IN_NAMESPACE_2);
+    verify(mb, times(1)).addGauge(VolumeMetricsInfo.VolumeUsedNamespace, USED_NAMESPACE_2);
+  }
+
+  private static Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>> createMockEntry(
+      String volumeName, long quotaInBytes, long quotaInNamespace, long usedNamespace) {
+    Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>> entry = mock(Map.Entry.class);
+    CacheValue<OmVolumeArgs> cacheValue = mock(CacheValue.class);
+    OmVolumeArgs volumeArgs = mock(OmVolumeArgs.class);
+
+    when(volumeArgs.getVolume()).thenReturn(volumeName);
+    when(volumeArgs.getQuotaInBytes()).thenReturn(quotaInBytes);
+    when(volumeArgs.getQuotaInNamespace()).thenReturn(quotaInNamespace);
+    when(volumeArgs.getUsedNamespace()).thenReturn(usedNamespace);
+
+    when(cacheValue.getCacheValue()).thenReturn(volumeArgs);
+    when(entry.getValue()).thenReturn(cacheValue);
+
+    return entry;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVolumeUtilizationMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestVolumeUtilizationMetrics.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.VolumeUtilizationMetrics.VolumeMetricsInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.junit.jupiter.api.Test;
@@ -45,12 +44,12 @@ public class TestVolumeUtilizationMetrics {
 
   private static final String VOLUME_NAME_1 = "volume1";
   private static final String VOLUME_NAME_2 = "volume2";
-  private static final long QUOTA_IN_BYTES_1 = OzoneConsts.TB;
+  private static final long QUOTA_IN_BYTES_1 = 1;
   private static final long QUOTA_IN_BYTES_2 = -1;
-  private static final long QUOTA_IN_NAMESPACE_1 = 10;
+  private static final long QUOTA_IN_NAMESPACE_1 = 2;
   private static final long QUOTA_IN_NAMESPACE_2 = -1;
-  private static final long USED_NAMESPACE_1 = 4;
-  private static final long USED_NAMESPACE_2 = 0;
+  private static final long USED_NAMESPACE_1 = 3;
+  private static final long USED_NAMESPACE_2 = 4;
 
   @Test
   void testVolumeUtilizationMetrics() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Apache Ozone exposes bucket quota metrics from OM via /prom, for example:

bucket_utilization_metrics_bucket_used_bytes
bucket_utilization_metrics_bucket_quota_bytes
bucket_utilization_metrics_bucket_available_bytes
bucket_utilization_metrics_bucket_quota_namespace

These are useful for bucket byte quota monitoring, but there appear to be no equivalent Prometheus metrics for native volume quotas, even though volume quotas are available via the CLI/API.

Example CLI output:

ozone sh volume list

volume            quotaInBytes     quotaInNamespace
batch-accounting  1099511627776    -1
monitoring        10995116277760   -1
user              -1               -1

Also, for buckets, the CLI exposes namespace usage:

ozone sh bucket info /user/ekleszcz

usedNamespace: 4
quotaInNamespace: 10

but OM /prom appears to expose only the namespace quota limit:

bucket_utilization_metrics_bucket_quota_namespace

and not a matching used namespace metric.

This makes it possible to monitor bucket byte quota usage, but not:

native volume quota usage
volume quota limits via Prometheus
bucket namespace quota usage percentage
Requested improvement:

Expose OM Prometheus metrics for:

volume used bytes
volume quota bytes
volume available bytes, if applicable
volume namespace quota
volume used namespace
bucket used namespace
This would allow operators to build Grafana dashboards and alerts for both volume and bucket quota usage without relying on custom exporters or CLI polling.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15333

## How was this patch tested?
written test and manual checking of metrics.

```
curl -s http://localhost:9874/prom | grep 'volume_utilization_metrics.*quotatest'          
curl -s http://localhost:9874/prom | grep 'bucket_utilization_metrics_bucket_used_namespace.*metricsbucket'
volume_utilization_metrics_volume_quota_bytes{context="Volume metrics",volumename="quotatest",hostname="e4e7ec0ffb98"} 1073741824
volume_utilization_metrics_volume_quota_namespace{context="Volume metrics",volumename="quotatest",hostname="e4e7ec0ffb98"} 5
volume_utilization_metrics_volume_used_namespace{context="Volume metrics",volumename="quotatest",hostname="e4e7ec0ffb98"} 3
bucket_utilization_metrics_bucket_used_namespace{context="Bucket metrics",volumename="quotatest",bucketname="metricsbucket",hostname="e4e7ec0ffb98"} 4
```