### PR TITLE
HDDS-16169. Add old updateContainerState to handle upgrade path.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMHandler;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 
 /**
  * A ContainerStateManager is responsible for keeping track of all the
@@ -168,6 +169,11 @@ public interface ContainerStateManager extends SCMHandler {
   @Replicate
   void addContainer(ContainerInfoProto containerInfo)
       throws IOException;
+
+  @Deprecated
+  @Replicate
+  void updateContainerState(HddsProtos.ContainerID id,
+      HddsProtos.LifeCycleEvent event) throws IOException, InvalidStateTransitionException;
 
   /**
    * Updates container state with sequenceId synchronization for HA consistency.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -386,6 +386,36 @@ public final class ContainerStateManagerImpl
     }
   }
 
+  @Deprecated
+  @Override
+  public void updateContainerState(final HddsProtos.ContainerID containerID,
+      final LifeCycleEvent event)
+      throws IOException, InvalidStateTransitionException {
+    // TODO: Remove the protobuf conversion after fixing ContainerStateMap.
+    final ContainerID id = ContainerID.getFromProtobuf(containerID);
+
+    try (AutoCloseableLock ignored = writeLock(id)) {
+      if (containers.contains(id)) {
+        final ContainerInfo oldInfo = containers.getContainerInfo(id);
+        final LifeCycleState oldState = oldInfo.getState();
+        final LifeCycleState newState = stateMachine.getNextState(
+            oldInfo.getState(), event);
+        if (newState.getNumber() > oldState.getNumber()) {
+          ExecutionUtil.create(() -> {
+            containers.updateState(id, oldState, newState);
+            transactionBuffer.addToBuffer(containerStore, id,
+                containers.getContainerInfo(id));
+          }).onException(() -> {
+            transactionBuffer.addToBuffer(containerStore, id, oldInfo);
+            containers.updateState(id, newState, oldState);
+          }).execute();
+          containerStateChangeActions.getOrDefault(event, info -> { })
+              .accept(oldInfo);
+        }
+      }
+    }
+  }
+
   @Override
   public void updateContainerStateWithSequenceId(final HddsProtos.ContainerID containerID,
                                                   final LifeCycleEvent event,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.ratis.protocol.Message;
 
 /** Code generated for {@link ContainerStateManager}.  Do not modify. */
@@ -56,6 +57,12 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
     updateContainerInfo(new Class<?>[][] {
         null,
         new Class<?>[] {ContainerInfoProto.class}
+    }),
+    updateContainerState(new Class<?>[][]{
+        null,
+        null,
+        null,
+        new Class<?>[]{HddsProtos.ContainerID.class, LifeCycleEvent.class}
     }),
     updateContainerStateWithSequenceId(new Class<?>[][] {
         null,
@@ -177,6 +184,13 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
       @Override
       public void updateContainerReplica(ContainerReplica arg0) {
         invoker.getImpl().updateContainerReplica(arg0);
+      }
+
+      @Override
+      public void updateContainerState(HddsProtos.ContainerID arg0, LifeCycleEvent arg1) throws IOException,
+          InvalidStateTransitionException {
+        final Object[] args = {arg0, arg1};
+        invoker.invokeReplicateDirect(ReplicateMethod.updateContainerState, args);
       }
 
       @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/invoker/ContainerStateManagerInvoker.java
@@ -58,11 +58,10 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
         null,
         new Class<?>[] {ContainerInfoProto.class}
     }),
-    updateContainerState(new Class<?>[][]{
+    updateContainerState(new Class<?>[][] {
         null,
         null,
-        null,
-        new Class<?>[]{HddsProtos.ContainerID.class, LifeCycleEvent.class}
+        new Class<?>[] {HddsProtos.ContainerID.class, LifeCycleEvent.class}
     }),
     updateContainerStateWithSequenceId(new Class<?>[][] {
         null,
@@ -317,11 +316,17 @@ public class ContainerStateManagerInvoker extends ScmInvoker<ContainerStateManag
       getImpl().updateContainerReplica(arg26);
       return Message.EMPTY;
 
-    case "updateContainerStateWithSequenceId":
+    case "updateContainerState":
       final HddsProtos.ContainerID arg27 = p.length > 0 ? (HddsProtos.ContainerID) p[0] : null;
       final LifeCycleEvent arg28 = p.length > 1 ? (LifeCycleEvent) p[1] : null;
-      final Long arg29 = p.length > 2 ? (Long) p[2] : null;
-      getImpl().updateContainerStateWithSequenceId(arg27, arg28, arg29);
+      getImpl().updateContainerState(arg27, arg28);
+      return Message.EMPTY;
+
+    case "updateContainerStateWithSequenceId":
+      final HddsProtos.ContainerID arg29 = p.length > 0 ? (HddsProtos.ContainerID) p[0] : null;
+      final LifeCycleEvent arg30 = p.length > 1 ? (LifeCycleEvent) p[1] : null;
+      final Long arg31 = p.length > 2 ? (Long) p[2] : null;
+      getImpl().updateContainerStateWithSequenceId(arg29, arg30, arg31);
       return Message.EMPTY;
 
     default:


### PR DESCRIPTION
## What changes were proposed in this pull request?

To handle upgrade path added old implementation of updateContainerState.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16169

## How was this patch tested?

Added old API for backward compatibilty