### PR TITLE
HDDS-16131. Intermittent failure in TestBlockDeletingService#testBlockDeletionMetricsUpdatedProperlyAfterEachExecution

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -134,6 +134,7 @@ public class TestBlockDeletingService {
   private String schemaVersion;
   private int blockLimitPerInterval;
   private MutableVolumeSet volumeSet;
+  private BlockDeletingService blockDeletingService;
   private static final int BLOCK_CHUNK_SIZE = 100;
 
   @BeforeEach
@@ -150,6 +151,10 @@ public class TestBlockDeletingService {
 
   @AfterEach
   public void cleanup() throws IOException {
+    if (blockDeletingService != null) {
+      // Wait for deletion tasks to release container DB references before cleanup.
+      blockDeletingService.shutdown();
+    }
     BlockUtils.shutdownCache(conf);
     CodecBuffer.assertNoLeaks();
   }
@@ -703,42 +708,37 @@ public class TestBlockDeletingService {
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet, metrics);
     BlockDeletingServiceTestImpl svc =
         getBlockDeletingService(containerSet, conf, keyValueHandler);
-    try {
-      svc.start();
-      GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
+    svc.start();
+    GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
 
-      // Ensure 1 container was created
-      List<ContainerData> containerData = Lists.newArrayList();
-      containerSet.listContainer(0L, 1, containerData);
-      assertEquals(1, containerData.size());
-      KeyValueContainerData data = (KeyValueContainerData) containerData.get(0);
+    // Ensure 1 container was created
+    List<ContainerData> containerData = Lists.newArrayList();
+    containerSet.listContainer(0L, 1, containerData);
+    assertEquals(1, containerData.size());
+    KeyValueContainerData data = (KeyValueContainerData) containerData.get(0);
 
-      try (DBHandle meta = BlockUtils.getDB(data, conf)) {
-        //Execute fist delete to update metrics
-        deleteAndWait(svc, 1);
+    try (DBHandle meta = BlockUtils.getDB(data, conf)) {
+      //Execute fist delete to update metrics
+      deleteAndWait(svc, 1);
 
-        assertEquals(3, blockDeletingServiceMetrics.getTotalPendingBlockCount());
-        assertEquals(3 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
+      assertEquals(3, blockDeletingServiceMetrics.getTotalPendingBlockCount());
+      assertEquals(3 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
 
-        //Execute the second delete to check whether metrics values decreased
-        deleteAndWait(svc, 2);
+      //Execute the second delete to check whether metrics values decreased
+      deleteAndWait(svc, 2);
 
-        assertEquals(2, blockDeletingServiceMetrics.getTotalPendingBlockCount());
-        assertEquals(2 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
+      assertEquals(2, blockDeletingServiceMetrics.getTotalPendingBlockCount());
+      assertEquals(2 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
 
-        //Execute the third delete to check whether metrics values decreased
-        deleteAndWait(svc, 3);
+      //Execute the third delete to check whether metrics values decreased
+      deleteAndWait(svc, 3);
 
-        assertEquals(1, blockDeletingServiceMetrics.getTotalPendingBlockCount());
-        assertEquals(1 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
+      assertEquals(1, blockDeletingServiceMetrics.getTotalPendingBlockCount());
+      assertEquals(1 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
 
-      } catch (Exception ex) {
-        ex.printStackTrace();
-        fail("Test failed with exception: " + ex.getMessage());
-      }
-    } finally {
-      // Wait for deletion tasks to release container DB references before cleanup.
-      svc.shutdown();
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      fail("Test failed with exception: " + ex.getMessage());
     }
   }
 
@@ -956,7 +956,10 @@ public class TestBlockDeletingService {
       KeyValueHandler keyValueHandler) {
     OzoneContainer ozoneContainer =
         mockDependencies(containerSet, keyValueHandler);
-    return new BlockDeletingServiceTestImpl(ozoneContainer, 1000, config);
+    BlockDeletingServiceTestImpl service =
+        new BlockDeletingServiceTestImpl(ozoneContainer, 1000, config);
+    blockDeletingService = service;
+    return service;
   }
 
   private OzoneContainer mockDependencies(ContainerSet containerSet,
@@ -1186,30 +1189,25 @@ public class TestBlockDeletingService {
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet);
     BlockDeletingServiceTestImpl svc =
         getBlockDeletingService(containerSet, conf, keyValueHandler);
-    try {
-      svc.start();
-      GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
+    svc.start();
+    GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
 
-      // Remove all the block files from the disk, as if they were deleted previously but the system failed before
-      // doing any metadata updates or removing the transaction of to-delete block IDs from the DB.
-      File blockDataDir = new File(contData.getChunksPath());
-      try (DirectoryStream<Path> stream = Files.newDirectoryStream(blockDataDir.toPath())) {
-        for (Path entry : stream) {
-          assertTrue(entry.toFile().delete());
-        }
+    // Remove all the block files from the disk, as if they were deleted previously but the system failed before
+    // doing any metadata updates or removing the transaction of to-delete block IDs from the DB.
+    File blockDataDir = new File(contData.getChunksPath());
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(blockDataDir.toPath())) {
+      for (Path entry : stream) {
+        assertTrue(entry.toFile().delete());
       }
-
-      String[] blockFilesRemaining = blockDataDir.list();
-      assertNotNull(blockFilesRemaining);
-      assertEquals(0, blockFilesRemaining.length);
-
-      deleteAndWait(svc, 1);
-
-      assertDeletionsInChecksumFile(contData, numBlocks);
-    } finally {
-      // Wait for deletion tasks to release container DB references before cleanup.
-      svc.shutdown();
     }
+
+    String[] blockFilesRemaining = blockDataDir.list();
+    assertNotNull(blockFilesRemaining);
+    assertEquals(0, blockFilesRemaining.length);
+
+    deleteAndWait(svc, 1);
+
+    assertDeletionsInChecksumFile(contData, numBlocks);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -703,37 +703,42 @@ public class TestBlockDeletingService {
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet, metrics);
     BlockDeletingServiceTestImpl svc =
         getBlockDeletingService(containerSet, conf, keyValueHandler);
-    svc.start();
-    GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
+    try {
+      svc.start();
+      GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
 
-    // Ensure 1 container was created
-    List<ContainerData> containerData = Lists.newArrayList();
-    containerSet.listContainer(0L, 1, containerData);
-    assertEquals(1, containerData.size());
-    KeyValueContainerData data = (KeyValueContainerData) containerData.get(0);
+      // Ensure 1 container was created
+      List<ContainerData> containerData = Lists.newArrayList();
+      containerSet.listContainer(0L, 1, containerData);
+      assertEquals(1, containerData.size());
+      KeyValueContainerData data = (KeyValueContainerData) containerData.get(0);
 
-    try (DBHandle meta = BlockUtils.getDB(data, conf)) {
-      //Execute fist delete to update metrics
-      deleteAndWait(svc, 1);
+      try (DBHandle meta = BlockUtils.getDB(data, conf)) {
+        //Execute fist delete to update metrics
+        deleteAndWait(svc, 1);
 
-      assertEquals(3, blockDeletingServiceMetrics.getTotalPendingBlockCount());
-      assertEquals(3 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
+        assertEquals(3, blockDeletingServiceMetrics.getTotalPendingBlockCount());
+        assertEquals(3 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
 
-      //Execute the second delete to check whether metrics values decreased
-      deleteAndWait(svc, 2);
+        //Execute the second delete to check whether metrics values decreased
+        deleteAndWait(svc, 2);
 
-      assertEquals(2, blockDeletingServiceMetrics.getTotalPendingBlockCount());
-      assertEquals(2 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
+        assertEquals(2, blockDeletingServiceMetrics.getTotalPendingBlockCount());
+        assertEquals(2 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
 
-      //Execute the third delete to check whether metrics values decreased
-      deleteAndWait(svc, 3);
+        //Execute the third delete to check whether metrics values decreased
+        deleteAndWait(svc, 3);
 
-      assertEquals(1, blockDeletingServiceMetrics.getTotalPendingBlockCount());
-      assertEquals(1 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
+        assertEquals(1, blockDeletingServiceMetrics.getTotalPendingBlockCount());
+        assertEquals(1 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
 
-    } catch (Exception ex) {
-      ex.printStackTrace();
-      fail("Test failed with exception: " + ex.getMessage());
+      } catch (Exception ex) {
+        ex.printStackTrace();
+        fail("Test failed with exception: " + ex.getMessage());
+      }
+    } finally {
+      // Wait for deletion tasks to release container DB references before cleanup.
+      svc.shutdown();
     }
   }
 
@@ -1181,25 +1186,30 @@ public class TestBlockDeletingService {
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet);
     BlockDeletingServiceTestImpl svc =
         getBlockDeletingService(containerSet, conf, keyValueHandler);
-    svc.start();
-    GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
+    try {
+      svc.start();
+      GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
 
-    // Remove all the block files from the disk, as if they were deleted previously but the system failed before
-    // doing any metadata updates or removing the transaction of to-delete block IDs from the DB.
-    File blockDataDir = new File(contData.getChunksPath());
-    try (DirectoryStream<Path> stream = Files.newDirectoryStream(blockDataDir.toPath())) {
-      for (Path entry : stream) {
-        assertTrue(entry.toFile().delete());
+      // Remove all the block files from the disk, as if they were deleted previously but the system failed before
+      // doing any metadata updates or removing the transaction of to-delete block IDs from the DB.
+      File blockDataDir = new File(contData.getChunksPath());
+      try (DirectoryStream<Path> stream = Files.newDirectoryStream(blockDataDir.toPath())) {
+        for (Path entry : stream) {
+          assertTrue(entry.toFile().delete());
+        }
       }
+
+      String[] blockFilesRemaining = blockDataDir.list();
+      assertNotNull(blockFilesRemaining);
+      assertEquals(0, blockFilesRemaining.length);
+
+      deleteAndWait(svc, 1);
+
+      assertDeletionsInChecksumFile(contData, numBlocks);
+    } finally {
+      // Wait for deletion tasks to release container DB references before cleanup.
+      svc.shutdown();
     }
-
-    String[] blockFilesRemaining = blockDataDir.list();
-    assertNotNull(blockFilesRemaining);
-    assertEquals(0, blockFilesRemaining.length);
-
-    deleteAndWait(svc, 1);
-
-    assertDeletionsInChecksumFile(contData, numBlocks);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -134,11 +134,12 @@ public class TestBlockDeletingService {
   private String schemaVersion;
   private int blockLimitPerInterval;
   private MutableVolumeSet volumeSet;
-  private BlockDeletingService blockDeletingService;
+  private BlockDeletingServiceTestImpl blockDeletingService;
   private static final int BLOCK_CHUNK_SIZE = 100;
 
   @BeforeEach
   public void init() throws IOException {
+    blockDeletingService = null;
     CodecBuffer.enableLeakDetection();
     scmId = UUID.randomUUID().toString();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());
@@ -573,11 +574,10 @@ public class TestBlockDeletingService {
     ContainerMetrics metrics = ContainerMetrics.create(conf);
     KeyValueHandler keyValueHandler =
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet, metrics);
-    BlockDeletingServiceTestImpl svc =
-        getBlockDeletingService(containerSet, conf, keyValueHandler);
-    svc.start();
-    BlockDeletingServiceMetrics deletingServiceMetrics = svc.getMetrics();
-    GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
+    createBlockDeletingService(containerSet, conf, keyValueHandler);
+    blockDeletingService.start();
+    BlockDeletingServiceMetrics deletingServiceMetrics = blockDeletingService.getMetrics();
+    GenericTestUtils.waitFor(blockDeletingService::isStarted, 100, 3000);
 
     // Ensure 1 container was created
     List<ContainerData> containerData = Lists.newArrayList();
@@ -620,7 +620,7 @@ public class TestBlockDeletingService {
       assertThat(containerSpace).isGreaterThan(0);
 
       // An interval will delete 1 * 2 blocks
-      deleteAndWait(svc, 1);
+      deleteAndWait(blockDeletingService, 1);
 
       // Make sure that deletions for each container were recorded in the checksum tree file.
       containerData.forEach(c -> assertDeletionsInChecksumFile(c, 2));
@@ -650,7 +650,7 @@ public class TestBlockDeletingService {
       assertEquals(3 * BLOCK_CHUNK_SIZE,
           deletingServiceMetrics.getTotalPendingBlockBytes());
 
-      deleteAndWait(svc, 2);
+      deleteAndWait(blockDeletingService, 2);
 
       containerData.forEach(c -> assertDeletionsInChecksumFile(c, 3));
 
@@ -686,7 +686,7 @@ public class TestBlockDeletingService {
       assertEquals(BLOCK_CHUNK_SIZE,
           deletingServiceMetrics.getTotalPendingBlockBytes());
     }
-    svc.shutdown();
+    blockDeletingService.shutdown();
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -706,10 +706,9 @@ public class TestBlockDeletingService {
     BlockDeletingServiceMetrics blockDeletingServiceMetrics = BlockDeletingServiceMetrics.create();
     KeyValueHandler keyValueHandler =
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet, metrics);
-    BlockDeletingServiceTestImpl svc =
-        getBlockDeletingService(containerSet, conf, keyValueHandler);
-    svc.start();
-    GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
+    createBlockDeletingService(containerSet, conf, keyValueHandler);
+    blockDeletingService.start();
+    GenericTestUtils.waitFor(blockDeletingService::isStarted, 100, 3000);
 
     // Ensure 1 container was created
     List<ContainerData> containerData = Lists.newArrayList();
@@ -719,19 +718,19 @@ public class TestBlockDeletingService {
 
     try (DBHandle meta = BlockUtils.getDB(data, conf)) {
       //Execute fist delete to update metrics
-      deleteAndWait(svc, 1);
+      deleteAndWait(blockDeletingService, 1);
 
       assertEquals(3, blockDeletingServiceMetrics.getTotalPendingBlockCount());
       assertEquals(3 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
 
       //Execute the second delete to check whether metrics values decreased
-      deleteAndWait(svc, 2);
+      deleteAndWait(blockDeletingService, 2);
 
       assertEquals(2, blockDeletingServiceMetrics.getTotalPendingBlockCount());
       assertEquals(2 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
 
       //Execute the third delete to check whether metrics values decreased
-      deleteAndWait(svc, 3);
+      deleteAndWait(blockDeletingService, 3);
 
       assertEquals(1, blockDeletingServiceMetrics.getTotalPendingBlockCount());
       assertEquals(1 * BLOCK_CHUNK_SIZE, blockDeletingServiceMetrics.getTotalPendingBlockBytes());
@@ -765,10 +764,9 @@ public class TestBlockDeletingService {
     ContainerMetrics metrics = ContainerMetrics.create(conf);
     KeyValueHandler keyValueHandler =
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet, metrics);
-    BlockDeletingServiceTestImpl svc =
-        getBlockDeletingService(containerSet, conf, keyValueHandler);
-    svc.start();
-    GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
+    createBlockDeletingService(containerSet, conf, keyValueHandler);
+    blockDeletingService.start();
+    GenericTestUtils.waitFor(blockDeletingService::isStarted, 100, 3000);
 
     // Ensure 2 container was created
     List<ContainerData> containerData = Lists.newArrayList();
@@ -830,11 +828,11 @@ public class TestBlockDeletingService {
     // Totally 2 container * 3 blocks + 4 unrecorded block = 10 blocks
     // So we shall experience 5 rounds to delete all blocks
     // Unrecorded blocks should not affect the actual NumPendingDeletionBlocks
-    deleteAndWait(svc, 1);
-    deleteAndWait(svc, 2);
-    deleteAndWait(svc, 3);
-    deleteAndWait(svc, 4);
-    deleteAndWait(svc, 5);
+    deleteAndWait(blockDeletingService, 1);
+    deleteAndWait(blockDeletingService, 2);
+    deleteAndWait(blockDeletingService, 3);
+    deleteAndWait(blockDeletingService, 4);
+    deleteAndWait(blockDeletingService, 5);
     GenericTestUtils.waitFor(() -> ctr2.getNumPendingDeletionBlocks() == 0,
         200, 2000);
 
@@ -853,7 +851,7 @@ public class TestBlockDeletingService {
       assertFalse(f.exists());
     }
 
-    svc.shutdown();
+    blockDeletingService.shutdown();
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -869,18 +867,17 @@ public class TestBlockDeletingService {
     ContainerMetrics metrics = ContainerMetrics.create(conf);
     KeyValueHandler keyValueHandler =
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet, metrics);
-    BlockDeletingServiceTestImpl service =
-        getBlockDeletingService(containerSet, conf, keyValueHandler);
-    service.start();
-    GenericTestUtils.waitFor(service::isStarted, 100, 3000);
+    createBlockDeletingService(containerSet, conf, keyValueHandler);
+    blockDeletingService.start();
+    GenericTestUtils.waitFor(blockDeletingService::isStarted, 100, 3000);
 
     // Run some deleting tasks and verify there are threads running
-    service.runDeletingTasks();
-    GenericTestUtils.waitFor(() -> service.getThreadCount() > 0, 100, 1000);
+    blockDeletingService.runDeletingTasks();
+    GenericTestUtils.waitFor(() -> blockDeletingService.getThreadCount() > 0, 100, 1000);
 
     // Shutdown service and verify all threads are stopped
-    service.shutdown();
-    GenericTestUtils.waitFor(() -> service.getThreadCount() == 0, 100, 1000);
+    blockDeletingService.shutdown();
+    GenericTestUtils.waitFor(() -> blockDeletingService.getThreadCount() == 0, 100, 1000);
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -951,15 +948,13 @@ public class TestBlockDeletingService {
     svc.shutdown();
   }
 
-  private BlockDeletingServiceTestImpl getBlockDeletingService(
+  private void createBlockDeletingService(
       ContainerSet containerSet, ConfigurationSource config,
       KeyValueHandler keyValueHandler) {
     OzoneContainer ozoneContainer =
         mockDependencies(containerSet, keyValueHandler);
-    BlockDeletingServiceTestImpl service =
+    blockDeletingService =
         new BlockDeletingServiceTestImpl(ozoneContainer, 1000, config);
-    blockDeletingService = service;
-    return service;
   }
 
   private OzoneContainer mockDependencies(ContainerSet containerSet,
@@ -1005,18 +1000,17 @@ public class TestBlockDeletingService {
     ContainerMetrics metrics = ContainerMetrics.create(conf);
     KeyValueHandler keyValueHandler =
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet, metrics);
-    BlockDeletingServiceTestImpl service =
-        getBlockDeletingService(containerSet, conf, keyValueHandler);
-    service.start();
+    createBlockDeletingService(containerSet, conf, keyValueHandler);
+    blockDeletingService.start();
     List<ContainerData> containerData = Lists.newArrayList();
     containerSet.listContainer(0L, containerCount, containerData);
     try {
-      GenericTestUtils.waitFor(service::isStarted, 100, 3000);
+      GenericTestUtils.waitFor(blockDeletingService::isStarted, 100, 3000);
 
       // Deleting one of the two containers and its single block.
       // Hence, space used by the container of whose block has been
       // deleted should be zero.
-      deleteAndWait(service, 1);
+      deleteAndWait(blockDeletingService, 1);
 
       GenericTestUtils.waitFor(() ->
               (containerData.get(0).getBytesUsed() == 0 ||
@@ -1028,14 +1022,14 @@ public class TestBlockDeletingService {
 
       // Deleting the second container. Hence, space used by both the
       // containers should be zero.
-      deleteAndWait(service, 2);
+      deleteAndWait(blockDeletingService, 2);
 
       GenericTestUtils.waitFor(() ->
               (containerData.get(0).getBytesUsed() ==
                   0 && containerData.get(1).getBytesUsed() == 0),
           100, 3000);
     } finally {
-      service.shutdown();
+      blockDeletingService.shutdown();
     }
   }
 
@@ -1060,14 +1054,13 @@ public class TestBlockDeletingService {
         chunksPerBlock);
     KeyValueHandler keyValueHandler =
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet);
-    BlockDeletingServiceTestImpl service =
-        getBlockDeletingService(containerSet, conf, keyValueHandler);
-    service.start();
+    createBlockDeletingService(containerSet, conf, keyValueHandler);
+    blockDeletingService.start();
     List<ContainerData> containerData = Lists.newArrayList();
     containerSet.listContainer(0L, containerCount, containerData);
     try {
-      GenericTestUtils.waitFor(service::isStarted, 100, 3000);
-      deleteAndWait(service, 1);
+      GenericTestUtils.waitFor(blockDeletingService::isStarted, 100, 3000);
+      deleteAndWait(blockDeletingService, 1);
       GenericTestUtils.waitFor(() ->
               (containerData.get(0).getBytesUsed() == 0),
           100, 3000);
@@ -1082,7 +1075,7 @@ public class TestBlockDeletingService {
             StringUtils.countMatches(log.getOutput(), "Max lock hold time"));
       }
     } finally {
-      service.shutdown();
+      blockDeletingService.shutdown();
     }
   }
 
@@ -1122,16 +1115,15 @@ public class TestBlockDeletingService {
     createToDeleteBlocks(containerSet, containerCount,
         blocksPerContainer, 1);
 
-    BlockDeletingServiceTestImpl service =
-        getBlockDeletingService(containerSet, conf, keyValueHandler);
-    service.start();
+    createBlockDeletingService(containerSet, conf, keyValueHandler);
+    blockDeletingService.start();
     List<ContainerData> containerData = Lists.newArrayList();
     containerSet.listContainer(0L, containerCount, containerData);
     long blockSpace = containerData.get(0).getBytesUsed() / blocksPerContainer;
     long totalContainerSpace =
         containerCount * containerData.get(0).getBytesUsed();
     try {
-      GenericTestUtils.waitFor(service::isStarted, 100, 3000);
+      GenericTestUtils.waitFor(blockDeletingService::isStarted, 100, 3000);
       // Total blocks = 3 * 5 = 15
       // blockLimitPerInterval = 10
       // each interval will at most runDeletingTasks = 10 blocks
@@ -1141,7 +1133,7 @@ public class TestBlockDeletingService {
 
       // Deleted space of 10 blocks should be equal to (initial total space
       // of container - current total space of container).
-      deleteAndWait(service, 1);
+      deleteAndWait(blockDeletingService, 1);
 
       GenericTestUtils.waitFor(() ->
               blockLimitPerInterval * blockSpace ==
@@ -1155,7 +1147,7 @@ public class TestBlockDeletingService {
       // be equal to (initial total space of container
       // - current total space of container(it will be zero as all blocks
       // in all the containers are deleted)).
-      deleteAndWait(service, 2);
+      deleteAndWait(blockDeletingService, 2);
 
       long totalContainerBlocks = blocksPerContainer * containerCount;
       GenericTestUtils.waitFor(() ->
@@ -1165,7 +1157,7 @@ public class TestBlockDeletingService {
               100, 3000);
 
     } finally {
-      service.shutdown();
+      blockDeletingService.shutdown();
     }
   }
 
@@ -1187,10 +1179,9 @@ public class TestBlockDeletingService {
     KeyValueContainerData contData = createToDeleteBlocks(containerSet, numBlocks, 4);
     KeyValueHandler keyValueHandler =
         ContainerTestUtils.getKeyValueHandler(conf, datanodeUuid, containerSet, volumeSet);
-    BlockDeletingServiceTestImpl svc =
-        getBlockDeletingService(containerSet, conf, keyValueHandler);
-    svc.start();
-    GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
+    createBlockDeletingService(containerSet, conf, keyValueHandler);
+    blockDeletingService.start();
+    GenericTestUtils.waitFor(blockDeletingService::isStarted, 100, 3000);
 
     // Remove all the block files from the disk, as if they were deleted previously but the system failed before
     // doing any metadata updates or removing the transaction of to-delete block IDs from the DB.
@@ -1205,7 +1196,7 @@ public class TestBlockDeletingService {
     assertNotNull(blockFilesRemaining);
     assertEquals(0, blockFilesRemaining.length);
 
-    deleteAndWait(svc, 1);
+    deleteAndWait(blockDeletingService, 1);
 
     assertDeletionsInChecksumFile(contData, numBlocks);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch ensures that `BlockDeletingServiceTestImpl` is shut down in a finally block. Service shutdown waits for the deletion tasks to finish and release their container DB references before test cleanup runs.

The same lifecycle handling is also added to `testChecksumFileUpdatedWhenDeleteRetried`, which starts the service without shutting it down and is susceptible to the same teardown race.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16131

## How was this patch tested?

Local Test
```
mvn -pl :hdds-container-service test \
    -Dtest='TestBlockDeletingService#testBlockDeletionMetricsUpdatedProperlyAfterEachExecution+testChecksumFileUpdatedWhenDeleteRetried' \
    -DskipShade -DskipRecon -DskipDocs
```

### GitHub Actions CI
- build-branch: https://github.com/echonesis/ozone/actions/runs/31658338732
- flaky-test-check: https://github.com/echonesis/ozone/actions/runs/31658570932