### PR TITLE
HDDS-16170. Intermittent failure in TestSnapshotDiffManager#testLoadJobsOnStartUp

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -1135,14 +1135,17 @@ public class TestSnapshotDiffManager {
 
     spy.loadJobsOnStartUp();
 
-    // Wait for sometime to make sure that job finishes.
-    attempt(() ->
-        verify(spy, atLeast(1))
-            .generateSnapshotDiffReport(anyString(), anyString(),
-                eq(VOLUME_NAME), eq(BUCKET_NAME), eq(snapshotInfo.getName()),
-                eq(snapshotInfoList.get(1).getName()), eq(false),
-                eq(false)),
-        10, TimeDuration.ONE_SECOND, null, null);
+    // Wait until the job's status is persisted as DONE. Mockito records the
+    // invocation before running the stubbed answer, so waiting on verify(...)
+    // alone can return while the answer is still executing and has not yet
+    // written DONE to the DB, leaving the read below to observe IN_PROGRESS.
+    attempt(() -> {
+      if (getSnapshotDiffJobFromDb(snapshotInfo, snapshotInfoList.get(1))
+          .getStatus() != DONE) {
+        throw new IllegalStateException("Snapshot diff job is not DONE yet.");
+      }
+      return null;
+    }, 10, TimeDuration.ONE_SECOND, null, null);
 
     SnapshotDiffJob snapDiffJob = getSnapshotDiffJobFromDb(snapshotInfo,
         snapshotInfoList.get(1));


### PR DESCRIPTION
Generated-by: Claude Code (Opus 4.8)

## What changes were proposed in this pull request?

`TestSnapshotDiffManager#testLoadJobsOnStartUp` fails intermittently with `expected: <DONE> but was: <IN_PROGRESS>`.

The test stubs `generateSnapshotDiffReport` with a `doAnswer` that writes `DONE` to the DB inside the answer body, calls `loadJobsOnStartUp()`, then waits with `attempt(() -> verify(spy, atLeast(1)).generateSnapshotDiffReport(...))` before reading the job back and asserting `DONE`.

Mockito records an invocation before it runs the stubbed answer, so the `verify(...)` wait can pass as soon as the worker thread enters `generateSnapshotDiffReport`, while the answer is still running and has not yet persisted `DONE`. The main thread then reads the job and observes the original `IN_PROGRESS`, so the assertion fails.

The fix waits on the actual observable end state the test asserts: it polls `getSnapshotDiffJobFromDb(...).getStatus()` until it is `DONE`, instead of waiting on the Mockito invocation. This is deterministic by construction because the read the assertion depends on is exactly what is waited on. No production code changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16170

## How was this patch tested?

Ran the affected test locally against the change:

```
mvn -pl :ozone-manager -am test -Dtest='TestSnapshotDiffManager#testLoadJobsOnStartUp' -DskipShade -DskipRecon -DskipDocs -Dsurefire.failIfNoSpecifiedTests=false
```

A single green run cannot prove non-flakiness, so the fix is made deterministic by construction: the wait polls the same persisted job status that the subsequent assertion reads, closing the window between Mockito recording the invocation and the stubbed answer writing `DONE` to the DB.

Run 10x10: https://github.com/smengcl/hadoop-ozone/actions/runs/32387971098

Another 10x10 run: https://github.com/smengcl/hadoop-ozone/actions/runs/32432617806