### PR TITLE
HDDS-12208. Give `ozone debug replicas verify` options for OM container location cache behavior.

### DIFF
--- a/hadoop-hdds/docs/content/tools/debug/DebugReplicas.md
+++ b/hadoop-hdds/docs/content/tools/debug/DebugReplicas.md
@@ -71,6 +71,7 @@ Verify data across replicas. There are multiple checks available, which can be s
 ```bash 
 Usage: ozone debug replicas verify [-hV] [--all-results] [--verbose]
                                    [--container-cache-size=<containerCacheSize>]
+                                   [--refresh-container-locations-from-scm]
                                     [-id=<scmServiceId>] [--scm=<scm>]
                                    ([--checksums] [--block-existence]
                                    [--container-state]) <uri>
@@ -109,6 +110,13 @@ failed checks.
       --container-state   Check the container and replica states. Containers in
                             [DELETING, DELETED] states, or it's replicas in
                             [DELETED, UNHEALTHY, INVALID] states fail the check.
+      --refresh-container-locations-from-scm
+                          Force OM to refresh container locations from SCM
+                            before returning key info. This can slow down
+                            verification but may avoid stale location results
+                            from OM cache.
+      --refresh-from-scm  Short alias for
+                            --refresh-container-locations-from-scm.
   -h, --help              Show this help message and exit.
       -id, --service-id=<scmServiceId>
                           ServiceId of SCM HA Cluster

--- a/hadoop-hdds/docs/content/tools/debug/DebugReplicas.md
+++ b/hadoop-hdds/docs/content/tools/debug/DebugReplicas.md
@@ -71,7 +71,7 @@ Verify data across replicas. There are multiple checks available, which can be s
 ```bash 
 Usage: ozone debug replicas verify [-hV] [--all-results] [--verbose]
                                    [--container-cache-size=<containerCacheSize>]
-                                   [--refresh-container-locations-from-scm]
+                                   [--refresh-from-scm]
                                     [-id=<scmServiceId>] [--scm=<scm>]
                                    ([--checksums] [--block-existence]
                                    [--container-state]) <uri>
@@ -110,13 +110,11 @@ failed checks.
       --container-state   Check the container and replica states. Containers in
                             [DELETING, DELETED] states, or it's replicas in
                             [DELETED, UNHEALTHY, INVALID] states fail the check.
-      --refresh-container-locations-from-scm
+      --refresh-from-scm
                           Force OM to refresh container locations from SCM
                             before returning key info. This can slow down
                             verification but may avoid stale location results
                             from OM cache.
-      --refresh-from-scm  Short alias for
-                            --refresh-container-locations-from-scm.
   -h, --help              Show this help message and exit.
       -id, --service-id=<scmServiceId>
                           ServiceId of SCM HA Cluster

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
@@ -82,6 +82,11 @@ public class ReplicasVerify extends Handler {
       description = "Print results for all passing and failing keys")
   private boolean allResults;
 
+  @CommandLine.Option(names = {"--refresh-container-locations-from-scm", "--refresh-from-scm"},
+      description = "Force OM to refresh container locations from SCM before returning key info. " +
+          "This can slow down verification but may avoid stale location results from OM cache.")
+  private boolean refreshContainerLocationsFromScm;
+
   @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
   private Verification verification;
 
@@ -334,7 +339,7 @@ public class ReplicasVerify extends Handler {
       ArrayNode keysArray, AtomicBoolean allKeysPassed) throws IOException {
     keysProcessed.incrementAndGet();
     OmKeyInfo keyInfo = ozoneClient.getProxy().getKeyInfo(
-        volumeName, bucketName, keyName, false);
+        volumeName, bucketName, keyName, refreshContainerLocationsFromScm);
 
     // Check if key should be processed based on replication config
     if (!shouldProcessKeyByReplicationType(keyInfo)) {

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/ReplicasVerify.java
@@ -82,7 +82,7 @@ public class ReplicasVerify extends Handler {
       description = "Print results for all passing and failing keys")
   private boolean allResults;
 
-  @CommandLine.Option(names = {"--refresh-container-locations-from-scm", "--refresh-from-scm"},
+  @CommandLine.Option(names = {"--refresh-from-scm"},
       description = "Force OM to refresh container locations from SCM before returning key info. " +
           "This can slow down verification but may avoid stale location results from OM cache.")
   private boolean refreshContainerLocationsFromScm;

--- a/hadoop-ozone/cli-debug/src/test/java/org/apache/hadoop/ozone/debug/replicas/TestReplicasVerify.java
+++ b/hadoop-ozone/cli-debug/src/test/java/org/apache/hadoop/ozone/debug/replicas/TestReplicasVerify.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.replicas;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+/**
+ * Unit tests for replicas verify command option parsing.
+ */
+public class TestReplicasVerify {
+
+  @Test
+  void testRefreshContainerLocationsFromScmOption() throws Exception {
+    ReplicasVerify command = new ReplicasVerify();
+
+    new CommandLine(command).parseArgs("--checksums", "--refresh-from-scm", "/volume1");
+
+    assertThat(isRefreshContainerLocationsFromScmEnabled(command)).isTrue();
+  }
+
+  @Test
+  void testRefreshContainerLocationsFromScmDefault() throws Exception {
+    ReplicasVerify command = new ReplicasVerify();
+
+    new CommandLine(command).parseArgs("--checksums", "/volume1");
+
+    assertThat(isRefreshContainerLocationsFromScmEnabled(command)).isFalse();
+  }
+
+  private boolean isRefreshContainerLocationsFromScmEnabled(ReplicasVerify command) throws Exception {
+    Field field = ReplicasVerify.class.getDeclaredField("refreshContainerLocationsFromScm");
+    field.setAccessible(true);
+    return field.getBoolean(command);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
@@ -270,25 +270,6 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
   }
 
   @Test
-  void testVerifyWithContainerLocationRefreshFromScm() {
-    List<String> parameters = new ArrayList<>();
-    parameters.add(0, getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY));
-    parameters.add(0, getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY));
-    parameters.add("replicas");
-    parameters.add("verify");
-    parameters.add("--checksums");
-    parameters.add("--refresh-from-scm");
-    parameters.add(ozoneAddress);
-
-    int exitCode = ozoneDebugShell.execute(parameters.toArray(new String[0]));
-
-    assertEquals(0, exitCode, err.toString());
-    assertThat(out.get())
-        .doesNotContain("Checksum mismatch")
-        .doesNotContain("Unexpected read size");
-  }
-
-  @Test
   void testSplitOutputToNewDirectory(@TempDir Path tempDir) throws IOException {
     int maxRecordsPerFile = 2;
     int expectedKeyFiles = (int) Math.ceil(keyInfoMap.size() / (maxRecordsPerFile * 1.0));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
@@ -277,25 +277,6 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
     parameters.add("replicas");
     parameters.add("verify");
     parameters.add("--checksums");
-    parameters.add("--refresh-container-locations-from-scm");
-    parameters.add(ozoneAddress);
-
-    int exitCode = ozoneDebugShell.execute(parameters.toArray(new String[0]));
-
-    assertEquals(0, exitCode, err.toString());
-    assertThat(out.get())
-        .doesNotContain("Checksum mismatch")
-        .doesNotContain("Unexpected read size");
-  }
-
-  @Test
-  void testVerifyWithRefreshFromScmAlias() {
-    List<String> parameters = new ArrayList<>();
-    parameters.add(0, getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY));
-    parameters.add(0, getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY));
-    parameters.add("replicas");
-    parameters.add("verify");
-    parameters.add("--checksums");
     parameters.add("--refresh-from-scm");
     parameters.add(ozoneAddress);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
@@ -270,6 +270,44 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
   }
 
   @Test
+  void testVerifyWithContainerLocationRefreshFromScm() {
+    List<String> parameters = new ArrayList<>();
+    parameters.add(0, getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY));
+    parameters.add(0, getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY));
+    parameters.add("replicas");
+    parameters.add("verify");
+    parameters.add("--checksums");
+    parameters.add("--refresh-container-locations-from-scm");
+    parameters.add(ozoneAddress);
+
+    int exitCode = ozoneDebugShell.execute(parameters.toArray(new String[0]));
+
+    assertEquals(0, exitCode, err.toString());
+    assertThat(out.get())
+        .doesNotContain("Checksum mismatch")
+        .doesNotContain("Unexpected read size");
+  }
+
+  @Test
+  void testVerifyWithRefreshFromScmAlias() {
+    List<String> parameters = new ArrayList<>();
+    parameters.add(0, getSetConfStringFromConf(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY));
+    parameters.add(0, getSetConfStringFromConf(OMConfigKeys.OZONE_OM_ADDRESS_KEY));
+    parameters.add("replicas");
+    parameters.add("verify");
+    parameters.add("--checksums");
+    parameters.add("--refresh-from-scm");
+    parameters.add(ozoneAddress);
+
+    int exitCode = ozoneDebugShell.execute(parameters.toArray(new String[0]));
+
+    assertEquals(0, exitCode, err.toString());
+    assertThat(out.get())
+        .doesNotContain("Checksum mismatch")
+        .doesNotContain("Unexpected read size");
+  }
+
+  @Test
   void testSplitOutputToNewDirectory(@TempDir Path tempDir) throws IOException {
     int maxRecordsPerFile = 2;
     int expectedKeyFiles = (int) Math.ceil(keyInfoMap.size() / (maxRecordsPerFile * 1.0));


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change adds explicit ozone debug replicas verify options to control OM container location cache behavior during key verification.

Adds --refresh-from-scm to force OM to refresh container locations from SCM before returning key info.
Keeps default behavior unchanged (no flag: OM cache path remains as-is, for faster execution).
Updates debug CLI docs and integration tests to cover both the long and short flags.

Replica verification can be affected by stale OM container location cache entries in some situations.
This option gives operators a slower but potentially more reliable verification mode when they need fresh container location data.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12208

## How was this patch tested?

Tested manually.