### PR TITLE
HDDS-16183. Avoid the per-group list copy in OMKeyRequest.sumBlockLengths

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -887,9 +887,11 @@ public abstract class OMKeyRequest extends OMClientRequest {
   public static long sumBlockLengths(OmKeyInfo omKeyInfo) {
     long bytesUsed = 0;
     for (OmKeyLocationInfoGroup group: omKeyInfo.getKeyLocationVersions()) {
-      for (OmKeyLocationInfo locationInfo : group.getLocationList()) {
-        bytesUsed += QuotaUtil.getReplicatedSize(
-            locationInfo.getLength(), omKeyInfo.getReplicationConfig());
+      for (List<OmKeyLocationInfo> locationInfoList : group.getLocationLists()) {
+        for (OmKeyLocationInfo locationInfo : locationInfoList) {
+          bytesUsed += QuotaUtil.getReplicatedSize(
+              locationInfo.getLength(), omKeyInfo.getReplicationConfig());
+        }
       }
     }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

`OMKeyRequest.sumBlockLengths` uses `OmKeyLocationInfoGroup#getLocationList`, which creates a flattened copy of the block locations on every call.  The method javadoc already suggest using `getLocationLists` instead:

https://github.com/apache/ozone/blob/502cdaa6d314a92b78a13ad59f509e4d08bce99d/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java#L103-L109

This change iterates `getLocationLists()` directly, avoiding that allocation. Both accessors contain the same block objects, so quota calculation and other behavior remain unchanged.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-16183

## How was this patch tested?

Existing tests cover quota accounting through the callers of `sumBlockLengths`, including key commit and directory purge requests.

The following request test suites passed (88 tests):

- `TestOMKeyDeleteRequest` and FSO variant
- `TestOMKeysDeleteRequest` and FSO variant
- `TestOMKeyCommitRequest` and FSO variant
- `TestOMDirectoriesPurgeRequestAndResponse`

Also ran `checkstyle.sh` and `author.sh` successfully.

