### PR TITLE
HDDS-16195. Reuse computed replicated sizes in KeyDeletingService

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -170,7 +170,6 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
-import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
 import org.apache.hadoop.ozone.om.service.CompactionService;
 import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
@@ -858,6 +857,8 @@ public class KeyManagerImpl implements KeyManager {
                           QuotaUtil.getReplicatedSize(b.getLength(), info.getReplicationConfig()),
                           QuotaUtil.getSizePerReplica(b.getLength(), info.getReplicationConfig())
                       ))).collect(Collectors.toList());
+              // Reuse the replicated sizes computed above.
+              long purgedBytes = deletedBlocks.stream().mapToLong(DeletedBlock::getReplicatedSize).sum();
               String blockGroupName = kv.getKey() + "/" + reclaimableKeyCount++;
 
               BlockGroup keyBlocks = BlockGroup.newBuilder().setKeyName(blockGroupName)
@@ -865,7 +866,7 @@ public class KeyManagerImpl implements KeyManager {
                   .build();
               reclaimableKeys.put(blockGroupName,
                   new PurgedKey(info.getVolumeName(), info.getBucketName(), bucketId,
-                  keyBlocks, kv.getKey(), OMKeyRequest.sumBlockLengths(info), info.isDeletedKeyCommitted()));
+                  keyBlocks, kv.getKey(), purgedBytes, info.isDeletedKeyCommitted()));
               currentCount++;
             } else {
               notReclaimableKeyInfo.addOmKeyInfo(info);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -339,6 +339,44 @@ class TestKeyDeletingService extends OzoneTestBase {
     }
 
     @Test
+    void checkPurgedBytesMatchBlocksQueuedForDeletion() throws Exception {
+      final String volumeName = getTestName();
+      final String bucketName = uniqueObjectName("bucket");
+      final String keyName = uniqueObjectName("key");
+      final long initialDeletedCount = getDeletedKeyCount();
+
+      // Versioning keeps both committed versions on the key, so the delete entry spans two version groups.
+      createVolumeAndBucket(volumeName, bucketName, true);
+
+      keyDeletingService.suspend();
+      OmKeyArgs keyArgs = createAndCommitKey(volumeName, bucketName, keyName, 1);
+      createAndCommitKey(volumeName, bucketName, keyName, 3);
+      writeClient.deleteKey(keyArgs);
+      // The delete has to reach RocksDB before getPendingDeletionKeys() can see it.
+      om.awaitDoubleBufferFlush();
+
+      Map<String, PurgedKey> purgedKeys =
+          keyManager.getPendingDeletionKeys((kv) -> true, Integer.MAX_VALUE).getPurgedKeys();
+      assertThat(purgedKeys).isNotEmpty();
+
+      for (PurgedKey purgedKey : purgedKeys.values()) {
+        assertEquals(4, purgedKey.getBlockGroup().getDeletedBlocks().size(),
+            "both committed versions must be queued for deletion");
+        long blockSum = purgedKey.getBlockGroup().getDeletedBlocks().stream()
+            .mapToLong(DeletedBlock::getReplicatedSize)
+            .sum();
+        assertEquals(blockSum, purgedKey.getPurgedBytes(),
+            "purged bytes must cover exactly the blocks queued for deletion");
+      }
+
+      // Drain the key so it does not remain pending for the next test.
+      keyDeletingService.resume();
+      GenericTestUtils.waitFor(
+          () -> getDeletedKeyCount() >= initialDeletedCount + 1,
+          1000, 10000);
+    }
+
+    @Test
     void checkDeletedTableCleanUpForSnapshot() throws Exception {
       final String volumeName = getTestName();
       final String bucketName1 = uniqueObjectName("bucket");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -345,29 +345,30 @@ class TestKeyDeletingService extends OzoneTestBase {
       final String keyName = uniqueObjectName("key");
       final long initialDeletedCount = getDeletedKeyCount();
 
-      // Versioning keeps both committed versions on the key, so the delete entry spans two version groups.
+      // Create Volume and Bucket with versioning enabled
       createVolumeAndBucket(volumeName, bucketName, true);
 
       keyDeletingService.suspend();
-      OmKeyArgs keyArgs = createAndCommitKey(volumeName, bucketName, keyName, 1);
-      createAndCommitKey(volumeName, bucketName, keyName, 3);
-      writeClient.deleteKey(keyArgs);
+
+      // Create 2 versions of the same key, so the delete entry spans two version groups
+      OmKeyArgs firstVersion = createAndCommitKey(volumeName, bucketName, keyName, 1);
+      OmKeyArgs secondVersion = createAndCommitKey(volumeName, bucketName, keyName, 3);
+      writeClient.deleteKey(firstVersion);
       // The delete has to reach RocksDB before getPendingDeletionKeys() can see it.
       om.awaitDoubleBufferFlush();
 
+      // Both versions are queued for deletion, so the purged bytes must account for both.
+      long expectedPurgedBytes =
+          QuotaUtil.getReplicatedSize(firstVersion.getDataSize(), firstVersion.getReplicationConfig())
+              + QuotaUtil.getReplicatedSize(secondVersion.getDataSize(), secondVersion.getReplicationConfig());
+
       Map<String, PurgedKey> purgedKeys =
           keyManager.getPendingDeletionKeys((kv) -> true, Integer.MAX_VALUE).getPurgedKeys();
-      assertThat(purgedKeys).isNotEmpty();
-
-      for (PurgedKey purgedKey : purgedKeys.values()) {
-        assertEquals(4, purgedKey.getBlockGroup().getDeletedBlocks().size(),
-            "both committed versions must be queued for deletion");
-        long blockSum = purgedKey.getBlockGroup().getDeletedBlocks().stream()
-            .mapToLong(DeletedBlock::getReplicatedSize)
-            .sum();
-        assertEquals(blockSum, purgedKey.getPurgedBytes(),
-            "purged bytes must cover exactly the blocks queued for deletion");
-      }
+      assertThat(purgedKeys).hasSize(1);
+      PurgedKey purgedKey = purgedKeys.values().iterator().next();
+      assertEquals(4, purgedKey.getBlockGroup().getDeletedBlocks().size(),
+          "the 1st version has 1 block and the 2nd version has 3");
+      assertEquals(expectedPurgedBytes, purgedKey.getPurgedBytes());
 
       // Drain the key so it does not remain pending for the next test.
       keyDeletingService.resume();


### PR DESCRIPTION
## What changes were proposed in this pull request?

While building the reclaimable-key list, `KeyManagerImpl` already computes and stores each block's replicated size in `DeletedBlock`. It then traverses the key locations again through `OMKeyRequest.sumBlockLengths()` to recompute the same values for `PurgedKey`.

This change calculates `purgedBytes` from the `DeletedBlock` values already produced. It avoids another traversal of the key-location groups, their flattened-list allocations, and repeated `QuotaUtil.getReplicatedSize()` calls.

The resulting quota value and behavior are unchanged.

This complements HDDS-16183: that change improves `sumBlockLengths()` for its remaining callers, while this change removes a redundant call from the pending-deletion scan. The patches touch different files and can be merged independently.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-16195

## How was this patch tested?

Added `checkPurgedBytesMatchBlocksQueuedForDeletion`, which creates a versioned key spanning two location groups and verifies that `purgedBytes` equals the replicated-size sum of the blocks queued for deletion.

The targeted test passed:

- `TestKeyDeletingService$Normal#checkPurgedBytesMatchBlocksQueuedForDeletion`

Checkstyle reports no errors for the changed files.

Generated-by: Claude Code (Opus 5)
