### PR TITLE
HDDS-11646. Intermittent timeout in TestXceiverClientMetrics

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientMetrics.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.hdds.scm;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.ozone.test.MetricsAsserts.assertCounter;
-import static org.apache.ozone.test.MetricsAsserts.getLongCounter;
 import static org.apache.ozone.test.MetricsAsserts.getMetrics;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -105,54 +105,44 @@ public class TestXceiverClientMetrics {
       assertCounter("CreateContainerLatencyNumOps", 1L, containerMetrics);
 
       breakFlag = false;
-      latch = new CountDownLatch(1);
+      int numSenderThreads = 10;
+      latch = new CountDownLatch(numSenderThreads);
+      List<CompletableFuture<ContainerCommandResponseProto>> computeResults =
+          Collections.synchronizedList(new ArrayList<>());
+      XceiverClientMetrics clientMetrics =
+          XceiverClientManager.getXceiverClientMetrics();
 
-      int numRequest = 10;
-      List<CompletableFuture<ContainerCommandResponseProto>> computeResults
-          = new ArrayList<>();
-      // start new thread to send async requests
-      Thread sendThread = new Thread(() -> {
-        while (!breakFlag) {
+      for (int i = 0; i < numSenderThreads; i++) {
+        Thread sendThread = new Thread(() -> {
           try {
-            // use async interface for testing pending metrics
-            for (int i = 0; i < numRequest; i++) {
-              BlockID blockID = ContainerTestHelper.
-                  getTestBlockID(container.getContainerInfo().getContainerID());
-              ContainerProtos.ContainerCommandRequestProto smallFileRequest;
-
-              smallFileRequest = ContainerTestHelper.getWriteSmallFileRequest(
-                  client.getPipeline(), blockID, 1024);
-              CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
-                  response =
-                  client.sendCommandAsync(smallFileRequest).getResponse();
-              computeResults.add(response);
+            while (!breakFlag) {
+              BlockID blockID = ContainerTestHelper.getTestBlockID(
+                  container.getContainerInfo().getContainerID());
+              ContainerCommandRequestProto smallFileRequest =
+                  ContainerTestHelper.getWriteSmallFileRequest(
+                      client.getPipeline(), blockID, 1024);
+              computeResults.add(
+                  client.sendCommandAsync(smallFileRequest).getResponse());
             }
-
-            Thread.sleep(1000);
           } catch (Exception ignored) {
+          } finally {
+            latch.countDown();
           }
-        }
-
-        latch.countDown();
-      });
-      sendThread.start();
+        });
+        sendThread.start();
+      }
 
       GenericTestUtils.waitFor(() -> {
         // check if pending metric count is increased
-        MetricsRecordBuilder metric =
-            getMetrics(XceiverClientMetrics.SOURCE_NAME);
-        long pendingOps = getLongCounter("PendingOps", metric);
-        long pendingPutSmallFileOps =
-            getLongCounter("numPendingPutSmallFile", metric);
-
-        if (pendingOps > 0 && pendingPutSmallFileOps > 0) {
+        if (clientMetrics.getPendingContainerOpCountMetrics(
+            ContainerProtos.Type.PutSmallFile) > 0) {
           // reset break flag
           breakFlag = true;
           return true;
         } else {
           return false;
         }
-      }, 100, 60000);
+      }, 10, 60000);
 
       // blocking until we stop sending async requests
       latch.await();
@@ -167,6 +157,9 @@ public class TestXceiverClientMetrics {
         return true;
       }, 100, 60000);
 
+      GenericTestUtils.waitFor(() ->
+          clientMetrics.getPendingContainerOpCountMetrics(
+              ContainerProtos.Type.PutSmallFile) == 0, 10, 5000);
       // the counter value of pending metrics should be decreased to 0
       containerMetrics = getMetrics(XceiverClientMetrics.SOURCE_NAME);
       assertCounter("PendingOps", 0L, containerMetrics);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientMetrics.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -76,7 +75,6 @@ public class TestXceiverClientMetrics {
   }
 
   @Test
-  @Flaky("HDDS-11646")
   public void testMetrics(@TempDir Path metaDir) throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HDDS_METADATA_DIR_NAME, metaDir.toString());
@@ -131,6 +129,12 @@ public class TestXceiverClientMetrics {
                 break;
               } catch (Exception e) {
                 firstSenderError.compareAndSet(null, e);
+                try {
+                  Thread.sleep(50);
+                } catch (InterruptedException ie) {
+                  Thread.currentThread().interrupt();
+                  break;
+                }
               }
             }
           } finally {
@@ -161,10 +165,11 @@ public class TestXceiverClientMetrics {
           e.addSuppressed(senderError);
         }
         throw e;
+      } finally {
+        breakFlag = true;
+        latch.await();
       }
 
-      // blocking until we stop sending async requests
-      latch.await();
       // Wait for all futures being done.
       GenericTestUtils.waitFor(() -> {
         for (CompletableFuture future : computeResults) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientMetrics.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.ozone.test.MetricsAsserts.assertCounter;
+import static org.apache.ozone.test.MetricsAsserts.getLongCounter;
 import static org.apache.ozone.test.MetricsAsserts.getMetrics;
 
 import java.nio.file.Path;
@@ -27,9 +28,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
@@ -109,22 +111,28 @@ public class TestXceiverClientMetrics {
       latch = new CountDownLatch(numSenderThreads);
       List<CompletableFuture<ContainerCommandResponseProto>> computeResults =
           Collections.synchronizedList(new ArrayList<>());
-      XceiverClientMetrics clientMetrics =
-          XceiverClientManager.getXceiverClientMetrics();
+      AtomicReference<Exception> firstSenderError = new AtomicReference<>();
 
       for (int i = 0; i < numSenderThreads; i++) {
         Thread sendThread = new Thread(() -> {
           try {
             while (!breakFlag) {
-              BlockID blockID = ContainerTestHelper.getTestBlockID(
-                  container.getContainerInfo().getContainerID());
-              ContainerCommandRequestProto smallFileRequest =
-                  ContainerTestHelper.getWriteSmallFileRequest(
-                      client.getPipeline(), blockID, 1024);
-              computeResults.add(
-                  client.sendCommandAsync(smallFileRequest).getResponse());
+              try {
+                BlockID blockID = ContainerTestHelper.getTestBlockID(
+                    container.getContainerInfo().getContainerID());
+                ContainerCommandRequestProto smallFileRequest =
+                    ContainerTestHelper.getWriteSmallFileRequest(
+                        client.getPipeline(), blockID, 1024);
+                computeResults.add(
+                    client.sendCommandAsync(smallFileRequest).getResponse());
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                firstSenderError.compareAndSet(null, e);
+                break;
+              } catch (Exception e) {
+                firstSenderError.compareAndSet(null, e);
+              }
             }
-          } catch (Exception ignored) {
           } finally {
             latch.countDown();
           }
@@ -132,17 +140,28 @@ public class TestXceiverClientMetrics {
         sendThread.start();
       }
 
-      GenericTestUtils.waitFor(() -> {
-        // check if pending metric count is increased
-        if (clientMetrics.getPendingContainerOpCountMetrics(
-            ContainerProtos.Type.PutSmallFile) > 0) {
-          // reset break flag
-          breakFlag = true;
-          return true;
-        } else {
-          return false;
+      try {
+        GenericTestUtils.waitFor(() -> {
+          // check if pending metric count is increased
+          MetricsRecordBuilder metric = getMetrics(XceiverClientMetrics.SOURCE_NAME);
+          long pendingOps = getLongCounter("PendingOps", metric);
+          long pendingPutSmallFileOps = getLongCounter("numPendingPutSmallFile", metric);
+
+          if (pendingOps > 0 && pendingPutSmallFileOps > 0) {
+            // reset break flag
+            breakFlag = true;
+            return true;
+          } else {
+            return false;
+          }
+        }, 10, 60000);
+      } catch (TimeoutException e) {
+        Exception senderError = firstSenderError.get();
+        if (senderError != null) {
+          e.addSuppressed(senderError);
         }
-      }, 10, 60000);
+        throw e;
+      }
 
       // blocking until we stop sending async requests
       latch.await();
@@ -157,9 +176,12 @@ public class TestXceiverClientMetrics {
         return true;
       }, 100, 60000);
 
-      GenericTestUtils.waitFor(() ->
-          clientMetrics.getPendingContainerOpCountMetrics(
-              ContainerProtos.Type.PutSmallFile) == 0, 10, 5000);
+      GenericTestUtils.waitFor(() -> {
+        MetricsRecordBuilder metric = getMetrics(XceiverClientMetrics.SOURCE_NAME);
+        long pendingOps = getLongCounter("PendingOps", metric);
+        long pendingPutSmallFileOps = getLongCounter("numPendingPutSmallFile", metric);
+        return pendingOps == 0 && pendingPutSmallFileOps == 0;
+      }, 10, 5000);
       // the counter value of pending metrics should be decreased to 0
       containerMetrics = getMetrics(XceiverClientMetrics.SOURCE_NAME);
       assertCounter("PendingOps", 0L, containerMetrics);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestXceiverClientMetrics#testMetrics` was tagged `@Flaky("HDDS-11646")` because of an intermittent `waitFor` `TimeoutException`.

Root cause: with the default `STAND_ALONE` pipeline, writes go through `XceiverClientGrpc`, whose `sendCommandAsync` already blocks the caller until the response arrives (`shouldBlockAndWaitAsyncReply` returns `true` for non-read-only requests). The test used a single background thread that fired 10 "async" writes serially and then slept 1s, so at most 1 request was ever in flight at a time, `PendingOps` floated back to 0 for most of each cycle, and the main thread's 100ms poll frequently missed the narrow non-zero window, causing the observed timeout.

This PR fixes the root cause by:

* Replaces the single serialized sender thread with 10 concurrent sender threads, each continuously sending blocking writes until the pending spike is observed. With genuine concurrent in-flight requests, `PendingOps` stays non-zero for a sustained window instead of spiking for microseconds, so the poll reliably catches it.

* `computeResults` is wrapped in `Collections.synchronizedList` for thread-safe concurrent writes, and each sender thread now calls countDown() on the shared CountDownLatch in a `finally` block so `latch.await()` can't hang if a thread exits via an exception.

* The pending count increased poll now reads`XceiverClientManager.getXceiverClientMetrics().getPendingContainerOpCountMetrics(...)` directly instead of going through `MetricsAsserts.getMetrics(SOURCE_NAME)` on every tick; the poll interval is also tightened from 100ms to 10ms.

* Adds a short retry before the final `PendingOps == 0` / `numPendingPutSmallFile == 0` assertions, absorbing the small window between a response future completing and its pending-metric decrement (two separate, non-atomic steps in `XceiverClientGrpc`'s gRPC callback).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11646

## How was this patch tested?

* Confirmed with `.github/workflows/intermittent-test-check.yml` all green https://github.com/shuan1026/ozone/actions/runs/31959022505