### PR TITLE
HDDS-16200. Flaky container balancer robot test

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
@@ -205,7 +205,7 @@ Verify Container Balancer for RATIS/EC containers
 
     Run Balancer Verbose Status
 
-    Wait Until Keyword Succeeds    40sec    5sec   Run Balancer Verbose History Status
+    Wait Until Keyword Succeeds    90s    5sec   Run Balancer Verbose History Status
 
     Wait Finish Of Balancing
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Random failures due to wait timeout. 

```
Verify Container Balancer for RATIS/EC containers                     | FAIL |
Keyword 'Run Balancer Verbose History Status' failed after retrying for 40 seconds. The last error was: 'ContainerBalancer is Running.
--
ozone-balancer-EC :: Smoketest ozone cluster startup                  | FAIL |
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16200

## How was this patch tested?

