### PR TITLE
HDDS-16198. Refactor the admin permission check for LifecycleService.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -100,7 +100,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
     Objects.requireNonNull(deleteKeysRequest, "deleteKeysRequest == null");
 
     if (deleteKeysRequest.getSourceType() == RequestSource.LIFECYCLE && deleteKeysRequest.hasScanState()) {
-      if (ozoneManager.getAclsEnabled()) {
+      if (ozoneManager.isAdminAuthorizationEnabled()) {
         UserGroupInformation ugi = createUGIForApi();
         if (!ozoneManager.isAdmin(ugi)) {
           throw new OMException("Access denied for user " + ugi + ". "

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleSaveScanStateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleSaveScanStateRequest.java
@@ -45,7 +45,7 @@ public class OMLifecycleSaveScanStateRequest extends OMClientRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     OMRequest omRequest = super.preExecute(ozoneManager);
-    if (ozoneManager.getAclsEnabled()) {
+    if (ozoneManager.isAdminAuthorizationEnabled()) {
       UserGroupInformation ugi = createUGIForApi();
       if (!ozoneManager.isAdmin(ugi)) {
         throw new OMException("Access denied for user " + ugi + ". "

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleSetServiceStatusRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/lifecycle/OMLifecycleSetServiceStatusRequest.java
@@ -59,7 +59,7 @@ public class OMLifecycleSetServiceStatusRequest extends OMClientRequest {
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     OMRequest request = super.preExecute(ozoneManager);
 
-    if (ozoneManager.getAclsEnabled()) {
+    if (ozoneManager.isAdminAuthorizationEnabled()) {
       boolean suspend = request.getSetLifecycleServiceStatusRequest().getSuspend();
       UserGroupInformation ugi = createUGIForApi();
       if (!ozoneManager.isAdmin(ugi)) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
@@ -18,12 +18,18 @@
 package org.apache.hadoop.ozone.om.request.key;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,14 +38,19 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyError;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LifecycleScanState;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RequestSource;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -153,6 +164,48 @@ public class TestOMKeysDeleteRequest extends OMKeyRequestTests {
     OMKeysDeleteRequest omKeysDeleteRequest =
         new OMKeysDeleteRequest(omRequest, getBucketLayout());
     checkDeleteKeysResponseForFailure(omKeysDeleteRequest, Status.INVALID_REQUEST);
+  }
+
+  @Test
+  public void testPreExecuteAdminCheckForPiggybackedScanState() throws Exception {
+    OzoneManager ozoneManager = mock(OzoneManager.class);
+    OMLayoutVersionManager versionManager = mock(OMLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(ozoneManager.getVersionManager()).thenReturn(versionManager);
+
+    when(ozoneManager.isAdminAuthorizationEnabled()).thenReturn(true);
+    when(ozoneManager.isAdmin(any(UserGroupInformation.class))).thenReturn(false);
+
+    omRequest = OMRequest.newBuilder()
+        .setCmdType(DeleteKeys)
+        .setClientId(UUID.randomUUID().toString())
+        .setDeleteKeysRequest(DeleteKeysRequest.newBuilder()
+            .setSourceType(RequestSource.LIFECYCLE)
+            .setScanState(LifecycleScanState.newBuilder()
+                .setBucketKey("vol/bucket")
+                .setScanStartTime(1L)
+                .build())
+            .setDeleteKeys(DeleteKeyArgs.newBuilder()
+                .setVolumeName("vol")
+                .setBucketName("bucket")
+                .addKeys("key1")
+                .build())
+            .build())
+        .build();
+
+    OMKeysDeleteRequest request = new OMKeysDeleteRequest(omRequest, getBucketLayout());
+    request.setUGI(UserGroupInformation.getCurrentUser());
+
+    OMException exception = assertThrows(OMException.class, () -> request.preExecute(ozoneManager));
+    assertEquals(OMException.ResultCodes.ACCESS_DENIED, exception.getResult());
+    assertTrue(exception.getMessage().contains("Superuser privilege is required"));
+
+    when(ozoneManager.isAdmin(any(UserGroupInformation.class))).thenReturn(true);
+    assertDoesNotThrow(() -> request.preExecute(ozoneManager));
+
+    when(ozoneManager.isAdminAuthorizationEnabled()).thenReturn(false);
+    when(ozoneManager.isAdmin(any(UserGroupInformation.class))).thenReturn(false);
+    assertDoesNotThrow(() -> request.preExecute(ozoneManager));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleSetServiceStatusRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/lifecycle/TestOMLifecycleSetServiceStatusRequest.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.request.lifecycle;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager.maxLayoutVersion;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,24 +27,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
-import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.OmLifecycleScanState;
-import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LifecycleScanState;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SaveLifecycleScanStateRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetLifecycleServiceStatusRequest;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests OMLifecycleSaveScanStateRequest.
+ * Tests OMLifecycleSetServiceStatusRequest.
  */
-public class TestOMLifecycleSaveScanStateRequest {
+public class TestOMLifecycleSetServiceStatusRequest {
 
   @Test
   public void testPreExecuteAdminCheck() throws Exception {
@@ -53,20 +47,19 @@ public class TestOMLifecycleSaveScanStateRequest {
     OMLayoutVersionManager versionManager = mock(OMLayoutVersionManager.class);
     when(versionManager.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
     when(ozoneManager.getVersionManager()).thenReturn(versionManager);
-    
-    // Test when admin authorization is enabled but user is not admin
+
     when(ozoneManager.isAdminAuthorizationEnabled()).thenReturn(true);
     when(ozoneManager.isAdmin(any(UserGroupInformation.class))).thenReturn(false);
 
     OMRequest omRequest = OMRequest.newBuilder()
-        .setCmdType(OzoneManagerProtocolProtos.Type.SaveLifecycleScanState)
+        .setCmdType(OzoneManagerProtocolProtos.Type.SetLifecycleServiceStatus)
         .setClientId(UUID.randomUUID().toString())
-        .setSaveLifecycleScanStateRequest(SaveLifecycleScanStateRequest.newBuilder()
-            .setState(LifecycleScanState.newBuilder().setBucketKey("dummy").setScanStartTime(1L).build())
+        .setSetLifecycleServiceStatusRequest(SetLifecycleServiceStatusRequest.newBuilder()
+            .setSuspend(true)
             .build())
         .build();
 
-    OMLifecycleSaveScanStateRequest request = new OMLifecycleSaveScanStateRequest(omRequest);
+    OMLifecycleSetServiceStatusRequest request = new OMLifecycleSetServiceStatusRequest(omRequest);
     request.setUGI(UserGroupInformation.getCurrentUser());
 
     OMException exception = assertThrows(OMException.class, () -> {
@@ -75,44 +68,12 @@ public class TestOMLifecycleSaveScanStateRequest {
 
     assertEquals(OMException.ResultCodes.ACCESS_DENIED, exception.getResult());
     assertTrue(exception.getMessage().contains("Superuser privilege is required"));
-    
-    // Test when user is admin
+
     when(ozoneManager.isAdmin(any(UserGroupInformation.class))).thenReturn(true);
     assertDoesNotThrow(() -> request.preExecute(ozoneManager));
 
-    // Test when admin authorization is disabled
     when(ozoneManager.isAdminAuthorizationEnabled()).thenReturn(false);
     when(ozoneManager.isAdmin(any(UserGroupInformation.class))).thenReturn(false);
     assertDoesNotThrow(() -> request.preExecute(ozoneManager));
-  }
-
-  @Test
-  public void testValidateAndUpdateCache() throws Exception {
-    OzoneManager ozoneManager = mock(OzoneManager.class);
-    OMMetadataManager omMetadataManager = mock(OMMetadataManager.class);
-    when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
-    Table<String, OmLifecycleScanState> table = mock(Table.class);
-    when(omMetadataManager.getLifecycleScanStateTable()).thenReturn(table);
-
-    LifecycleScanState stateProto = LifecycleScanState.newBuilder()
-        .setBucketKey("/vol1/bucket1")
-        .setScanStartTime(123456789L)
-        .setLastScannedKey("key1")
-        .build();
-
-    SaveLifecycleScanStateRequest saveRequest = SaveLifecycleScanStateRequest.newBuilder()
-        .setState(stateProto)
-        .build();
-
-    OMRequest omRequest = OMRequest.newBuilder()
-        .setCmdType(OzoneManagerProtocolProtos.Type.SaveLifecycleScanState)
-        .setClientId(UUID.randomUUID().toString())
-        .setSaveLifecycleScanStateRequest(saveRequest)
-        .build();
-
-    OMLifecycleSaveScanStateRequest request = new OMLifecycleSaveScanStateRequest(omRequest);
-    OMClientResponse response = request.validateAndUpdateCache(ozoneManager, 100L);
-    assertNotNull(response);
-    assertEquals(OzoneManagerProtocolProtos.Status.OK, response.getOMResponse().getStatus());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previous, admin check is guarded by isAclEnabled().
After https://issues.apache.org/jira/browse/HDDS-14207, it should be guarded by isAdminAuthorizationEnabled(). 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16198

## How was this patch tested?

new unit test. 
