### PR TITLE
HDDS-16197. Remove all bucket tagging outstanding TODOs

### DIFF
--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -157,7 +157,6 @@ enum Type {
   GetObjectTagging = 141;
   DeleteObjectTagging = 142;
   SubmitSnapshotDiff = 143;
-  // TODO(HDDS-15497): S3 bucket tagging RPCs; handled by OM in a follow-up PR (S3G maps to PUT/GET/DELETE ?tagging).
   PutBucketTagging = 144;
   GetBucketTagging = 145;
   DeleteBucketTagging = 146;
@@ -318,11 +317,8 @@ message OMRequest {
   optional DeleteObjectTaggingRequest       deleteObjectTaggingRequest     = 142;
   repeated SetSnapshotPropertyRequest       SetSnapshotPropertyRequests    = 143;
   optional SubmitSnapshotDiffRequest        submitSnapshotDiffRequest      = 144;
-  // TODO: PutBucketTagging — tags in bucketArgs.tags; OM persists to BucketInfo.tags.
   optional PutBucketTaggingRequest          putBucketTaggingRequest         = 145;
-  // TODO: GetBucketTagging — volume/bucket in bucketArgs; response returns tag list.
   optional GetBucketTaggingRequest          getBucketTaggingRequest          = 146;
-  // TODO: DeleteBucketTagging — clears tags on target bucket (link resolves in OM).
   optional DeleteBucketTaggingRequest       deleteBucketTaggingRequest       = 147;
   optional SetLifecycleConfigurationRequest setLifecycleConfigurationRequest = 148;
   optional GetLifecycleConfigurationRequest   getLifecycleConfigurationRequest   = 149;
@@ -465,11 +461,8 @@ message OMResponse {
   optional DeleteObjectTaggingResponse       deleteObjectTaggingResponse   = 142;
   optional SubmitSnapshotDiffResponse        submitSnapshotDiffResponse    = 143;
 
-  // TODO: Empty ack after OM applies tag set to OmBucketInfo.
   optional PutBucketTaggingResponse          putBucketTaggingResponse      = 144;
-  // TODO: Tag list for S3G GetBucketTagging XML; empty if no tags.
   optional GetBucketTaggingResponse          getBucketTaggingResponse      = 145;
-  // TODO: Empty ack after OM clears BucketInfo.tags.
   optional DeleteBucketTaggingResponse       deleteBucketTaggingResponse    = 146;
 
   optional SetLifecycleConfigurationResponse setLifecycleConfigurationResponse = 147;
@@ -824,7 +817,6 @@ message BucketInfo {
     optional hadoop.hdds.DefaultReplicationConfig defaultReplicationConfig = 20;
     optional uint64 snapshotUsedBytes = 21;
     optional uint64 snapshotUsedNamespace = 22;
-    // TODO: S3 bucket tags persisted in OM DB; set by PutBucketTagging, read by GetBucketTagging.
     repeated hadoop.hdds.KeyValue tags = 23;
 }
 
@@ -899,7 +891,6 @@ message BucketArgs {
     optional string ownerName = 10;
     optional hadoop.hdds.DefaultReplicationConfig defaultReplicationConfig = 11;
     optional BucketEncryptionInfoProto bekInfo = 12;
-    // TODO: Tag payload for PutBucketTagging only.
     repeated hadoop.hdds.KeyValue tags = 13;
 }
 
@@ -2678,32 +2669,26 @@ message SaveLifecycleScanStateRequest {
 message SaveLifecycleScanStateResponse {
 }
 
-// TODO: S3 PutBucketTagging — bucketArgs identifies bucket; tags in bucketArgs.tags replace existing set.
 message PutBucketTaggingRequest {
   required BucketArgs bucketArgs = 1;
   optional uint64 modificationTime = 2;
 }
 
-// TODO: Success response; no body (tags stored on OmBucketInfo).
 message PutBucketTaggingResponse {
 }
 
-// TODO: S3 GetBucketTagging — bucketArgs.volumeName/bucketName; link resolved in OM reader.
 message GetBucketTaggingRequest {
   required BucketArgs bucketArgs = 1;
 }
 
-// TODO: Returns current bucket tags for S3G Tagging XML response.
 message GetBucketTaggingResponse {
   repeated hadoop.hdds.KeyValue tags = 1;
 }
 
-// TODO: S3 DeleteBucketTagging — clears all tags on bucket (link → source bucket in OM).
 message DeleteBucketTaggingRequest {
   required BucketArgs bucketArgs = 1;
   optional uint64 modificationTime = 2;
 }
 
-// TODO: Success response; bucket has no tags after commit.
 message DeleteBucketTaggingResponse {
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove leftover TODO for bucket tagging although the bucket tagging has been implemented.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16197

## How was this patch tested?

Green CI on fork.