### PR TITLE
HDDS-16173. Add cluster utilization analysis for container balancer CLI commands

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
@@ -81,11 +81,6 @@ public final class ContainerBalancerClusterAnalyzer {
       return emptySnapshot(thresholdRatio);
     }
 
-    long clusterCapacityBytes = 0;
-    for (DatanodeUsageInfoProto node : eligible) {
-      clusterCapacityBytes += node.getCapacity();
-    }
-
     double clusterAvgUtilization = calculateAvgUtilization(eligible);
     double upperLimit = clusterAvgUtilization + thresholdRatio;
     double lowerLimit = clusterAvgUtilization - thresholdRatio;
@@ -94,11 +89,13 @@ public final class ContainerBalancerClusterAnalyzer {
     List<NodeClassification> targets = new ArrayList<>();
     double maxUtilization = Double.NEGATIVE_INFINITY;
     double minUtilization = Double.POSITIVE_INFINITY;
+    long clusterCapacityBytes = 0;
     long totalOverUtilizedBytes = 0;
     long totalUnderUtilizedBytes = 0;
 
     for (DatanodeUsageInfoProto node : eligible) {
       long capacity = node.getCapacity();
+      clusterCapacityBytes += capacity;
       double utilization = calculateNodeUtilization(node);
 
       maxUtilization = Math.max(maxUtilization, utilization);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
@@ -135,24 +135,22 @@ public final class ContainerBalancerClusterAnalyzer {
         targets.size(),
         totalOverUtilizedBytes,
         totalUnderUtilizedBytes,
-        totalOverUtilizedBytes,
         imbalance,
         topHostnames(sources),
         topHostnames(targets));
   }
 
   /**
-   * Same rules as {@code ContainerBalancer.shouldExcludeDatanode}.
+   * Function that excludes is datanode should be excluded or not.
+   * The node is in exclude set or the node is not in include set
+   * when include set is not empty.
    */
-  public static boolean shouldExcludeDatanode(
-      DatanodeDetails datanode,
-      Set<String> excludeNodes,
-      Set<String> includeNodes) {
+  public static boolean shouldExcludeDatanode(DatanodeDetails datanode,
+                                       Set<String> excludeNodes, Set<String> includeNodes) {
     if (excludeNodes.contains(datanode.getHostName()) ||
         excludeNodes.contains(datanode.getIpAddress())) {
       return true;
-    }
-    if (!includeNodes.isEmpty()) {
+    } else if (!includeNodes.isEmpty()) {
       return !includeNodes.contains(datanode.getHostName()) &&
           !includeNodes.contains(datanode.getIpAddress());
     }
@@ -184,7 +182,14 @@ public final class ContainerBalancerClusterAnalyzer {
     return eligible;
   }
 
-  private static long ratioToBytes(long nodeCapacity, double utilizationRatio) {
+  /**
+   * Calculates the number of used bytes given capacity and utilization ratio.
+   *
+   * @param nodeCapacity     capacity of the node.
+   * @param utilizationRatio used space by capacity ratio of the node.
+   * @return number of bytes
+   */
+  public static long ratioToBytes(long nodeCapacity, double utilizationRatio) {
     return (long) (nodeCapacity * utilizationRatio);
   }
 
@@ -215,7 +220,6 @@ public final class ContainerBalancerClusterAnalyzer {
         0,
         thresholdRatio,
         -thresholdRatio,
-        0,
         0,
         0,
         0,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeUsageInfoProto;
+
+/**
+ * Classifies datanode usage protos using the same rules as
+ * {@code ContainerBalancerTask.initializeIteration()}.
+ */
+public final class ContainerBalancerClusterAnalyzer {
+
+  private static final int TOP_NODE_LIMIT = 5;
+
+  private ContainerBalancerClusterAnalyzer() {
+  }
+
+  /**
+   * Core shared formula: (totalCapacity - totalRemaining) / totalCapacity.
+   */
+  public static double calculateAvgUtilization(long totalCapacity, long totalRemaining) {
+    if (totalCapacity == 0) {
+      return 0;
+    }
+    return (totalCapacity - totalRemaining) / (double) totalCapacity;
+  }
+
+  /**
+   * Cluster average from datanode usage protos.
+   */
+  public static double calculateAvgUtilization(List<DatanodeUsageInfoProto> nodes) {
+    if (nodes.isEmpty()) {
+      return 0;
+    }
+    long totalCapacity = 0;
+    long totalRemaining = 0;
+    for (DatanodeUsageInfoProto node : nodes) {
+      totalCapacity += node.getCapacity();
+      totalRemaining += node.getRemaining();
+    }
+    return calculateAvgUtilization(totalCapacity, totalRemaining);
+  }
+
+  /**
+   * Builds a cluster snapshot after applying include/exclude filters.
+   *
+   * @param nodes all nodes from getDatanodeUsageInfo (typically healthy IN_SERVICE)
+   * @param thresholdRatio threshold as ratio, e.g. 0.10 for 10%
+   * @param includeNodes empty = all included; non-empty = allow-list
+   * @param excludeNodes nodes to skip
+   */
+  public static ContainerBalancerClusterSnapshot analyze(
+      List<DatanodeUsageInfoProto> nodes,
+      double thresholdRatio,
+      Set<String> includeNodes,
+      Set<String> excludeNodes) {
+    List<DatanodeUsageInfoProto> eligible = filterEligibleNodes(nodes, includeNodes, excludeNodes);
+
+    if (eligible.isEmpty()) {
+      return emptySnapshot(thresholdRatio);
+    }
+
+    long clusterCapacityBytes = 0;
+    for (DatanodeUsageInfoProto node : eligible) {
+      clusterCapacityBytes += node.getCapacity();
+    }
+
+    double clusterAvgUtilization = calculateAvgUtilization(eligible);
+    double upperLimit = clusterAvgUtilization + thresholdRatio;
+    double lowerLimit = clusterAvgUtilization - thresholdRatio;
+
+    List<NodeClassification> sources = new ArrayList<>();
+    List<NodeClassification> targets = new ArrayList<>();
+    double maxUtilization = Double.NEGATIVE_INFINITY;
+    double minUtilization = Double.POSITIVE_INFINITY;
+    long totalOverUtilizedBytes = 0;
+    long totalUnderUtilizedBytes = 0;
+
+    for (DatanodeUsageInfoProto node : eligible) {
+      long capacity = node.getCapacity();
+      double utilization = calculateNodeUtilization(node);
+
+      maxUtilization = Math.max(maxUtilization, utilization);
+      minUtilization = Math.min(minUtilization, utilization);
+
+      String hostname = getDisplayHostname(node);
+      if (Double.compare(utilization, upperLimit) > 0) {
+        long overBytes = ratioToBytes(capacity, utilization)
+            - ratioToBytes(capacity, upperLimit);
+        totalOverUtilizedBytes += overBytes;
+        sources.add(new NodeClassification(hostname, utilization));
+      } else if (Double.compare(utilization, lowerLimit) < 0) {
+        long underBytes = ratioToBytes(capacity, lowerLimit)
+            - ratioToBytes(capacity, utilization);
+        totalUnderUtilizedBytes += underBytes;
+        targets.add(new NodeClassification(hostname, utilization));
+      }
+    }
+
+    sources.sort(Comparator.comparingDouble(NodeClassification::getUtilization).reversed());
+    targets.sort(Comparator.comparingDouble(NodeClassification::getUtilization));
+
+    double imbalance = maxUtilization - minUtilization;
+
+    return new ContainerBalancerClusterSnapshot(
+        eligible.size(),
+        clusterAvgUtilization,
+        clusterCapacityBytes,
+        maxUtilization,
+        minUtilization,
+        upperLimit,
+        lowerLimit,
+        sources.size(),
+        targets.size(),
+        totalOverUtilizedBytes,
+        totalUnderUtilizedBytes,
+        totalOverUtilizedBytes,
+        imbalance,
+        topHostnames(sources),
+        topHostnames(targets));
+  }
+
+  /**
+   * Same rules as {@code ContainerBalancer.shouldExcludeDatanode}.
+   */
+  public static boolean shouldExcludeDatanode(
+      DatanodeDetails datanode,
+      Set<String> excludeNodes,
+      Set<String> includeNodes) {
+    if (excludeNodes.contains(datanode.getHostName()) ||
+        excludeNodes.contains(datanode.getIpAddress())) {
+      return true;
+    }
+    if (!includeNodes.isEmpty()) {
+      return !includeNodes.contains(datanode.getHostName()) &&
+          !includeNodes.contains(datanode.getIpAddress());
+    }
+    return false;
+  }
+
+  static double calculateNodeUtilization(DatanodeUsageInfoProto node) {
+    long capacity = node.getCapacity();
+    if (capacity == 0) {
+      return 0;
+    }
+    return (capacity - node.getRemaining()) / (double) capacity;
+  }
+
+  private static List<DatanodeUsageInfoProto> filterEligibleNodes(
+      List<DatanodeUsageInfoProto> nodes,
+      Set<String> includeNodes,
+      Set<String> excludeNodes) {
+    List<DatanodeUsageInfoProto> eligible = new ArrayList<>();
+    for (DatanodeUsageInfoProto node : nodes) {
+      if (!node.hasNode()) {
+        continue;
+      }
+      DatanodeDetails datanode = DatanodeDetails.getFromProtoBuf(node.getNode());
+      if (!shouldExcludeDatanode(datanode, excludeNodes, includeNodes)) {
+        eligible.add(node);
+      }
+    }
+    return eligible;
+  }
+
+  private static long ratioToBytes(long nodeCapacity, double utilizationRatio) {
+    return (long) (nodeCapacity * utilizationRatio);
+  }
+
+  private static String getDisplayHostname(DatanodeUsageInfoProto node) {
+    DatanodeDetails datanode = DatanodeDetails.getFromProtoBuf(node.getNode());
+    String hostname = datanode.getHostName();
+    if (hostname != null && !hostname.isEmpty()) {
+      return hostname;
+    }
+    return datanode.getIpAddress();
+  }
+
+  private static List<String> topHostnames(List<NodeClassification> nodes) {
+    int limit = Math.min(TOP_NODE_LIMIT, nodes.size());
+    List<String> hostnames = new ArrayList<>(limit);
+    for (int i = 0; i < limit; i++) {
+      hostnames.add(nodes.get(i).getHostname());
+    }
+    return hostnames;
+  }
+
+  private static ContainerBalancerClusterSnapshot emptySnapshot(double thresholdRatio) {
+    return new ContainerBalancerClusterSnapshot(
+        0,
+        0,
+        0,
+        0,
+        0,
+        thresholdRatio,
+        -thresholdRatio,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  private static final class NodeClassification {
+    private final String hostname;
+    private final double utilization;
+
+    private NodeClassification(String hostname, double utilization) {
+      this.hostname = hostname;
+      this.utilization = utilization;
+    }
+
+    private String getHostname() {
+      return hostname;
+    }
+
+    private double getUtilization() {
+      return utilization;
+    }
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
@@ -120,27 +120,29 @@ public final class ContainerBalancerClusterAnalyzer {
 
     double imbalance = maxUtilization - minUtilization;
 
-    return new ContainerBalancerClusterSnapshot(
-        eligible.size(),
-        clusterAvgUtilization,
-        clusterCapacityBytes,
-        maxUtilization,
-        minUtilization,
-        upperLimit,
-        lowerLimit,
-        sources.size(),
-        targets.size(),
-        totalOverUtilizedBytes,
-        totalUnderUtilizedBytes,
-        imbalance,
-        topHostnames(sources),
-        topHostnames(targets));
+    return ContainerBalancerClusterSnapshot.newBuilder()
+        .setTotalEligibleDatanodes(eligible.size())
+        .setClusterAvgUtilization(clusterAvgUtilization)
+        .setClusterCapacityBytes(clusterCapacityBytes)
+        .setMaxUtilization(maxUtilization)
+        .setMinUtilization(minUtilization)
+        .setUpperLimit(upperLimit)
+        .setLowerLimit(lowerLimit)
+        .setSourceCount(sources.size())
+        .setTargetCount(targets.size())
+        .setTotalOverUtilizedBytes(totalOverUtilizedBytes)
+        .setTotalUnderUtilizedBytes(totalUnderUtilizedBytes)
+        .setImbalance(imbalance)
+        .setTopSourceNodeHostnames(topHostnames(sources))
+        .setBottomTargetNodeHostnames(topHostnames(targets))
+        .build();
   }
 
   /**
-   * Function that excludes is datanode should be excluded or not.
-   * The node is in exclude set or the node is not in include set
-   * when include set is not empty.
+   * Function that returns whether a datanode should be excluded from cluster analysis.
+   * A datanode is excluded if it appears in excludeNodes set, or if
+   * includeNodes is non-empty and the datanode is not listed there
+   * by hostname or IP address.
    */
   public static boolean shouldExcludeDatanode(DatanodeDetails datanode,
                                        Set<String> excludeNodes, Set<String> includeNodes) {
@@ -209,21 +211,22 @@ public final class ContainerBalancerClusterAnalyzer {
   }
 
   private static ContainerBalancerClusterSnapshot emptySnapshot(double thresholdRatio) {
-    return new ContainerBalancerClusterSnapshot(
-        0,
-        0,
-        0,
-        0,
-        0,
-        thresholdRatio,
-        -thresholdRatio,
-        0,
-        0,
-        0,
-        0,
-        0,
-        Collections.emptyList(),
-        Collections.emptyList());
+    return ContainerBalancerClusterSnapshot.newBuilder()
+        .setTotalEligibleDatanodes(0)
+        .setClusterAvgUtilization(0)
+        .setClusterCapacityBytes(0)
+        .setMaxUtilization(0)
+        .setMinUtilization(0)
+        .setUpperLimit(thresholdRatio)
+        .setLowerLimit(-thresholdRatio)
+        .setSourceCount(0)
+        .setTargetCount(0)
+        .setTotalOverUtilizedBytes(0)
+        .setTotalUnderUtilizedBytes(0)
+        .setImbalance(0)
+        .setTopSourceNodeHostnames(Collections.emptyList())
+        .setBottomTargetNodeHostnames(Collections.emptyList())
+        .build();
   }
 
   private static final class NodeClassification {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
@@ -63,6 +63,50 @@ public final class ContainerBalancerClusterAnalyzer {
   }
 
   /**
+   * Returns true if utilization is above the upper limit (source candidate).
+   */
+  public static boolean isOverUtilized(double utilization, double upperLimit) {
+    return Double.compare(utilization, upperLimit) > 0;
+  }
+
+  /**
+   * Returns true if utilization is below the lower limit (target candidate).
+   */
+  public static boolean isUnderUtilized(double utilization, double lowerLimit) {
+    return Double.compare(utilization, lowerLimit) < 0;
+  }
+
+  /**
+   * Bytes above the upper limit on an over-utilized node.
+   */
+  public static long overUtilizedBytes(long capacity, double utilization, double upperLimit) {
+    return ratioToBytes(capacity, utilization) - ratioToBytes(capacity, upperLimit);
+  }
+
+  /**
+   * Bytes below the lower limit on an under-utilized node.
+   */
+  public static long underUtilizedBytes(long capacity, double utilization, double lowerLimit) {
+    return ratioToBytes(capacity, lowerLimit) - ratioToBytes(capacity, utilization);
+  }
+
+  /**
+   * Upper utilization band: cluster average plus threshold.
+   * Nodes above this are candidates to be source nodes.
+   */
+  public static double computeUpperLimit(double clusterAvgUtilization, double thresholdRatio) {
+    return clusterAvgUtilization + thresholdRatio;
+  }
+
+  /**
+   * Lower utilization band: cluster average minus threshold.
+   * Nodes below this are candidates to be target nodes.
+   */
+  public static double computeLowerLimit(double clusterAvgUtilization, double thresholdRatio) {
+    return clusterAvgUtilization - thresholdRatio;
+  }
+
+  /**
    * Builds a cluster snapshot after applying include/exclude filters.
    *
    * @param nodes all nodes from getDatanodeUsageInfo (typically healthy IN_SERVICE)
@@ -82,8 +126,8 @@ public final class ContainerBalancerClusterAnalyzer {
     }
 
     double clusterAvgUtilization = calculateAvgUtilization(eligible);
-    double upperLimit = clusterAvgUtilization + thresholdRatio;
-    double lowerLimit = clusterAvgUtilization - thresholdRatio;
+    double upperLimit = computeUpperLimit(clusterAvgUtilization, thresholdRatio);
+    double lowerLimit = computeLowerLimit(clusterAvgUtilization, thresholdRatio);
 
     List<NodeClassification> sources = new ArrayList<>();
     List<NodeClassification> targets = new ArrayList<>();
@@ -102,15 +146,11 @@ public final class ContainerBalancerClusterAnalyzer {
       minUtilization = Math.min(minUtilization, utilization);
 
       String hostname = getDisplayHostname(node);
-      if (Double.compare(utilization, upperLimit) > 0) {
-        long overBytes = ratioToBytes(capacity, utilization)
-            - ratioToBytes(capacity, upperLimit);
-        totalOverUtilizedBytes += overBytes;
+      if (isOverUtilized(utilization, upperLimit)) {
+        totalOverUtilizedBytes += overUtilizedBytes(capacity, utilization, upperLimit);
         sources.add(new NodeClassification(hostname, utilization));
-      } else if (Double.compare(utilization, lowerLimit) < 0) {
-        long underBytes = ratioToBytes(capacity, lowerLimit)
-            - ratioToBytes(capacity, utilization);
-        totalUnderUtilizedBytes += underBytes;
+      } else if (isUnderUtilized(utilization, lowerLimit)) {
+        totalUnderUtilizedBytes += underUtilizedBytes(capacity, utilization, lowerLimit);
         targets.add(new NodeClassification(hostname, utilization));
       }
     }
@@ -145,7 +185,7 @@ public final class ContainerBalancerClusterAnalyzer {
    * by hostname or IP address.
    */
   public static boolean shouldExcludeDatanode(DatanodeDetails datanode,
-                                       Set<String> excludeNodes, Set<String> includeNodes) {
+                                              Set<String> excludeNodes, Set<String> includeNodes) {
     if (excludeNodes.contains(datanode.getHostName()) ||
         excludeNodes.contains(datanode.getIpAddress())) {
       return true;
@@ -217,8 +257,8 @@ public final class ContainerBalancerClusterAnalyzer {
         .setClusterCapacityBytes(0)
         .setMaxUtilization(0)
         .setMinUtilization(0)
-        .setUpperLimit(thresholdRatio)
-        .setLowerLimit(-thresholdRatio)
+        .setUpperLimit(computeUpperLimit(0, thresholdRatio))
+        .setLowerLimit(computeLowerLimit(0, thresholdRatio))
         .setSourceCount(0)
         .setTargetCount(0)
         .setTotalOverUtilizedBytes(0)

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterAnalyzer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeUsageInfoProto;
+import org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancerClusterSnapshot.NodeUtilization;
 
 /**
  * Classifies datanode usage protos using the same rules as
@@ -129,8 +130,8 @@ public final class ContainerBalancerClusterAnalyzer {
     double upperLimit = computeUpperLimit(clusterAvgUtilization, thresholdRatio);
     double lowerLimit = computeLowerLimit(clusterAvgUtilization, thresholdRatio);
 
-    List<NodeClassification> sources = new ArrayList<>();
-    List<NodeClassification> targets = new ArrayList<>();
+    List<NodeUtilization> sources = new ArrayList<>();
+    List<NodeUtilization> targets = new ArrayList<>();
     double maxUtilization = Double.NEGATIVE_INFINITY;
     double minUtilization = Double.POSITIVE_INFINITY;
     long clusterCapacityBytes = 0;
@@ -148,15 +149,15 @@ public final class ContainerBalancerClusterAnalyzer {
       String hostname = getDisplayHostname(node);
       if (isOverUtilized(utilization, upperLimit)) {
         totalOverUtilizedBytes += overUtilizedBytes(capacity, utilization, upperLimit);
-        sources.add(new NodeClassification(hostname, utilization));
+        sources.add(new NodeUtilization(hostname, utilization));
       } else if (isUnderUtilized(utilization, lowerLimit)) {
         totalUnderUtilizedBytes += underUtilizedBytes(capacity, utilization, lowerLimit);
-        targets.add(new NodeClassification(hostname, utilization));
+        targets.add(new NodeUtilization(hostname, utilization));
       }
     }
 
-    sources.sort(Comparator.comparingDouble(NodeClassification::getUtilization).reversed());
-    targets.sort(Comparator.comparingDouble(NodeClassification::getUtilization));
+    sources.sort(Comparator.comparingDouble(NodeUtilization::getUtilization).reversed());
+    targets.sort(Comparator.comparingDouble(NodeUtilization::getUtilization));
 
     double imbalance = maxUtilization - minUtilization;
 
@@ -173,8 +174,8 @@ public final class ContainerBalancerClusterAnalyzer {
         .setTotalOverUtilizedBytes(totalOverUtilizedBytes)
         .setTotalUnderUtilizedBytes(totalUnderUtilizedBytes)
         .setImbalance(imbalance)
-        .setTopSourceNodeHostnames(topHostnames(sources))
-        .setBottomTargetNodeHostnames(topHostnames(targets))
+        .setTopSourceNodes(topNodes(sources))
+        .setBottomTargetNodes(topNodes(targets))
         .build();
   }
 
@@ -241,13 +242,13 @@ public final class ContainerBalancerClusterAnalyzer {
     return datanode.getIpAddress();
   }
 
-  private static List<String> topHostnames(List<NodeClassification> nodes) {
+  private static List<NodeUtilization> topNodes(List<NodeUtilization> nodes) {
     int limit = Math.min(TOP_NODE_LIMIT, nodes.size());
-    List<String> hostnames = new ArrayList<>(limit);
+    List<NodeUtilization> result = new ArrayList<>(limit);
     for (int i = 0; i < limit; i++) {
-      hostnames.add(nodes.get(i).getHostname());
+      result.add(nodes.get(i));
     }
-    return hostnames;
+    return result;
   }
 
   private static ContainerBalancerClusterSnapshot emptySnapshot(double thresholdRatio) {
@@ -264,26 +265,8 @@ public final class ContainerBalancerClusterAnalyzer {
         .setTotalOverUtilizedBytes(0)
         .setTotalUnderUtilizedBytes(0)
         .setImbalance(0)
-        .setTopSourceNodeHostnames(Collections.emptyList())
-        .setBottomTargetNodeHostnames(Collections.emptyList())
+        .setTopSourceNodes(Collections.emptyList())
+        .setBottomTargetNodes(Collections.emptyList())
         .build();
-  }
-
-  private static final class NodeClassification {
-    private final String hostname;
-    private final double utilization;
-
-    private NodeClassification(String hostname, double utilization) {
-      this.hostname = hostname;
-      this.utilization = utilization;
-    }
-
-    private String getHostname() {
-      return hostname;
-    }
-
-    private double getUtilization() {
-      return utilization;
-    }
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterSnapshot.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterSnapshot.java
@@ -55,7 +55,6 @@ public final class ContainerBalancerClusterSnapshot {
       int targetCount,
       long totalOverUtilizedBytes,
       long totalUnderUtilizedBytes,
-      long bytesToMove,
       double imbalance,
       List<String> topSourceNodeHostnames,
       List<String> bottomTargetNodeHostnames) {
@@ -70,7 +69,7 @@ public final class ContainerBalancerClusterSnapshot {
     this.targetCount = targetCount;
     this.totalOverUtilizedBytes = totalOverUtilizedBytes;
     this.totalUnderUtilizedBytes = totalUnderUtilizedBytes;
-    this.bytesToMove = bytesToMove;
+    this.bytesToMove = totalOverUtilizedBytes;
     this.imbalance = imbalance;
     this.topSourceNodeHostnames = Collections.unmodifiableList(
         Objects.requireNonNull(topSourceNodeHostnames));

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterSnapshot.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterSnapshot.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Point-in-time cluster imbalance view built from datanode usage protos.
+ */
+public final class ContainerBalancerClusterSnapshot {
+
+  private final int totalEligibleDatanodes;
+  private final double clusterAvgUtilization;
+  private final long clusterCapacityBytes;
+  private final double maxUtilization;
+  private final double minUtilization;
+  private final double upperLimit;
+  private final double lowerLimit;
+  private final int sourceCount;
+  private final int targetCount;
+  private final long totalOverUtilizedBytes;
+  private final long totalUnderUtilizedBytes;
+  private final long bytesToMove;
+  private final double imbalance;
+  private final List<String> topSourceNodeHostnames;
+  private final List<String> bottomTargetNodeHostnames;
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public ContainerBalancerClusterSnapshot(
+      int totalEligibleDatanodes,
+      double clusterAvgUtilization,
+      long clusterCapacityBytes,
+      double maxUtilization,
+      double minUtilization,
+      double upperLimit,
+      double lowerLimit,
+      int sourceCount,
+      int targetCount,
+      long totalOverUtilizedBytes,
+      long totalUnderUtilizedBytes,
+      long bytesToMove,
+      double imbalance,
+      List<String> topSourceNodeHostnames,
+      List<String> bottomTargetNodeHostnames) {
+    this.totalEligibleDatanodes = totalEligibleDatanodes;
+    this.clusterAvgUtilization = clusterAvgUtilization;
+    this.clusterCapacityBytes = clusterCapacityBytes;
+    this.maxUtilization = maxUtilization;
+    this.minUtilization = minUtilization;
+    this.upperLimit = upperLimit;
+    this.lowerLimit = lowerLimit;
+    this.sourceCount = sourceCount;
+    this.targetCount = targetCount;
+    this.totalOverUtilizedBytes = totalOverUtilizedBytes;
+    this.totalUnderUtilizedBytes = totalUnderUtilizedBytes;
+    this.bytesToMove = bytesToMove;
+    this.imbalance = imbalance;
+    this.topSourceNodeHostnames = Collections.unmodifiableList(
+        Objects.requireNonNull(topSourceNodeHostnames));
+    this.bottomTargetNodeHostnames = Collections.unmodifiableList(
+        Objects.requireNonNull(bottomTargetNodeHostnames));
+  }
+
+  public int getTotalEligibleDatanodes() {
+    return totalEligibleDatanodes;
+  }
+
+  public double getClusterAvgUtilization() {
+    return clusterAvgUtilization;
+  }
+
+  public long getClusterCapacityBytes() {
+    return clusterCapacityBytes;
+  }
+
+  public double getMaxUtilization() {
+    return maxUtilization;
+  }
+
+  public double getMinUtilization() {
+    return minUtilization;
+  }
+
+  public double getUpperLimit() {
+    return upperLimit;
+  }
+
+  public double getLowerLimit() {
+    return lowerLimit;
+  }
+
+  public int getSourceCount() {
+    return sourceCount;
+  }
+
+  public int getTargetCount() {
+    return targetCount;
+  }
+
+  public long getTotalOverUtilizedBytes() {
+    return totalOverUtilizedBytes;
+  }
+
+  public long getTotalUnderUtilizedBytes() {
+    return totalUnderUtilizedBytes;
+  }
+
+  public long getBytesToMove() {
+    return bytesToMove;
+  }
+
+  public double getImbalance() {
+    return imbalance;
+  }
+
+  public List<String> getTopSourceNodeHostnames() {
+    return topSourceNodeHostnames;
+  }
+
+  public List<String> getBottomTargetNodeHostnames() {
+    return bottomTargetNodeHostnames;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterSnapshot.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterSnapshot.java
@@ -42,39 +42,24 @@ public final class ContainerBalancerClusterSnapshot {
   private final List<String> topSourceNodeHostnames;
   private final List<String> bottomTargetNodeHostnames;
 
-  @SuppressWarnings("checkstyle:ParameterNumber")
-  public ContainerBalancerClusterSnapshot(
-      int totalEligibleDatanodes,
-      double clusterAvgUtilization,
-      long clusterCapacityBytes,
-      double maxUtilization,
-      double minUtilization,
-      double upperLimit,
-      double lowerLimit,
-      int sourceCount,
-      int targetCount,
-      long totalOverUtilizedBytes,
-      long totalUnderUtilizedBytes,
-      double imbalance,
-      List<String> topSourceNodeHostnames,
-      List<String> bottomTargetNodeHostnames) {
-    this.totalEligibleDatanodes = totalEligibleDatanodes;
-    this.clusterAvgUtilization = clusterAvgUtilization;
-    this.clusterCapacityBytes = clusterCapacityBytes;
-    this.maxUtilization = maxUtilization;
-    this.minUtilization = minUtilization;
-    this.upperLimit = upperLimit;
-    this.lowerLimit = lowerLimit;
-    this.sourceCount = sourceCount;
-    this.targetCount = targetCount;
-    this.totalOverUtilizedBytes = totalOverUtilizedBytes;
-    this.totalUnderUtilizedBytes = totalUnderUtilizedBytes;
-    this.bytesToMove = totalOverUtilizedBytes;
-    this.imbalance = imbalance;
+  private ContainerBalancerClusterSnapshot(Builder b) {
+    this.totalEligibleDatanodes = b.totalEligibleDatanodes;
+    this.clusterAvgUtilization = b.clusterAvgUtilization;
+    this.clusterCapacityBytes = b.clusterCapacityBytes;
+    this.maxUtilization = b.maxUtilization;
+    this.minUtilization = b.minUtilization;
+    this.upperLimit = b.upperLimit;
+    this.lowerLimit = b.lowerLimit;
+    this.sourceCount = b.sourceCount;
+    this.targetCount = b.targetCount;
+    this.totalOverUtilizedBytes = b.totalOverUtilizedBytes;
+    this.totalUnderUtilizedBytes = b.totalUnderUtilizedBytes;
+    this.bytesToMove = b.totalOverUtilizedBytes;
+    this.imbalance = b.imbalance;
     this.topSourceNodeHostnames = Collections.unmodifiableList(
-        Objects.requireNonNull(topSourceNodeHostnames));
+        Objects.requireNonNull(b.topSourceNodeHostnames));
     this.bottomTargetNodeHostnames = Collections.unmodifiableList(
-        Objects.requireNonNull(bottomTargetNodeHostnames));
+        Objects.requireNonNull(b.bottomTargetNodeHostnames));
   }
 
   public int getTotalEligibleDatanodes() {
@@ -135,5 +120,106 @@ public final class ContainerBalancerClusterSnapshot {
 
   public List<String> getBottomTargetNodeHostnames() {
     return bottomTargetNodeHostnames;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder class for building ContainerBalancerClusterSnapshot.
+   */
+  public static final class Builder {
+    private int totalEligibleDatanodes;
+    private double clusterAvgUtilization;
+    private long clusterCapacityBytes;
+    private double maxUtilization;
+    private double minUtilization;
+    private double upperLimit;
+    private double lowerLimit;
+    private int sourceCount;
+    private int targetCount;
+    private long totalOverUtilizedBytes;
+    private long totalUnderUtilizedBytes;
+    private double imbalance;
+    private List<String> topSourceNodeHostnames = Collections.emptyList();
+    private List<String> bottomTargetNodeHostnames = Collections.emptyList();
+
+    private Builder() {
+    }
+
+    public Builder setTotalEligibleDatanodes(int totalEligibleDatanodes) {
+      this.totalEligibleDatanodes = totalEligibleDatanodes;
+      return this;
+    }
+
+    public Builder setClusterAvgUtilization(double clusterAvgUtilization) {
+      this.clusterAvgUtilization = clusterAvgUtilization;
+      return this;
+    }
+
+    public Builder setClusterCapacityBytes(long clusterCapacityBytes) {
+      this.clusterCapacityBytes = clusterCapacityBytes;
+      return this;
+    }
+
+    public Builder setMaxUtilization(double maxUtilization) {
+      this.maxUtilization = maxUtilization;
+      return this;
+    }
+
+    public Builder setMinUtilization(double minUtilization) {
+      this.minUtilization = minUtilization;
+      return this;
+    }
+
+    public Builder setUpperLimit(double upperLimit) {
+      this.upperLimit = upperLimit;
+      return this;
+    }
+
+    public Builder setLowerLimit(double lowerLimit) {
+      this.lowerLimit = lowerLimit;
+      return this;
+    }
+
+    public Builder setSourceCount(int sourceCount) {
+      this.sourceCount = sourceCount;
+      return this;
+    }
+
+    public Builder setTargetCount(int targetCount) {
+      this.targetCount = targetCount;
+      return this;
+    }
+
+    public Builder setTotalOverUtilizedBytes(long totalOverUtilizedBytes) {
+      this.totalOverUtilizedBytes = totalOverUtilizedBytes;
+      return this;
+    }
+
+    public Builder setTotalUnderUtilizedBytes(long totalUnderUtilizedBytes) {
+      this.totalUnderUtilizedBytes = totalUnderUtilizedBytes;
+      return this;
+    }
+
+    public Builder setImbalance(double imbalance) {
+      this.imbalance = imbalance;
+      return this;
+    }
+
+    public Builder setTopSourceNodeHostnames(List<String> topSourceNodeHostnames) {
+      this.topSourceNodeHostnames = topSourceNodeHostnames;
+      return this;
+    }
+
+    public Builder setBottomTargetNodeHostnames(List<String> bottomTargetNodeHostnames) {
+      this.bottomTargetNodeHostnames = bottomTargetNodeHostnames;
+      return this;
+    }
+
+    public ContainerBalancerClusterSnapshot build() {
+      return new ContainerBalancerClusterSnapshot(this);
+    }
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterSnapshot.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerClusterSnapshot.java
@@ -39,8 +39,8 @@ public final class ContainerBalancerClusterSnapshot {
   private final long totalUnderUtilizedBytes;
   private final long bytesToMove;
   private final double imbalance;
-  private final List<String> topSourceNodeHostnames;
-  private final List<String> bottomTargetNodeHostnames;
+  private final List<NodeUtilization> topSourceNodes;
+  private final List<NodeUtilization> bottomTargetNodes;
 
   private ContainerBalancerClusterSnapshot(Builder b) {
     this.totalEligibleDatanodes = b.totalEligibleDatanodes;
@@ -56,10 +56,10 @@ public final class ContainerBalancerClusterSnapshot {
     this.totalUnderUtilizedBytes = b.totalUnderUtilizedBytes;
     this.bytesToMove = b.totalOverUtilizedBytes;
     this.imbalance = b.imbalance;
-    this.topSourceNodeHostnames = Collections.unmodifiableList(
-        Objects.requireNonNull(b.topSourceNodeHostnames));
-    this.bottomTargetNodeHostnames = Collections.unmodifiableList(
-        Objects.requireNonNull(b.bottomTargetNodeHostnames));
+    this.topSourceNodes = Collections.unmodifiableList(
+        Objects.requireNonNull(b.topSourceNodes));
+    this.bottomTargetNodes = Collections.unmodifiableList(
+        Objects.requireNonNull(b.bottomTargetNodes));
   }
 
   public int getTotalEligibleDatanodes() {
@@ -114,12 +114,12 @@ public final class ContainerBalancerClusterSnapshot {
     return imbalance;
   }
 
-  public List<String> getTopSourceNodeHostnames() {
-    return topSourceNodeHostnames;
+  public List<NodeUtilization> getTopSourceNodes() {
+    return topSourceNodes;
   }
 
-  public List<String> getBottomTargetNodeHostnames() {
-    return bottomTargetNodeHostnames;
+  public List<NodeUtilization> getBottomTargetNodes() {
+    return bottomTargetNodes;
   }
 
   public static Builder newBuilder() {
@@ -142,8 +142,8 @@ public final class ContainerBalancerClusterSnapshot {
     private long totalOverUtilizedBytes;
     private long totalUnderUtilizedBytes;
     private double imbalance;
-    private List<String> topSourceNodeHostnames = Collections.emptyList();
-    private List<String> bottomTargetNodeHostnames = Collections.emptyList();
+    private List<NodeUtilization> topSourceNodes = Collections.emptyList();
+    private List<NodeUtilization> bottomTargetNodes = Collections.emptyList();
 
     private Builder() {
     }
@@ -208,18 +208,40 @@ public final class ContainerBalancerClusterSnapshot {
       return this;
     }
 
-    public Builder setTopSourceNodeHostnames(List<String> topSourceNodeHostnames) {
-      this.topSourceNodeHostnames = topSourceNodeHostnames;
+    public Builder setTopSourceNodes(List<NodeUtilization> topSourceNodes) {
+      this.topSourceNodes = topSourceNodes;
       return this;
     }
 
-    public Builder setBottomTargetNodeHostnames(List<String> bottomTargetNodeHostnames) {
-      this.bottomTargetNodeHostnames = bottomTargetNodeHostnames;
+    public Builder setBottomTargetNodes(List<NodeUtilization> bottomTargetNodes) {
+      this.bottomTargetNodes = bottomTargetNodes;
       return this;
     }
 
     public ContainerBalancerClusterSnapshot build() {
       return new ContainerBalancerClusterSnapshot(this);
+    }
+  }
+
+  /**
+   * Hostname and utilization ratio of a single datanode, retained on the snapshot
+   * for per-node display in CLI output (e.g., assessment).
+   */
+  public static final class NodeUtilization {
+    private final String hostname;
+    private final double utilization;
+
+    public NodeUtilization(String hostname, double utilization) {
+      this.hostname = hostname;
+      this.utilization = utilization;
+    }
+
+    public String getHostname() {
+      return hostname;
+    }
+
+    public double getUtilization() {
+      return utilization;
     }
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerClusterAnalyzer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerClusterAnalyzer.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+import static org.apache.hadoop.ozone.ClientVersion.DEFAULT_VERSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeUsageInfoProto;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link ContainerBalancerClusterAnalyzer}. */
+public final class TestContainerBalancerClusterAnalyzer {
+
+  private static final double THRESHOLD = 0.10;
+
+  @Test
+  void testCalculateAvgUtilizationFromTotals() {
+    assertEquals(0.70d, ContainerBalancerClusterAnalyzer
+        .calculateAvgUtilization(200, 60), 0.0001);
+    assertEquals(0, ContainerBalancerClusterAnalyzer
+        .calculateAvgUtilization(0, 0));
+  }
+
+  @Test
+  void testBalancedClusterHasNoSourcesOrTargets() {
+    List<DatanodeUsageInfoProto> nodes = Arrays.asList(
+        proto("dn-1", 100, 30),
+        proto("dn-2", 100, 30));
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(nodes, THRESHOLD,
+            Collections.emptySet(), Collections.emptySet());
+
+    assertEquals(2, snapshot.getTotalEligibleDatanodes());
+    assertEquals(0.70d, snapshot.getClusterAvgUtilization(), 0.0001);
+    assertEquals(0, snapshot.getSourceCount());
+    assertEquals(0, snapshot.getTargetCount());
+    assertEquals(0, snapshot.getBytesToMove());
+    assertTrue(snapshot.getTopSourceNodeHostnames().isEmpty());
+    assertTrue(snapshot.getBottomTargetNodeHostnames().isEmpty());
+  }
+
+  @Test
+  void testOverAndUnderUtilizedClassification() {
+    List<DatanodeUsageInfoProto> nodes = Arrays.asList(
+        proto("source-1", 100, 10),
+        proto("target-1", 100, 50));
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(nodes, THRESHOLD,
+            Collections.emptySet(), Collections.emptySet());
+
+    assertEquals(1, snapshot.getSourceCount());
+    assertEquals(1, snapshot.getTargetCount());
+    assertEquals(0.90d, snapshot.getMaxUtilization(), 0.0001);
+    assertEquals(0.50d, snapshot.getMinUtilization(), 0.0001);
+    assertEquals(0.40d, snapshot.getImbalance(), 0.0001);
+    assertEquals(10, snapshot.getTotalOverUtilizedBytes());
+    assertEquals(10, snapshot.getTotalUnderUtilizedBytes());
+    assertEquals(snapshot.getTotalOverUtilizedBytes(), snapshot.getBytesToMove());
+    assertEquals(Collections.singletonList("source-1"),
+        snapshot.getTopSourceNodeHostnames());
+    assertEquals(Collections.singletonList("target-1"),
+        snapshot.getBottomTargetNodeHostnames());
+  }
+
+  @Test
+  void testIncludeExcludeFilters() {
+    List<DatanodeUsageInfoProto> nodes = Arrays.asList(
+        proto("keep-me", 100, 10),    // 90%
+        proto("also-keep", 100, 50),  // 50%
+        proto("drop-me", 100, 30));   // filtered out
+
+    Set<String> include = new HashSet<>(Arrays.asList("keep-me", "also-keep"));
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(nodes, THRESHOLD, include,
+            Collections.emptySet());
+
+    assertEquals(2, snapshot.getTotalEligibleDatanodes());
+    assertEquals(1, snapshot.getSourceCount());  // keep-me
+    assertEquals(1, snapshot.getTargetCount()); // also-keep
+  }
+
+  @Test
+  void testEmptyAfterFilterReturnsEmptySnapshot() {
+    List<DatanodeUsageInfoProto> nodes = Collections.singletonList(
+        proto("excluded", 100, 10));
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(nodes, THRESHOLD,
+            Collections.emptySet(), Collections.singleton("excluded"));
+
+    assertEquals(0, snapshot.getTotalEligibleDatanodes());
+    assertEquals(0, snapshot.getClusterCapacityBytes());
+    assertEquals(0, snapshot.getBytesToMove());
+  }
+
+  @Test
+  void testZeroCapacityNodeTreatedAsZeroUtilization() {
+    List<DatanodeUsageInfoProto> nodes = Arrays.asList(
+        proto("zero-cap", 0, 0),
+        proto("normal", 100, 30));
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(nodes, THRESHOLD,
+            Collections.emptySet(), Collections.emptySet());
+
+    assertEquals(2, snapshot.getTotalEligibleDatanodes());
+    assertEquals(0, snapshot.getMinUtilization(), 0.0001);
+  }
+
+  @Test
+  void testProtoWithoutNodeIsSkipped() {
+    DatanodeUsageInfoProto noNode = DatanodeUsageInfoProto.newBuilder()
+        .setCapacity(100)
+        .setRemaining(10)
+        .setUsed(90)
+        .build();
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(
+            Collections.singletonList(noNode), THRESHOLD,
+            Collections.emptySet(), Collections.emptySet());
+
+    assertEquals(0, snapshot.getTotalEligibleDatanodes());
+  }
+
+  @Test
+  void testEmptyInputListReturnsEmptySnapshot() {
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(
+            Collections.emptyList(), THRESHOLD,
+            Collections.emptySet(), Collections.emptySet());
+
+    assertEquals(0, snapshot.getTotalEligibleDatanodes());
+    assertEquals(0, snapshot.getClusterAvgUtilization(), 0.0001);
+    assertEquals(0, snapshot.getBytesToMove());
+  }
+
+  @Test
+  void testExcludeByIpAddress() {
+    DatanodeDetails datanode = DatanodeDetails.newBuilder()
+        .setHostName("dn-host")
+        .setIpAddress("10.0.0.5")
+        .setUuid(UUID.randomUUID())
+        .build();
+    DatanodeUsageInfoProto node = DatanodeUsageInfoProto.newBuilder()
+        .setNode(datanode.toProto(DEFAULT_VERSION.toProtoValue()))
+        .setCapacity(100)
+        .setRemaining(10)
+        .setUsed(90)
+        .build();
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(
+            Collections.singletonList(node), THRESHOLD,
+            Collections.emptySet(), Collections.singleton("10.0.0.5"));
+
+    assertEquals(0, snapshot.getTotalEligibleDatanodes());
+  }
+
+  @Test
+  void testExcludeWinsOverInclude() {
+    List<DatanodeUsageInfoProto> nodes = Collections.singletonList(
+        proto("both-lists", 100, 10));
+
+    Set<String> include = Collections.singleton("both-lists");
+    Set<String> exclude = Collections.singleton("both-lists");
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(nodes, THRESHOLD, include, exclude);
+
+    assertEquals(0, snapshot.getTotalEligibleDatanodes());
+  }
+
+  @Test
+  void testTopFiveSourcesAndBottomFiveTargets() {
+    List<DatanodeUsageInfoProto> nodes = new ArrayList<>();
+    for (int i = 0; i < 7; i++) {
+      nodes.add(proto(String.format("source-%02d", i), 100, 10));
+    }
+    for (int i = 0; i < 7; i++) {
+      nodes.add(proto(String.format("target-%02d", i), 100, 50));
+    }
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(nodes, THRESHOLD,
+            Collections.emptySet(), Collections.emptySet());
+
+    assertEquals(7, snapshot.getSourceCount());
+    assertEquals(7, snapshot.getTargetCount());
+    assertEquals(5, snapshot.getTopSourceNodeHostnames().size());
+    assertEquals(5, snapshot.getBottomTargetNodeHostnames().size());
+    Set<String> expectedSources = new HashSet<>();
+    for (int i = 0; i < 7; i++) {
+      expectedSources.add(String.format("source-%02d", i));
+    }
+    Set<String> expectedTargets = new HashSet<>();
+    for (int i = 0; i < 7; i++) {
+      expectedTargets.add(String.format("target-%02d", i));
+    }
+    assertTrue(expectedSources.containsAll(snapshot.getTopSourceNodeHostnames()));
+    assertTrue(expectedTargets.containsAll(snapshot.getBottomTargetNodeHostnames()));
+  }
+
+  @Test
+  void testShouldExcludeDatanodeDirectly() {
+    DatanodeDetails datanode = DatanodeDetails.newBuilder()
+        .setHostName("dn-1")
+        .setIpAddress("10.0.0.1")
+        .setUuid(UUID.randomUUID())
+        .build();
+
+    assertTrue(ContainerBalancerClusterAnalyzer.shouldExcludeDatanode(
+        datanode, Collections.singleton("dn-1"), Collections.emptySet()));
+    assertTrue(ContainerBalancerClusterAnalyzer.shouldExcludeDatanode(
+        datanode, Collections.singleton("10.0.0.1"), Collections.emptySet()));
+    assertTrue(ContainerBalancerClusterAnalyzer.shouldExcludeDatanode(
+        datanode, Collections.emptySet(), Collections.singleton("other")));
+    assertFalse(ContainerBalancerClusterAnalyzer.shouldExcludeDatanode(
+        datanode, Collections.emptySet(), Collections.singleton("dn-1")));
+  }
+
+  private static DatanodeUsageInfoProto proto(String hostname, long capacity, long remaining) {
+    DatanodeDetails datanode = DatanodeDetails.newBuilder()
+        .setHostName(hostname)
+        .setIpAddress("127.0.0.1")
+        .setUuid(UUID.randomUUID())
+        .build();
+    long used = capacity - remaining;
+    return DatanodeUsageInfoProto.newBuilder()
+        .setNode(datanode.toProto(DEFAULT_VERSION.toProtoValue()))
+        .setCapacity(capacity)
+        .setRemaining(remaining)
+        .setUsed(used)
+        .build();
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerClusterAnalyzer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerClusterAnalyzer.java
@@ -29,8 +29,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeUsageInfoProto;
+import org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancerClusterSnapshot.NodeUtilization;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link ContainerBalancerClusterAnalyzer}. */
@@ -61,8 +63,8 @@ public final class TestContainerBalancerClusterAnalyzer {
     assertEquals(0, snapshot.getSourceCount());
     assertEquals(0, snapshot.getTargetCount());
     assertEquals(0, snapshot.getBytesToMove());
-    assertTrue(snapshot.getTopSourceNodeHostnames().isEmpty());
-    assertTrue(snapshot.getBottomTargetNodeHostnames().isEmpty());
+    assertTrue(snapshot.getTopSourceNodes().isEmpty());
+    assertTrue(snapshot.getBottomTargetNodes().isEmpty());
   }
 
   @Test
@@ -84,9 +86,11 @@ public final class TestContainerBalancerClusterAnalyzer {
     assertEquals(10, snapshot.getTotalUnderUtilizedBytes());
     assertEquals(snapshot.getTotalOverUtilizedBytes(), snapshot.getBytesToMove());
     assertEquals(Collections.singletonList("source-1"),
-        snapshot.getTopSourceNodeHostnames());
+        snapshot.getTopSourceNodes().stream()
+            .map(NodeUtilization::getHostname).collect(Collectors.toList()));
     assertEquals(Collections.singletonList("target-1"),
-        snapshot.getBottomTargetNodeHostnames());
+        snapshot.getBottomTargetNodes().stream()
+            .map(NodeUtilization::getHostname).collect(Collectors.toList()));
   }
 
   @Test
@@ -215,8 +219,8 @@ public final class TestContainerBalancerClusterAnalyzer {
 
     assertEquals(7, snapshot.getSourceCount());
     assertEquals(7, snapshot.getTargetCount());
-    assertEquals(5, snapshot.getTopSourceNodeHostnames().size());
-    assertEquals(5, snapshot.getBottomTargetNodeHostnames().size());
+    assertEquals(5, snapshot.getTopSourceNodes().size());
+    assertEquals(5, snapshot.getBottomTargetNodes().size());
     Set<String> expectedSources = new HashSet<>();
     for (int i = 0; i < 7; i++) {
       expectedSources.add(String.format("source-%02d", i));
@@ -225,8 +229,36 @@ public final class TestContainerBalancerClusterAnalyzer {
     for (int i = 0; i < 7; i++) {
       expectedTargets.add(String.format("target-%02d", i));
     }
-    assertTrue(expectedSources.containsAll(snapshot.getTopSourceNodeHostnames()));
-    assertTrue(expectedTargets.containsAll(snapshot.getBottomTargetNodeHostnames()));
+    assertTrue(expectedSources.containsAll(
+        snapshot.getTopSourceNodes().stream()
+            .map(NodeUtilization::getHostname).collect(Collectors.toList())));
+    assertTrue(expectedTargets.containsAll(
+        snapshot.getBottomTargetNodes().stream()
+            .map(NodeUtilization::getHostname).collect(Collectors.toList())));
+  }
+
+  @Test
+  void testTopSourceNodesCarryUtilization() {
+    List<DatanodeUsageInfoProto> nodes = Arrays.asList(
+        proto("source-hot", 100, 5),   // 95% used
+        proto("source-warm", 100, 15), // 85% used
+        proto("balanced", 100, 50),
+        proto("target-cool", 100, 90)  // 10% used
+    );
+
+    ContainerBalancerClusterSnapshot snapshot =
+        ContainerBalancerClusterAnalyzer.analyze(nodes, THRESHOLD,
+            Collections.emptySet(), Collections.emptySet());
+
+    List<NodeUtilization> top = snapshot.getTopSourceNodes();
+    assertEquals("source-hot", top.get(0).getHostname());
+    assertEquals(0.95, top.get(0).getUtilization(), 1e-9);
+    assertEquals("source-warm", top.get(1).getHostname());
+    assertEquals(0.85, top.get(1).getUtilization(), 1e-9);
+
+    List<NodeUtilization> bottom = snapshot.getBottomTargetNodes();
+    assertEquals("target-cool", bottom.get(0).getHostname());
+    assertEquals(0.10, bottom.get(0).getUtilization(), 1e-9);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -660,14 +660,8 @@ public class ContainerBalancer extends StatefulService<ContainerBalancerConfigur
 
   static boolean shouldExcludeDatanode(DatanodeDetails datanode,
       Set<String> excludeNodes, Set<String> includeNodes) {
-    if (excludeNodes.contains(datanode.getHostName()) ||
-        excludeNodes.contains(datanode.getIpAddress())) {
-      return true;
-    } else if (!includeNodes.isEmpty()) {
-      return !includeNodes.contains(datanode.getHostName()) &&
-          !includeNodes.contains(datanode.getIpAddress());
-    }
-    return false;
+    return ContainerBalancerClusterAnalyzer.shouldExcludeDatanode(
+        datanode, excludeNodes, includeNodes);
   }
 
   public ContainerBalancerMetrics getMetrics() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -1119,7 +1119,8 @@ public class ContainerBalancerTask implements Runnable {
           "ContainerBalancer.");
       return 0;
     }
-    SCMNodeStat aggregatedStats = new SCMNodeStat(0, 0, 0, 0, 0, 0);
+    SCMNodeStat aggregatedStats = new SCMNodeStat(
+        0, 0, 0, 0, 0, 0);
     for (DatanodeUsageInfo node : nodes) {
       aggregatedStats.add(node.getScmNodeStat());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
@@ -581,9 +582,9 @@ public class ContainerBalancerTask implements Runnable {
         metrics.incrementNumDatanodesUnbalanced(1);
 
         // amount of bytes greater than upper limit in this node
-        long overUtilizedBytes = ratioToBytes(
+        long overUtilizedBytes = ContainerBalancerClusterAnalyzer.ratioToBytes(
             datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
-            utilization) - ratioToBytes(
+            utilization) - ContainerBalancerClusterAnalyzer.ratioToBytes(
             datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
             upperLimit);
         totalOverUtilizedBytes += overUtilizedBytes;
@@ -592,9 +593,9 @@ public class ContainerBalancerTask implements Runnable {
         metrics.incrementNumDatanodesUnbalanced(1);
 
         // amount of bytes lesser than lower limit in this node
-        long underUtilizedBytes = ratioToBytes(
+        long underUtilizedBytes = ContainerBalancerClusterAnalyzer.ratioToBytes(
             datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
-            lowerLimit) - ratioToBytes(
+            lowerLimit) - ContainerBalancerClusterAnalyzer.ratioToBytes(
             datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
             utilization);
         totalUnderUtilizedBytes += underUtilizedBytes;
@@ -1105,17 +1106,6 @@ public class ContainerBalancerTask implements Runnable {
   }
 
   /**
-   * Calculates the number of used bytes given capacity and utilization ratio.
-   *
-   * @param nodeCapacity     capacity of the node.
-   * @param utilizationRatio used space by capacity ratio of the node.
-   * @return number of bytes
-   */
-  private long ratioToBytes(Long nodeCapacity, double utilizationRatio) {
-    return (long) (nodeCapacity * utilizationRatio);
-  }
-
-  /**
    * Calculates the average utilization for the specified nodes.
    * Utilization is (capacity - remaining) divided by capacity.
    *
@@ -1129,14 +1119,14 @@ public class ContainerBalancerTask implements Runnable {
           "ContainerBalancer.");
       return 0;
     }
-    long totalCapacity = 0;
-    long totalRemaining = 0;
+    SCMNodeStat aggregatedStats = new SCMNodeStat(0, 0, 0, 0, 0, 0);
     for (DatanodeUsageInfo node : nodes) {
-      totalCapacity += node.getScmNodeStat().getCapacity().get();
-      totalRemaining += node.getScmNodeStat().getRemaining().get();
+      aggregatedStats.add(node.getScmNodeStat());
     }
+    long clusterCapacity = aggregatedStats.getCapacity().get();
+    long clusterRemaining = aggregatedStats.getRemaining().get();
     return ContainerBalancerClusterAnalyzer.calculateAvgUtilization(
-        totalCapacity, totalRemaining);
+        clusterCapacity, clusterRemaining);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -55,7 +55,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
-import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
@@ -1130,15 +1129,14 @@ public class ContainerBalancerTask implements Runnable {
           "ContainerBalancer.");
       return 0;
     }
-    SCMNodeStat aggregatedStats = new SCMNodeStat(
-        0, 0, 0, 0, 0, 0);
+    long totalCapacity = 0;
+    long totalRemaining = 0;
     for (DatanodeUsageInfo node : nodes) {
-      aggregatedStats.add(node.getScmNodeStat());
+      totalCapacity += node.getScmNodeStat().getCapacity().get();
+      totalRemaining += node.getScmNodeStat().getRemaining().get();
     }
-    long clusterCapacity = aggregatedStats.getCapacity().get();
-    long clusterRemaining = aggregatedStats.getRemaining().get();
-
-    return (clusterCapacity - clusterRemaining) / (double) clusterCapacity;
+    return ContainerBalancerClusterAnalyzer.calculateAvgUtilization(
+        totalCapacity, totalRemaining);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -553,9 +553,11 @@ public class ContainerBalancerTask implements Runnable {
 
     double threshold = config.getThresholdAsRatio();
     // over utilized nodes have utilization(that is, used / capacity) greater than upper limit
-    this.upperLimit = clusterAvgUtilisation + threshold;
+    this.upperLimit = ContainerBalancerClusterAnalyzer.computeUpperLimit(
+        clusterAvgUtilisation, threshold);
     // under utilized nodes have utilization(that is, used / capacity) less than lower limit
-    this.lowerLimit = clusterAvgUtilisation - threshold;
+    this.lowerLimit = ContainerBalancerClusterAnalyzer.computeLowerLimit(
+        clusterAvgUtilisation, threshold);
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("Lower limit for utilization is {} and Upper limit for utilization is {}", lowerLimit, upperLimit);
@@ -577,28 +579,18 @@ public class ContainerBalancerTask implements Runnable {
             datanodeUsageInfo.getScmNodeStat().getRemaining().get(),
             utilization);
       }
-      if (Double.compare(utilization, upperLimit) > 0) {
+      if (ContainerBalancerClusterAnalyzer.isOverUtilized(utilization, upperLimit)) {
         overUtilizedNodes.add(datanodeUsageInfo);
         metrics.incrementNumDatanodesUnbalanced(1);
-
-        // amount of bytes greater than upper limit in this node
-        long overUtilizedBytes = ContainerBalancerClusterAnalyzer.ratioToBytes(
-            datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
-            utilization) - ContainerBalancerClusterAnalyzer.ratioToBytes(
-            datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
-            upperLimit);
-        totalOverUtilizedBytes += overUtilizedBytes;
-      } else if (Double.compare(utilization, lowerLimit) < 0) {
+        totalOverUtilizedBytes +=
+            ContainerBalancerClusterAnalyzer.overUtilizedBytes(datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
+                utilization, upperLimit);
+      } else if (ContainerBalancerClusterAnalyzer.isUnderUtilized(utilization, lowerLimit)) {
         underUtilizedNodes.add(datanodeUsageInfo);
         metrics.incrementNumDatanodesUnbalanced(1);
-
-        // amount of bytes lesser than lower limit in this node
-        long underUtilizedBytes = ContainerBalancerClusterAnalyzer.ratioToBytes(
-            datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
-            lowerLimit) - ContainerBalancerClusterAnalyzer.ratioToBytes(
-            datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
-            utilization);
-        totalUnderUtilizedBytes += underUtilizedBytes;
+        totalUnderUtilizedBytes +=
+            ContainerBalancerClusterAnalyzer.underUtilizedBytes(datanodeUsageInfo.getScmNodeStat().getCapacity().get(),
+                utilization, lowerLimit);
       }
     }
     metrics.incrementDataSizeUnbalancedGB(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,7 @@ import java.util.stream.Stream;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeUsageInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -56,6 +58,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -94,6 +97,72 @@ public class TestContainerBalancerDatanodeNodeLimit {
         Arguments.of(getMockedSCM(19)),
         Arguments.of(getMockedSCM(20)),
         Arguments.of(getMockedSCM(30)));
+  }
+
+  @ParameterizedTest(name = "MockedSCM #{index}: {0}")
+  @MethodSource("createMockedSCMs")
+  void analyzerMatchesTaskAfterInitializeIteration(@Nonnull MockedSCM mockedSCM) {
+    ContainerBalancerConfiguration config =
+        new ContainerBalancerConfigBuilder(mockedSCM.getNodeCount()).build();
+
+    ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
+
+    List<DatanodeUsageInfo> eligible = mockedSCM.getNodeManager().getMostOrLeastUsedDatanodes(true)
+        .stream()
+        .filter(n -> !ContainerBalancerClusterAnalyzer.shouldExcludeDatanode(
+            n.getDatanodeDetails(), config.getExcludeNodes(), config.getIncludeNodes()))
+        .collect(Collectors.toList());
+    List<DatanodeUsageInfoProto> protos = eligible.stream()
+        .map(n -> n.toProto(ClientVersion.DEFAULT_VERSION.toProtoValue()))
+        .collect(Collectors.toList());
+
+    ContainerBalancerClusterSnapshot snapshot = ContainerBalancerClusterAnalyzer.analyze(
+        protos, config.getThresholdAsRatio(), config.getIncludeNodes(), config.getExcludeNodes());
+
+    double taskAvg = ContainerBalancerTask.calculateAvgUtilization(eligible);
+    double upperLimit = taskAvg + config.getThresholdAsRatio();
+    double lowerLimit = taskAvg - config.getThresholdAsRatio();
+
+    assertEquals(eligible.size(), snapshot.getTotalEligibleDatanodes());
+    assertEquals(task.getOverUtilizedNodes().size(), snapshot.getSourceCount());
+    assertEquals(task.getUnderUtilizedNodes().size(), snapshot.getTargetCount());
+    assertEquals(taskAvg, snapshot.getClusterAvgUtilization(), 0.0001);
+    assertEquals(upperLimit, snapshot.getUpperLimit(), 0.0001);
+    assertEquals(lowerLimit, snapshot.getLowerLimit(), 0.0001);
+
+    long expectedOverBytes = task.getOverUtilizedNodes().stream()
+        .mapToLong(n -> {
+          long capacity = n.getScmNodeStat().getCapacity().get();
+          double utilization = n.calculateUtilization();
+          return (long) (capacity * utilization) - (long) (capacity * upperLimit);
+        })
+        .sum();
+    long expectedUnderBytes = task.getUnderUtilizedNodes().stream()
+        .mapToLong(n -> {
+          long capacity = n.getScmNodeStat().getCapacity().get();
+          double utilization = n.calculateUtilization();
+          return (long) (capacity * lowerLimit) - (long) (capacity * utilization);
+        })
+        .sum();
+    assertEquals(expectedOverBytes, snapshot.getTotalOverUtilizedBytes());
+    assertEquals(expectedUnderBytes, snapshot.getTotalUnderUtilizedBytes());
+    assertEquals(expectedOverBytes, snapshot.getBytesToMove());
+    assertEquals(
+        Math.max(snapshot.getTotalOverUtilizedBytes(), snapshot.getTotalUnderUtilizedBytes()) / OzoneConsts.GB,
+        task.getMetrics().getDataSizeUnbalancedGB());
+
+    List<String> expectedTopSources = task.getOverUtilizedNodes().stream()
+        .sorted(Comparator.comparingDouble((DatanodeUsageInfo n) -> n.calculateUtilization()).reversed())
+        .limit(5)
+        .map(n -> n.getDatanodeDetails().getHostName())
+        .collect(Collectors.toList());
+    List<String> expectedBottomTargets = task.getUnderUtilizedNodes().stream()
+        .sorted(Comparator.comparingDouble((DatanodeUsageInfo n) -> n.calculateUtilization()))
+        .limit(5)
+        .map(n -> n.getDatanodeDetails().getHostName())
+        .collect(Collectors.toList());
+    assertEquals(expectedTopSources, snapshot.getTopSourceNodeHostnames());
+    assertEquals(expectedBottomTargets, snapshot.getBottomTargetNodeHostnames());
   }
 
   @ParameterizedTest(name = "MockedSCM #{index}: {0}")

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
+import org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancerClusterSnapshot.NodeUtilization;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -155,18 +156,32 @@ public class TestContainerBalancerDatanodeNodeLimit {
         Math.max(snapshot.getTotalOverUtilizedBytes(), snapshot.getTotalUnderUtilizedBytes()) / OzoneConsts.GB,
         task.getMetrics().getDataSizeUnbalancedGB());
 
-    List<String> expectedTopSources = task.getOverUtilizedNodes().stream()
+    List<NodeUtilization> expectedTopSources = task.getOverUtilizedNodes().stream()
         .sorted(Comparator.comparingDouble((DatanodeUsageInfo n) -> n.calculateUtilization()).reversed())
         .limit(5)
-        .map(n -> n.getDatanodeDetails().getHostName())
+        .map(n -> new NodeUtilization(n.getDatanodeDetails().getHostName(),
+            n.calculateUtilization()))
         .collect(Collectors.toList());
-    List<String> expectedBottomTargets = task.getUnderUtilizedNodes().stream()
+    List<NodeUtilization> expectedBottomTargets = task.getUnderUtilizedNodes().stream()
         .sorted(Comparator.comparingDouble((DatanodeUsageInfo n) -> n.calculateUtilization()))
         .limit(5)
-        .map(n -> n.getDatanodeDetails().getHostName())
+        .map(n -> new NodeUtilization(n.getDatanodeDetails().getHostName(),
+            n.calculateUtilization()))
         .collect(Collectors.toList());
-    assertEquals(expectedTopSources, snapshot.getTopSourceNodeHostnames());
-    assertEquals(expectedBottomTargets, snapshot.getBottomTargetNodeHostnames());
+
+    List<NodeUtilization> actualTopSources = snapshot.getTopSourceNodes();
+    assertEquals(expectedTopSources.size(), actualTopSources.size());
+    for (int i = 0; i < expectedTopSources.size(); i++) {
+      assertEquals(expectedTopSources.get(i).getHostname(), actualTopSources.get(i).getHostname());
+      assertEquals(expectedTopSources.get(i).getUtilization(), actualTopSources.get(i).getUtilization(), 0.0001);
+    }
+
+    List<NodeUtilization> actualBottomTargets = snapshot.getBottomTargetNodes();
+    assertEquals(expectedBottomTargets.size(), actualBottomTargets.size());
+    for (int i = 0; i < expectedBottomTargets.size(); i++) {
+      assertEquals(expectedBottomTargets.get(i).getHostname(), actualBottomTargets.get(i).getHostname());
+      assertEquals(expectedBottomTargets.get(i).getUtilization(), actualBottomTargets.get(i).getUtilization(), 0.0001);
+    }
   }
 
   @ParameterizedTest(name = "MockedSCM #{index}: {0}")

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -120,8 +120,10 @@ public class TestContainerBalancerDatanodeNodeLimit {
         protos, config.getThresholdAsRatio(), config.getIncludeNodes(), config.getExcludeNodes());
 
     double taskAvg = ContainerBalancerTask.calculateAvgUtilization(eligible);
-    double upperLimit = taskAvg + config.getThresholdAsRatio();
-    double lowerLimit = taskAvg - config.getThresholdAsRatio();
+    double upperLimit = ContainerBalancerClusterAnalyzer.computeUpperLimit(
+        taskAvg, config.getThresholdAsRatio());
+    double lowerLimit = ContainerBalancerClusterAnalyzer.computeLowerLimit(
+        taskAvg, config.getThresholdAsRatio());
 
     assertEquals(eligible.size(), snapshot.getTotalEligibleDatanodes());
     assertEquals(task.getOverUtilizedNodes().size(), snapshot.getSourceCount());
@@ -134,14 +136,16 @@ public class TestContainerBalancerDatanodeNodeLimit {
         .mapToLong(n -> {
           long capacity = n.getScmNodeStat().getCapacity().get();
           double utilization = n.calculateUtilization();
-          return (long) (capacity * utilization) - (long) (capacity * upperLimit);
+          return ContainerBalancerClusterAnalyzer.overUtilizedBytes(
+              capacity, utilization, upperLimit);
         })
         .sum();
     long expectedUnderBytes = task.getUnderUtilizedNodes().stream()
         .mapToLong(n -> {
           long capacity = n.getScmNodeStat().getCapacity().get();
           double utilization = n.calculateUtilization();
-          return (long) (capacity * lowerLimit) - (long) (capacity * utilization);
+          return ContainerBalancerClusterAnalyzer.underUtilizedBytes(
+              capacity, utilization, lowerLimit);
         })
         .sum();
     assertEquals(expectedOverBytes, snapshot.getTotalOverUtilizedBytes());


### PR DESCRIPTION
## What changes were proposed in this pull request?
We are adding three new CLI commands — assessment, dry-run, and recommend — that all need the same cluster view. These commands run at client-side and fetch datanode usage info via the existing getDatanodeUsageInfo RPC.

 

This Jira builds the shared foundation that is a common module that takes datanode usage protos,

Responsibilities:

Apply include/exclude filters on the proto list
Compute cluster average utilization
Compute upper/lower utilization limits from cluster average and threshold
Compute each eligible node’s utilization (utilization = (capacity - remaining) / capacity) and classify each as source, target, or balanced by comparing with the upper/lower limits.
Accumulate source/target counts and totalOverUtilizedBytes/totalUnderUtilizedBytes
Compute MaxUtilization, MinUtilization
Compute cluster imbalance and bytes to move
Build and return ContainerBalancerClusterSnapshot
The logic should match the way the running balancer uses in ContainerBalancerTask.initializeIteration(), so CLI output and actual balancer behaviour stay consistent.

Analyzer should return an object(ContainerBalancerClusterSnapshot) containing totalEligibleDatanodes count, clusterAvgUtilization, clusterCapacityBytes, MaxUtilization, MinUtilization, upperLimit, lowerLimit, sourceCount, targetCount, totalOverUtilizedBytes, totalUnderUtilizedBytes, bytesToMove, Imbalance (drift), top 5 sourceNodes hostnames, bottom 5 targetNodes hostnames.

We should also test this analysis.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16173

## How was this patch tested?

Written Unit Tests.
