### PR TITLE
HDDS-16202. Avoid the list copy in ContainerEndpoint.getBlocks

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -745,14 +745,15 @@ public class ContainerEndpoint {
       List<OmKeyLocationInfoGroup> matchedKeys, long containerID) {
     List<ContainerBlockMetadata> blockIds = new ArrayList<>();
     for (OmKeyLocationInfoGroup omKeyLocationInfoGroup : matchedKeys) {
-      List<OmKeyLocationInfo> omKeyLocationInfos = omKeyLocationInfoGroup
-          .getLocationList()
-          .stream()
-          .filter(c -> c.getContainerID() == containerID)
-          .collect(Collectors.toList());
-      for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfos) {
-        blockIds.add(new ContainerBlockMetadata(omKeyLocationInfo
-            .getContainerID(), omKeyLocationInfo.getLocalID()));
+      for (List<OmKeyLocationInfo> omKeyLocationInfos :
+          omKeyLocationInfoGroup.getLocationLists()) {
+        for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfos) {
+          if (omKeyLocationInfo.getContainerID() == containerID) {
+            blockIds.add(new ContainerBlockMetadata(
+                omKeyLocationInfo.getContainerID(),
+                omKeyLocationInfo.getLocalID()));
+          }
+        }
       }
     }
     return blockIds;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ContainerEndpoint.getBlocks` called `OmKeyLocationInfoGroup.getLocationList()` and then `stream().filter().collect(toList())` on the result, allocating two throwaway lists per key just to walk each block once. `getLocationList()` is documented as expensive: it flattens `locationVersionMap.values()` into a brand-new `List` on every call, instead of the O(1) `getLocationLists()` accessor.

This PR rewrites `getBlocks` to iterate `getLocationLists()` directly with a nested loop and an inline containerID check, removing both list allocations. Same pattern as `OMKeyRequest.sumBlockLengths` (HDDS-16183)
and `KeyManagerImpl.refreshPipeline` (HDDS-5384). Output ordering and contents are unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16202

## How was this patch tested?

Existing tests cover `getBlocks` through the Recon `GET /api/v1/containers/:id/keys` endpoint, including block-id and pagination assertions.

The following test suite passed (2 tests):

- `TestContainerEndpoint#testGetKeysForContainer`
- `TestContainerEndpoint#testGetKeysForContainerWithPrevKey`

Also ran `checkstyle.sh` and `author.sh` successfully.