### PR TITLE
HDDS-16207. Streaming read hangs until read timeout on out-of-range ReadBlock offsets

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
@@ -351,7 +351,9 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
   synchronized void readBlock(int length, boolean preRead) throws IOException {
     final long required = position + length - requestedLength;
     final long preReadLength = preRead ? preReadSize : 0;
-    final long readLength = required + preReadLength;
+    // Clamp so requestedLength never exceeds blockLength: requesting past the end
+    // produces an offset the DataNode cannot serve, causing a read timeout.
+    final long readLength = Math.min(required + preReadLength, blockLength - requestedLength);
 
     if (readLength > 0) {
       LOG.debug("position {}, length {}, requested {}, diff {}, readLength {}, preReadSize={}",
@@ -573,6 +575,12 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
 
     @Override
     public void onNext(ContainerProtos.ContainerCommandResponseProto containerCommandResponseProto) {
+      if (containerCommandResponseProto.getResult() != ContainerProtos.Result.SUCCESS) {
+        // The datanode streamed back an error (e.g. CONTAINER_NOT_FOUND or a token failure);
+        // fail the stream now instead of waiting for the read timeout.
+        failOnErrorResponse(containerCommandResponseProto);
+        return;
+      }
       final ReadBlockResponseProto readBlock = containerCommandResponseProto.getReadBlock();
       try {
         ByteBuffer data = readBlock.getData().asReadOnlyByteBuffer();
@@ -598,13 +606,28 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
       }
     }
 
+    private void failOnErrorResponse(ContainerProtos.ContainerCommandResponseProto errorResponse) {
+      try {
+        ContainerProtocolCalls.validateContainerResponse(errorResponse);
+      } catch (StorageContainerException e) {
+        // Record the failure first: the log and observer calls below must not mask it.
+        setFailed(e);
+        LOG.warn("Failed to read block {}: result={}",
+            getBlockID().getContainerBlockID(), errorResponse.getResult(), e);
+        final StreamingReadResponse r = getResponse();
+        if (r != null) {
+          r.getRequestObserver().onError(e);
+        }
+        releaseResources();
+      }
+    }
+
     @Override
     public void onError(Throwable throwable) {
-      if (throwable instanceof StatusRuntimeException) {
-        if (((StatusRuntimeException) throwable).getStatus().getCode() == CANCELLED) {
-          // This is expected when the client cancels the stream.
-          setCompleted();
-        }
+      if (throwable instanceof StatusRuntimeException
+          && ((StatusRuntimeException) throwable).getStatus().getCode() == CANCELLED) {
+        // This is expected when the client cancels the stream.
+        setCompleted();
       } else {
         setFailed(throwable);
       }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
@@ -39,6 +39,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -56,11 +57,15 @@ import org.apache.hadoop.hdds.scm.StreamingReadResponse;
 import org.apache.hadoop.hdds.scm.StreamingReaderSpi;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.hadoop.security.token.Token;
+import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.grpc.Status;
+import org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException;
 import org.apache.ratis.thirdparty.io.grpc.stub.ClientCallStreamObserver;
 import org.junit.jupiter.api.Test;
 
@@ -742,6 +747,115 @@ public class TestStreamBlockInputStream {
       assertThat(thrown).hasRootCauseInstanceOf(OzoneChecksumException.class);
     }
     verify(requestObserver, never()).onError(any());
+  }
+
+  /**
+   * A streamed error response (e.g. CONTAINER_NOT_FOUND) must fail the read immediately
+   * instead of stalling until the stream read timeout expires.
+   */
+  @Test
+  public void testFailFastOnErrorResponseProto() throws Exception {
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    clientConfig.setMaxReadRetryCount(0);
+    BlockID blockID = new BlockID(1L, 20L);
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver =
+        mock(ClientCallStreamObserver.class);
+
+    XceiverClientGrpc xceiverClient = mockCapturingStreamingReadClient(requestObserver,
+        reader -> reader.onNext(ContainerCommandResponseProto.newBuilder()
+            .setCmdType(Type.ReadBlock)
+            .setResult(ContainerProtos.Result.CONTAINER_NOT_FOUND)
+            .setMessage("Container not found")
+            .build()));
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
+        .thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, 1024L, mockStandalonePipeline(), null, xceiverClientFactory,
+        NO_REFRESH, clientConfig)) {
+
+      ByteBuffer buf = ByteBuffer.allocate(1024);
+      final long startTime = System.nanoTime();
+      IOException thrown = assertThrows(IOException.class, () -> sbis.read(buf),
+          "an error response proto should surface as an IOException");
+      final long elapsedMillis = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
+
+      assertThat(hasCause(thrown, StorageContainerException.class)).isTrue();
+      assertThat(hasCause(thrown, TimeoutIOException.class)).isFalse();
+      assertThat(elapsedMillis).isLessThan(sbis.getReadTimeout().toMillis());
+      verify(requestObserver, times(1)).onError(any(StorageContainerException.class));
+    }
+  }
+
+  /**
+   * A server-sent gRPC status other than CANCELLED (here OUT_OF_RANGE) must fail the
+   * pending read promptly rather than waiting for the stream read timeout.
+   */
+  @Test
+  public void testFailFastOnGrpcOutOfRangeStatus() throws Exception {
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    clientConfig.setMaxReadRetryCount(0);
+    BlockID blockID = new BlockID(1L, 21L);
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver =
+        mock(ClientCallStreamObserver.class);
+
+    XceiverClientGrpc xceiverClient = mockCapturingStreamingReadClient(requestObserver,
+        reader -> reader.onError(Status.OUT_OF_RANGE.asRuntimeException()));
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
+        .thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, 1024L, mockStandalonePipeline(), null, xceiverClientFactory,
+        NO_REFRESH, clientConfig)) {
+
+      ByteBuffer buf = ByteBuffer.allocate(1024);
+      final long startTime = System.nanoTime();
+      IOException thrown = assertThrows(IOException.class, () -> sbis.read(buf),
+          "a gRPC OUT_OF_RANGE should surface as an IOException");
+      final long elapsedMillis = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
+
+      assertThat(hasCause(thrown, StatusRuntimeException.class)).isTrue();
+      assertThat(hasCause(thrown, TimeoutIOException.class)).isFalse();
+      assertThat(elapsedMillis).isLessThan(sbis.getReadTimeout().toMillis());
+    }
+  }
+
+  /**
+   * Mocks a streaming read client which captures the StreamingReaderSpi during
+   * initStreamRead and drives the given callback when a ReadBlock request is sent.
+   */
+  private XceiverClientGrpc mockCapturingStreamingReadClient(
+      ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver,
+      Consumer<StreamingReaderSpi> onStreamRead) throws Exception {
+    StreamingReadResponse streamingReadResponse = mock(StreamingReadResponse.class);
+    when(streamingReadResponse.getRequestObserver()).thenReturn(requestObserver);
+
+    AtomicReference<StreamingReaderSpi> readerRef = new AtomicReference<>();
+    XceiverClientGrpc xceiverClient = mock(XceiverClientGrpc.class);
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = inv.getArgument(1);
+      reader.setStreamingReadResponse(streamingReadResponse);
+      readerRef.set(reader);
+      return null;
+    }).when(xceiverClient).initStreamRead(any(BlockID.class), any(), any());
+
+    doAnswer(inv -> {
+      onStreamRead.accept(readerRef.get());
+      return null;
+    }).when(xceiverClient).streamRead(any(), any());
+
+    return xceiverClient;
+  }
+
+  private static boolean hasCause(Throwable throwable, Class<? extends Throwable> type) {
+    for (Throwable t = throwable; t != null; t = t.getCause()) {
+      if (type.isInstance(t)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private ReadBlockResponseProto buildReadBlockResponse(byte[] data) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -176,6 +176,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.grpc.Status;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.util.function.CheckedConsumer;
 import org.slf4j.Logger;
@@ -2343,6 +2344,16 @@ public class KeyValueHandler extends Handler {
     BlockUtils.verifyBCSId(kvContainer, blockID);
 
     final BlockData blockData = getBlockManager().getBlock(kvContainer, blockID);
+    if (readBlock.getOffset() >= blockData.getSize()) {
+      // An out of range offset is a client fault, so report it on the stream instead of throwing: throwing would be
+      // turned into a CONTAINER_INTERNAL_ERROR response by readBlock, and a non-null response makes the dispatcher
+      // scan the container as if the data were corrupt.
+      streamObserver.onError(Status.OUT_OF_RANGE
+          .withDescription("Requested offset " + readBlock.getOffset() + " is beyond the end of block " + blockID
+              + " with size " + blockData.getSize())
+          .asRuntimeException());
+      return 0;
+    }
     final List<ContainerProtos.ChunkInfo> chunkInfos = blockData.getChunks();
     final int bytesPerChunk = Math.toIntExact(chunkInfos.get(0).getLen());
     final ChecksumType checksumType = chunkInfos.get(0).getChecksumData().getType();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -35,6 +35,7 @@ import static org.apache.ozone.test.MetricsAsserts.getMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -60,6 +61,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -119,6 +121,8 @@ import org.apache.hadoop.ozone.container.ozoneimpl.OnDemandContainerScanner;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
+import org.apache.ratis.thirdparty.io.grpc.Status;
+import org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -144,6 +148,11 @@ public class TestKeyValueHandler {
   private static final String DUMMY_PATH = "dummy/dir/doesnt/exist";
   private static final String DATANODE_UUID = UUID.randomUUID().toString();
   private static final String CLUSTER_ID = UUID.randomUUID().toString();
+  // The checksum boundary readBlock aligns to when the chunk carries no checksums.
+  private static final long BYTES_PER_CHECKSUM = 1024 * 64;
+  // Deliberately not a multiple of BYTES_PER_CHECKSUM, so an offset past the end of the block can still have its
+  // checksum aligned floor inside the block.
+  private static final int BLOCK_SIZE = 1000;
 
   private HddsDispatcher dispatcher;
   private KeyValueHandler handler;
@@ -1125,6 +1134,173 @@ public class TestKeyValueHandler {
       }
       FileUtils.deleteDirectory(testDir.toFile());
       ContainerMetrics.remove();
+    }
+  }
+
+  /**
+   * An offset which is aligned to the checksum boundary but past the end of the block must be rejected before any
+   * data is streamed.
+   */
+  @Test
+  public void testReadBlockOutOfRangeAlignedOffset() throws Exception {
+    // BYTES_PER_CHECKSUM below is used when the chunk has no checksums, so this offset is checksum aligned.
+    ReadBlockResult result = readBlock(BLOCK_SIZE, BYTES_PER_CHECKSUM, 1024);
+    assertOutOfRange(result, BYTES_PER_CHECKSUM);
+  }
+
+  /**
+   * An offset past the end of the block whose checksum aligned floor still falls inside the block must be rejected
+   * as well, even though the aligned read itself would be in range.
+   */
+  @Test
+  public void testReadBlockOutOfRangeMisalignedSliver() throws Exception {
+    final long offset = BLOCK_SIZE + 500;
+    assertThat(offset - offset % BYTES_PER_CHECKSUM).isLessThan((long) BLOCK_SIZE);
+    ReadBlockResult result = readBlock(BLOCK_SIZE, offset, 1024);
+    assertOutOfRange(result, offset);
+  }
+
+  /**
+   * The first offset past the last byte of the block must be rejected.
+   */
+  @Test
+  public void testReadBlockOutOfRangeAtBlockSize() throws Exception {
+    ReadBlockResult result = readBlock(BLOCK_SIZE, BLOCK_SIZE, 1024);
+    assertOutOfRange(result, BLOCK_SIZE);
+  }
+
+  /**
+   * The last byte of the block is still in range, even if the requested length runs past the end of the block.
+   */
+  @Test
+  public void testReadBlockOutOfRangeLastByteInRange() throws Exception {
+    ReadBlockResult result = readBlock(BLOCK_SIZE, BLOCK_SIZE - 1, 1024);
+    assertNull(result.getResponse(), "ReadBlock should return null on success");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getDataResponses()).isNotEmpty();
+    for (ContainerCommandResponseProto response : result.getDataResponses()) {
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+    }
+  }
+
+  private void assertOutOfRange(ReadBlockResult result, long offset) {
+    assertNull(result.getResponse(),
+        "ReadBlock must return null so the dispatcher does not scan the container");
+    assertThat(result.getDataResponses()).isEmpty();
+    assertEquals(1, result.getErrors().size(), "Exactly one onError is expected");
+    StatusRuntimeException sre = assertInstanceOf(StatusRuntimeException.class, result.getErrors().get(0));
+    assertEquals(Status.Code.OUT_OF_RANGE, sre.getStatus().getCode());
+    assertThat(sre.getStatus().getDescription())
+        .contains(String.valueOf(result.getBlockID().getContainerID()))
+        .contains(String.valueOf(result.getBlockID().getLocalID()))
+        .contains(String.valueOf(offset))
+        .contains(String.valueOf(BLOCK_SIZE));
+  }
+
+  /**
+   * Reads a block of {@code blockSize} bytes from a real container through {@link KeyValueHandler#readBlock},
+   * collecting the streamed responses and errors.
+   */
+  private ReadBlockResult readBlock(int blockSize, long offset, long length) throws Exception {
+    Path testDir = Files.createTempDirectory("testReadBlockOutOfRange");
+    RandomAccessFileChannel blockFile = null;
+    try {
+      conf.set(OZONE_SCM_CONTAINER_LAYOUT_KEY, ContainerLayoutVersion.FILE_PER_BLOCK.name());
+      HandlerWithVolumeSet handlerWithVolume = createKeyValueHandlerWithVolumeSet(testDir);
+      KeyValueHandler kvHandler = handlerWithVolume.getHandler();
+      MutableVolumeSet volumeSet = handlerWithVolume.getVolumeSet();
+      ContainerSet containerSet = handlerWithVolume.getContainerSet();
+
+      long containerID = ContainerTestHelper.getTestContainerID();
+      KeyValueContainerData containerData = new KeyValueContainerData(
+          containerID, ContainerLayoutVersion.FILE_PER_BLOCK,
+          (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
+          DATANODE_UUID);
+      KeyValueContainer container = new KeyValueContainer(containerData, conf);
+      container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(), CLUSTER_ID);
+      containerSet.addContainer(container);
+
+      BlockID blockID = ContainerTestHelper.getTestBlockID(containerID);
+      BlockData blockData = new BlockData(blockID);
+      ChunkInfo chunkInfo = new ChunkInfo("chunk1", 0, blockSize);
+      blockData.addChunk(chunkInfo.getProtoBufMessage());
+      kvHandler.getBlockManager().putBlock(container, blockData);
+
+      ChunkBuffer data = ChunkBuffer.wrap(ByteBuffer.allocate(blockSize));
+      kvHandler.getChunkManager().writeChunk(container, blockID, chunkInfo, data,
+          DispatcherContext.getHandleWriteChunk());
+
+      ContainerCommandRequestProto readBlockRequest =
+          ContainerCommandRequestProto.newBuilder()
+              .setCmdType(ContainerProtos.Type.ReadBlock)
+              .setContainerID(containerID)
+              .setDatanodeUuid(DATANODE_UUID)
+              .setReadBlock(ContainerProtos.ReadBlockRequestProto.newBuilder()
+                  .setBlockID(blockID.getDatanodeBlockIDProtobuf())
+                  .setOffset(offset)
+                  .setLength(length)
+                  .build())
+              .build();
+
+      ReadBlockResult result = new ReadBlockResult(blockID);
+      blockFile = new RandomAccessFileChannel();
+      result.setResponse(kvHandler.readBlock(readBlockRequest, container, blockFile, result));
+      return result;
+    } finally {
+      if (blockFile != null) {
+        blockFile.close();
+      }
+      FileUtils.deleteDirectory(testDir.toFile());
+      ContainerMetrics.remove();
+    }
+  }
+
+  /**
+   * Collects everything a single readBlock call produced: the streamed data responses, the errors and the response
+   * proto returned by the handler.
+   */
+  private static final class ReadBlockResult implements StreamObserver<ContainerCommandResponseProto> {
+    private final BlockID blockID;
+    private final List<ContainerCommandResponseProto> dataResponses = new ArrayList<>();
+    private final List<Throwable> errors = new ArrayList<>();
+    private ContainerCommandResponseProto response;
+
+    ReadBlockResult(BlockID blockID) {
+      this.blockID = blockID;
+    }
+
+    @Override
+    public void onNext(ContainerCommandResponseProto dataResponse) {
+      dataResponses.add(dataResponse);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      errors.add(t);
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+
+    BlockID getBlockID() {
+      return blockID;
+    }
+
+    List<ContainerCommandResponseProto> getDataResponses() {
+      return dataResponses;
+    }
+
+    List<Throwable> getErrors() {
+      return errors;
+    }
+
+    ContainerCommandResponseProto getResponse() {
+      return response;
+    }
+
+    void setResponse(ContainerCommandResponseProto response) {
+      this.response = response;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-16207. Streaming read hangs until read timeout on out-of-range ReadBlock offsets

Please describe your PR in detail:
When a streaming read (StreamBlockInputStream / ReadBlock) requests an offset at or past the end of the block, the client does not get an error or an EOF — it blocks until the stream read timeout (default PT10S) expires. 
The fix includes:
1. clamp readLength in readBlock() so requestedLength never exceeds blockLength
2. have the datanode reject a ReadBlock whose raw offset is >= block size with gRPC OUT_OF_RANGE via streamObserver.onError (not a thrown exception, so the client fault is not converted to CONTAINER_INTERNAL_ERROR or treated as container corruption by the dispatcher)
3. make StreamingReader fail the stream immediately on non-SUCCESS response protos and on non-CANCELLED gRPC errors.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16207

## How was this patch tested?
1. UT coverage
2. HBase cluster with root dir pointed to Ozone FS under YCSB workloads. 