### PR TITLE
HDDS-16142. Fix double-decrement of deleted-block summary on Ratis timeout

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMDeletedBlockTransactionStatusManager.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
@@ -468,6 +469,9 @@ public class SCMDeletedBlockTransactionStatusManager {
       try {
         deletedBlockLogStateManager.addTransactionsToDB(txList, getSummary());
       } catch (IOException e) {
+        if (isRatisTimeout(e)) {
+          throw e;
+        }
         // Revert the in-memory changes if the DB update fails
         for (DeletedBlocksTransaction tx: txList) {
           if (tx.hasTotalBlockSize()) {
@@ -480,6 +484,21 @@ public class SCMDeletedBlockTransactionStatusManager {
       return;
     }
     deletedBlockLogStateManager.addTransactionsToDB(txList);
+  }
+
+  private static boolean isRatisTimeout(IOException e) {
+    if (!(e instanceof SCMException)) {
+      return false;
+    }
+    SCMException.ResultCodes code = ((SCMException) e).getResult();
+    if (code == SCMException.ResultCodes.TIMEOUT) {
+      return true;
+    }
+    if (code == SCMException.ResultCodes.INTERNAL_ERROR) {
+      Throwable cause = e.getCause();
+      return cause instanceof InterruptedException;
+    }
+    return false;
   }
 
   private void rollbackDeletedBlocksSummary(TxBlockInfo txBlockInfo) {
@@ -516,6 +535,9 @@ public class SCMDeletedBlockTransactionStatusManager {
       try {
         deletedBlockLogStateManager.removeTransactionsFromDB(txIDs, getSummary());
       } catch (IOException e) {
+        if (isRatisTimeout(e)) {
+          throw e;
+        }
         // Revert the in-memory changes if the DB update fails
         for (TxBlockInfo txBlockInfo : removedTxBlockInfos) {
           txSizeMap.put(txBlockInfo.getTxId(), txBlockInfo);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -21,11 +21,14 @@ import static org.apache.hadoop.hdds.scm.block.SCMDeletedBlockTransactionStatusM
 import static org.apache.hadoop.ozone.common.BlockGroup.SIZE_NOT_AVAILABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -72,6 +75,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMHADBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.ha.SCMHADBTransactionBufferStub;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
@@ -944,6 +948,170 @@ public class TestDeletedBlockLog {
     when(containerManager.getContainerReplicas(
         ContainerID.valueOf(containerID)))
         .thenReturn(replicaSet);
+  }
+
+  private SCMException ratisTimeout() {
+    return new SCMException("Simulated Ratis submit timeout", SCMException.ResultCodes.TIMEOUT);
+  }
+
+  private SCMException hardDbFailure() {
+    return new SCMException("Simulated hard DB failure", SCMException.ResultCodes.IO_EXCEPTION);
+  }
+
+  private DeletedBlocksTransaction buildTx(long txId, long containerId, long blockSize, long blockCount) {
+    return DeletedBlocksTransaction.newBuilder()
+        .setTxID(txId)
+        .setContainerID(containerId)
+        .setCount(0)
+        .addLocalID(1L)
+        .setTotalBlockSize(blockSize * blockCount)
+        .setTotalBlockReplicatedSize(blockSize * blockCount * 3L)
+        .build();
+  }
+
+  /**
+   * Ratis timeout on addTransactionsToDB: the abandoned future may still commit,
+   * so the in-memory increment must NOT be rolled back (HDDS-16142).
+   */
+  @Test
+  public void testSummaryDoesNotDoubleDecrementOnRatisSubmitTimeout() throws IOException {
+    long txId = 1L;
+    long containerId = 100L;
+    long blockSize = 64L * 1024 * 1024;
+    long blockCount = 5L;
+    ArrayList<DeletedBlocksTransaction> txList = new ArrayList<>();
+    txList.add(buildTx(txId, containerId, blockSize, blockCount));
+
+    DeletedBlockLogStateManager mockStateManager = mock(DeletedBlockLogStateManager.class);
+    doThrow(ratisTimeout()).when(mockStateManager).addTransactionsToDB(any(ArrayList.class), any());
+
+    SCMDeletedBlockTransactionStatusManager statusManager =
+        new SCMDeletedBlockTransactionStatusManager(
+            mockStateManager,
+            scm.getScmMetadataStore().getStatefulServiceConfigTable(),
+            containerManager, metrics, Long.MAX_VALUE);
+
+    assertThrows(IOException.class, () -> statusManager.addTransactions(txList));
+    // Increment must NOT be rolled back: the late commit can still apply.
+    assertEquals(1, statusManager.getSummary().getTotalTransactionCount(),
+        "Ratis timeout on add: summary must stay incremented (no rollback)");
+
+    // Simulate the late Ratis commit landing and the tx being found by getTransactions.
+    statusManager.getTxSizeMap().put(txId,
+        new TxBlockInfo(txId, containerId, blockCount, blockSize * blockCount, blockSize * blockCount * 3L));
+    ArrayList<Long> txIds = new ArrayList<>();
+    txIds.add(txId);
+    statusManager.removeTransactions(txIds);
+
+    assertEquals(0, statusManager.getSummary().getTotalTransactionCount(),
+        "One add (no rollback) + one remove must yield 0, not -1");
+  }
+
+  /**
+   * Hard DB failure on addTransactionsToDB: the write definitively did not land,
+   * so the in-memory increment must be rolled back.
+   */
+  @Test
+  public void testSummaryRollsBackOnHardAddFailure() throws IOException {
+    long txId = 3L;
+    long containerId = 300L;
+    long blockSize = 16L * 1024 * 1024;
+    long blockCount = 2L;
+    ArrayList<DeletedBlocksTransaction> txList = new ArrayList<>();
+    txList.add(buildTx(txId, containerId, blockSize, blockCount));
+
+    DeletedBlockLogStateManager mockStateManager = mock(DeletedBlockLogStateManager.class);
+    doThrow(hardDbFailure()).when(mockStateManager).addTransactionsToDB(any(ArrayList.class), any());
+
+    SCMDeletedBlockTransactionStatusManager statusManager =
+        new SCMDeletedBlockTransactionStatusManager(
+            mockStateManager,
+            scm.getScmMetadataStore().getStatefulServiceConfigTable(),
+            containerManager, metrics, Long.MAX_VALUE);
+
+    assertThrows(IOException.class, () -> statusManager.addTransactions(txList));
+    // Hard failure: write did not land, rollback must restore summary to 0.
+    assertEquals(0, statusManager.getSummary().getTotalTransactionCount(),
+        "Hard add failure: summary must be rolled back to 0");
+  }
+
+  /**
+   * Ratis timeout on removeTransactionsFromDB: the abandoned future may still commit
+   * and remove the tx durably, so the in-memory decrement must NOT be rolled back (HDDS-16142).
+   */
+  @Test
+  public void testSummaryDoesNotOvercountOnRatisRemoveTimeout() throws IOException {
+    long txId = 2L;
+    long containerId = 200L;
+    long blockSize = 32L * 1024 * 1024;
+    long blockCount = 3L;
+
+    DeletedBlockLogStateManager mockStateManager = mock(DeletedBlockLogStateManager.class);
+
+    SCMDeletedBlockTransactionStatusManager statusManager =
+        new SCMDeletedBlockTransactionStatusManager(
+            mockStateManager,
+            scm.getScmMetadataStore().getStatefulServiceConfigTable(),
+            containerManager, metrics, Long.MAX_VALUE);
+
+    statusManager.addTransactions(new ArrayList<>(
+        Collections.singletonList(buildTx(txId, containerId, blockSize, blockCount))));
+    assertEquals(1, statusManager.getSummary().getTotalTransactionCount());
+
+    statusManager.getTxSizeMap().put(txId,
+        new TxBlockInfo(txId, containerId, blockCount, blockSize * blockCount, blockSize * blockCount * 3L));
+
+    doThrow(ratisTimeout()).when(mockStateManager).removeTransactionsFromDB(any(ArrayList.class), any());
+
+    ArrayList<Long> txIds = new ArrayList<>();
+    txIds.add(txId);
+    assertThrows(IOException.class, () -> statusManager.removeTransactions(txIds));
+
+    // Decrement must NOT be rolled back: the late commit may have removed the tx.
+    assertEquals(0, statusManager.getSummary().getTotalTransactionCount(),
+        "Ratis timeout on remove: summary must stay decremented (no rollback)");
+    // txSizeMap must also not be restored (same reasoning).
+    assertFalse(statusManager.getTxSizeMap().containsKey(txId),
+        "Ratis timeout on remove: txSizeMap entry must not be restored");
+  }
+
+  /**
+   * Hard DB failure on removeTransactionsFromDB: the write definitively did not land,
+   * so the in-memory decrement must be rolled back and txSizeMap restored.
+   */
+  @Test
+  public void testSummaryRollsBackOnHardRemoveFailure() throws IOException {
+    long txId = 4L;
+    long containerId = 400L;
+    long blockSize = 8L * 1024 * 1024;
+    long blockCount = 4L;
+
+    DeletedBlockLogStateManager mockStateManager = mock(DeletedBlockLogStateManager.class);
+
+    SCMDeletedBlockTransactionStatusManager statusManager =
+        new SCMDeletedBlockTransactionStatusManager(
+            mockStateManager,
+            scm.getScmMetadataStore().getStatefulServiceConfigTable(),
+            containerManager, metrics, Long.MAX_VALUE);
+
+    statusManager.addTransactions(new ArrayList<>(
+        Collections.singletonList(buildTx(txId, containerId, blockSize, blockCount))));
+    assertEquals(1, statusManager.getSummary().getTotalTransactionCount());
+
+    statusManager.getTxSizeMap().put(txId,
+        new TxBlockInfo(txId, containerId, blockCount, blockSize * blockCount, blockSize * blockCount * 3L));
+
+    doThrow(hardDbFailure()).when(mockStateManager).removeTransactionsFromDB(any(ArrayList.class), any());
+
+    ArrayList<Long> txIds = new ArrayList<>();
+    txIds.add(txId);
+    assertThrows(IOException.class, () -> statusManager.removeTransactions(txIds));
+
+    // Hard failure: write did not land, rollback must restore summary to 1.
+    assertEquals(1, statusManager.getSummary().getTotalTransactionCount(),
+        "Hard remove failure: summary must be rolled back to 1");
+    assertTrue(statusManager.getTxSizeMap().containsKey(txId),
+        "Hard remove failure: txSizeMap entry must be restored for retry");
   }
 
   private void mockInadequateReplicaUnhealthyContainerInfo(long containerID,


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-15726 introduced rollback logic that reverts those counters on IOException from addTransactionsToDB / removeTransactionsFromDB. That is correct for definitive failures (not-leader, connection error,
state-machine IO error), but wrong for a Ratis timeout.

SCMRatisServerImpl.submitRequest calls server.submitClientRequestAsync(request).get(requestTimeout, ms)

A TimeoutException from .get() only abandons the client-side wait. The CompletableFuture is discarded, but the in-flight log entry continues through the Ratis pipeline and can still be committed and applied after the caller has already seen the exception.  Rolling back the summary at that point produces:
  - a double-decrement on the add path (summary goes negative), or
  - an overcount on the remove path (summary stays inflated).

Both divergences persist until the next leader transfer, which reconciles the counters by reloading from the durable state via
initDataDistributionData().

### Fix
Introduce isRatisTimeout(IOException) to distinguish ambiguous outcomes from definitive failures.  The check covers two cases:
  - SCMException(ResultCodes.TIMEOUT): translateException maps a java.util.concurrent.TimeoutException to this code.
  - SCMException(ResultCodes.INTERNAL_ERROR) whose cause is InterruptedException: .get() can also throw InterruptedException if the thread is interrupted while waiting; the request is already in-flight, giving the same ambiguous outcome as a timeout.

## What is the link to the Apache JIRA

HDDS-16142

## How was this patch tested?

Tested by added cases and existing tests.
