### PR TITLE
HDDS-16150. Fix error code in testS3LifecycleConfigurationCreationFailed

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -2549,7 +2549,7 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
             .bucket(bucketName)
             .lifecycleConfiguration(configuration)));
     assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, exception.statusCode());
-    assertEquals(S3ErrorTable.INVALID_REQUEST.getCode(), exception.awsErrorDetails().errorCode());
+    assertEquals(S3ErrorTable.INVALID_ARGUMENT.getCode(), exception.awsErrorDetails().errorCode());
 
     // Test 2: Non-existent bucket
     final String nonExistentBucket = getBucketName("nonexistent");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix error code in the new test method which was introduced in https://github.com/apache/ozone/pull/10986, It seems that https://github.com/apache/ozone/pull/11003 missed rebasing on top of #10986 and thus missed to change the error code in `testS3LifecycleConfigurationCreationFailed` test

Failure: https://github.com/apache/ozone/actions/runs/32106730115/job/95621289054

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16150

## How was this patch tested?

https://github.com/krvikash/ozone/actions/runs/32133497720
