### PR TITLE
HDDS-16218. Fix SCM HA log messages that drop values and stack traces

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -321,8 +321,8 @@ public class SCMHAManagerImpl implements SCMHAManager {
       // this exception. In this way reinitialize can throw exception to
       // ratis to handle properly.
       LOG.error("Failed to install Snapshot as SCM failed to replace"
-          + " DB with downloaded checkpoint. Checkpoint transaction {}", e,
-          checkpointTxnInfo.getTransactionIndex());
+          + " DB with downloaded checkpoint. Checkpoint transaction {}",
+          checkpointTxnInfo.getTransactionIndex(), e);
       throw e;
     }
 
@@ -341,8 +341,8 @@ public class SCMHAManagerImpl implements SCMHAManager {
           dbBackup =
               HAUtils.replaceDBWithCheckpoint(lastAppliedIndex, oldDBLocation,
                   dbBackup.toPath(), OzoneConsts.SCM_DB_BACKUP_PREFIX);
-          LOG.error("Replacing SCM state with Term : {} and Index:",
-              termIndex.getTerm(), termIndex.getTerm());
+          LOG.error("Replacing SCM state with Term: {} and Index: {}",
+              termIndex.getTerm(), termIndex.getIndex());
           // This is being done to check before stop with old db
           // try to reload and then finally terminate and also test has
           // assumption for re-verify after corrupt DB loading without

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -356,7 +356,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
       if (raftClientReply.isSuccess()) {
         LOG.info("Successfully added new SCM: {}.", request.getScmId());
       } else {
-        LOG.error("Failed to add new SCM: {}. Ratis reply: {}" +
+        LOG.error("Failed to add new SCM: {}. Ratis reply: {}",
             request.getScmId(), raftClientReply);
         throw new IOException(raftClientReply.getException());
       }
@@ -392,7 +392,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
       if (raftClientReply.isSuccess()) {
         LOG.info("Successfully removed SCM: {}.", request.getScmId());
       } else {
-        LOG.error("Failed to remove SCM: {}. Ratis reply: {}" +
+        LOG.error("Failed to remove SCM: {}. Ratis reply: {}",
             request.getScmId(), raftClientReply);
         throw new IOException(raftClientReply.getException());
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Four log statements in the SCM HA code print something other than what they promise, and all of them are on failure paths. The checkpoint-install failure line advertises the checkpoint transaction index but shows the exception's text in its place, because SLF4J only treats the final argument as a throwable — so the index is dropped and that line carries no stack trace of its own. The revert path a few lines later never prints an index either: its message has one placeholder for two values, so the state SCM fell back to goes unrecorded before the process terminates. In `addSCM` and `removeSCM` the SCM id is concatenated onto the format string instead of being passed as an argument, which leaves the Ratis reply in the slot meant for the id:

```
Failed to add new SCM: <ratis reply>. Ratis reply: {}<scmId>
```

These paths run only once something has already gone wrong, which is when an operator needs the values they omit. Behaviour is unchanged; only the rendered messages differ.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16218

## How was this patch tested?

`mvn -pl :hdds-server-scm test -Dtest=TestSCMHAManagerImpl` passes (3 tests; the class exercises the `addSCM`/`removeSCM` paths), and `checkstyle:check` on the module reports no violations. The rendering was verified against slf4j-reload4j 2.0.18, the binding Ozone ships: with the exception ahead of the index, `MessageFormatter` extracts no throwable, the index appears nowhere and no trace is logged; with the order corrected, the index renders and the trace is attached. No test asserts any of these strings, so none is added for text-only changes.

Generated-by: Claude Code (Claude Opus 5)
