### PR TITLE
HDDS-1159. Fix flaky testGetMatchingContainerMultipleThreads

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -224,7 +224,7 @@ public class TestContainerStateManagerIntegration {
   @Test
   @Flaky("HDDS-1159")
   public void testGetMatchingContainerMultipleThreads()
-      throws IOException, InterruptedException {
+      throws IOException {
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
         allocateContainer(SCMTestUtils.getReplicationType(conf),
             SCMTestUtils.getReplicationFactor(conf), OzoneConsts.OZONE);
@@ -234,8 +234,9 @@ public class TestContainerStateManagerIntegration {
 
     // allocate blocks using multiple threads
     int numBlockAllocates = 100000;
+    CompletableFuture<?>[] futures = new CompletableFuture[numBlockAllocates];
     for (int i = 0; i < numBlockAllocates; i++) {
-      CompletableFuture.supplyAsync(() -> {
+      futures[i] = CompletableFuture.supplyAsync(() -> {
         ContainerInfo info = containerManager
             .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
                 container1.getPipeline());
@@ -244,12 +245,12 @@ public class TestContainerStateManagerIntegration {
         return null;
       }, executor);
     }
+    CompletableFuture.allOf(futures).join();
 
     // make sure pipeline has has numContainerPerOwnerInPipeline number of
     // containers.
     assertEquals(numContainerPerOwnerInPipeline, scm.getPipelineManager()
             .getNumberOfContainers(container1.getPipeline().getId()));
-    Thread.sleep(5000);
     long threshold = 2000;
     // check the way the block allocations are distributed in the different
     // containers.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -31,8 +31,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -49,7 +51,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -222,9 +223,8 @@ public class TestContainerStateManagerIntegration {
   }
 
   @Test
-  @Flaky("HDDS-1159")
   public void testGetMatchingContainerMultipleThreads()
-      throws IOException {
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
         allocateContainer(SCMTestUtils.getReplicationType(conf),
             SCMTestUtils.getReplicationFactor(conf), OzoneConsts.OZONE);
@@ -245,7 +245,7 @@ public class TestContainerStateManagerIntegration {
         return null;
       }, executor);
     }
-    CompletableFuture.allOf(futures).join();
+    CompletableFuture.allOf(futures).get(60, TimeUnit.SECONDS);
 
     // make sure pipeline has has numContainerPerOwnerInPipeline number of
     // containers.


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestContainerStateManagerIntegration#testGetMatchingContainerMultipleThreads` was tagged `@Flaky("HDDS-1159")` because it intermittently failed with `expected: <3> but was: <2>` (occasionally `<1>`) at the pipeline container-count assertion.

**Root cause:** the test fires 100,000 `CompletableFuture.supplyAsync(...)` calls to `ContainerManager.getMatchingContainer` on a 4-thread pool, then immediately asserts that the pipeline already has `numContainerPerOwnerInPipeline` (3) containers without joining those futures. The loop finishing only means the tasks were submitted. When the pool has not yet allocated the 2nd/3rd container, the assertion fails. The existing `Thread.sleep(5000)` runs *after* the assertion, so it never stabilizes it.

This is a test timing issue: `getMatchingContainer` already serializes allocation on `pipeline.getId()`. Reproduced at 2.5% (5/200) via `flaky-test-check` (10×20), matching the historical Jira signature.

This PR waits for the work to finish before asserting:

* Collect the 100k futures and `CompletableFuture.allOf(...).join()` before checking container count.
* Remove the misplaced `Thread.sleep(5000)` and the unused `InterruptedException` on the method.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-1159

## How was this patch tested?

* Full class: all 7 tests pass.
* Pre-fix baseline: 2.5% (5/200)
  https://github.com/shuan1026/ozone/actions/runs/31984414534
* Post-fix: 0/200 failures
  https://github.com/shuan1026/ozone/actions/runs/32152547832