### PR TITLE
HDDS-16209. KeyLifecycleService leaks inFlight entry when a task runs while shouldRun() is false

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
@@ -466,6 +466,11 @@ public class KeyLifecycleService extends BackgroundService {
         }
 
         onSuccess(bucketKey);
+      } else {
+        // The task was registered in inFlight when scheduled, but the service got suspended/disabled
+        // or lost leadership before the task ran. Clear the registration, otherwise this bucket is
+        // skipped as "already running" in every following getTasks() cycle.
+        inFlight.remove(bucketKey);
       }
 
       // By design, no one cares about the results of this call back.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -92,6 +92,8 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.hdds.utils.BackgroundTask;
+import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.db.DBConfigFromFile;
 import org.apache.hadoop.hdds.utils.db.RocksDatabaseException;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -527,6 +529,44 @@ class TestKeyLifecycleService extends OzoneTestBase {
       // confirm it hasn't deleted all keys
       assertEquals(testKeyCount - expectedDeleted, getKeyCount(bucketLayout) - initialKeyCount);
       deleteLifecyclePolicy(volumeName, bucketName);
+    }
+
+    @Test
+    void testInFlightClearedWhenTaskSkipsRun() throws Exception {
+      final String volumeName = getTestName();
+      final String bucketName = uniqueObjectName("bucket");
+
+      keyLifecycleService.suspend();
+      createVolumeAndBucket(volumeName, bucketName, BucketLayout.OBJECT_STORE,
+          UserGroupInformation.getCurrentUser().getShortUserName());
+      ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(EXPIRE_SECONDS);
+      createLifecyclePolicy(volumeName, bucketName, BucketLayout.OBJECT_STORE, "key", null, date.toString(), true);
+      String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
+
+      try {
+        // Schedule the task manually. The service's own scheduler may win the registration and run
+        // the task to completion; in that case getTasks() returns nothing, so retry until this
+        // thread holds the scheduled task.
+        keyLifecycleService.resume();
+        BackgroundTaskQueue queue = keyLifecycleService.getTasks();
+        for (int i = 0; queue.isEmpty() && i < 200; i++) {
+          Thread.sleep(WAIT_CHECK_INTERVAL);
+          queue = keyLifecycleService.getTasks();
+        }
+        assertFalse(queue.isEmpty());
+
+        // Suspend before the scheduled task executes, then run it: call() skips the scan because
+        // shouldRun() is false, but must still clear the in-flight registration, otherwise the
+        // bucket is never scheduled again.
+        keyLifecycleService.suspend();
+        for (BackgroundTask task = queue.poll(); task != null; task = queue.poll()) {
+          task.call();
+        }
+        assertFalse(keyLifecycleService.status().getRunningBucketsList().contains(bucketKey));
+      } finally {
+        keyLifecycleService.resume();
+        deleteLifecyclePolicy(volumeName, bucketName);
+      }
     }
 
     @ParameterizedTest


### PR DESCRIPTION

## What changes were proposed in this pull request?
HDDS-16209. KeyLifecycleService leaks inFlight entry when a task runswhile shouldRun() is false, permanently blocking the bucket
KeyLifecycleService registers a bucket in the inFlight map when a LifecycleActionTask is scheduled, and removes it when the task finishes scanning. However, if the service is suspended, disabled, or loses OM leadership between scheduling and execution, LifecycleActionTask.call() returns early because shouldRun() is false, without removing the bucket from inFlight. Since nothing else ever clears that entry, every subsequent getTasks() cycle skips the bucket as "already running", so lifecycle actions for that bucket are permanently blocked until the OM restarts.

  The fix adds an else branch in LifecycleActionTask.call(): when shouldRun() is false and the scan is skipped, the bucket's inFlight registration is removed so the bucket can be scheduled again on the next cycle.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16209

## How was this patch tested?
Unit test has been added to reproduce the scenario. Passed with the fix. 