### PR TITLE
HDDS-16208. Cache out-of-order streaming ReadBlock responses instead of discarding them to avoid client poll timeout

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
@@ -24,7 +24,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -229,6 +231,9 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
     LOG.debug("{}: seek {} -> {}", getName(streamingReader), position, pos);
     readBuffer = reuseReadBuffer(readBuffer, pos);
     position = pos;
+    if (streamingReader != null) {
+      streamingReader.clearPendingProtosBelow(pos);
+    }
     if (readBuffer == null) {
       // Only rewind the request high-watermark when the buffered (already requested/served) data cannot be reused;
       // otherwise we would re-request data that is still buffered.
@@ -486,6 +491,15 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
     /** Response queue: poll is blocking while offer is non-blocking. */
     private final BlockingQueue<ReadBlockResponseProto> responseQueue = new LinkedBlockingQueue<>();
 
+    /**
+     * Responses received ahead of the current position, keyed by their block offset.
+     * Concurrent readers on the datanode may complete out of order, so a response covering a later
+     * offset can arrive before the one covering the current position. Such a response is kept here
+     * instead of being discarded, and served once the reader reaches its offset.
+     * Only accessed from the read path, which holds the {@link StreamBlockInputStream} lock.
+     */
+    private final TreeMap<Long, ReadBlockResponseProto> pendingProtos = new TreeMap<>();
+
     private final CompletableFuture<Void> future = new CompletableFuture<>();
     private final AtomicBoolean semaphoreReleased = new AtomicBoolean(false);
     private final AtomicReference<StreamingReadResponse> response = new AtomicReference<>();
@@ -539,6 +553,12 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
 
     private ReadBuffer read(int length, boolean preRead) throws IOException {
       checkError();
+      // A previously cached out-of-order response may already cover the current position.
+      final ReadBuffer cached = pollPendingProtos();
+      if (cached != null) {
+        LOG.debug("{}: read(length={}, preRead={}) returns cached {}", name, length, preRead, cached);
+        return cached;
+      }
       if (future.isDone()) {
         // Don't return null while items remain in the queue. onNext() may have delivered items just before
         // onCompleted() fired.
@@ -556,6 +576,14 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
         if (proto == null) {
           return null;
         }
+        if (getPos() < proto.getOffset()) {
+          // Out-of-order response: the chunk covering the current position is still in flight.
+          // Cache this one instead of dropping it, otherwise its data would be lost for good.
+          LOG.debug("{}: caching out-of-order response at offset {}, position {}",
+              name, proto.getOffset(), getPos());
+          pendingProtos.put(proto.getOffset(), proto);
+          continue;
+        }
         final ByteBuffer buffer = getByteBuffer(proto, getPos());
         final ReadBuffer read = buffer != null ? new ReadBuffer(proto, buffer) : null;
         if (hasRemaining(read)) {
@@ -563,6 +591,34 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
           return read;
         }
       }
+    }
+
+    /**
+     * Returns the smallest cached response that covers the current position, or null when the
+     * cache is empty or its first entry is still ahead of the reader. Entries the reader has
+     * already advanced past are dropped.
+     */
+    private ReadBuffer pollPendingProtos() {
+      while (!pendingProtos.isEmpty()) {
+        final Map.Entry<Long, ReadBlockResponseProto> first = pendingProtos.firstEntry();
+        final long pos = getPos();
+        if (pos < first.getKey()) {
+          return null;
+        }
+        pendingProtos.pollFirstEntry();
+        final ByteBuffer buffer = getByteBuffer(first.getValue(), pos);
+        final ReadBuffer read = buffer != null ? new ReadBuffer(first.getValue(), buffer) : null;
+        if (hasRemaining(read)) {
+          return read;
+        }
+      }
+      return null;
+    }
+
+    /** Drops cached responses whose data ends at or before the given block offset. */
+    private void clearPendingProtosBelow(long blockOffset) {
+      pendingProtos.headMap(blockOffset, true).values()
+          .removeIf(p -> p.getOffset() + p.getData().size() <= blockOffset);
     }
 
     private void releaseResources() {

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
@@ -744,6 +744,118 @@ public class TestStreamBlockInputStream {
     verify(requestObserver, never()).onError(any());
   }
 
+  /**
+   * Concurrent chunk readers on the datanode serve pre-read requests in non-deterministic order, so
+   * a response covering a later offset can arrive before the one covering the current position. The
+   * later response must be cached and served once the reader reaches its offset. It used to be
+   * dropped, leaving the reader waiting for data that is never resent until the read times out.
+   */
+  @Test
+  public void testOutOfOrderResponseIsCachedAndServed() throws Exception {
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    clientConfig.setStreamReadResponseDataSize(4);
+    // Short timeout so a regression fails fast instead of waiting for the default timeout.
+    clientConfig.setStreamReadTimeout(Duration.ofMillis(200));
+    BlockID blockID = new BlockID(1L, 17L);
+    long length = 8;
+    Pipeline pipeline = mockStandalonePipeline();
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver =
+        mock(ClientCallStreamObserver.class);
+    StreamingReadResponse streamingReadResponse = mock(StreamingReadResponse.class);
+    when(streamingReadResponse.getRequestObserver()).thenReturn(requestObserver);
+
+    AtomicReference<StreamingReaderSpi> readerRef = new AtomicReference<>();
+    XceiverClientGrpc xceiverClient = mock(XceiverClientGrpc.class);
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = inv.getArgument(1);
+      reader.setStreamingReadResponse(streamingReadResponse);
+      readerRef.set(reader);
+      return null;
+    }).when(xceiverClient).initStreamRead(any(BlockID.class), any(), any());
+
+    AtomicInteger streamReads = new AtomicInteger();
+    doAnswer(inv -> {
+      if (streamReads.getAndIncrement() == 0) {
+        StreamingReaderSpi reader = readerRef.get();
+        // The chunk at offset 4 completes first, before the chunk covering position 0.
+        reader.onNext(buildResponseProto(new byte[]{4, 5, 6, 7}, 4));
+        reader.onNext(buildResponseProto(new byte[]{0, 1, 2, 3}, 0));
+      }
+      return null;
+    }).when(xceiverClient).streamRead(any(), any());
+
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
+        .thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, length, pipeline, null, xceiverClientFactory,
+        NO_REFRESH, clientConfig)) {
+      byte[] out = new byte[8];
+      assertEquals(8, sbis.read(out, 0, 8), "the out-of-order response must not be dropped");
+      assertArrayEquals(new byte[]{0, 1, 2, 3, 4, 5, 6, 7}, out);
+      assertEquals(1, streamReads.get(), "cached data must be served without re-requesting it");
+    }
+  }
+
+  /**
+   * A cached out-of-order response must not be served after the reader has seeked past it.
+   */
+  @Test
+  public void testCachedResponseIsNotServedAfterForwardSeek() throws Exception {
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    clientConfig.setStreamReadResponseDataSize(4);
+    clientConfig.setStreamReadTimeout(Duration.ofMillis(200));
+    BlockID blockID = new BlockID(1L, 18L);
+    long length = 12;
+    Pipeline pipeline = mockStandalonePipeline();
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver =
+        mock(ClientCallStreamObserver.class);
+    StreamingReadResponse streamingReadResponse = mock(StreamingReadResponse.class);
+    when(streamingReadResponse.getRequestObserver()).thenReturn(requestObserver);
+
+    AtomicReference<StreamingReaderSpi> readerRef = new AtomicReference<>();
+    XceiverClientGrpc xceiverClient = mock(XceiverClientGrpc.class);
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = inv.getArgument(1);
+      reader.setStreamingReadResponse(streamingReadResponse);
+      readerRef.set(reader);
+      return null;
+    }).when(xceiverClient).initStreamRead(any(BlockID.class), any(), any());
+
+    AtomicInteger streamReads = new AtomicInteger();
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = readerRef.get();
+      if (streamReads.getAndIncrement() == 0) {
+        // The chunk at offset 4 completes before the chunk covering position 0 and is cached.
+        reader.onNext(buildResponseProto(new byte[]{4, 5, 6, 7}, 4));
+        reader.onNext(buildResponseProto(new byte[]{0, 1, 2, 3}, 0));
+      } else {
+        reader.onNext(buildResponseProto(new byte[]{8, 9, 10, 11}, 8));
+      }
+      return null;
+    }).when(xceiverClient).streamRead(any(), any());
+
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
+        .thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, length, pipeline, null, xceiverClientFactory,
+        NO_REFRESH, clientConfig)) {
+      byte[] first = new byte[4];
+      assertEquals(4, sbis.read(first, 0, 4));
+      assertArrayEquals(new byte[]{0, 1, 2, 3}, first);
+
+      sbis.seek(8);
+
+      byte[] second = new byte[4];
+      assertEquals(4, sbis.read(second, 0, 4));
+      assertArrayEquals(new byte[]{8, 9, 10, 11}, second,
+          "the cached chunk the reader seeked past must not be served");
+    }
+  }
+
   private ReadBlockResponseProto buildReadBlockResponse(byte[] data) {
     return ReadBlockResponseProto.newBuilder()
         .setOffset(0)


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-16208. Cache out-of-order streaming ReadBlock responses instead of discarding them to avoid client poll timeout
StreamBlockInputStream assumes that streaming ReadBlock responses arrive in offset order. However, concurrent chunk readers on the datanode serve pre-read requests in non-deterministic order, so a response covering a later offset can arrive before the one covering the current position. When that happened, the reader dropped the out-of-order response after taking it from the response queue. Since the datanode never resends that data, the client was then stuck waiting for a chunk that would never arrive again, and the read eventually failed with a poll timeout.

This PR makes the client keep such responses instead of discarding them:

- StreamingReader gains a pendingProtos TreeMap keyed by block offset. When read() polls a response whose offset is ahead of the current position, the response is cached there instead of being dropped.
- On every read(), the cache is checked first (pollPendingProtos()): the smallest cached entry covering the current position is served directly, without re-requesting the data from the datanode. Entries the reader has already advanced past are dropped.
- seek() clears cached entries whose data ends at or before the new position (clearPendingProtosBelow()), so a chunk the reader seeked past is never served and does not leak memory.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16208

## How was this patch tested?
Two UTs has been added
Real cluster with HBase on top of Ozone FS with ReadBlock enabled under YCSB workloads. 