### PR TITLE
HDDS-16211. Avoid the throwaway list copy in OMAllocateBlockRequest quota check

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -216,7 +216,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
       long preAllocatedKeySize = newLocationList.size()
           * ozoneManager.getScmBlockSize();
       long hadAllocatedKeySize =
-          openKeyInfo.getLatestVersionLocations().getLocationList().size()
+          openKeyInfo.getLatestVersionLocations().getLocationListCount()
               * ozoneManager.getScmBlockSize();
       ReplicationConfig repConfig = openKeyInfo.getReplicationConfig();
       long totalAllocatedSpace = QuotaUtil.getReplicatedSize(


### PR DESCRIPTION
## What changes were proposed in this pull request?
OMAllocateBlockRequest.validateAndUpdateCache computes the already-allocated key size only to multiply by the block size, but calls getLocationList() (documented as not O(1)) purely to read size(), then discards the list — on every block allocation, under the bucket write lock:

long hadAllocatedKeySize =
    openKeyInfo.getLatestVersionLocations().getLocationList().size()
        * ozoneManager.getScmBlockSize();
Fix: use getLocationListCount() (values().stream().mapToLong(List::size).sum()), which returns the same total with no allocation. The result already widens to long for the multiplication, so the value is unchanged. Behavior unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16211

## How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/32219890598