### PR TITLE
HDDS-16134. Fix flaky testPipelineExclusionWithPipelineFailure

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -537,7 +537,8 @@ public class TestFailureHandlingByClient {
       assertThat(keyOutputStream.getExcludeList().getPipelineIds())
           .contains(pipeline.getId());
       assertThat(keyOutputStream.getExcludeList().getContainerIds()).isEmpty();
-      assertThat(keyOutputStream.getExcludeList().getDatanodes()).isEmpty();
+      // Datanodes are not asserted: watchForCommit can time out against the two shut down
+      // followers, which then get recorded as failed servers and added to the exclude list.
       // The close will just write to the buffer
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
@@ -185,8 +185,8 @@ public class TestFailureHandlingByClientFlushDelay {
       key.write(data.getBytes(UTF_8));
       key.flush();
       assertThat(keyOutputStream.getExcludeList().getContainerIds()).isEmpty();
-      assertThat(keyOutputStream.getExcludeList().getDatanodes()).isEmpty();
-      assertThat(keyOutputStream.getExcludeList().getDatanodes()).isEmpty();
+      // Datanodes are not asserted: watchForCommit can time out against the two shut down
+      // followers, which then get recorded as failed servers and added to the exclude list.
       key.write(data.getBytes(UTF_8));
       // The close will just write to the buffer
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testPipelineExclusionWithPipelineFailure` intermittently fails on the `getDatanodes()` assertion:

```
Expecting empty but was: [c587cf9d-ea5d-466b-a23b-e96f6cfca97f(null/null)]
```

The test shuts down two of the three datanodes, so `watchForCommit` can time out and report them as failed servers. `KeyOutputStream.handleExceptionInternal` adds those to the exclude list independently of the pipeline exclusion the test is actually checking, so an empty datanode set is not an invariant here - it just depends on whether the watch reply lands first.

This drops the `getDatanodes()` assertion. The pipeline assertion, which is the property under test, stays.

Same fix as HDDS-15823 (a8fcb09c02), which removed the equivalent assertions from `testContainerExclusionWithClosedContainerException` in this file.

## What is the link to the Apache Jira

https://issues.apache.org/jira/browse/HDDS-16134

## How was this patch tested?

`flaky-test-check` 10x10 (100 runs), all splits green:
https://github.com/Eason09053360/ozone/actions/runs/32264781480

checkstyle clean.

Generated-by: Claude Code (Claude Opus 5)