### PR TITLE
HDDS-16223. Remove racy pre-condition assertion in TestRefreshVolumeUsageHandler

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
@@ -102,10 +102,6 @@ public class TestRefreshVolumeUsageHandler {
       //a new key is created, but the datanode default REFRESH_PERIOD is 1 hour,
       //still the cache is updated, so the scm will eventually get the new
       //used space from the datanode through node report.
-      assertTrue(cluster.getStorageContainerManager()
-          .getScmNodeManager().getUsageInfo(datanodeDetails)
-          .getScmNodeStat().getScmUsed().isEqual(currentScmUsed));
-
       try {
         GenericTestUtils.waitFor(() -> isUsageInfoRefreshed(cluster,
             datanodeDetails, currentScmUsed), 500, 5 * 1000);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The test sets HDDS_NODE_REPORT_INTERVAL to 1s, so the datanode node report can reach SCM between key.close() and the assertion that SCM still shows the pre-write used space, making assertTrue(...getScmUsed().isEqual(baseline)) intermittently fail (expected true but was false). That pre-condition asserts a transient not-yet-propagated state and adds no coverage; the intended behavior (SCM eventually reflects the increased used space) is already verified by the following waitFor and assertTrue(...isGreater(baseline)). Remove the racy assertion.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16223

## How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/32255956955/

https://github.com/rich7420/ozone/actions/runs/32255725038