### PR TITLE
HDDS-16205. Avoid the duplicate list copy in S3MultipartUploadCompleteRequest.getMultipartDataSize

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -691,10 +691,11 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
           .getKeyLocationVersions().get(0);
 
       // Set partNumber in each block.
-      currentKeyInfoGroup.getLocationList().forEach(
-          omKeyLocationInfo -> omKeyLocationInfo.setPartNumber(partNumber));
-
-      partLocationInfos.addAll(currentKeyInfoGroup.getLocationList());
+      currentKeyInfoGroup.getLocationLists().forEach(locationList -> {
+        locationList.forEach(
+            omKeyLocationInfo -> omKeyLocationInfo.setPartNumber(partNumber));
+        partLocationInfos.addAll(locationList);
+      });
       dataSize += currentPartKeyInfo.getDataSize();
     }
     return dataSize;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`S3MultipartUploadCompleteRequest.getMultipartDataSize` calls `OmKeyLocationInfoGroup.getLocationList()` twice for the same version group per MPU part: once to set `partNumber` on each block, and again to `addAll` those same blocks into `partLocationInfos`. `getLocationList()` is documented as expensive: it flatten-copies `locationVersionMap.values()` into a brand-new `ArrayList` on every call. Since `OmKeyLocationInfo` is a mutable object, the second call re-flattens the same data the first call already produced, just to read it once more.

Replaces both calls with a single `getLocationLists()` walk of the live, uncopied `Collection<List<OmKeyLocationInfo>>` view of `locationVersionMap.values()`, setting `partNumber` and doing `addAll` in one pass per inner list. Zero list copies instead of two, same `forEach` idiom as before.

Same accessor-usage fix already applied in `KeyManagerImpl.refreshPipeline` (HDDS-5384), `ContainerEndpoint.getBlocks` (HDDS-16202), and `ContainerToKeyMapping.getContainers` (HDDS-16204). Behavior and ordering are unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16205

## How was this patch tested?

The following test suites passed (16 tests):

- TestS3MultipartUploadCompleteRequest
- TestS3MultipartUploadCompleteRequestWithFSO

Also ran checkstyle.sh and author.sh successfully.
Fork CI (build-branch) for this branch: https://github.com/shuan1026/ozone/actions/runs/32261921025