### PR TITLE
HDDS-16037. Support Storage Tier per pipeline in Ozone Admin Datanode List Command

### DIFF
--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.client.StorageTier;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
@@ -204,14 +205,15 @@ public class ListInfoSubcommand extends ScmSubcommand {
             .append(System.lineSeparator());
       } else {
         relatedPipelineNum = relatedPipelines.size();
-        relatedPipelines.forEach(
-            p -> pipelineListInfo.append(p.getId().getId().toString())
-                .append('/').append(p.getReplicationConfig().toString())
-                .append('/').append(p.getType().toString())
-                .append('/').append(p.getPipelineState().toString()).append('/')
-                .append(datanode.getID().equals(p.getLeaderId()) ?
-                    "Leader" : "Follower")
-                .append(System.lineSeparator()));
+        relatedPipelines.forEach(p -> {
+          pipelineListInfo.append(p.getId().getId().toString())
+              .append('/').append(p.getReplicationConfig().toString())
+              .append('/').append(p.getType().toString())
+              .append('/').append(p.getPipelineState().toString())
+              .append('/').append(datanode.getID().equals(p.getLeaderId()) ? "Leader" : "Follower")
+              .append('/').append(formatSupportedStorageTier(p.getSupportedStorageTier()))
+              .append(System.lineSeparator());
+        });
       }
     } else {
       pipelineListInfo
@@ -242,5 +244,9 @@ public class ListInfoSubcommand extends ScmSubcommand {
       System.out.println("Used: " + dn.getUsed());
       System.out.printf("Percentage Used : %.2f%%%n%n", dn.getPercentUsed());
     }
+  }
+
+  private static String formatSupportedStorageTier(StorageTier tier) {
+    return tier == null ? "[]" : "[" + tier.getTierName() + "]";
   }
 }

--- a/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -205,15 +205,14 @@ public class ListInfoSubcommand extends ScmSubcommand {
             .append(System.lineSeparator());
       } else {
         relatedPipelineNum = relatedPipelines.size();
-        relatedPipelines.forEach(p -> {
-          pipelineListInfo.append(p.getId().getId().toString())
-              .append('/').append(p.getReplicationConfig().toString())
-              .append('/').append(p.getType().toString())
-              .append('/').append(p.getPipelineState().toString())
-              .append('/').append(datanode.getID().equals(p.getLeaderId()) ? "Leader" : "Follower")
-              .append('/').append(formatSupportedStorageTier(p.getSupportedStorageTier()))
-              .append(System.lineSeparator());
-        });
+        relatedPipelines.forEach(
+            p -> pipelineListInfo.append(p.getId().getId().toString())
+                .append('/').append(p.getReplicationConfig().toString())
+                .append('/').append(p.getType().toString())
+                .append('/').append(p.getPipelineState().toString())
+                .append('/').append(datanode.getID().equals(p.getLeaderId()) ? "Leader" : "Follower")
+                .append('/').append(formatSupportedStorageTier(p.getSupportedStorageTier()))
+                .append(System.lineSeparator()));
       }
     } else {
       pipelineListInfo

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
@@ -40,13 +40,20 @@ import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StorageTier;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import picocli.CommandLine;
 
 /**
@@ -457,6 +464,54 @@ public class TestListInfoSubcommand {
         assertTrue(ratio1 >= ratio2, "Expected descending order, got: " + ratio1 + " < " + ratio2);
       }
     }
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = StorageTier.class, names = {"EMPTY"}, mode = EnumSource.Mode.EXCLUDE)
+  public void testRelatedPipelineShowsStorageTier(StorageTier tier) throws Exception {
+    List<HddsProtos.Node> nodes = getNodeDetails();
+    HddsProtos.Node node = nodes.get(0);
+
+    ScmClient scmClient = mock(ScmClient.class);
+    when(scmClient.queryNode(any(), any(), any(), any())).thenReturn(nodes);
+    when(scmClient.listPipelines()).thenReturn(
+        Collections.singletonList(pipelineContaining(node, tier)));
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs();
+    cmd.execute(scmClient);
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertThat(output).contains("/[" + tier.getTierName() + "]");
+  }
+
+  @Test
+  public void testRelatedPipelineOmitsTierWhenNull() throws Exception {
+    List<HddsProtos.Node> nodes = getNodeDetails();
+    HddsProtos.Node node = nodes.get(0);
+
+    ScmClient scmClient = mock(ScmClient.class);
+    when(scmClient.queryNode(any(), any(), any(), any())).thenReturn(nodes);
+    when(scmClient.listPipelines()).thenReturn(
+        Collections.singletonList(pipelineContaining(node, null)));
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs();
+    cmd.execute(scmClient);
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertThat(output).contains("/[]").doesNotContain("null");
+  }
+
+  private Pipeline pipelineContaining(HddsProtos.Node node, StorageTier tier) {
+    DatanodeDetails dn = DatanodeDetails.getFromProtoBuf(node.getNodeID());
+    return Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
+        .setState(Pipeline.PipelineState.OPEN)
+        .setNodes(Collections.singletonList(dn))
+        .setSupportedStorageTier(tier)
+        .build();
   }
 
   private List<HddsProtos.Node> getNodeDetails() {

--- a/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
+++ b/hadoop-ozone/cli-admin/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
@@ -482,7 +482,8 @@ public class TestListInfoSubcommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertThat(output).contains("/[" + tier.getTierName() + "]");
+    assertThat(output).containsPattern(
+        "[^/]+/[^/]+/[^/]+/[^/]+/(Leader|Follower)/\\[" + tier.getTierName() + "\\]");
   }
 
   @Test
@@ -500,7 +501,31 @@ public class TestListInfoSubcommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertThat(output).contains("/[]").doesNotContain("null");
+    assertThat(output).containsPattern(
+        "[^/]+/[^/]+/[^/]+/[^/]+/(Leader|Follower)/\\[\\]").doesNotContain("null");
+  }
+
+  @Test
+  public void testRelatedPipelineShowsLeaderAndFollower() throws Exception {
+    List<HddsProtos.Node> nodes = getNodeDetails();
+    List<HddsProtos.Node> pipelineNodes = nodes.subList(0, 2);
+    DatanodeDetails leader = DatanodeDetails.getFromProtoBuf(pipelineNodes.get(0).getNodeID());
+
+    ScmClient scmClient = mock(ScmClient.class);
+    when(scmClient.queryNode(any(), any(), any(), any())).thenReturn(nodes);
+    when(scmClient.listPipelines()).thenReturn(
+        Collections.singletonList(pipelineContaining(pipelineNodes, leader, StorageTier.SSD)));
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs();
+    cmd.execute(scmClient);
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    String tierName = StorageTier.SSD.getTierName();
+    assertThat(output).containsPattern(
+        "[^/]+/[^/]+/[^/]+/[^/]+/Leader/\\[" + tierName + "\\]");
+    assertThat(output).containsPattern(
+        "[^/]+/[^/]+/[^/]+/[^/]+/Follower/\\[" + tierName + "\\]");
   }
 
   private Pipeline pipelineContaining(HddsProtos.Node node, StorageTier tier) {
@@ -510,6 +535,21 @@ public class TestListInfoSubcommand {
         .setReplicationConfig(RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setState(Pipeline.PipelineState.OPEN)
         .setNodes(Collections.singletonList(dn))
+        .setSupportedStorageTier(tier)
+        .build();
+  }
+
+  private Pipeline pipelineContaining(List<HddsProtos.Node> nodes, DatanodeDetails leader, StorageTier tier) {
+    List<DatanodeDetails> dns = new ArrayList<>();
+    for (HddsProtos.Node node : nodes) {
+      dns.add(DatanodeDetails.getFromProtoBuf(node.getNodeID()));
+    }
+    return Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
+        .setState(Pipeline.PipelineState.OPEN)
+        .setNodes(dns)
+        .setLeaderId(leader.getID())
         .setSupportedStorageTier(tier)
         .build();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The command `ozone admin datanode list` includes all the pipelines a given node is part of. But, the supported `storageTier` of every pipeline is not displayed. This PR adds the supported `storageTier` when printing related pipelines.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16037

## How was this patch tested?

1. Unit Test
2. Functional validation:
```
bash-5.1$ ozone admin datanode list
Datanode: 930e5429-88e2-4575-91f1-09dd5693bcc3 (/default-rack/172.18.0.9/ozone-datanode-disk-2.ozone_default/2 pipelines)
Operational State: IN_SERVICE
Health State: HEALTHY
Total volume count: 1
Healthy volume count: 1
Related pipelines:
d9b3eb02-9447-4558-a7e3-6a5b57da95ed/RATIS/THREE/RATIS/ALLOCATED/Follower/[DISK]
42f4899f-5db9-445d-81a0-2c65ba7ad6a2/RATIS/ONE/RATIS/OPEN/Leader/[DISK]

Datanode: dbab6522-e04b-4951-ad47-c26c0f4bd5c6 (/default-rack/172.18.0.8/ozone-datanode-disk-1.ozone_default/2 pipelines)
Operational State: IN_SERVICE
Health State: HEALTHY
Total volume count: 1
Healthy volume count: 1
Related pipelines:
d9b3eb02-9447-4558-a7e3-6a5b57da95ed/RATIS/THREE/RATIS/ALLOCATED/Follower/[DISK]
c4326157-5f26-44d2-bdf1-4117a7e91c46/RATIS/ONE/RATIS/OPEN/Leader/[DISK]

Datanode: 404f9115-040b-4f91-a1e5-13f681299be7 (/default-rack/172.18.0.6/ozone-datanode-disk-3.ozone_default/2 pipelines)
Operational State: IN_SERVICE
Health State: HEALTHY
Total volume count: 1
Healthy volume count: 1
Related pipelines:
d9b3eb02-9447-4558-a7e3-6a5b57da95ed/RATIS/THREE/RATIS/ALLOCATED/Follower/[DISK]
b9e88083-19ac-4e1b-9390-9672c817d65f/RATIS/ONE/RATIS/OPEN/Leader/[DISK]
```

Generated using Cursor