### PR TITLE
HDDS-11421. Invalid token generated by "ozone dtutil get" command

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -24,6 +24,8 @@ Suite Setup         Get Security Enabled From Config
 
 *** Variables ***
 ${TOKEN_FILE}    ${TEMP_DIR}/ozone.token
+${DTUTIL_OFS_TOKEN_FILE}    ${TEMP_DIR}/dtutil-ofs.token
+${DTUTIL_O3_TOKEN_FILE}     ${TEMP_DIR}/dtutil-o3.token
 
 *** Keywords ***
 Get and use Token in Secure Cluster
@@ -48,6 +50,13 @@ Get Token in Unsecure Cluster
 Print Valid Token File
     ${output} =                  Execute             ozone sh token print -t ${TOKEN_FILE}
     Should Not Be Empty          ${output}
+
+Get Token With Dtutil
+    [Arguments]                  ${uri}    ${token_file}
+    Remove File                  ${token_file}
+    Execute                      ozone dtutil get ${uri} ${token_file}
+    ${output} =                  Execute             ozone dtutil print ${token_file}
+    Should Contain               ${output}           OzoneToken
 
 Print Nonexistent Token File
     ${output} =                  Execute             ozone sh token print -t /asdf
@@ -74,6 +83,8 @@ Cancel Token in Unsecure Cluster
 Token Test in Secure Cluster
     Get and use Token in Secure Cluster
     Print Valid Token File
+    Get Token With Dtutil        ofs://${OM_SERVICE_ID}/    ${DTUTIL_OFS_TOKEN_FILE}
+    Get Token With Dtutil        o3://${OM_SERVICE_ID}/     ${DTUTIL_O3_TOKEN_FILE}
     Renew Token in Secure Cluster
     Cancel Token in Secure Cluster
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/AbstractOzoneDtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/AbstractOzoneDtFetcher.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import java.io.IOException;
+import java.net.URI;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.DtFetcher;
+import org.apache.hadoop.security.token.Token;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base DT fetcher for Ozone URL schemes.
+ */
+abstract class AbstractOzoneDtFetcher implements DtFetcher {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(AbstractOzoneDtFetcher.class);
+
+  private static final String FETCH_FAILED =
+      "Fetch ozone delegation token failed";
+
+  @Override
+  public boolean isTokenRequired() {
+    return UserGroupInformation.isSecurityEnabled();
+  }
+
+  @Override
+  public Token<?> addDelegationTokens(Configuration conf, Credentials creds,
+      String renewer, String url) throws Exception {
+    if (!url.startsWith(getServiceName().toString())) {
+      url = getServiceName().toString() + "://" + url;
+    }
+    return addDelegationTokens(conf, creds, renewer, URI.create(url));
+  }
+
+  protected Token<?> addDelegationTokens(Configuration conf, Credentials creds,
+      String renewer, URI uri) throws IOException {
+    LOG.debug("addDelegationTokens from {} renewer {}.", uri, renewer);
+    FileSystem fs = FileSystem.get(uri, conf);
+    Token<?> token = fs.getDelegationToken(renewer);
+    if (token == null) {
+      LOG.error(FETCH_FAILED);
+      throw new IOException(FETCH_FAILED);
+    }
+    creds.addToken(token.getService(), token);
+    return token;
+  }
+}

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/AbstractOzoneDtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/AbstractOzoneDtFetcher.java
@@ -46,8 +46,9 @@ abstract class AbstractOzoneDtFetcher implements DtFetcher {
   @Override
   public Token<?> addDelegationTokens(Configuration conf, Credentials creds,
       String renewer, String url) throws Exception {
-    if (!url.startsWith(getServiceName().toString())) {
-      url = getServiceName().toString() + "://" + url;
+    String serviceName = getServiceName().toString();
+    if (!url.startsWith(serviceName + "://")) {
+      url = serviceName + "://" + url;
     }
     return addDelegationTokens(conf, creds, renewer, URI.create(url));
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3DtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3DtFetcher.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.security.token.Token;
 /**
  * A DT fetcher for Ozone RPC URLs.
  */
-public class O3DtFetcher extends O3fsDtFetcher {
+public class O3DtFetcher extends AbstractOzoneDtFetcher {
   @Override
   public Text getServiceName() {
     return new Text(OzoneConsts.OZONE_RPC_SCHEME);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3DtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3DtFetcher.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import java.net.URI;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.token.Token;
+
+/**
+ * A DT fetcher for Ozone RPC URLs.
+ */
+public class O3DtFetcher extends O3fsDtFetcher {
+  @Override
+  public Text getServiceName() {
+    return new Text(OzoneConsts.OZONE_RPC_SCHEME);
+  }
+
+  @Override
+  public Token<?> addDelegationTokens(Configuration conf, Credentials creds,
+      String renewer, String url) throws Exception {
+    String serviceName = getServiceName().toString();
+    if (!url.startsWith(serviceName + "://")) {
+      url = serviceName + "://" + url;
+    }
+    URI uri = URI.create(url);
+    if (uri.getAuthority() == null) {
+      throw new IllegalArgumentException(
+          "OM authority is required in Ozone RPC URL: " + url);
+    }
+    URI ofsUri = new URI(OzoneConsts.OZONE_OFS_URI_SCHEME,
+        uri.getAuthority(), "/", null, null);
+    return addDelegationTokens(conf, creds, renewer, ofsUri);
+  }
+}

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3DtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3DtFetcher.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import java.io.IOException;
 import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -34,19 +35,14 @@ public class O3DtFetcher extends AbstractOzoneDtFetcher {
   }
 
   @Override
-  public Token<?> addDelegationTokens(Configuration conf, Credentials creds,
-      String renewer, String url) throws Exception {
-    String serviceName = getServiceName().toString();
-    if (!url.startsWith(serviceName + "://")) {
-      url = serviceName + "://" + url;
-    }
-    URI uri = URI.create(url);
+  protected Token<?> addDelegationTokens(Configuration conf, Credentials creds,
+      String renewer, URI uri) throws IOException {
     if (uri.getAuthority() == null) {
       throw new IllegalArgumentException(
-          "OM authority is required in Ozone RPC URL: " + url);
+          "OM authority is required in Ozone RPC URL: " + uri);
     }
-    URI ofsUri = new URI(OzoneConsts.OZONE_OFS_URI_SCHEME,
-        uri.getAuthority(), "/", null, null);
-    return addDelegationTokens(conf, creds, renewer, ofsUri);
+    URI ofsUri = URI.create(OzoneConsts.OZONE_OFS_URI_SCHEME + "://"
+        + uri.getRawAuthority() + "/");
+    return super.addDelegationTokens(conf, creds, renewer, ofsUri);
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3fsDtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3fsDtFetcher.java
@@ -70,8 +70,13 @@ public class O3fsDtFetcher implements DtFetcher {
     if (!url.startsWith(getServiceName().toString())) {
       url = getServiceName().toString() + "://" + url;
     }
-    LOG.debug("addDelegationTokens from {} renewer {}.", url, renewer);
-    FileSystem fs = FileSystem.get(URI.create(url), conf);
+    return addDelegationTokens(conf, creds, renewer, URI.create(url));
+  }
+
+  protected Token<?> addDelegationTokens(Configuration conf, Credentials creds,
+      String renewer, URI uri) throws IOException {
+    LOG.debug("addDelegationTokens from {} renewer {}.", uri, renewer);
+    FileSystem fs = FileSystem.get(uri, conf);
     Token<?> token = fs.getDelegationToken(renewer);
     if (token == null) {
       LOG.error(FETCH_FAILED);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3fsDtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/O3fsDtFetcher.java
@@ -17,31 +17,15 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import java.io.IOException;
-import java.net.URI;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.security.Credentials;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.token.DtFetcher;
-import org.apache.hadoop.security.token.Token;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A DT fetcher for OzoneFileSystem.
  * It is only needed for the `hadoop dtutil` command.
  */
-public class O3fsDtFetcher implements DtFetcher {
-  private static final Logger LOG =
-      LoggerFactory.getLogger(O3fsDtFetcher.class);
-
+public class O3fsDtFetcher extends AbstractOzoneDtFetcher {
   private static final String SERVICE_NAME = OzoneConsts.OZONE_URI_SCHEME;
-
-  private static final String FETCH_FAILED =
-      "Fetch ozone delegation token failed";
 
   /**
    * Returns the service name for O3fs, which is also a valid URL prefix.
@@ -49,40 +33,5 @@ public class O3fsDtFetcher implements DtFetcher {
   @Override
   public Text getServiceName() {
     return new Text(SERVICE_NAME);
-  }
-
-  @Override
-  public boolean isTokenRequired() {
-    return UserGroupInformation.isSecurityEnabled();
-  }
-
-  /**
-   *  Returns Token object via FileSystem, null if bad argument.
-   *  @param conf - a Configuration object used with FileSystem.get()
-   *  @param creds - a Credentials object to which token(s) will be added
-   *  @param renewer  - the renewer to send with the token request
-   *  @param url  - the URL to which the request is sent
-   *  @return a Token, or null if fetch fails.
-   */
-  @Override
-  public Token<?> addDelegationTokens(Configuration conf, Credentials creds,
-      String renewer, String url) throws Exception {
-    if (!url.startsWith(getServiceName().toString())) {
-      url = getServiceName().toString() + "://" + url;
-    }
-    return addDelegationTokens(conf, creds, renewer, URI.create(url));
-  }
-
-  protected Token<?> addDelegationTokens(Configuration conf, Credentials creds,
-      String renewer, URI uri) throws IOException {
-    LOG.debug("addDelegationTokens from {} renewer {}.", uri, renewer);
-    FileSystem fs = FileSystem.get(uri, conf);
-    Token<?> token = fs.getDelegationToken(renewer);
-    if (token == null) {
-      LOG.error(FETCH_FAILED);
-      throw new IOException(FETCH_FAILED);
-    }
-    creds.addToken(token.getService(), token);
-    return token;
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OfsDtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OfsDtFetcher.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 /**
  * A DT fetcher for RootedOzoneFileSystem.
  */
-public class OfsDtFetcher extends O3fsDtFetcher {
+public class OfsDtFetcher extends AbstractOzoneDtFetcher {
   @Override
   public Text getServiceName() {
     return new Text(OzoneConsts.OZONE_OFS_URI_SCHEME);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OfsDtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OfsDtFetcher.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.OzoneConsts;
+
+/**
+ * A DT fetcher for RootedOzoneFileSystem.
+ */
+public class OfsDtFetcher extends O3fsDtFetcher {
+  @Override
+  public Text getServiceName() {
+    return new Text(OzoneConsts.OZONE_OFS_URI_SCHEME);
+  }
+}

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneDtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneDtFetcher.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.stream.Stream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.token.DtFetcher;
+import org.apache.hadoop.security.token.Token;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+
+/**
+ * Tests Ozone delegation token fetchers.
+ */
+public class TestOzoneDtFetcher {
+  private static final String RENEWER = "renewer";
+
+  @ParameterizedTest
+  @MethodSource("fetchers")
+  public void fetchesTokenFromExpectedFileSystem(DtFetcher fetcher,
+      String url, URI expectedUri) throws Exception {
+    Configuration conf = new OzoneConfiguration();
+    Credentials creds = new Credentials();
+    FileSystem fs = mock(FileSystem.class);
+    Token<?> token = new Token<>();
+    Text service = new Text("om-service");
+    token.setService(service);
+    doReturn(token).when(fs).getDelegationToken(RENEWER);
+
+    try (MockedStatic<FileSystem> fileSystems = mockStatic(FileSystem.class)) {
+      fileSystems.when(() -> FileSystem.get(expectedUri, conf)).thenReturn(fs);
+
+      assertSame(token,
+          fetcher.addDelegationTokens(conf, creds, RENEWER, url));
+      assertSame(token, creds.getToken(service));
+      fileSystems.verify(() -> FileSystem.get(expectedUri, conf));
+    }
+  }
+
+  private static Stream<Arguments> fetchers() {
+    return Stream.of(
+        Arguments.of(new O3fsDtFetcher(),
+            "o3fs://bucket.volume.om/key",
+            URI.create("o3fs://bucket.volume.om/key")),
+        Arguments.of(new OfsDtFetcher(),
+            "ofs://om/volume/bucket/key",
+            URI.create("ofs://om/volume/bucket/key")),
+        Arguments.of(new O3DtFetcher(),
+            "o3://om-service/volume/bucket/key",
+            URI.create("ofs://om-service/")),
+        Arguments.of(new O3DtFetcher(),
+            "o3://om:9862/volume/bucket/key?query#fragment",
+            URI.create("ofs://om:9862/")));
+  }
+
+  @Test
+  public void hasExpectedServiceNames() {
+    assertEquals(new Text("o3fs"), new O3fsDtFetcher().getServiceName());
+    assertEquals(new Text("ofs"), new OfsDtFetcher().getServiceName());
+    assertEquals(new Text("o3"), new O3DtFetcher().getServiceName());
+  }
+
+  @Test
+  public void rejectsO3UrlWithoutAuthority() {
+    O3DtFetcher fetcher = new O3DtFetcher();
+    assertThrows(IllegalArgumentException.class,
+        () -> fetcher.addDelegationTokens(new OzoneConfiguration(),
+            new Credentials(), RENEWER, "o3:///"));
+  }
+
+  @Test
+  public void rejectsNullToken() throws Exception {
+    Configuration conf = new OzoneConfiguration();
+    Credentials creds = new Credentials();
+    FileSystem fs = mock(FileSystem.class);
+    URI uri = URI.create("ofs://om/");
+    doReturn(null).when(fs).getDelegationToken(RENEWER);
+
+    try (MockedStatic<FileSystem> fileSystems = mockStatic(FileSystem.class)) {
+      fileSystems.when(() -> FileSystem.get(uri, conf)).thenReturn(fs);
+      assertThrows(IOException.class,
+          () -> new OfsDtFetcher().addDelegationTokens(
+              conf, creds, RENEWER, uri.toString()));
+    }
+  }
+}

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneDtFetcher.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneDtFetcher.java
@@ -80,8 +80,31 @@ public class TestOzoneDtFetcher {
             "o3://om-service/volume/bucket/key",
             URI.create("ofs://om-service/")),
         Arguments.of(new O3DtFetcher(),
+            "om-service/volume/bucket/key",
+            URI.create("ofs://om-service/")),
+        Arguments.of(new O3DtFetcher(),
             "o3://om:9862/volume/bucket/key?query#fragment",
             URI.create("ofs://om:9862/")));
+  }
+
+  @Test
+  public void checksFullServiceNamePrefix() throws Exception {
+    AbstractOzoneDtFetcher fetcher = new AbstractOzoneDtFetcher() {
+      @Override
+      public Text getServiceName() {
+        return new Text("o3");
+      }
+
+      @Override
+      protected Token<?> addDelegationTokens(Configuration conf,
+          Credentials creds, String renewer, URI uri) {
+        assertEquals(URI.create("o3://o3fs://bucket.volume.om/key"), uri);
+        return null;
+      }
+    };
+
+    fetcher.addDelegationTokens(new OzoneConfiguration(), new Credentials(),
+        RENEWER, "o3fs://bucket.volume.om/key");
   }
 
   @Test

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/resources/META-INF/services/org.apache.hadoop.security.token.DtFetcher
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/resources/META-INF/services/org.apache.hadoop.security.token.DtFetcher
@@ -17,3 +17,5 @@
 #
 
 org.apache.hadoop.fs.ozone.O3fsDtFetcher
+org.apache.hadoop.fs.ozone.OfsDtFetcher
+org.apache.hadoop.fs.ozone.O3DtFetcher

--- a/hadoop-ozone/ozonefs/src/main/resources/META-INF/services/org.apache.hadoop.security.token.DtFetcher
+++ b/hadoop-ozone/ozonefs/src/main/resources/META-INF/services/org.apache.hadoop.security.token.DtFetcher
@@ -17,3 +17,5 @@
 #
 
 org.apache.hadoop.fs.ozone.O3fsDtFetcher
+org.apache.hadoop.fs.ozone.OfsDtFetcher
+org.apache.hadoop.fs.ozone.O3DtFetcher

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestDtFetcherProviders.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestDtFetcherProviders.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.ServiceLoader;
@@ -36,8 +36,6 @@ public class TestDtFetcherProviders {
       serviceNames.add(fetcher.getServiceName().toString());
     }
 
-    assertTrue(serviceNames.contains("o3fs"));
-    assertTrue(serviceNames.contains("ofs"));
-    assertTrue(serviceNames.contains("o3"));
+    assertThat(serviceNames).contains("o3", "ofs", "o3fs");
   }
 }

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestDtFetcherProviders.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestDtFetcherProviders.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+import org.apache.hadoop.security.token.DtFetcher;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests Ozone delegation token fetcher registrations.
+ */
+public class TestDtFetcherProviders {
+  @Test
+  public void loadsOzoneDtFetchers() {
+    Set<String> serviceNames = new HashSet<>();
+    for (DtFetcher fetcher : ServiceLoader.load(DtFetcher.class)) {
+      serviceNames.add(fetcher.getServiceName().toString());
+    }
+
+    assertTrue(serviceNames.contains("o3fs"));
+    assertTrue(serviceNames.contains("ofs"));
+    assertTrue(serviceNames.contains("o3"));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
`ozone dtutil get` previously generated an empty credentials file when an `o3://` or `ofs://` URL was used. Only `O3fsDtFetcher` was registered, so Hadoop `dtutil` could not find a delegation token fetcher matching the `o3` or `ofs` scheme.

This PR:
- adds and registers `OfsDtFetcher` for `ofs://` URLs;
- adds and registers `O3DtFetcher` for `o3://` URLs;
- refactors the shared token-fetching logic into a package-private AbstractOzoneDtFetcher, making O3fsDtFetcher, OfsDtFetcher, and O3DtFetcher sibling scheme providers;
- maps the OM authority from an o3:// URL to an ofs:// URI before invoking the shared FileSystem-based delegation token retrieval path;
- preserves support for OM HA service IDs and direct host/port authorities;
- adds unit tests for scheme handling, URI conversion, token storage, missing authorities, and failed token retrieval;
- adds tests verifying that all Ozone `DtFetcher` providers can be loaded through `ServiceLoader`;
- adds secure smoke coverage for generating and printing tokens with both `o3://` and `ofs://` URLs.

The change is client-side only and does not modify OM behavior or the delegation token format.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11421

## How was this patch tested?

Local Test (Unit Test)

```shell
mvn -pl :ozone-filesystem-common test \
 -Dtest=TestOzoneDtFetcher \
 -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/32243533098

Generated-by: Codex (GPT-5)
