### PR TITLE
HDDS-16227. Aborted LifecycleActionTask should not mark scan state completed

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
@@ -440,9 +440,7 @@ public class KeyLifecycleService extends BackgroundService {
             boolean scanFinished = !scanAborted;
             if (expiredKeyList.isEmpty() && expiredDirList.isEmpty()) {
               LOG.info("No expired keys/dirs found/remained for bucket {}", bucketKey);
-              if (scanFinished || test) {
-                sendSaveScanStateRequest(scanStateBuilder, scanFinished);
-              }
+              sendSaveScanStateRequest(scanStateBuilder, scanFinished);
             } else {
               LOG.info("{} expired keys and {} expired dirs found and remained for bucket {}",
                   expiredKeyList.size(), expiredDirList.size(), bucketKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
@@ -311,6 +311,7 @@ public class KeyLifecycleService extends BackgroundService {
 
     private long lastStateSaveTime = Time.monotonicNow();
     private long lastStateSaveKeyCount = 0;
+    private boolean scanAborted;
 
     private boolean shouldSaveState() {
       if ((Time.monotonicNow() - lastStateSaveTime) > stateSaveIntervalMs ||
@@ -436,9 +437,12 @@ public class KeyLifecycleService extends BackgroundService {
               evaluateBucket(bucket, keyTable, expirationRules, expiredKeyList, scanStateBuilder);
             }
 
+            boolean scanFinished = !scanAborted;
             if (expiredKeyList.isEmpty() && expiredDirList.isEmpty()) {
               LOG.info("No expired keys/dirs found/remained for bucket {}", bucketKey);
-              sendSaveScanStateRequest(scanStateBuilder, true);
+              if (scanFinished || test) {
+                sendSaveScanStateRequest(scanStateBuilder, scanFinished);
+              }
             } else {
               LOG.info("{} expired keys and {} expired dirs found and remained for bucket {}",
                   expiredKeyList.size(), expiredDirList.size(), bucketKey);
@@ -447,11 +451,11 @@ public class KeyLifecycleService extends BackgroundService {
               // OBS bucket doesn't support trash.
               if (bucket.getBucketLayout() == OBJECT_STORE) {
                 sendDeleteKeysRequestAndClearList(bucket.getVolumeName(), bucket.getBucketName(),
-                    bucket.getOwner(), expiredKeyList, false, scanStateBuilder, true);
+                    bucket.getOwner(), expiredKeyList, false, scanStateBuilder, scanFinished);
               } else {
                 // handle keys first, then directories
-                handleAndClearFullList(bucket, expiredKeyList, false, scanStateBuilder, true);
-                handleAndClearFullList(bucket, expiredDirList, true, scanStateBuilder, true);
+                handleAndClearFullList(bucket, expiredKeyList, false, scanStateBuilder, scanFinished);
+                handleAndClearFullList(bucket, expiredDirList, true, scanStateBuilder, scanFinished);
               }
             }
           }
@@ -677,10 +681,8 @@ public class KeyLifecycleService extends BackgroundService {
       HashSet<Long> deletedDirSet = new HashSet<>();
       while (!stack.isEmpty()) {
         if (!shouldRun()) {
-          LOG.info("LifecycleActionTask for bucket {} stopping. " +
-              "Service enabled: {}, suspended: {}, leader ready: {}",
-              bucketName, isServiceEnabled.get(), suspended.get(), 
-              getOzoneManager() != null ? getOzoneManager().isLeaderReady() : "N/A");
+          scanAborted = true;
+          LOG.info("KeyLifecycleService is suspended or disabled. Stopping task for bucket {}.", bucketName);
           return;
         }
 
@@ -1028,8 +1030,8 @@ public class KeyLifecycleService extends BackgroundService {
 
         while (keyTblItr.hasNext()) {
           if (!shouldRun()) {
-            LOG.info("KeyLifecycleService is suspended or disabled. " +
-                "Stopping LifecycleActionTask for bucket {}.", bucketName);
+            scanAborted = true;
+            LOG.info("KeyLifecycleService is suspended or disabled. Stopping task for bucket {}.", bucketName);
             return;
           }
           if (shouldSaveState()) {
@@ -1093,8 +1095,8 @@ public class KeyLifecycleService extends BackgroundService {
                omMetadataManager.getMultipartInfoTable().iterator(bucketPrefix)) {
         while (mpuIterator.hasNext()) {
           if (!shouldRun()) {
-            LOG.info("KeyLifecycleService is suspended or disabled. " +
-                "Stopping multipart upload processing for bucket {}.", bucketName);
+            scanAborted = true;
+            LOG.info("KeyLifecycleService is suspended or disabled. Stopping task for bucket {}.", bucketName);
             return;
           }
           Table.KeyValue<String, OmMultipartKeyInfo> entry = mpuIterator.next();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
@@ -680,7 +680,8 @@ public class KeyLifecycleService extends BackgroundService {
       while (!stack.isEmpty()) {
         if (!shouldRun()) {
           scanAborted = true;
-          LOG.info("KeyLifecycleService is suspended, disabled, or leader not ready. Stopping task for bucket {}.", bucketName);
+          LOG.info("KeyLifecycleService is suspended, disabled, or leader not ready. Stopping task for bucket {}.",
+              bucketName);
           return;
         }
 
@@ -1029,7 +1030,8 @@ public class KeyLifecycleService extends BackgroundService {
         while (keyTblItr.hasNext()) {
           if (!shouldRun()) {
             scanAborted = true;
-            LOG.info("KeyLifecycleService is suspended or disabled. Stopping task for bucket {}.", bucketName);
+            LOG.info("KeyLifecycleService is suspended, disabled, or leader not ready. Stopping task for bucket {}.",
+                bucketName);
             return;
           }
           if (shouldSaveState()) {
@@ -1094,7 +1096,8 @@ public class KeyLifecycleService extends BackgroundService {
         while (mpuIterator.hasNext()) {
           if (!shouldRun()) {
             scanAborted = true;
-            LOG.info("KeyLifecycleService is suspended or disabled. Stopping task for bucket {}.", bucketName);
+            LOG.info("KeyLifecycleService is suspended, disabled, or leader not ready. Stopping task for bucket {}.",
+                bucketName);
             return;
           }
           Table.KeyValue<String, OmMultipartKeyInfo> entry = mpuIterator.next();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleService.java
@@ -682,7 +682,7 @@ public class KeyLifecycleService extends BackgroundService {
       while (!stack.isEmpty()) {
         if (!shouldRun()) {
           scanAborted = true;
-          LOG.info("KeyLifecycleService is suspended or disabled. Stopping task for bucket {}.", bucketName);
+          LOG.info("KeyLifecycleService is suspended, disabled, or leader not ready. Stopping task for bucket {}.", bucketName);
           return;
         }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -32,6 +32,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDC
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_LIFECYCLE_SERVICE_ENABLED;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_LIFECYCLE_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_LIFECYCLE_SERVICE_STATE_SAVE_INTERVAL_MS;
@@ -275,6 +276,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
       keyLifecycleService.setOzoneTrash(null);
       keyLifecycleService.setMoveToTrashEnabled(true);
       KeyLifecycleService.setInjectors(null);
+      keyLifecycleService.setListMaxSize(conf.getInt(OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE,
+          OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE_DEFAULT));
     }
 
     @AfterAll
@@ -567,6 +570,55 @@ class TestKeyLifecycleService extends OzoneTestBase {
         keyLifecycleService.resume();
         deleteLifecyclePolicy(volumeName, bucketName);
       }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters1")
+    void testAbortedScanDoesNotMarkScanComplete(BucketLayout bucketLayout, boolean createPrefix)
+        throws Exception {
+      final String volumeName = getTestName();
+      final String bucketName = uniqueObjectName("bucket");
+      String keyPrefix = "key";
+      String rulePrefix = bucketLayout == FILE_SYSTEM_OPTIMIZED ? "" : "key";
+      int testKeyCount = 3;
+
+      keyLifecycleService.setListMaxSize(1);
+      //keyLifecycleService.suspend();
+      KeyLifecycleService.setInjectors(Arrays.asList(new FaultInjectorImpl()));
+
+      List<OmKeyArgs> keyList =
+          createKeys(volumeName, bucketName, bucketLayout, testKeyCount, 1, keyPrefix, null);
+      assertEquals(testKeyCount, keyList.size());
+
+      ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+      ZonedDateTime date = now.plusSeconds(EXPIRE_SECONDS);
+      if (createPrefix) {
+        createLifecyclePolicy(volumeName, bucketName, bucketLayout, rulePrefix, null, date.toString(), true);
+      } else {
+        OmLCFilter.Builder filter = getOmLCFilterBuilder(rulePrefix, null, null);
+        createLifecyclePolicy(volumeName, bucketName, bucketLayout, null, filter.build(), date.toString(), true);
+      }
+
+      String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
+      //keyLifecycleService.resume();
+
+      GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().contains(bucketKey),
+          WAIT_CHECK_INTERVAL, 10000);
+      keyLifecycleService.suspend();
+      KeyLifecycleService.getInjector(0).resume();
+
+      GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.captureLogs(
+          LoggerFactory.getLogger(KeyLifecycleService.class));
+      GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().isEmpty(),
+          WAIT_CHECK_INTERVAL, 10000);
+
+      OmLifecycleScanState scanState = metadataManager.getLifecycleScanStateTable().get(bucketKey);
+      assertNotNull(scanState);
+      assertNull(scanState.getScanEndTime(),
+          "Aborted scan must not persist scanEndTime so a new leader can resume");
+      assertTrue(logCapturer.getOutput().contains("KeyLifecycleService is suspended or disabled"));
+      keyLifecycleService.resume();
+      deleteLifecyclePolicy(volumeName, bucketName);
     }
 
     @ParameterizedTest

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -583,7 +583,6 @@ class TestKeyLifecycleService extends OzoneTestBase {
       int testKeyCount = 3;
 
       keyLifecycleService.setListMaxSize(1);
-      //keyLifecycleService.suspend();
       KeyLifecycleService.setInjectors(Arrays.asList(new FaultInjectorImpl()));
 
       List<OmKeyArgs> keyList =
@@ -600,15 +599,13 @@ class TestKeyLifecycleService extends OzoneTestBase {
       }
 
       String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
-      //keyLifecycleService.resume();
-
       GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().contains(bucketKey),
           WAIT_CHECK_INTERVAL, 10000);
-      keyLifecycleService.suspend();
-      KeyLifecycleService.getInjector(0).resume();
 
       GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.captureLogs(
           LoggerFactory.getLogger(KeyLifecycleService.class));
+      keyLifecycleService.suspend();
+      KeyLifecycleService.getInjector(0).resume();
       GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().isEmpty(),
           WAIT_CHECK_INTERVAL, 10000);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -613,7 +613,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertNotNull(scanState);
       assertNull(scanState.getScanEndTime(),
           "Aborted scan must not persist scanEndTime so a new leader can resume");
-      assertTrue(logCapturer.getOutput().contains("KeyLifecycleService is suspended or disabled"));
+      assertTrue(logCapturer.getOutput().contains("KeyLifecycleService is suspended, disabled, or leader not ready"));
       keyLifecycleService.resume();
       deleteLifecyclePolicy(volumeName, bucketName);
     }
@@ -1776,7 +1776,9 @@ class TestKeyLifecycleService extends OzoneTestBase {
       KeyInfoWithVolumeContext keyInfo = getDirectory(volumeName, bucketName, dirName);
       assertFalse(keyInfo.getKeyInfo().isFile());
       Thread.sleep(SERVICE_INTERVAL);
-      assertEquals(dirDepth, getDirCount() - initialDirCount);
+
+      GenericTestUtils.waitFor(() -> dirDepth == getDirCount() - initialDirCount,
+          WAIT_CHECK_INTERVAL, 5000);
       assertEquals(0, getDeletedDirectoryCount() - initialDeletedDirCount);
 
       GenericTestUtils.LogCapturer log =
@@ -3484,9 +3486,14 @@ class TestKeyLifecycleService extends OzoneTestBase {
     }
   }
 
-  private long getDirCount() throws IOException {
+  private long getDirCount() {
     final Table<String, OmDirectoryInfo> table = metadataManager.getDirectoryTable();
-    return metadataManager.countRowsInTable(table);
+    try {
+      return metadataManager.countRowsInTable(table);
+    } catch (IOException e) {
+      fail("Failed to count directories " + e.getMessage());
+      return -1;
+    }
   }
 
   private long getKeyCount(BucketLayout layout) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

LifecycleActionTask can be aborted due to leader transfer or leader is not ready. In this case, we should not mark the scan state as completed, so that the new leader can resume the scan from the saved state(checkpoint). 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16227

## How was this patch tested?

New unit test
