### PR TITLE
HDDS-16242. Remove redundant RPC metadata from StorageContainerLocationProtocol

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.Type;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
-import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -47,23 +46,13 @@ import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
-import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.security.token.Token;
 
 /**
  * ContainerLocationProtocol is used by an HDFS node to find the set of nodes
  * that currently host a container.
  */
-@KerberosInfo(serverPrincipal = ScmConfig.ConfigStrings
-      .HDDS_SCM_KERBEROS_PRINCIPAL_KEY)
 public interface StorageContainerLocationProtocol extends Closeable {
-
-  // Accessed and checked via reflection in Hadoop RPC - changing it is incompatible
-  @SuppressWarnings({"checkstyle:ConstantName", "unused"})
-  /**
-   * Version 1: Initial version.
-   */
-  long versionID = 1L;
 
   /**
    * Admin command should take effect on all SCM instance.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/protocolPB/TestStorageContainerLocationProtocolPB.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/protocolPB/TestStorageContainerLocationProtocolPB.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.protocolPB;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.hadoop.hdds.scm.ScmConfig;
+import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+import org.apache.hadoop.ipc_.RPC;
+import org.apache.hadoop.security.KerberosInfo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the Hadoop RPC metadata for the SCM container location protocol.
+ */
+public class TestStorageContainerLocationProtocolPB {
+
+  @Test
+  public void testProtocolMetadata() {
+    assertEquals(StorageContainerLocationProtocol.class.getName(),
+        RPC.getProtocolName(StorageContainerLocationProtocolPB.class));
+    assertEquals(1L,
+        RPC.getProtocolVersion(StorageContainerLocationProtocolPB.class));
+
+    KerberosInfo kerberosInfo = StorageContainerLocationProtocolPB.class
+        .getAnnotation(KerberosInfo.class);
+    assertNotNull(kerberosInfo);
+    assertEquals(ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_PRINCIPAL_KEY,
+        kerberosInfo.serverPrincipal());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
`StorageContainerLocationProtocol` is an internal Java interface, while Hadoop RPC uses `StorageContainerLocationProtocolPB`, which extends the generated protobuf service interface.

Both interfaces previously defined the protocol version and Kerberos metadata. However, the RPC server registration, client proxy, and failover provider use `StorageContainerLocationProtocolPB`, so the metadata on `StorageContainerLocationProtocol` was redundant and could incorrectly imply that this Java interface defines the wire protocol.

This PR:
- Removes `versionID` and `@KerberosInfo` from `StorageContainerLocationProtocol`.
- Keeps the interface, its FQCN, methods, PB interface, translators, protobuf definitions, and `SCMPolicyProvider` unchanged.
- Adds a focused test confirming that the historical protocol name, protocol version, and Kerberos metadata are provided by `StorageContainerLocationProtocolPB`.

The historical FQCN is preserved because it remains the protocol name declared by `StorageContainerLocationProtocolPB` and is used by service authorization through `SCMPolicyProvider`.

This change does not modify the protobuf service or Hadoop RPC protocol identity, so the wire protocol remains unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16242

## How was this patch tested?

Local Test
```shell
mvn -pl :hdds-server-framework -am test \
  -Dtest=TestStorageContainerLocationProtocolPB \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipShade -DskipRecon -DskipDocs

mvn -pl :ozone-integration-test test \
  -Dtest=TestSecureOzoneCluster#testSecureScmAndOmStartupAndAccessControl \
  -DskipShade -DskipRecon
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/32326358698

Generated-by: Codex (GPT-5)