### PR TITLE
HDDS-16239. Support injecting apparent version into Datanode through testing configuration

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeStorage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeStorage.java
@@ -36,6 +36,9 @@ import org.apache.hadoop.ozone.common.Storage;
  * StorageDirectories used by the DataNode.
  */
 public class DatanodeStorage extends Storage {
+
+  public static final String TESTING_INIT_APPARENT_VERSION_KEY = "testing.hdds.datanode.init.apparent.version";
+
   /**
    * Construct DataNodeStorageConfig.
    * @throws IOException if any directories are inaccessible.
@@ -43,7 +46,8 @@ public class DatanodeStorage extends Storage {
   public DatanodeStorage(ConfigurationSource conf, String dataNodeId)
       throws IOException {
     super(NodeType.DATANODE, ServerUtils.getOzoneMetaDirPath(conf),
-        DATANODE_LAYOUT_VERSION_DIR, dataNodeId, getDefaultApparentVersion(conf));
+        DATANODE_LAYOUT_VERSION_DIR, dataNodeId,
+        getInitApparentVersion(conf, TESTING_INIT_APPARENT_VERSION_KEY, () -> getDefaultApparentVersion(conf)));
   }
 
   public DatanodeStorage(OzoneConfiguration conf, String dataNodeId, int apparentVersion)
@@ -55,7 +59,8 @@ public class DatanodeStorage extends Storage {
   public DatanodeStorage(ConfigurationSource conf)
       throws IOException {
     super(NodeType.DATANODE, ServerUtils.getOzoneMetaDirPath(conf),
-        DATANODE_LAYOUT_VERSION_DIR, getDefaultApparentVersion(conf));
+        DATANODE_LAYOUT_VERSION_DIR,
+        getInitApparentVersion(conf, TESTING_INIT_APPARENT_VERSION_KEY, () -> getDefaultApparentVersion(conf)));
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeVersionManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeVersionManager.java
@@ -224,6 +224,25 @@ class TestDatanodeVersionManager extends AbstractComponentVersionManagerTest {
     }
   }
 
+  @Test
+  public void testInitApparentVersionConfigKeyOverridesDefault(@TempDir Path storageRoot) throws IOException {
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, storageRoot.toString());
+    conf.setInt(DatanodeStorage.TESTING_INIT_APPARENT_VERSION_KEY, INITIAL_VERSION.serialize());
+
+    DatanodeStorage storage = new DatanodeStorage(conf, UUID.randomUUID().toString());
+    assertEquals(INITIAL_VERSION.serialize(), storage.getApparentVersion());
+    assertDatanodeApparentVersionOnDisk(conf, INITIAL_VERSION.serialize());
+  }
+
+  @Test
+  public void testInitApparentVersionDefaultsToSoftwareVersionWhenUnset(@TempDir Path storageRoot) throws IOException {
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, storageRoot.toString());
+
+    DatanodeStorage storage = new DatanodeStorage(conf, UUID.randomUUID().toString());
+    assertEquals(HDDSVersion.SOFTWARE_VERSION.serialize(), storage.getApparentVersion());
+    assertDatanodeApparentVersionOnDisk(conf, HDDSVersion.SOFTWARE_VERSION.serialize());
+  }
+
   private static void assertDatanodeApparentVersionOnDisk(OzoneConfiguration conf, int expected)
       throws IOException {
     DatanodeStorage reloaded = new DatanodeStorage(conf, UUID.randomUUID().toString());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/common/Storage.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/common/Storage.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.util.Properties;
 import java.util.function.IntSupplier;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
@@ -280,7 +280,7 @@ public abstract class Storage {
     storageInfo.writeTo(getVersionFile());
   }
 
-  protected static int getInitApparentVersion(OzoneConfiguration conf, String configKey,
+  protected static int getInitApparentVersion(ConfigurationSource conf, String configKey,
       IntSupplier defaultLvSupplier) {
     int lV = conf.getInt(configKey, OZONE_INIT_DEFAULT_LAYOUT_VERSION_DEFAULT);
     if (lV == OZONE_INIT_DEFAULT_LAYOUT_VERSION_DEFAULT) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM and SCM support injecting an apparent version at startup through a testing config key. Add the same support to Datanodes.

## What is the link to the Apache JIRA

HDDS-16239
## How was this patch tested?

Unit tests added
