### PR TITLE
HDDS-16240. [STS] Remove /sts from endpoint to enhance compatibility

### DIFF
--- a/hadoop-hdds/docs/content/design/ozone-sts.md
+++ b/hadoop-hdds/docs/content/design/ozone-sts.md
@@ -42,7 +42,7 @@ solutions that want to aggregate data across multiple cloud providers.
 # 3. How Ozone STS Works
 
 The initial implementation of Ozone STS supports only the [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
-API from the AWS specification.  A new STS endpoint `/sts` on port `9880` (port `9881` for https) will be created to service STS requests in the S3 Gateway.
+API from the AWS specification.  A new STS endpoint on port `9880` (port `9881` for https) will be created to service STS requests in the S3 Gateway at the root path (`/`).
 We use a separate port for STS to align with AWS so we don't have conflicts at a later time.  This means we have:
 - Admin port for Ozone specific S3 admin operations
 - STS port for STS APIs, analogous to AWS' separate STS endpoint

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -104,7 +104,7 @@ OZONE-SITE.XML_ozone.security.http.kerberos.enabled=true
 OZONE-SITE.XML_ozone.s3g.secret.http.enabled=true
 OZONE-SITE.XML_ozone.http.filter.initializers=org.apache.hadoop.security.AuthenticationFilterInitializer
 
-# Enable S3 Gateway STS (AWS STS compatible) endpoint on s3g (http://s3g:9880/sts)
+# Enable S3 Gateway STS (AWS STS compatible) endpoint on s3g (http://s3g:9880)
 OZONE-SITE.XML_ozone.s3g.sts.http.enabled=true
 
 OZONE-SITE.XML_ozone.om.http.auth.type=kerberos

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/polaris-setup.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/polaris-setup.sh
@@ -23,7 +23,7 @@ realm="${POLARIS_REALM:-POLARIS}"
 catalog_name="${POLARIS_CATALOG_NAME:-quickstart_catalog}"
 storage_location="${POLARIS_STORAGE_LOCATION:-s3://iceberg-obs/polaris-smoke}"
 s3_endpoint="${POLARIS_S3_ENDPOINT:-http://s3g:9878}"
-sts_endpoint="${POLARIS_STS_ENDPOINT:-http://s3g:9880/sts}"
+sts_endpoint="${POLARIS_STS_ENDPOINT:-http://s3g:9880}"
 role_arn="${POLARIS_ROLE_ARN:-arn:aws:iam::123456789012:role/iceberg-data-all-access-obs}"
 
 if [ -z "${POLARIS_AWS_ACCESS_KEY_ID:-}" ] || [ -z "${POLARIS_AWS_SECRET_ACCESS_KEY:-}" ]; then

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/polaris.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/polaris.yaml
@@ -56,7 +56,7 @@ services:
       POLARIS_CATALOG_NAME: ${POLARIS_CATALOG_NAME:-quickstart_catalog}
       POLARIS_STORAGE_LOCATION: ${POLARIS_STORAGE_LOCATION:-s3://iceberg-obs/polaris-smoke}
       POLARIS_S3_ENDPOINT: http://s3g:9878
-      POLARIS_STS_ENDPOINT: http://s3g:9880/sts
+      POLARIS_STS_ENDPOINT: http://s3g:9880
       POLARIS_ROLE_ARN: arn:aws:iam::123456789012:role/iceberg-data-all-access-obs
       POLARIS_AWS_ACCESS_KEY_ID: ${POLARIS_AWS_ACCESS_KEY_ID}
       POLARIS_AWS_SECRET_ACCESS_KEY: ${POLARIS_AWS_SECRET_ACCESS_KEY}

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-sts.resource
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-sts.resource
@@ -24,7 +24,7 @@ Resource            ../s3/commonawslib.robot
 
 *** Variables ***
 ${RANGER_ENDPOINT_URL}                      ${EMPTY}
-${STS_ENDPOINT_URL}                         http://s3g:9880/sts
+${STS_ENDPOINT_URL}                         http://s3g:9880
 ${S3G_ENDPOINT_URL}                         http://s3g:9878
 ${ROLE_SESSION_NAME}                        sts-session-name
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3sts/S3STSEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3sts/S3STSEndpoint.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
  * AWS STS (Security Token Service) compatible endpoint for Ozone S3 Gateway.
  * <p>
  * This endpoint provides temporary security credentials compatible with
- * AWS STS API, exposed on the port 9880 or 9881.
+ * AWS STS API, exposed on port 9880 or 9881 at the root path ({@code /}).
  * <p>
  * Currently supports only AssumeRole operation. Other STS operations will
  * return appropriate error responses.

--- a/hadoop-ozone/s3gateway/src/main/resources/webapps/s3g-sts/WEB-INF/web.xml
+++ b/hadoop-ozone/s3gateway/src/main/resources/webapps/s3g-sts/WEB-INF/web.xml
@@ -25,7 +25,7 @@
   </servlet>
   <servlet-mapping>
     <servlet-name>sts-jaxrs</servlet-name>
-    <url-pattern>/sts/*</url-pattern>
+    <url-pattern>/*</url-pattern>
   </servlet-mapping>
   <listener>
     <listener-class>org.jboss.weld.environment.servlet.Listener</listener-class>

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestAuthorizationFilter.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestAuthorizationFilter.java
@@ -137,7 +137,7 @@ public class TestAuthorizationFilter {
             "Content-SHA",
             DATETIME,
             "application/x-www-form-urlencoded; charset=utf-8",
-            "/sts",
+            "/",
             PAYLOAD_TOO_LARGE.getErrorMessage()
         )
     );


### PR DESCRIPTION
Please describe your PR in detail:
* Currently, there is a bug in AWS SDK (https://github.com/aws/aws-sdk-java-v2/issues/3387) that strips the /sts off the path of an endpoint. There is a workaround to add an endpointOverride, but that is cumbersome for users. To enhance compatibility, we will remove the requirement for /sts in the endpoint path.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16240

## How was this patch tested?
smoke tests, viewing Docker access logs to ensure /sts was not in the endpoint path
