### PR TITLE
HDDS-16243. Remove redundant RPC metadata from ScmBlockLocationProtocol

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -26,28 +26,18 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
-import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.net.InnerNode;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
-import org.apache.hadoop.security.KerberosInfo;
 
 /**
  * ScmBlockLocationProtocol is used by an HDFS node to find the set of nodes
  * to read/write a block.
  */
-@KerberosInfo(serverPrincipal = ScmConfig.ConfigStrings
-      .HDDS_SCM_KERBEROS_PRINCIPAL_KEY)
 public interface ScmBlockLocationProtocol extends Closeable {
-
-  @SuppressWarnings("checkstyle:ConstantName")
-  /**
-   * Version 1: Initial version.
-   */
-  long versionID = 1L;
 
   /**
    * Asks SCM where a block should be allocated. SCM responds with the

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/protocolPB/TestScmBlockLocationProtocolPB.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/protocolPB/TestScmBlockLocationProtocolPB.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.protocolPB;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.hadoop.hdds.scm.ScmConfig;
+import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
+import org.apache.hadoop.ipc_.RPC;
+import org.apache.hadoop.security.KerberosInfo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the Hadoop RPC metadata for the SCM block location protocol.
+ */
+public class TestScmBlockLocationProtocolPB {
+
+  @Test
+  public void testProtocolMetadata() {
+    assertEquals(ScmBlockLocationProtocol.class.getName(),
+        RPC.getProtocolName(ScmBlockLocationProtocolPB.class));
+    assertEquals(1L,
+        RPC.getProtocolVersion(ScmBlockLocationProtocolPB.class));
+
+    KerberosInfo kerberosInfo = ScmBlockLocationProtocolPB.class
+        .getAnnotation(KerberosInfo.class);
+    assertNotNull(kerberosInfo);
+    assertEquals(ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_PRINCIPAL_KEY,
+        kerberosInfo.serverPrincipal());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
`ScmBlockLocationProtocol` duplicated the protocol version and Kerberos metadata already defined by `ScmBlockLocationProtocolPB`, which is the interface used by Hadoop RPC.

This PR:
- removes the redundant `versionID` and `@KerberosInfo` annotation from `ScmBlockLocationProtocol`;
- keeps the RPC metadata in `ScmBlockLocationProtocolPB`;
- adds a regression test verifying the protocol name, protocol version, and SCM Kerberos principal exposed by the PB protocol.

This consolidates the RPC metadata in the protocol interface where it is consumed and prevents the duplicated definitions from diverging.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16243

## How was this patch tested?

Local Test
```
mvn -pl :hdds-server-framework -am test \
    -Dtest=TestScmBlockLocationProtocolPB \
    -Dsurefire.failIfNoSpecifiedTests=false \
    -DskipShade -DskipRecon -DskipDocs

mvn -pl :ozone-integration-test test \
    -Dtest=TestSecureOzoneCluster#testSecureScmAndOmStartupAndAccessControl \
    -DskipShade -DskipRecon
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/32459716379

Generated-by: Codex (GPT-5)