### PR TITLE
HDDS-16201. Rename getLocationList to createLocationList

### DIFF
--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
@@ -94,7 +94,7 @@ public class ContainerMapper {
             for (OmKeyLocationInfoGroup keyLocationInfoGroup : keyInfo
                 .getKeyLocationVersions()) {
               List<OmKeyLocationInfo> keyLocationInfo = keyLocationInfoGroup
-                  .getLocationList();
+                  .createLocationList();
               for (OmKeyLocationInfo keyLocation : keyLocationInfo) {
                 BlockIdDetails blockIdDetails = new BlockIdDetails();
                 Map<Long, BlockIdDetails> innerMap = new HashMap<>();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
@@ -110,7 +110,7 @@ public class KeyInputStream extends MultipartInputStream {
       BlockID blockID) {
     List<OmKeyLocationInfo> collect =
         newKeyInfo.getLatestVersionLocations()
-            .getLocationList()
+            .createLocationList()
             .stream()
             .filter(l -> l.getBlockID().equals(blockID))
             .collect(Collectors.toList());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -353,7 +353,7 @@ public final class OmKeyInfo extends WithParentObjectId
     Map<ContainerBlockID, OmKeyLocationInfo> allocatedBlockLocations =
         new HashMap<>();
     for (OmKeyLocationInfo existingLocationInfo : keyLocationInfoGroup.
-        getLocationList()) {
+        createLocationList()) {
       ContainerBlockID existingBlockID = existingLocationInfo.getBlockID().
           getContainerBlockID();
       // The case of overwriting value should never happen
@@ -537,7 +537,7 @@ public final class OmKeyInfo extends WithParentObjectId
       obj.keyLocationVersions.forEach(keyLocationVersion ->
           this.omKeyLocationInfoGroups.add(
               new OmKeyLocationInfoGroup(keyLocationVersion.getVersion(),
-                  keyLocationVersion.getLocationList(),
+                  keyLocationVersion.createLocationList(),
                   keyLocationVersion.isMultipartKey())));
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -106,7 +106,7 @@ public class OmKeyLocationInfoGroup {
    * Use getLocationLists() instead.
    * @return a list of OmKeyLocationInfo
    */
-  public List<OmKeyLocationInfo> getLocationList() {
+  public List<OmKeyLocationInfo> createLocationList() {
     return locationVersionMap.values().stream().flatMap(List::stream)
         .collect(Collectors.toList());
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -179,12 +179,12 @@ public class TestOmKeyInfo {
       assertEquals(orig.isMultipartKey(), clone.isMultipartKey());
       assertEquals(orig.getVersion(), clone.getVersion());
 
-      assertEquals(orig.getLocationList().size(),
-          clone.getLocationList().size());
+      assertEquals(orig.createLocationList().size(),
+          clone.createLocationList().size());
 
-      for (int j = 0; j < orig.getLocationList().size(); j++) {
-        OmKeyLocationInfo origLocationInfo = orig.getLocationList().get(j);
-        OmKeyLocationInfo cloneLocationInfo = clone.getLocationList().get(j);
+      for (int j = 0; j < orig.createLocationList().size(); j++) {
+        OmKeyLocationInfo origLocationInfo = orig.createLocationList().get(j);
+        OmKeyLocationInfo cloneLocationInfo = clone.createLocationList().get(j);
         assertEquals(origLocationInfo, cloneLocationInfo);
       }
     }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
@@ -52,7 +52,7 @@ public class TestOmKeyLocationInfoGroup {
     List<OmKeyLocationInfo> locationInfoList = createLocationList();
     OmKeyLocationInfoGroup newInstance =
         testInstance.generateNextVersion(locationInfoList);
-    assertEquals(1, newInstance.getLocationList().size());
+    assertEquals(1, newInstance.createLocationList().size());
     // createTestInstance is of version 2, nextVersion should be 3
     assertEquals(3, newInstance.getVersion());
 

--- a/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test-recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -445,7 +445,7 @@ class TestReconAndAdminContainerCLI {
   private static List<Long> getContainerIdsForKey(OmKeyInfo omKeyInfo) {
     assertNotNull(omKeyInfo.getLatestVersionLocations());
     List<OmKeyLocationInfo> locations =
-        omKeyInfo.getLatestVersionLocations().getLocationList();
+        omKeyInfo.getLatestVersionLocations().createLocationList();
 
     List<Long> ids = new ArrayList<>();
     for (OmKeyLocationInfo location : locations) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -481,7 +481,7 @@ public class TestStorageContainerManager {
     // on datanodes.
     Set<Long> containerNames = new HashSet<>();
     for (Map.Entry<String, OmKeyInfo> entry : keyLocations.entrySet()) {
-      entry.getValue().getLatestVersionLocations().getLocationList()
+      entry.getValue().getLatestVersionLocations().createLocationList()
           .forEach(loc -> containerNames.add(loc.getContainerID()));
     }
 
@@ -499,7 +499,7 @@ public class TestStorageContainerManager {
     Map<Long, List<DeletedBlock>> containerBlocks = Maps.newHashMap();
     for (OmKeyInfo info : keyLocations.values()) {
       List<OmKeyLocationInfo> list =
-          info.getLatestVersionLocations().getLocationList();
+          info.getLatestVersionLocations().createLocationList();
       list.forEach(location -> {
         if (containerBlocks.containsKey(location.getContainerID())) {
           containerBlocks.get(location.getContainerID()).add(new DeletedBlock(location.getBlockID(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -131,7 +131,7 @@ public final class OzoneTestUtils {
     for (OmKeyLocationInfoGroup omKeyLocationInfoGroup :
         omKeyLocationInfoGroups) {
       List<OmKeyLocationInfo> omKeyLocationInfos =
-          omKeyLocationInfoGroup.getLocationList();
+          omKeyLocationInfoGroup.createLocationList();
       for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfos) {
         BlockID blockID = omKeyLocationInfo.getBlockID();
         consumer.accept(blockID);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java
@@ -219,7 +219,7 @@ public final class TestBlockTokens {
     OmKeyInfo keyInfo = getTestKeyInfo();
     // replace block token secret key id with wrong id.
     for (OmKeyLocationInfoGroup v : keyInfo.getKeyLocationVersions()) {
-      for (OmKeyLocationInfo l : v.getLocationList()) {
+      for (OmKeyLocationInfo l : v.createLocationList()) {
         Token<OzoneBlockTokenIdentifier> token = l.getToken();
         OzoneBlockTokenIdentifier tokenId = token.decodeIdentifier();
         tokenId.setSecretKeyId(UUID.randomUUID());
@@ -243,7 +243,7 @@ public final class TestBlockTokens {
     OmKeyInfo keyInfo = getTestKeyInfo();
     // replace block token secret key id with wrong id.
     for (OmKeyLocationInfoGroup v : keyInfo.getKeyLocationVersions()) {
-      for (OmKeyLocationInfo l : v.getLocationList()) {
+      for (OmKeyLocationInfo l : v.createLocationList()) {
         Token<OzoneBlockTokenIdentifier> token = l.getToken();
         byte[] randomPassword = RandomUtils.secure().randomBytes(100);
         Token<OzoneBlockTokenIdentifier> override = new Token<>(
@@ -263,7 +263,7 @@ public final class TestBlockTokens {
 
   private UUID extractSecretKeyId(OmKeyInfo keyInfo) throws IOException {
     OmKeyLocationInfo locationInfo =
-        keyInfo.getKeyLocationVersions().get(0).getLocationList().get(0);
+        keyInfo.getKeyLocationVersions().get(0).createLocationList().get(0);
     Token<OzoneBlockTokenIdentifier> token = locationInfo.getToken();
     return token.decodeIdentifier().getSecretKeyId();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -1238,7 +1238,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
         .build();
     OmKeyInfo keyInfo = ozoneManager.lookupKey(keyArgs);
     for (OmKeyLocationInfo info:
-        keyInfo.getLatestVersionLocations().getLocationList()) {
+        keyInfo.getLatestVersionLocations().createLocationList()) {
       ContainerInfo container =
           storageContainerLocationClient.getContainer(info.getContainerID());
       assertEquals(replication, container.getReplicationConfig());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithInAdequateDN.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithInAdequateDN.java
@@ -255,7 +255,7 @@ public class TestDeleteWithInAdequateDN {
         .setKeyName(keyName).build();
     OmKeyInfo info = cluster.getOzoneManager().lookupKey(keyArgs);
     BlockID blockID = info.getKeyLocationVersions().get(0)
-        .getLocationList().get(0).getBlockID();
+        .createLocationList().get(0).getBlockID();
     OzoneContainer ozoneContainer;
     final DatanodeStateMachine dnStateMachine =
         leader.getDatanodeStateMachine();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -251,7 +251,7 @@ public class TestFailureHandlingByClient {
 
     // Get information about the first and second block (in different pipelines)
     List<OmKeyLocationInfo> locationList = omKeyInfo.getLatestVersionLocations()
-        .getLocationList();
+        .createLocationList();
     long containerId1 = locationList.get(0).getContainerID();
     List<DatanodeDetails> block1DNs = locationList.get(0).getPipeline()
         .getNodes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -491,7 +491,7 @@ class TestOzoneAtRestEncryption {
         HddsProtos.ReplicationFactor.valueOf(factor.getValue());
     OmKeyInfo keyInfo = ozoneManager.lookupKey(keyArgs);
     for (OmKeyLocationInfo info:
-        keyInfo.getLatestVersionLocations().getLocationList()) {
+        keyInfo.getLatestVersionLocations().createLocationList()) {
       ContainerInfo container =
           storageContainerLocationClient.getContainer(info.getContainerID());
       if (!ReplicationConfig.getLegacyFactor(container.getReplicationConfig())

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -342,7 +342,7 @@ class TestSecureOzoneRpcClient extends OzoneRpcClientTests {
   private void assertTokenIsNull(OmKeyInfo value) {
     value.getKeyLocationVersions()
         .forEach(
-            keyLocationInfoGroup -> keyLocationInfoGroup.getLocationList()
+            keyLocationInfoGroup -> keyLocationInfoGroup.createLocationList()
                 .forEach(
                     keyLocationInfo -> assertNull(keyLocationInfo
                         .getToken())));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -405,7 +405,7 @@ class TestKeyInputStream extends InputStreamTests {
 
     OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
     assertNotNull(locations);
-    List<OmKeyLocationInfo> locationInfoList = locations.getLocationList();
+    List<OmKeyLocationInfo> locationInfoList = locations.createLocationList();
     assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo loc = locationInfoList.get(0);
     long containerID = loc.getContainerID();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestStreamRead.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestStreamRead.java
@@ -171,7 +171,7 @@ public class TestStreamRead {
 
           // get block file and generate md5
           final OmKeyInfo info = nonStreamReadClient.getProxy().getKeyInfo(volume, bucket, keyName, false);
-          final List<OmKeyLocationInfo> locations = info.getLatestVersionLocations().getLocationList();
+          final List<OmKeyLocationInfo> locations = info.getLatestVersionLocations().createLocationList();
           assertEquals(1, locations.size());
           final BlockID blockId = locations.get(0).getBlockID();
           final ContainerData containerData = datanode.getDatanodeStateMachine().getContainer().getContainerSet()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -197,7 +197,7 @@ class TestContainerReplication {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
     Assertions.assertNotNull(locations);
-    return locations.getLocationList().get(0);
+    return locations.createLocationList().get(0);
   }
 
   public void assertState(MiniOzoneCluster cluster, Map<Integer, DatanodeDetails> expectedReplicaMap)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -215,7 +215,7 @@ public class TestContainerReportHandling {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
     assertNotNull(locations);
-    return locations.getLocationList();
+    return locations.createLocationList();
   }
 
   private static class TestCase extends ImmutablePair<LifeCycleState, ReplicationInput> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -272,7 +272,7 @@ public class TestBlockDeletion {
         .getDatanodeStateMachine().getContainer().getContainerSet();
     GenericTestUtils.waitFor(() -> {
       return !(omKeyLocationInfoGroupList.stream().anyMatch((group) ->
-        group.getLocationList().stream().anyMatch((info) ->
+        group.createLocationList().stream().anyMatch((info) ->
           containerSet.getContainer(info.getContainerID()).getContainerData()
               .getState() != ContainerProtos.ContainerDataProto.State.CLOSED
         )
@@ -496,7 +496,7 @@ public class TestBlockDeletion {
         containerIdList.toArray(new Long[0]));
     // Make sure the containers are closed on the DN.
     omKeyLocationInfoGroupList.forEach((group) -> {
-      List<OmKeyLocationInfo> locationInfo = group.getLocationList();
+      List<OmKeyLocationInfo> locationInfo = group.createLocationList();
       locationInfo.forEach(
           (info) -> cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
               .getContainer().getContainerSet()
@@ -626,7 +626,7 @@ public class TestBlockDeletion {
         containerIdList.toArray(new Long[0]));
     // Make sure the containers are closed on the DN.
     omKeyLocationInfoGroupList.forEach((group) -> {
-      List<OmKeyLocationInfo> locationInfo = group.getLocationList();
+      List<OmKeyLocationInfo> locationInfo = group.createLocationList();
       locationInfo.forEach(
           (info) -> cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
               .getContainer().getContainerSet()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestFinalizeBlock.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestFinalizeBlock.java
@@ -160,7 +160,7 @@ public class TestFinalizeBlock {
     ContainerProtos.ContainerCommandRequestProto request =
         ContainerTestHelper.getWriteChunkRequest(pipeline, (
             new BlockID(containerId.getIdForTesting(), omKeyLocationInfoGroupList.get(0)
-                .getLocationList().get(0).getLocalID())), 100);
+                .createLocationList().get(0).getLocalID())), 100);
     xceiverClient.sendCommand(request);
 
     // Before finalize block PUT block on the same block should pass through
@@ -173,7 +173,7 @@ public class TestFinalizeBlock {
         xceiverClient.sendCommand(request);
 
     assertEquals(response.getFinalizeBlock().getBlockData().getBlockID().getLocalID(),
-        omKeyLocationInfoGroupList.get(0).getLocationList().get(0).getLocalID());
+        omKeyLocationInfoGroupList.get(0).createLocationList().get(0).getLocalID());
 
     assertEquals(1, ((KeyValueContainerData)getContainerfromDN(cluster.getHddsDatanodes().get(0),
         containerId.getIdForTesting()).getContainerData()).getFinalizedBlockSet().size());
@@ -226,7 +226,7 @@ public class TestFinalizeBlock {
     ContainerProtos.ContainerCommandRequestProto request =
         ContainerTestHelper.getWriteChunkRequest(pipeline,
             (new BlockID(containerId.getIdForTesting(), omKeyLocationInfoGroupList.get(0)
-                .getLocationList().get(0).getLocalID())), 100);
+                .createLocationList().get(0).getLocalID())), 100);
 
     try {
       xceiverClient.sendCommand(request);
@@ -251,7 +251,7 @@ public class TestFinalizeBlock {
   private ContainerProtos.ContainerCommandRequestProto getFinalizeBlockRequest(
       List<OmKeyLocationInfoGroup> omKeyLocationInfoGroupList, ContainerInfo container) {
     String uuidString = cluster.getHddsDatanodes().get(0).getDatanodeDetails().getUuidString();
-    long localID = omKeyLocationInfoGroupList.get(0).getLocationList().get(0).getLocalID();
+    long localID = omKeyLocationInfoGroupList.get(0).createLocationList().get(0).getLocalID();
 
     return ContainerTestHelper.getFinalizeBlockRequest(localID, container, uuidString);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -355,7 +355,7 @@ public class TestKeyManagerImpl {
     OpenKeySession keySession = writeClient.openKey(keyArgs);
     OmKeyInfo keyInfo = keySession.getKeyInfo();
     assertEquals(10,
-        keyInfo.getLatestVersionLocations().getLocationList().size());
+        keyInfo.getLatestVersionLocations().createLocationList().size());
   }
 
   @Test
@@ -390,7 +390,7 @@ public class TestKeyManagerImpl {
         .build();
     OpenKeySession keySession = writeClient.openKey(keyArgs);
     keyArgs.setLocationInfoList(
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
     OMException e =
         assertThrows(OMException.class, () -> writeClient.createDirectory(keyArgs),
@@ -408,7 +408,7 @@ public class TestKeyManagerImpl {
     writeClient.createDirectory(keyArgs);
     OzoneFileStatus fileStatus = keyManager.getFileStatus(keyArgs);
     assertTrue(fileStatus.isDirectory());
-    assertThat(fileStatus.getKeyInfo().getKeyLocationVersions().get(0).getLocationList())
+    assertThat(fileStatus.getKeyInfo().getKeyLocationVersions().get(0).createLocationList())
         .isEmpty();
   }
 
@@ -421,7 +421,7 @@ public class TestKeyManagerImpl {
         .build();
     OpenKeySession keySession = writeClient.createFile(keyArgs, false, false);
     keyArgs.setLocationInfoList(
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
 
     // try to open created key with overWrite flag set to false
@@ -455,7 +455,7 @@ public class TestKeyManagerImpl {
     // file create should pass when recursive flag is set to true
     OpenKeySession keySession = writeClient.createFile(keyArgs, false, true);
     keyArgs.setLocationInfoList(
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
     assertTrue(keyManager
         .getFileStatus(keyArgs).isFile());
@@ -480,7 +480,7 @@ public class TestKeyManagerImpl {
         .build();
     OpenKeySession keySession = writeClient.createFile(keyArgs, false, true);
     keyArgs.setLocationInfoList(
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
 
     reset(mockScmContainerClient);
@@ -740,7 +740,7 @@ public class TestKeyManagerImpl {
     // create a file
     OpenKeySession keySession = writeClient.createFile(keyArgs, false, false);
     keyArgs.setLocationInfoList(
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
     assertEquals(keyManager.lookupFile(keyArgs, null).getKeyName(),
         keyName);
@@ -776,7 +776,7 @@ public class TestKeyManagerImpl {
     OmKeyInfo key = keyManager.lookupKey(keyArgs, RESOLVED_BUCKET, null);
     assertEquals(key.getKeyName(), keyName);
     Pipeline keyPipeline =
-        key.getLatestVersionLocations().getLocationList().get(0).getPipeline();
+        key.getLatestVersionLocations().createLocationList().get(0).getPipeline();
     DatanodeDetails leader = keyPipeline.getFirstNode();
     DatanodeDetails follower1 = keyPipeline.getNodes().get(1);
     DatanodeDetails follower2 = keyPipeline.getNodes().get(2);
@@ -787,26 +787,26 @@ public class TestKeyManagerImpl {
     OmKeyInfo key1 = keyManager.lookupKey(keyArgs, RESOLVED_BUCKET,
         leader.getIpAddress());
     assertEquals(leader, key1.getLatestVersionLocations()
-        .getLocationList().get(0).getPipeline().getClosestNode());
+        .createLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower1 as client
     OmKeyInfo key2 = keyManager.lookupKey(keyArgs, RESOLVED_BUCKET,
         follower1.getIpAddress());
     assertEquals(follower1, key2.getLatestVersionLocations()
-        .getLocationList().get(0).getPipeline().getClosestNode());
+        .createLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower2 as client
     OmKeyInfo key3 = keyManager.lookupKey(keyArgs, RESOLVED_BUCKET,
         follower2.getIpAddress());
     assertEquals(follower2, key3.getLatestVersionLocations()
-        .getLocationList().get(0).getPipeline().getClosestNode());
+        .createLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, random node as client
     OmKeyInfo key4 = keyManager.lookupKey(keyArgs, RESOLVED_BUCKET,
         "/d=default-drack/127.0.0.1");
     assertThat(keyPipeline.getNodes())
         .containsAll(key4.getLatestVersionLocations()
-            .getLocationList().get(0).getPipeline().getNodesInOrder());
+            .createLocationList().get(0).getPipeline().getNodesInOrder());
   }
 
   private static void createKeyWithPipeline(OmKeyArgs keyArgs) throws IOException {
@@ -824,7 +824,7 @@ public class TestKeyManagerImpl {
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE), nodeList);
     List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
     List<OmKeyLocationInfo> locationList =
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList();
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList();
     assertEquals(1, locationList.size());
     long containerID = locationList.get(0).getContainerID();
     locationInfoList.add(
@@ -1229,7 +1229,7 @@ public class TestKeyManagerImpl {
     writeClient.createFile(keyArgs, false, false);
     OpenKeySession keySession = writeClient.createFile(keyArgs, true, true);
     keyArgs.setLocationInfoList(
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
     OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs);
     assertEquals(keyName, ozoneFileStatus.getKeyInfo().getFileName());
@@ -1249,14 +1249,14 @@ public class TestKeyManagerImpl {
     OmKeyArgs keyArgs = createBuilder().setKeyName(keyName1).build();
     OpenKeySession keySession = writeClient.openKey(keyArgs);
     keyArgs.setLocationInfoList(
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
 
     // create a key "dir1.key"
     keyArgs = createBuilder().setKeyName(keyName2).build();
     keySession = writeClient.createFile(keyArgs, true, true);
     keyArgs.setLocationInfoList(
-        keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
+        keySession.getKeyInfo().getLatestVersionLocations().createLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
 
     // verify key "dir1/key1" and "dir1.key1" can be found in the bucket, and
@@ -1477,7 +1477,7 @@ public class TestKeyManagerImpl {
     assertEquals(keyName, omKeyInfo.getKeyName());
     assertNotNull(omKeyInfo.getLatestVersionLocations());
 
-    List<OmKeyLocationInfo> locationList = omKeyInfo.getLatestVersionLocations().getLocationList();
+    List<OmKeyLocationInfo> locationList = omKeyInfo.getLatestVersionLocations().createLocationList();
     assertNotNull(locationList);
     assertEquals(5, locationList.size());
     for (int i = 0; i < 5; i++) {
@@ -1503,7 +1503,7 @@ public class TestKeyManagerImpl {
     assertEquals(keyName, omKeyInfo.getKeyName());
     assertNotNull(omKeyInfo.getLatestVersionLocations());
 
-    List<OmKeyLocationInfo> locationList = omKeyInfo.getLatestVersionLocations().getLocationList();
+    List<OmKeyLocationInfo> locationList = omKeyInfo.getLatestVersionLocations().createLocationList();
     assertNotNull(locationList);
     assertEquals(1, locationList.size());
     assertEquals(3, locationList.get(0).getPartNumber());
@@ -1798,7 +1798,7 @@ public class TestKeyManagerImpl {
       OpenKeySession keySession = writeClient.createFile(keyArgs, false, false);
       keyArgs.setLocationInfoList(
           keySession.getKeyInfo().getLatestVersionLocations()
-              .getLocationList());
+              .createLocationList());
       writeClient.commitKey(keyArgs, keySession.getId());
       keyNames.add(keyName);
     }
@@ -1811,7 +1811,7 @@ public class TestKeyManagerImpl {
       OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
       OpenKeySession keySession = writeClient.openKey(keyArgs);
       keyArgs.setLocationInfoList(keySession.getKeyInfo()
-          .getLatestVersionLocations().getLocationList());
+          .getLatestVersionLocations().createLocationList());
       writeClient.commitKey(keyArgs, keySession.getId());
 
       // verify key exist in table

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -98,7 +98,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
     OmKeyLocationInfoGroup highestVersion =
         checkVersions(keyInfo.getKeyLocationVersions());
     assertEquals(0, highestVersion.getVersion());
-    assertEquals(1, highestVersion.getLocationList().size());
+    assertEquals(1, highestVersion.createLocationList().size());
 
     // 2nd update, version 1
     openKey = writeClient.openKey(keyArgs);
@@ -112,7 +112,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
     keyInfo = ozoneManager.lookupKey(keyArgs);
     highestVersion = checkVersions(keyInfo.getKeyLocationVersions());
     assertEquals(1, highestVersion.getVersion());
-    assertEquals(1, highestVersion.getLocationList().size());
+    assertEquals(1, highestVersion.createLocationList().size());
 
     // 3rd update, version 2
     openKey = writeClient.openKey(keyArgs);
@@ -132,7 +132,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
     keyInfo = ozoneManager.lookupKey(keyArgs);
     highestVersion = checkVersions(keyInfo.getKeyLocationVersions());
     assertEquals(2, highestVersion.getVersion());
-    assertEquals(2, highestVersion.getLocationList().size());
+    assertEquals(2, highestVersion.createLocationList().size());
   }
 
   private OmKeyLocationInfoGroup checkVersions(
@@ -171,7 +171,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
     OmKeyInfo keyInfo = ozoneManager.lookupKey(omKeyArgs);
     assertEquals(0, keyInfo.getLatestVersionLocations().getVersion());
     assertEquals(1,
-        keyInfo.getLatestVersionLocations().getLocationList().size());
+        keyInfo.getLatestVersionLocations().createLocationList().size());
 
     // When bucket versioning is disabled, overwriting a key doesn't increment
     // its version count. Rather it always resets the version to 0
@@ -181,7 +181,7 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
     assertEquals(dataString, DataTestUtil.getKey(bucket, keyName));
     assertEquals(0, keyInfo.getLatestVersionLocations().getVersion());
     assertEquals(1,
-        keyInfo.getLatestVersionLocations().getLocationList().size());
+        keyInfo.getLatestVersionLocations().createLocationList().size());
 
     dataString = RandomStringUtils.secure().nextAlphabetic(200);
     DataTestUtil.createKey(bucket, keyName, dataString.getBytes(StandardCharsets.UTF_8));
@@ -190,6 +190,6 @@ public abstract class TestOmBlockVersioning implements NonHATests.TestCase {
     assertEquals(dataString, DataTestUtil.getKey(bucket, keyName));
     assertEquals(0, keyInfo.getLatestVersionLocations().getVersion());
     assertEquals(1,
-        keyInfo.getLatestVersionLocations().getLocationList().size());
+        keyInfo.getLatestVersionLocations().createLocationList().size());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingServiceIntegrationTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingServiceIntegrationTest.java
@@ -527,8 +527,8 @@ public class TestSnapshotDeletingServiceIntegrationTest {
                   activeDbDeletedKeyInfo.getKeyName());
           OmKeyInfo snap1keyInfo = snap1KeyTable.get(keyForSnap);
           assertEquals(activeDbDeletedKeyInfo.getLatestVersionLocations()
-              .getLocationList(), snap1keyInfo.getLatestVersionLocations()
-              .getLocationList());
+              .createLocationList(), snap1keyInfo.getLatestVersionLocations()
+              .createLocationList());
         }
       }
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugReplicasVerify.java
@@ -216,7 +216,8 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
       fail("No suitable key is available in the cluster");
     }
     OmKeyInfo keyInfo = keyInfoMap.get(key.get());
-    OmKeyLocationInfo location = Objects.requireNonNull(keyInfo.getLatestVersionLocations()).getLocationList().get(0);
+    OmKeyLocationInfo location = Objects.requireNonNull(
+        keyInfo.getLatestVersionLocations()).createLocationList().get(0);
     Container<?> container = getFirstContainer(location.getContainerID());
     long localID = location.getLocalID();
     LOG.info("Corrupting key: {}/{}/{} with localID {}", keyInfoMap.get(key.get()).getVolumeName(),
@@ -247,7 +248,8 @@ public abstract class TestOzoneDebugReplicasVerify implements NonHATests.TestCas
       fail("No suitable key is available in the cluster");
     }
     OmKeyInfo keyInfo = keyInfoMap.get(key.get());
-    OmKeyLocationInfo location = Objects.requireNonNull(keyInfo.getLatestVersionLocations()).getLocationList().get(0);
+    OmKeyLocationInfo location = Objects.requireNonNull(
+        keyInfo.getLatestVersionLocations()).createLocationList().get(0);
     Container<?> container = getFirstContainer(location.getContainerID());
     long localID = location.getLocalID();
     LOG.info("Truncating key: {} with localID {}", key, localID);

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
@@ -145,7 +145,7 @@ public class TestOmKeyInfoCodec extends Proto2CodecTestBase<OmKeyInfo> {
     OmKeyInfo key = codec.fromPersistedFormat(rawData);
     System.out.println("Chunk number = " + chunkNum +
         ", Serialized key size without pipeline = " + rawData.length);
-    assertNull(key.getLatestVersionLocations().getLocationList().get(0)
+    assertNull(key.getLatestVersionLocations().createLocationList().get(0)
         .getPipeline());
     assertNotNull(key.getFileChecksum());
     assertEquals(key.getFileChecksum(), checksum);

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestRepeatedOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestRepeatedOmKeyInfoCodec.java
@@ -104,7 +104,7 @@ public class TestRepeatedOmKeyInfoCodec
     byte[] rawData = codec.toPersistedFormat(repeatedOmKeyInfo);
     RepeatedOmKeyInfo key = codec.fromPersistedFormat(rawData);
     assertNull(key.getOmKeyInfoList().get(0).getLatestVersionLocations()
-        .getLocationList().get(0).getPipeline());
+        .createLocationList().get(0).getPipeline());
     assertEquals(bucketId, key.getBucketId());
   }
 
@@ -119,7 +119,7 @@ public class TestRepeatedOmKeyInfoCodec
     byte[] rawData = codecWithPipeline.toPersistedFormat(repeatedOmKeyInfo);
     RepeatedOmKeyInfo key = codecWithoutPipeline.fromPersistedFormat(rawData);
     assertNotNull(key.getOmKeyInfoList().get(0).getLatestVersionLocations()
-        .getLocationList().get(0).getPipeline());
+        .createLocationList().get(0).getPipeline());
     assertEquals(bucketId, key.getBucketId());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -724,7 +724,7 @@ public class KeyManagerImpl implements KeyManager {
     if (grpcBlockTokenEnabled) {
       String remoteUser = getRemoteUser().getShortUserName();
       for (OmKeyLocationInfoGroup key : value.getKeyLocationVersions()) {
-        key.getLocationList().forEach(k -> {
+        key.createLocationList().forEach(k -> {
           k.setToken(secretManager.generateToken(remoteUser, k.getBlockID(),
               EnumSet.of(READ), k.getLength()));
         });
@@ -887,7 +887,7 @@ public class KeyManagerImpl implements KeyManager {
             // Skip the key if the filter doesn't allow the file to be deleted.
             if (filter == null || filter.apply(Table.newKeyValue(kv.getKey(), info))) {
               List<DeletedBlock> deletedBlocks = info.getKeyLocationVersions().stream()
-                  .flatMap(versionLocations -> versionLocations.getLocationList().stream()
+                  .flatMap(versionLocations -> versionLocations.createLocationList().stream()
                       .map(b -> new DeletedBlock(
                           new BlockID(b.getContainerID(), b.getLocalID()),
                           b.getLength(),
@@ -2263,7 +2263,7 @@ public class KeyManagerImpl implements KeyManager {
           LOG.warn("No location for key {}", keyInfo);
           continue;
         }
-        for (OmKeyLocationInfo k : key.getLocationList()) {
+        for (OmKeyLocationInfo k : key.createLocationList()) {
           Pipeline pipeline = k.getPipeline();
           List<DatanodeDetails> nodes = pipeline.getNodes();
           if (nodes.isEmpty()) {
@@ -2569,7 +2569,7 @@ public class KeyManagerImpl implements KeyManager {
   @Nonnull
   private Stream<Long> extractContainerIDs(OmKeyInfo keyInfo) {
     return keyInfo.getKeyLocationVersions().stream()
-        .flatMap(v -> v.getLocationList().stream())
+        .flatMap(v -> v.createLocationList().stream())
         .map(BlockLocationInfo::getContainerID);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1504,7 +1504,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
                 .setKeyName(openKeyInfo.getKeyName())
                 .setDataSize(info.getDataSize());
             java.util.Optional.ofNullable(info.getLatestVersionLocations())
-                .map(OmKeyLocationInfoGroup::getLocationList)
+                .map(OmKeyLocationInfoGroup::createLocationList)
                 .map(Collection::stream)
                 .orElseGet(Stream::empty)
                 .map(loc -> loc.getProtobuf(ClientVersion.CURRENT_VERSION))
@@ -1959,7 +1959,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     for (OmKeyInfo info : omKeyInfo.cloneOmKeyInfoList()) {
       for (OmKeyLocationInfoGroup keyLocations :
           info.getKeyLocationVersions()) {
-        List<DeletedBlock> item = keyLocations.getLocationList().stream()
+        List<DeletedBlock> item = keyLocations.createLocationList().stream()
             .map(b -> new DeletedBlock(
                 new BlockID(b.getContainerID(), b.getLocalID()),
                 b.getLength(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -242,9 +242,9 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
     openKeyInfo.setKeyName(keyName);
 
     OmKeyLocationInfoGroup keyLatestVersionLocations = keyInfo.getLatestVersionLocations();
-    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.getLocationList();
+    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.createLocationList();
     OmKeyLocationInfoGroup openKeyLatestVersionLocations = openKeyInfo.getLatestVersionLocations();
-    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
+    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.createLocationList();
 
     if (!keyLocationInfoList.isEmpty()) {
       updateBlockInfo(ozoneManager, keyLocationInfoList.get(keyLocationInfoList.size() - 1));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1255,7 +1255,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // the referenceKey.
     Map<ContainerBlockID, OmKeyLocationInfo> cbIdSet = referenceKey.getKeyLocationVersions()
         .stream()
-        .flatMap(e -> e.getLocationList().stream())
+        .flatMap(e -> e.createLocationList().stream())
         .collect(Collectors.toMap(omKeyLocationInfo -> omKeyLocationInfo.getBlockID().getContainerBlockID(),
             Function.identity()));
     Map<OmKeyInfo, List<OmKeyLocationInfo>> filteredOutBlocks = new HashMap<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -691,10 +691,10 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
           .getKeyLocationVersions().get(0);
 
       // Set partNumber in each block.
-      currentKeyInfoGroup.getLocationList().forEach(
+      currentKeyInfoGroup.createLocationList().forEach(
           omKeyLocationInfo -> omKeyLocationInfo.setPartNumber(partNumber));
 
-      partLocationInfos.addAll(currentKeyInfoGroup.getLocationList());
+      partLocationInfos.addAll(currentKeyInfoGroup.createLocationList());
       dataSize += currentPartKeyInfo.getDataSize();
     }
     return dataSize;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -319,9 +319,9 @@ public final class SnapshotUtils {
     }
 
     List<OmKeyLocationInfo> deletedLocationList =
-        deletedOmKeyLocation.getLocationList();
+        deletedOmKeyLocation.createLocationList();
     List<OmKeyLocationInfo> prevLocationList =
-        prevOmKeyLocation.getLocationList();
+        prevOmKeyLocation.createLocationList();
 
     if (deletedLocationList.size() != prevLocationList.size()) {
       return false;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -175,7 +175,7 @@ public class TestOMFileCreateRequest extends OMKeyRequestTests {
     omKeyInfo = verifyPathInOpenKeyTable(keyName, id, true);
 
     List< OmKeyLocationInfo > omKeyLocationInfoList =
-        omKeyInfo.getLatestVersionLocations().getLocationList();
+        omKeyInfo.getLatestVersionLocations().createLocationList();
     assertEquals(1, omKeyLocationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = omKeyLocationInfoList.get(0);
@@ -622,7 +622,7 @@ public class TestOMFileCreateRequest extends OMKeyRequestTests {
       OmKeyInfo omKeyInfo = verifyPathInOpenKeyTable(key, id, true);
 
       List< OmKeyLocationInfo > omKeyLocationInfoList =
-          omKeyInfo.getLatestVersionLocations().getLocationList();
+          omKeyInfo.getLatestVersionLocations().createLocationList();
       assertEquals(1, omKeyLocationInfoList.size());
 
       OmKeyLocationInfo omKeyLocationInfo = omKeyLocationInfoList.get(0);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -103,7 +103,7 @@ public class TestOMAllocateBlockRequest extends OMKeyRequestTests {
             true);
 
     List<OmKeyLocationInfo> omKeyLocationInfo =
-        omKeyInfo.getLatestVersionLocations().getLocationList();
+        omKeyInfo.getLatestVersionLocations().createLocationList();
 
     assertEquals(0, omKeyLocationInfo.size());
 
@@ -133,7 +133,7 @@ public class TestOMAllocateBlockRequest extends OMKeyRequestTests {
         modifiedOmRequest.getAllocateBlockRequest().getKeyLocation();
 
     omKeyLocationInfo =
-        omKeyInfo.getLatestVersionLocations().getLocationList();
+        omKeyInfo.getLatestVersionLocations().createLocationList();
 
     assertEquals(1, omKeyLocationInfo.size());
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -142,7 +142,7 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
 
     // Check block location.
     assertEquals(allocatedLocationList,
-        omKeyInfo.getLatestVersionLocations().getLocationList());
+        omKeyInfo.getLatestVersionLocations().createLocationList());
 
   }
 
@@ -215,9 +215,9 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
         .collect(Collectors.toList());
 
     assertEquals(locationInfoListFromCommitKeyRequest,
-        omKeyInfo.getLatestVersionLocations().getLocationList());
+        omKeyInfo.getLatestVersionLocations().createLocationList());
     assertEquals(allocatedLocationList,
-        omKeyInfo.getLatestVersionLocations().getLocationList());
+        omKeyInfo.getLatestVersionLocations().createLocationList());
   }
 
   @Test
@@ -402,7 +402,7 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
     assertEquals(allocatedKeyLocationList.size() - committedKeyLocationList.size(),
         toDeleteKeyList.values().stream()
         .findFirst().get().cloneOmKeyInfoList().get(0).getKeyLocationVersions()
-        .get(0).getLocationList().size());
+        .get(0).createLocationList().size());
 
     // Entry should be deleted from openKey Table.
     omKeyInfo =
@@ -437,7 +437,7 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
 
     // Key table should have three blocks.
     assertEquals(intersection,
-        omKeyInfo.getLatestVersionLocations().getLocationList());
+        omKeyInfo.getLatestVersionLocations().createLocationList());
     assertEquals(3, intersection.size());
 
   }
@@ -760,8 +760,8 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
         commitKeyRequest.getKeyArgs().getKeyLocationsList().stream().map(OmKeyLocationInfo::getFromProtobuf)
             .collect(Collectors.toList());
 
-    assertEquals(locationInfoListFromCommitKeyRequest, omKeyInfo.getLatestVersionLocations().getLocationList());
-    assertEquals(allocatedLocationList, omKeyInfo.getLatestVersionLocations().getLocationList());
+    assertEquals(locationInfoListFromCommitKeyRequest, omKeyInfo.getLatestVersionLocations().createLocationList());
+    assertEquals(allocatedLocationList, omKeyInfo.getLatestVersionLocations().createLocationList());
     assertEquals(1, omKeyInfo.getKeyLocationVersions().size());
 
     // flush response content to db
@@ -847,8 +847,8 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
         commitKeyRequest.getKeyArgs().getKeyLocationsList().stream().map(OmKeyLocationInfo::getFromProtobuf)
             .collect(Collectors.toList());
 
-    assertEquals(locationInfoListFromCommitKeyRequest, omKeyInfo.getLatestVersionLocations().getLocationList());
-    assertEquals(committedBlockList, omKeyInfo.getLatestVersionLocations().getLocationList());
+    assertEquals(locationInfoListFromCommitKeyRequest, omKeyInfo.getLatestVersionLocations().createLocationList());
+    assertEquals(committedBlockList, omKeyInfo.getLatestVersionLocations().createLocationList());
     assertEquals(1, omKeyInfo.getKeyLocationVersions().size());
 
     Map<String, RepeatedOmKeyInfo> toDeleteKeyList
@@ -862,9 +862,9 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
     assertEquals(2, keysToDelete.size());
     OmKeyInfo overwrittenKey = keysToDelete.get(0);
     OmKeyInfo uncommittedPseudoKey = keysToDelete.get(1);
-    assertEquals(DEFAULT_COMMIT_BLOCK_SIZE, overwrittenKey.getLatestVersionLocations().getLocationList().size());
+    assertEquals(DEFAULT_COMMIT_BLOCK_SIZE, overwrittenKey.getLatestVersionLocations().createLocationList().size());
     assertEquals(allocatedKeyLocationList.size() - committedKeyLocationList.size(),
-        uncommittedPseudoKey.getLatestVersionLocations().getLocationList().size());
+        uncommittedPseudoKey.getLatestVersionLocations().createLocationList().size());
 
     // flush response content to db
     BatchOperation batchOperation = omMetadataManager.getStore().initBatchOperation();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -499,7 +499,7 @@ public class TestOMKeyCreateRequest extends OMKeyRequestTests {
     assertNotNull(omKeyInfo.getLatestVersionLocations());
 
     List<OmKeyLocationInfo> omKeyLocationInfoList =
-        omKeyInfo.getLatestVersionLocations().getLocationList();
+        omKeyInfo.getLatestVersionLocations().createLocationList();
     if (modifiedOmRequest.getCreateKeyRequest().getKeyArgs().getDataSize() > 0) {
       // As our data size is 100, and scmBlockSize is default to 1000, so we
       // shall have only one block.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -443,7 +443,7 @@ public class TestS3MultipartUploadCommitPartRequest
             .collect(Collectors.toList());
 
     assertEquals(overwriteKeyLocationInfos, locationsInfoListFromCommitPartRequest);
-    assertEquals(overwriteKeyLocationInfos, newPartOmKeyInfo.getLatestVersionLocations().getLocationList());
+    assertEquals(overwriteKeyLocationInfos, newPartOmKeyInfo.getLatestVersionLocations().createLocationList());
     assertEquals(1, newPartOmKeyInfo.getKeyLocationVersions().size());
 
     Map<String, RepeatedOmKeyInfo> toDeleteKeyList =
@@ -453,7 +453,7 @@ public class TestS3MultipartUploadCommitPartRequest
     assertEquals(1, toDeleteKeyList.size());
     assertEquals(originalKeyLocationList.size(), toDeleteKeyList.values().stream()
         .findFirst().get().cloneOmKeyInfoList().get(0).getKeyLocationVersions()
-        .get(0).getLocationList().size());
+        .get(0).createLocationList().size());
   }
 
   @Test
@@ -516,7 +516,7 @@ public class TestS3MultipartUploadCommitPartRequest
     assertEquals(1, toDeleteKeyList.size());
     assertEquals(2, toDeleteKeyList.values().stream()
         .findFirst().get().cloneOmKeyInfoList().get(0).getKeyLocationVersions()
-        .get(0).getLocationList().size());
+        .get(0).createLocationList().size());
 
     String multipartOpenKey = getMultipartOpenKey(volumeName, bucketName,
         keyName, multipartUploadID);
@@ -653,7 +653,7 @@ public class TestS3MultipartUploadCommitPartRequest
             .collect(Collectors.toList());
 
     assertEquals(overwriteCommittedBlockList, locationsInfoListFromCommitPartRequest);
-    assertEquals(overwriteCommittedBlockList, newPartOmKeyInfo.getLatestVersionLocations().getLocationList());
+    assertEquals(overwriteCommittedBlockList, newPartOmKeyInfo.getLatestVersionLocations().createLocationList());
     assertEquals(1, newPartOmKeyInfo.getKeyLocationVersions().size());
 
     Map<String, RepeatedOmKeyInfo> toDeleteKeyMap =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -180,7 +180,7 @@ public class TestOzoneNativeAuthorizer {
       OpenKeySession keySession = writeClient.createFile(keyArgs, true, false);
       keyArgs.setLocationInfoList(
           keySession.getKeyInfo().getLatestVersionLocations()
-              .getLocationList());
+              .createLocationList());
       writeClient.commitKey(keyArgs, keySession.getId());
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -344,7 +344,7 @@ public class TestParentAcl {
       OpenKeySession keySession = writeClient.createFile(keyArgs, true, false);
       keyArgs.setLocationInfoList(
           keySession.getKeyInfo().getLatestVersionLocations()
-              .getLocationList());
+              .createLocationList());
       writeClient.commitKey(keyArgs, keySession.getId());
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
@@ -143,7 +143,7 @@ public class TestVolumeOwner {
               false);
           keyArgs.setLocationInfoList(
               keySession.getKeyInfo().getLatestVersionLocations()
-                  .getLocationList());
+                  .createLocationList());
           writeClient.commitKey(keyArgs, keySession.getId());
         }
       }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/LeaseRecoveryClientDNHandler.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/LeaseRecoveryClientDNHandler.java
@@ -52,9 +52,9 @@ public final class LeaseRecoveryClientDNHandler {
   public static List<OmKeyLocationInfo> getOmKeyLocationInfos(LeaseKeyInfo leaseKeyInfo,
       OzoneClientAdapter adapter, boolean forceRecovery) throws IOException {
     OmKeyLocationInfoGroup keyLatestVersionLocations = leaseKeyInfo.getKeyInfo().getLatestVersionLocations();
-    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.getLocationList();
+    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.createLocationList();
     OmKeyLocationInfoGroup openKeyLatestVersionLocations = leaseKeyInfo.getOpenKeyInfo().getLatestVersionLocations();
-    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
+    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.createLocationList();
 
     int openKeyLocationSize = openKeyLocationInfoList.size();
     int keyLocationSize = keyLocationInfoList.size();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -516,7 +516,7 @@ public class ReconContainerMetadataManagerImpl
     if (null != omKeyInfo) {
       omKeyInfo.getKeyLocationVersions().stream().map(
           omKeyLocationInfoGroup ->
-              omKeyLocationInfoGroup.getLocationList()
+              omKeyLocationInfoGroup.createLocationList()
                   .stream().map(omKeyLocationInfo -> pipelines.add(
                       omKeyLocationInfo.getPipeline())));
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperHelper.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperHelper.java
@@ -319,7 +319,7 @@ public abstract class ContainerKeyMapperHelper {
     long containerCountToIncrement = 0;
     for (OmKeyLocationInfoGroup omKeyLocationInfoGroup : omKeyInfo.getKeyLocationVersions()) {
       long keyVersion = omKeyLocationInfoGroup.getVersion();
-      for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfoGroup.getLocationList()) {
+      for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfoGroup.createLocationList()) {
         long containerId = omKeyLocationInfo.getContainerID();
         ContainerKeyPrefix containerKeyPrefix = ContainerKeyPrefix.get(containerId, key, keyVersion);
         if (reconContainerMetadataManager.getCountForContainerKeyPrefix(containerKeyPrefix) == 0 &&
@@ -490,7 +490,7 @@ public abstract class ContainerKeyMapperHelper {
 
     for (OmKeyLocationInfoGroup omKeyLocationInfoGroup : omKeyInfo.getKeyLocationVersions()) {
       long keyVersion = omKeyLocationInfoGroup.getVersion();
-      for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfoGroup.getLocationList()) {
+      for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfoGroup.createLocationList()) {
         long containerId = omKeyLocationInfo.getContainerID();
         ContainerKeyPrefix containerKeyPrefix = ContainerKeyPrefix.get(containerId, key, keyVersion);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename the zero-argument `OmKeyLocationInfoGroup#getLocationList()` method to
`createLocationList()`.

The method flattens `locationVersionMap` and creates a new list on every
invocation. The new name makes the allocation behavior explicit and avoids
giving callers the impression that it is a lightweight O(1) getter.

All production and test call sites have been updated, including method
references. The deprecated `getLocationList(Long)` overload remains unchanged.

This is a naming-only change with no functional behavior changes.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-16201

## How was this patch tested?

- `mvn -pl :ozone-common test -Dtest=TestOmKeyLocationInfoGroup -DskipShade -DskipRecon -DskipDocs`
- Compiled the main and test sources of all affected modules.
- `./hadoop-ozone/dev-support/checks/checkstyle.sh`
