### PR TITLE
HDDS-16244. Remove redundant RPC metadata from SCMSecurityProtocol

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -25,22 +25,12 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmNodeDetailsProto;
-import org.apache.hadoop.hdds.scm.ScmConfig;
-import org.apache.hadoop.security.KerberosInfo;
 
 /**
  * The protocol used to perform security related operations with SCM.
  */
-@KerberosInfo(
-    serverPrincipal = ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_PRINCIPAL_KEY)
 @InterfaceAudience.Private
 public interface SCMSecurityProtocol {
-
-  @SuppressWarnings("checkstyle:ConstantName")
-  /**
-   * Version 1: Initial version.
-   */
-  long versionID = 1L;
 
   /**
    * Get SCM signed certificate for DataNode.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/protocolPB/TestSCMSecurityProtocolPB.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/protocolPB/TestSCMSecurityProtocolPB.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.protocolPB;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
+import org.apache.hadoop.hdds.scm.ScmConfig;
+import org.apache.hadoop.ipc_.RPC;
+import org.apache.hadoop.security.KerberosInfo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the Hadoop RPC metadata for the SCM security protocol.
+ */
+public class TestSCMSecurityProtocolPB {
+
+  private static final String PROTOCOL_NAME =
+      "org.apache.hadoop.hdds.protocol.SCMSecurityProtocol";
+
+  @Test
+  public void testProtocolMetadata() {
+    assertEquals(PROTOCOL_NAME, SCMSecurityProtocol.class.getName());
+    assertEquals(PROTOCOL_NAME,
+        RPC.getProtocolName(SCMSecurityProtocolPB.class));
+    assertEquals(1L, RPC.getProtocolVersion(SCMSecurityProtocolPB.class));
+
+    KerberosInfo kerberosInfo = SCMSecurityProtocolPB.class
+        .getAnnotation(KerberosInfo.class);
+    assertNotNull(kerberosInfo);
+    assertEquals(ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_PRINCIPAL_KEY,
+        kerberosInfo.serverPrincipal());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
`SCMSecurityProtocol` duplicated the protocol version and Kerberos metadata already defined by `SCMSecurityProtocolPB`, which is the interface used by Hadoop RPC.

This PR:
- removes the redundant `versionID` and `@KerberosInfo` annotation from `SCMSecurityProtocol`;
- keeps the RPC metadata in `SCMSecurityProtocolPB`;
- adds a regression test verifying the protocol name, protocol version, and SCM Kerberos principal exposed by the PB protocol.

This consolidates the RPC metadata in the protocol interface where it is consumed and prevents the duplicated definitions from diverging.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16244

## How was this patch tested?

Local Test
```
mvn -pl :hdds-server-framework -am test \
      -Dtest=TestSCMSecurityProtocolPB \
      -Dsurefire.failIfNoSpecifiedTests=false \
      -DskipShade -DskipRecon -DskipDocs

mvn -pl :ozone-integration-test test \
      -Dtest=TestSecureOzoneCluster#testSecureScmAndOmStartupAndAccessControl \
      -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/32463288850

Generated-by: Codex (GPT-5)