### PR TITLE
HDDS-16241. gRPC deadline kills long-lived block streams after 30 seconds and the client never recovers

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -619,9 +619,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
           throw new IOException("Failed to get gRPC stub for DataNode: " + dn);
         }
         LOG.debug("initStreamRead {} on datanode {}", blockID.getContainerBlockID(), dn);
-        StreamObserver<ContainerCommandRequestProto> requestObserver = stub
-            .withDeadlineAfter(timeout, TimeUnit.SECONDS)
-            .send(streamObserver);
+        // No deadline: it would bound the entire long-lived streaming call. Per-request timeliness is
+        // enforced by streamReadTimeout in streamRead() and StreamingReader.poll().
+        StreamObserver<ContainerCommandRequestProto> requestObserver = stub.send(streamObserver);
         streamObserver.setStreamingReadResponse(new StreamingReadResponse(dn,
             (ClientCallStreamObserver<ContainerCommandRequestProto>) requestObserver));
         return;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.grpc.Status;
 import org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException;
 import org.apache.ratis.thirdparty.io.grpc.stub.ClientCallStreamObserver;
 import org.apache.ratis.util.Preconditions;
@@ -373,6 +374,15 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
     }
     xceiverClient.streamRead(ContainerProtocolCalls.buildReadBlockCommandProto(
         blockID, requestedLength, length, responseDataSize, tokenRef.get(), pipelineRef.get()), r);
+  }
+
+  /**
+   * A stream killed by a gRPC deadline is a transport failure of the long-lived call, not a data error:
+   * fail over to another datanode the same way as UNAVAILABLE. The classic per-request path is unaffected.
+   */
+  @Override
+  protected boolean isConnectivityIssue(IOException ex) {
+    return super.isConnectivityIssue(ex) || Status.fromThrowable(ex).getCode() == Status.DEADLINE_EXCEEDED.getCode();
   }
 
   private void handleExceptions(IOException cause) throws IOException {

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
@@ -270,6 +270,52 @@ public class TestStreamBlockInputStream {
     }
   }
 
+  /**
+   * A stream killed with DEADLINE_EXCEEDED (e.g. by a deadline on the long-lived call) must be treated
+   * like any other connectivity failure: fail over to a fresh stream instead of surfacing the error.
+   */
+  @Test
+  public void testDeadlineExceededFailsOverToFreshStream() throws Exception {
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    clientConfig.setReadRetryInterval(0);
+    BlockID blockID = new BlockID(1L, 13L);
+    byte[] data = {1, 2, 3, 4};
+    Pipeline pipeline = mockStandalonePipeline();
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver = mock(ClientCallStreamObserver.class);
+    StreamingReadResponse streamingReadResponse = mock(StreamingReadResponse.class);
+    when(streamingReadResponse.getRequestObserver()).thenReturn(requestObserver);
+    when(streamingReadResponse.getDatanodeDetails()).thenReturn(MockDatanodeDetails.randomDatanodeDetails());
+
+    AtomicInteger initCount = new AtomicInteger();
+    XceiverClientGrpc xceiverClient = mock(XceiverClientGrpc.class);
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = inv.getArgument(1);
+      reader.setStreamingReadResponse(streamingReadResponse);
+      if (initCount.incrementAndGet() == 1) {
+        // First stream is killed by the transport.
+        reader.onError(Status.DEADLINE_EXCEEDED.asRuntimeException());
+      } else {
+        reader.onNext(ContainerCommandResponseProto.newBuilder()
+            .setCmdType(Type.ReadBlock)
+            .setResult(ContainerProtos.Result.SUCCESS)
+            .setReadBlock(buildReadBlockResponse(data))
+            .build());
+      }
+      return null;
+    }).when(xceiverClient).initStreamRead(any(BlockID.class), any(), any());
+
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class))).thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, data.length, pipeline, null, xceiverClientFactory, NO_REFRESH, clientConfig)) {
+      ByteBuffer buf = ByteBuffer.allocate(data.length);
+      assertEquals(data.length, sbis.read(buf), "read should succeed after failing over to a fresh stream");
+      assertArrayEquals(data, buf.array());
+    }
+    assertEquals(2, initCount.get(), "a fresh stream should have been initialized for the retry");
+  }
+
   private OzoneClientConfig newStreamReadConfig() {
     OzoneClientConfig clientConfig = new OzoneClientConfig();
     clientConfig.setChecksumVerify(false);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -150,6 +150,8 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   public static final String BLOCK_DELETE_COMMAND_WORKER_INTERVAL =
       "hdds.datanode.block.delete.command.worker.interval";
   public static final Duration BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT = Duration.ofSeconds(2);
+  public static final String STREAM_READ_FILE_IDLE_TIMEOUT_KEY = "hdds.datanode.stream.read.file.idle.timeout";
+  public static final Duration STREAM_READ_FILE_IDLE_TIMEOUT_DEFAULT = Duration.ofMinutes(1);
 
   /**
    * Number of threads per volume that Datanode will use for chunk read.
@@ -161,6 +163,16 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
       description = "Number of threads per volume that Datanode will use for reading replicated chunks."
   )
   private int numReadThreadPerVolume = 10;
+
+  @Config(key = STREAM_READ_FILE_IDLE_TIMEOUT_KEY,
+      type = ConfigType.TIME,
+      defaultValue = "1m",
+      tags = {DATANODE},
+      description = "How long a streaming ReadBlock stream may stay idle before the datanode closes the block file "
+          + "held open for it. The stream itself stays open and the file is reopened by the next request, so this "
+          + "only bounds the file descriptors pinned by idle streams."
+  )
+  private Duration streamReadFileIdleTimeout = STREAM_READ_FILE_IDLE_TIMEOUT_DEFAULT;
 
   /**
    * SO_BACKLOG value for the gRPC server socket.
@@ -836,6 +848,12 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
           BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
     }
 
+    if (streamReadFileIdleTimeout.isNegative() || streamReadFileIdleTimeout.isZero()) {
+      LOG.warn(STREAM_READ_FILE_IDLE_TIMEOUT_KEY + " must be greater than zero and was set to {}. Defaulting to {}",
+          streamReadFileIdleTimeout, STREAM_READ_FILE_IDLE_TIMEOUT_DEFAULT);
+      streamReadFileIdleTimeout = STREAM_READ_FILE_IDLE_TIMEOUT_DEFAULT;
+    }
+
     if (rocksdbLogMaxFileSize < 0) {
       LOG.warn(ROCKSDB_LOG_MAX_FILE_SIZE_BYTES_KEY +
               " must be no less than zero and was set to {}. Defaulting to {}",
@@ -1182,6 +1200,10 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
 
   public int getNumReadThreadPerVolume() {
     return numReadThreadPerVolume;
+  }
+
+  public Duration getStreamReadFileIdleTimeout() {
+    return streamReadFileIdleTimeout;
   }
 
   public void setNumReadThreadPerVolume(int threads) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
@@ -19,7 +19,15 @@ package org.apache.hadoop.ozone.container.common.transport.server;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.XceiverClientProtocolServiceGrpc.getSendMethod;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
@@ -47,12 +55,24 @@ public class GrpcXceiverService extends
       LOG = LoggerFactory.getLogger(GrpcXceiverService.class);
 
   private final ContainerDispatcher dispatcher;
+  // A streaming ReadBlock call has no deadline, so an idle stream would pin its block file indefinitely.
+  // This timer closes the file of any stream idle for longer than the timeout; the next request reopens it.
+  private final long streamReadFileIdleTimeoutNanos;
+  private final ScheduledExecutorService idleFileCloser;
   private final ZeroCopyMessageMarshaller<ContainerCommandRequestProto>
       zeroCopyMessageMarshaller = new ZeroCopyMessageMarshaller<>(
           ContainerCommandRequestProto.getDefaultInstance());
 
-  public GrpcXceiverService(ContainerDispatcher dispatcher) {
+  public GrpcXceiverService(ContainerDispatcher dispatcher, Duration streamReadFileIdleTimeout,
+      String threadNamePrefix) {
     this.dispatcher = dispatcher;
+    this.streamReadFileIdleTimeoutNanos = streamReadFileIdleTimeout.toNanos();
+    this.idleFileCloser = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setDaemon(true)
+        .setNameFormat(threadNamePrefix + "ReadBlockIdleFileCloser").build());
+  }
+
+  public void shutdown() {
+    idleFileCloser.shutdownNow();
   }
 
   /**
@@ -99,13 +119,53 @@ public class GrpcXceiverService extends
     return new StreamObserver<ContainerCommandRequestProto>() {
       private final AtomicBoolean isClosed = new AtomicBoolean(false);
       private final RandomAccessFileChannel blockFile = new RandomAccessFileChannel();
+      // Held while a request is served, so the idle closer never closes the file under an in-flight read.
+      private final ReentrantLock requestLock = new ReentrantLock();
+      private volatile long lastRequestNanos;
+      private volatile ScheduledFuture<?> idleFileCheck;
 
       boolean close() {
         if (isClosed.compareAndSet(false, true)) {
+          final ScheduledFuture<?> check = idleFileCheck;
+          if (check != null) {
+            check.cancel(false);
+          }
           blockFile.close();
           return true;
         }
         return false;
+      }
+
+      private void scheduleIdleFileCheck(long delayNanos) {
+        try {
+          idleFileCheck = idleFileCloser.schedule(this::closeFileIfIdle, delayNanos, TimeUnit.NANOSECONDS);
+        } catch (RejectedExecutionException e) {
+          // Server is shutting down; the file is closed when the stream ends.
+          LOG.debug("Idle file closer is shut down, not scheduling check", e);
+        }
+      }
+
+      private void closeFileIfIdle() {
+        if (isClosed.get()) {
+          return;
+        }
+        final long idleNanos = System.nanoTime() - lastRequestNanos;
+        if (idleNanos < streamReadFileIdleTimeoutNanos || !requestLock.tryLock()) {
+          // Not idle for long enough, or a request is in flight: check again later.
+          scheduleIdleFileCheck(idleNanos < streamReadFileIdleTimeoutNanos
+              ? streamReadFileIdleTimeoutNanos - idleNanos : streamReadFileIdleTimeoutNanos);
+          return;
+        }
+        try {
+          if (blockFile.isOpen()) {
+            LOG.debug("Closing block file of streaming read idle for {}ms", TimeUnit.NANOSECONDS.toMillis(idleNanos));
+            blockFile.close();
+          }
+          // The next request reopens the file and schedules a new check.
+          idleFileCheck = null;
+        } finally {
+          requestLock.unlock();
+        }
       }
 
       @Override
@@ -115,6 +175,7 @@ public class GrpcXceiverService extends
             .setReleaseSupported(true)
             .build();
 
+        requestLock.lock();
         try {
           if (request.getCmdType() == Type.ReadBlock) {
             dispatcher.streamDataReadOnly(request, responseObserver, blockFile, context);
@@ -132,6 +193,11 @@ public class GrpcXceiverService extends
           if (context != null) {
             context.release();
           }
+          lastRequestNanos = System.nanoTime();
+          if (!isClosed.get() && blockFile.isOpen() && idleFileCheck == null) {
+            scheduleIdleFileCheck(streamReadFileIdleTimeoutNanos);
+          }
+          requestLock.unlock();
         }
       }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
@@ -76,6 +76,7 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
   private DatanodeID id;
   private Server server;
   private final ContainerDispatcher storageContainer;
+  private final GrpcXceiverService xceiverService;
   private boolean isStarted;
   private DatanodeDetails datanodeDetails;
   private EventLoopGroup eventLoopGroup;
@@ -136,7 +137,8 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
     }
 
     LOG.info("GrpcServer channel type {}", channelType.getSimpleName());
-    GrpcXceiverService xceiverService = new GrpcXceiverService(dispatcher);
+    xceiverService = new GrpcXceiverService(dispatcher, dnConf.getStreamReadFileIdleTimeout(),
+        datanodeDetails.threadNamePrefix());
     NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forPort(port)
         .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
         .bossEventLoopGroup(eventLoopGroup)
@@ -234,6 +236,7 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
       try {
         server.shutdown();
         server.awaitTermination(5, TimeUnit.SECONDS);
+        xceiverService.shutdown();
         eventLoopGroup.shutdownGracefully().sync();
       } catch (InterruptedException e) {
         LOG.error("failed to shutdown XceiverServerGrpc", e);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/TestGrpcXceiverService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/TestGrpcXceiverService.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.transport.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.DatanodeBlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadBlockRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
+import org.apache.hadoop.hdds.utils.io.RandomAccessFileChannel;
+import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
+import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for the streaming ReadBlock handling in {@link GrpcXceiverService}: the block file held open for a
+ * stream is closed once the stream is idle and reopened by the next request.
+ */
+class TestGrpcXceiverService {
+
+  private static final Duration IDLE_TIMEOUT = Duration.ofMillis(200);
+
+  @TempDir
+  private Path tempDir;
+
+  private GrpcXceiverService service;
+
+  @AfterEach
+  void shutdown() {
+    if (service != null) {
+      service.shutdown();
+    }
+  }
+
+  private static ContainerCommandRequestProto readBlockRequest() {
+    return ContainerCommandRequestProto.newBuilder()
+        .setCmdType(Type.ReadBlock)
+        .setContainerID(1)
+        .setDatanodeUuid("dn")
+        .setReadBlock(ReadBlockRequestProto.newBuilder()
+            .setBlockID(DatanodeBlockID.newBuilder().setContainerID(1).setLocalID(1))
+            .setOffset(0))
+        .build();
+  }
+
+  /**
+   * Mimics {@code KeyValueHandler.readBlockImpl}: open the block file on first use, then serve the request.
+   * The optional hook runs while the request is in flight.
+   */
+  private ContainerDispatcher mockDispatcher(File blockFile, AtomicReference<RandomAccessFileChannel> channelRef,
+      Runnable inFlight) throws Exception {
+    ContainerDispatcher dispatcher = mock(ContainerDispatcher.class);
+    doAnswer(inv -> {
+      RandomAccessFileChannel channel = inv.getArgument(2);
+      channelRef.set(channel);
+      if (!channel.isOpen()) {
+        channel.open(blockFile);
+      }
+      inFlight.run();
+      return null;
+    }).when(dispatcher).streamDataReadOnly(any(), any(), any(), any());
+    return dispatcher;
+  }
+
+  @Test
+  void idleStreamClosesBlockFileAndNextRequestReopensIt() throws Exception {
+    File blockFile = Files.createFile(tempDir.resolve("block")).toFile();
+    AtomicReference<RandomAccessFileChannel> channelRef = new AtomicReference<>();
+    service = new GrpcXceiverService(mockDispatcher(blockFile, channelRef, () -> { }), IDLE_TIMEOUT, "test-");
+    StreamObserver<ContainerCommandResponseProto> responseObserver = mock(StreamObserver.class);
+    StreamObserver<ContainerCommandRequestProto> requestObserver = service.send(responseObserver);
+
+    requestObserver.onNext(readBlockRequest());
+    RandomAccessFileChannel channel = channelRef.get();
+    assertNotNull(channel);
+    assertTrue(channel.isOpen(), "block file should be open right after a request");
+
+    GenericTestUtils.waitFor(() -> !channel.isOpen(), 20, 5000);
+    verify(responseObserver, never()).onError(any());
+    verify(responseObserver, never()).onCompleted();
+
+    requestObserver.onNext(readBlockRequest());
+    assertTrue(channel.isOpen(), "next request should reopen the block file");
+    GenericTestUtils.waitFor(() -> !channel.isOpen(), 20, 5000);
+
+    requestObserver.onCompleted();
+    assertFalse(channel.isOpen());
+    verify(responseObserver).onCompleted();
+  }
+
+  @Test
+  void inFlightRequestKeepsBlockFileOpen() throws Exception {
+    File blockFile = Files.createFile(tempDir.resolve("block")).toFile();
+    AtomicReference<RandomAccessFileChannel> channelRef = new AtomicReference<>();
+    AtomicReference<Boolean> openDuringSlowRequest = new AtomicReference<>();
+    Runnable slowRequest = () -> {
+      // Stay in flight well past the idle timeout, then record whether the file survived.
+      try {
+        Thread.sleep(3 * IDLE_TIMEOUT.toMillis());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      openDuringSlowRequest.set(channelRef.get().isOpen());
+    };
+    AtomicReference<Runnable> inFlight = new AtomicReference<>(() -> { });
+    service = new GrpcXceiverService(mockDispatcher(blockFile, channelRef, () -> inFlight.get().run()),
+        IDLE_TIMEOUT, "test-");
+    StreamObserver<ContainerCommandRequestProto> requestObserver = service.send(mock(StreamObserver.class));
+
+    // First request arms the idle check; the second one is still running when it fires.
+    requestObserver.onNext(readBlockRequest());
+    inFlight.set(slowRequest);
+    requestObserver.onNext(readBlockRequest());
+    assertTrue(openDuringSlowRequest.get(), "an in-flight request must not lose its block file");
+
+    RandomAccessFileChannel channel = channelRef.get();
+    GenericTestUtils.waitFor(() -> !channel.isOpen(), 20, 5000);
+    requestObserver.onCompleted();
+  }
+
+  @Test
+  void errorClosesBlockFileImmediately() throws Exception {
+    File blockFile = Files.createFile(tempDir.resolve("block")).toFile();
+    AtomicReference<RandomAccessFileChannel> channelRef = new AtomicReference<>();
+    service = new GrpcXceiverService(mockDispatcher(blockFile, channelRef, () -> { }), Duration.ofHours(1), "test-");
+    StreamObserver<ContainerCommandRequestProto> requestObserver = service.send(mock(StreamObserver.class));
+
+    requestObserver.onNext(readBlockRequest());
+    assertTrue(channelRef.get().isOpen());
+    requestObserver.onError(new RuntimeException("client went away"));
+    assertFalse(channelRef.get().isOpen(), "stream teardown must close the block file");
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-16241. gRPC deadline kills long-lived block streams after 30 seconds and the client never recovers

XceiverClientGrpc.initStreamRead arms a gRPC deadline (withDeadlineAfter, ozone.client.read.timeout, default 30 seconds) on the long-lived streaming ReadBlock call introduced by HDDS-13974. A gRPC deadline bounds the entire call, not a single request, so every block stream is cancelled with DEADLINE_EXCEEDED 30 seconds after it opens, even when it is perfectly healthy. The failure then becomes permanent on the client side:
1. The cancellation lands in StreamingReader.onError and completes the reader future exceptionally. StreamBlockInputStream never re-initializes a reader whose future has failed, so checkError replays the stale exception on every subsequent read of that block for as long as the input stream stays open.
2. The failure is not classified as retryable: isConnectivityIssue only accepts UNAVAILABLE, and checkError wraps the original exception in a new IOException whose cause chain (IOException -> ExecutionException -> StatusRuntimeException) the retry classification cannot unwrap. So the failover/refresh path in handleExceptions never engages.

Long-lived readers hit this hard. On an HBase-on-Ozone cluster, RegionServers keep store file input streams open indefinitely; after each stream's first 30 seconds, every pread through it fails instantly. A YCSB read workload showed a steady ~42 percent error rate (reads served from HBase block cache or memstore still succeeded, masking the problem for the first 30 seconds of each stream's life). Short-lived readers (CLI, file copies) close before the deadline fires.

A related capacity problem: initStreamRead held a permit from the shared request semaphore for the stream's whole lifetime, so a client with many open files could exhaust the permits, starve short RPCs, and block new streams indefinitely (observed as 30-second RegionServer-wide stalls).
What fix does:
Remove the trigger, make recovery work, and separate stream capacity from request capacity:
1. Drop the call-lifetime deadline from the streaming call. Per-request timeliness is already enforced by ozone.client.stream.read.timeout in streamRead flow-control waits and StreamingReader.poll, which fails a stuck request with a retryable TimeoutIOException.
2. Never poison the stream. handleExceptions now marks the reader failed and, on the non-retryable path, tears down the failed stream and resets the request high-water mark before rethrowing, so the next read builds a fresh stream instead of replaying the stale failure. closeReader also resets requestedLength, since requested-but-unreceived data dies with the stream (this also fixes read-after-unbuffer resuming from a stale prefetch offset and stalling).
3. Make the failure classifiable. checkError rethrows the original IOException from the ExecutionException cause so retry classification sees the real failure, and isConnectivityIssue treats DEADLINE_EXCEEDED as a connectivity issue alongside UNAVAILABLE, enabling datanode failover.
4. Cancel failed streams instead of half-closing them. closeReader now calls cancel on a failed call; onCompleted only half-closes it, which would leave the RPC alive against a stuck datanode.
5. Account long-lived streams separately from short RPCs. Streams now take permits from a dedicated semaphore sized by a new config, ozone.client.stream.read.max-concurrent-streams. Any non-positive value (the default) inherits hdds.ratis.raft.client.async.outstanding-requests.max, preserving the capacity streams had when they shared the request semaphore. Acquisition waits up to ozone.client.stream.read.timeout and then fails with an actionable message instead of blocking indefinitely; a failed initStreamRead releases its permit.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16241
## How was this patch tested?
UT has been added. 
Basic freon/cli workloads to confirm that basic functionality hasn't been broken
HBase on Ozone cluster with YCSB workloads. The rate of failures dropped from ~60% to less than 1%. This 1% would be addressed as a separate jira because it has different root cause.
