### PR TITLE
HDDS-16249. Fix no-op assertThat in TestOzoneClientRetriesOnExceptions

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
@@ -201,7 +201,7 @@ public class TestOzoneClientRetriesOnExceptions {
                 .getPipeline(container.getPipelineID());
         XceiverClientSpi xceiverClient =
             xceiverClientManager.acquireClient(pipeline);
-        assertThat(containerList.contains(containerID));
+        assertThat(containerList.contains(containerID)).isFalse();
         containerList.add(containerID);
         xceiverClient.sendCommand(ContainerTestHelper
             .getCreateContainerRequest(containerID, pipeline));


### PR DESCRIPTION
### What changes were proposed in this pull request?

TestOzoneClientRetriesOnExceptions#testMaxRetriesByOzoneClient had a no-op assertion:

`assertThat(containerList.contains(containerID));`

assertThat(boolean) returns an AbstractBooleanAssert that is discarded without a trailing isTrue()/isFalse() call, so this line never actually checked anything.

This PR adds .isFalse():

`assertThat(containerList.contains(containerID)).isFalse();`

matching the loop's evident intent: each newly-allocated entry should get a containerID not already seen in this loop, before it is added to containerList, per the comment a few lines below about blocks being allocated to "N+1 different containers".

Note: with the assertion active, local runs occasionally hit a failure here (~1 in 5 runs), this may be a flaky test and looks related to the pipeline/container allocation behavior discussed under HDDS-16235. Filing that as a follow-up rather than fixing it in this PR, to keep this change scoped to the assertion bug.

### What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16249

### How was this patch tested?

mvn -pl :ozone-integration-test test -Dtest=TestOzoneClientRetriesOnExceptions -DskipShade -DskipRecon