### PR TITLE
HDDS-16213. Avoid the per-group list copy in KeyManagerImpl.getPendingDeletionKeys

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -887,7 +887,8 @@ public class KeyManagerImpl implements KeyManager {
             // Skip the key if the filter doesn't allow the file to be deleted.
             if (filter == null || filter.apply(Table.newKeyValue(kv.getKey(), info))) {
               List<DeletedBlock> deletedBlocks = info.getKeyLocationVersions().stream()
-                  .flatMap(versionLocations -> versionLocations.getLocationList().stream()
+                  .flatMap(versionLocations -> versionLocations.getLocationLists().stream()
+                      .flatMap(List::stream)
                       .map(b -> new DeletedBlock(
                           new BlockID(b.getContainerID(), b.getLocalID()),
                           b.getLength(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
In KeyManagerImpl.getPendingDeletionKeys (the KeyDeletingService reclaimable-key scan), each key's DeletedBlock list is built via a flatten-copy that is immediately re-streamed and discarded, once per key in the scan:

```
List<DeletedBlock> deletedBlocks = info.getKeyLocationVersions().stream()
    .flatMap(versionLocations -> versionLocations.createLocationList().stream()
        .map(b -> new DeletedBlock(
            new BlockID(b.getContainerID(), b.getLocalID()),
            b.getLength(),
            QuotaUtil.getReplicatedSize(b.getLength(), info.getReplicationConfig()),
            QuotaUtil.getSizePerReplica(b.getLength(), info.getReplicationConfig())
        ))).collect(Collectors.toList());
```
Fix: use `getLocationLists()` (no copy): `.flatMap(v -> v.getLocationLists().stream().flatMap(List::stream))`. Behavior unchanged. Complementary to [HDDS-16195](https://issues.apache.org/jira/browse/HDDS-16195), which reuses the computed replicated sizes on the same loop but leaves this copy in place.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16213

## How was this patch tested?

https://github.com/orca-07/ozone/actions/runs/32501303771

https://github.com/orca-07/ozone/actions/runs/32457228935
