### PR TITLE
HDDS-16251. Preserve signed empty Content-Type during preprocessing

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -572,6 +572,24 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
   }
 
   @Test
+  public void testPutObjectWithEmptyContentType() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    final String content = "bar";
+    s3Client.createBucket(bucketName);
+
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentType("");
+    InputStream inputStream = new ByteArrayInputStream(
+        content.getBytes(StandardCharsets.UTF_8));
+
+    PutObjectResult putObjectResult = s3Client.putObject(
+        bucketName, keyName, inputStream, metadata);
+    assertEquals("37b51d194a7513e45b56f6524f2d51f2",
+        putObjectResult.getETag());
+  }
+
+  @Test
   public void testPutObjectIfNoneMatch() {
     final String bucketName = getBucketName();
     final String keyName = getKeyName();

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -294,6 +294,24 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     assertEquals("\"37b51d194a7513e45b56f6524f2d51f2\"", getObjectResponse.eTag());
   }
 
+  @Test
+  public void testPutObjectWithEmptyContentType() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    final String content = "bar";
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    PutObjectResponse putObjectResponse = s3Client.putObject(b -> b
+            .bucket(bucketName)
+            .key(keyName)
+            .overrideConfiguration(c ->
+                c.putHeader("Content-Type", "")),
+        RequestBody.fromString(content));
+
+    assertEquals("\"37b51d194a7513e45b56f6524f2d51f2\"",
+        putObjectResponse.eTag());
+  }
+
   static Stream<Arguments> onlyTagKeyCasesV2() {
     Map<String, String> fooBarEmptyBar = new HashMap<>();
     fooBarEmptyBar.put("foo", "bar");

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/EmptyContentTypeFilter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/EmptyContentTypeFilter.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.s3;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.NoSuchElementException;
 import javax.servlet.Filter;
@@ -56,6 +57,9 @@ public class EmptyContentTypeFilter implements Filter {
           if (name.equalsIgnoreCase("Content-Type")) {
             return null;
           }
+          if (name.equalsIgnoreCase(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE)) {
+            return "";
+          }
           return super.getHeader(name);
         }
 
@@ -63,6 +67,9 @@ public class EmptyContentTypeFilter implements Filter {
         public Enumeration<String> getHeaders(String name) {
           if ("Content-Type".equalsIgnoreCase(name)) {
             return null;
+          }
+          if (HeaderPreprocessor.ORIGINAL_CONTENT_TYPE.equalsIgnoreCase(name)) {
+            return Collections.enumeration(Collections.singletonList(""));
           }
           return super.getHeaders(name);
         }
@@ -84,8 +91,8 @@ public class EmptyContentTypeFilter implements Filter {
   }
 
   /**
-   * Enumeration Wrapper which removes Content-Type from the original
-   * enumeration.
+   * Enumeration Wrapper which replaces Content-Type with the internal header
+   * used to preserve its original value.
    */
   public static class EnumerationWrapper implements Enumeration<String> {
 
@@ -93,24 +100,27 @@ public class EmptyContentTypeFilter implements Filter {
 
     private String nextElement;
 
+    private boolean contentTypeReplaced;
+
     public EnumerationWrapper(Enumeration<String> original) {
       this.original = original;
       step();
     }
 
     private void step() {
-      if (original.hasMoreElements()) {
+      while (original.hasMoreElements()) {
         nextElement = original.nextElement();
-      } else {
-        nextElement = null;
-      }
-      if ("Content-Type".equalsIgnoreCase(nextElement)) {
-        if (original.hasMoreElements()) {
-          nextElement = original.nextElement();
+        if ("Content-Type".equalsIgnoreCase(nextElement)) {
+          if (!contentTypeReplaced) {
+            nextElement = HeaderPreprocessor.ORIGINAL_CONTENT_TYPE;
+            contentTypeReplaced = true;
+            return;
+          }
         } else {
-          nextElement = null;
+          return;
         }
       }
+      nextElement = null;
     }
 
     @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestEmptyContentTypeFilter.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestEmptyContentTypeFilter.java
@@ -19,9 +19,15 @@ package org.apache.hadoop.ozone.s3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.Vector;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.servlet.http.HttpServletRequest;
 import org.apache.hadoop.ozone.s3.EmptyContentTypeFilter.EnumerationWrapper;
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +48,9 @@ public class TestEmptyContentTypeFilter {
         new EnumerationWrapper(values.elements());
 
     assertTrue(enumerationWrapper.hasMoreElements());
+    assertEquals(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE,
+        enumerationWrapper.nextElement());
+    assertTrue(enumerationWrapper.hasMoreElements());
     assertEquals("1", enumerationWrapper.nextElement());
     assertTrue(enumerationWrapper.hasMoreElements());
     assertEquals("2", enumerationWrapper.nextElement());
@@ -56,7 +65,33 @@ public class TestEmptyContentTypeFilter {
     final EnumerationWrapper enumerationWrapper =
         new EnumerationWrapper(values.elements());
 
+    assertTrue(enumerationWrapper.hasMoreElements());
+    assertEquals(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE,
+        enumerationWrapper.nextElement());
     assertFalse(enumerationWrapper.hasMoreElements());
+  }
+
+  @Test
+  public void preserveEmptyContentType() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getContentType()).thenReturn("");
+    when(request.getHeaderNames()).thenReturn(
+        Collections.enumeration(Collections.singletonList(HeaderPreprocessor.CONTENT_TYPE)));
+
+    AtomicReference<HttpServletRequest> wrappedRequest =
+        new AtomicReference<>();
+    new EmptyContentTypeFilter().doFilter(request, null,
+        (filteredRequest, response) -> wrappedRequest.set(
+            (HttpServletRequest) filteredRequest));
+
+    assertNull(wrappedRequest.get().getContentType());
+    assertNull(wrappedRequest.get().getHeader(HeaderPreprocessor.CONTENT_TYPE));
+    assertEquals("", wrappedRequest.get().getHeader(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE));
+    assertEquals(Collections.singletonList(""),
+        Collections.list(wrappedRequest.get().getHeaders(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE)));
+    assertEquals(Collections.singletonList(
+        HeaderPreprocessor.ORIGINAL_CONTENT_TYPE), Collections.list(
+        wrappedRequest.get().getHeaderNames()));
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAWSSignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAWSSignatureProcessor.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.s3.signature;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
+import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +46,18 @@ public class TestAWSSignatureProcessor {
     assertEquals("AWS4-HMAC-SHA256 value",
         headers.remove("AUTHORIZATION"));
     assertFalse(headers.containsKey("authorization"));
+  }
+
+  @Test
+  public void testRestoreEmptyContentType() {
+    MultivaluedMap<String, String> rawHeaders = new MultivaluedHashMap<>();
+    rawHeaders.putSingle(HeaderPreprocessor.ORIGINAL_CONTENT_TYPE, "");
+
+    AWSSignatureProcessor.LowerCaseKeyStringMap headers =
+        AWSSignatureProcessor.LowerCaseKeyStringMap.fromHeaderMap(rawHeaders);
+
+    assertTrue(headers.containsKey(HeaderPreprocessor.CONTENT_TYPE));
+    assertEquals("", headers.get(HeaderPreprocessor.CONTENT_TYPE));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3 Gateway's `EmptyContentTypeFilter` hides an explicitly empty `Content-Type` to avoid Jersey treating it as a request media type. However, when an S3 client includes the empty header in AWS V4 `SignedHeaders`, removing it entirely prevents `StringToSignProducer` from rebuilding the canonical request and the operation fails with `InvalidRequest`.

This patch preserves the empty value through the existing `X-Ozone-Original-Content-Type` internal header while continuing to hide `Content-Type` from Jersey. The existing signature header conversion then restores `Content-Type` with an empty value for AWS V4 canonical request generation. Unit tests cover both request wrapping and restoration into the signature header map.

This keeps the empty Content-Type workaround introduced for HDDS-4856 while supporting clients that sign the empty header.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16251

## How was this patch tested?
- From the ceph/s3-tests checkout: `S3TEST_CONF=<path-to-s3tests.conf> python -m pytest -vv s3tests/functional/test_headers.py::test_object_create_bad_contenttype_empty`

CI: https://github.com/F64116045/ozone/actions/runs/32574396997