### PR TITLE
HDDS-16215. Avoid the per-group list copy in OmMetadataManagerImpl.getBlocksForKeyDeletetBlocksForKeyDelete

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1959,7 +1959,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     for (OmKeyInfo info : omKeyInfo.cloneOmKeyInfoList()) {
       for (OmKeyLocationInfoGroup keyLocations :
           info.getKeyLocationVersions()) {
-        List<DeletedBlock> item = keyLocations.getLocationList().stream()
+        List<DeletedBlock> item = keyLocations.getLocationLists().stream()
+            .flatMap(List::stream)
             .map(b -> new DeletedBlock(
                 new BlockID(b.getContainerID(), b.getLocalID()),
                 b.getLength(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
`getBlocksForKeyDelete` flatten-copies each version group only to stream it once into `DeletedBlock` items:

```
      for (OmKeyLocationInfoGroup keyLocations :
          info.getKeyLocationVersions()) {
        List<DeletedBlock> item = keyLocations.createLocationList().stream()
            .map(b -> new DeletedBlock(
                new BlockID(b.getContainerID(), b.getLocalID()),
                b.getLength(),
                QuotaUtil.getReplicatedSize(b.getLength(), info.getReplicationConfig()),
                QuotaUtil.getSizePerReplica(b.getLength(), info.getReplicationConfig())))
            .collect(Collectors.toList());
        BlockGroup keyBlocks = BlockGroup.newBuilder()
            .setKeyName(deletedKey)
            .addAllDeletedBlocks(item)
            .build();
        result.add(keyBlocks);
      }
```
Fix: `keyLocations.getLocationLists().stream().flatMap(List::stream)`. Behavior unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16215

## How was this patch tested?

https://github.com/orca-07/ozone/actions/runs/32567086538
