### PR TITLE
HDDS-16253. Fix getPipelines() in Recon always returning an empty pipeline list

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -514,10 +514,10 @@ public class ReconContainerMetadataManagerImpl
     }
     List<Pipeline> pipelines = new ArrayList<>();
     if (null != omKeyInfo) {
-      omKeyInfo.getKeyLocationVersions().stream().map(
+      omKeyInfo.getKeyLocationVersions().forEach(
           omKeyLocationInfoGroup ->
-              omKeyLocationInfoGroup.getLocationList()
-                  .stream().map(omKeyLocationInfo -> pipelines.add(
+              omKeyLocationInfoGroup.getLocationList().forEach(
+                  omKeyLocationInfo -> pipelines.add(
                       omKeyLocationInfo.getPipeline())));
     }
     return pipelines;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ReconContainerMetadataManagerImpl#getPipelines(ContainerKeyPrefix)` builds a nested `Stream` pipeline to collect the `Pipeline`s for a key's block locations, but both `.stream().map(...)` calls are intermediate operations with no terminal operation attached. Because Java streams are lazily evaluated, the `pipelines.add(...)` is never actually executed, so the method unconditionally returns the empty `ArrayList` created at the top of the method.

This method is the only implementation backing `ContainerMetadataIterator#next()`, which is used by `ReconContainerMetadataManager#getContainersIterator()`. That iterator feeds two REST endpoints in `ContainerEndpoint`: `GET /containers/mismatch` and `GET /containers/mismatch/deleted`. Both currently return `"pipelines": []` for every container, even when the container's key actually has valid pipeline data in OM.

This PR replaces the two dangling `.stream().map(...)` chains with `.forEach(...)`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16253

## How was this patch tested?

- Ran the existing `TestReconContainerMetadataManagerImpl`: 15/15 tests pass.