### PR TITLE
HDDS-16252. Avoid the per-group list copy in OmKeyInfo.verifyAndGetKeyLocations

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -352,12 +352,14 @@ public final class OmKeyInfo extends WithParentObjectId
     // the pipeline field by default and bcsId would be updated in Ratis mode.
     Map<ContainerBlockID, OmKeyLocationInfo> allocatedBlockLocations =
         new HashMap<>();
-    for (OmKeyLocationInfo existingLocationInfo : keyLocationInfoGroup.
-        createLocationList()) {
-      ContainerBlockID existingBlockID = existingLocationInfo.getBlockID().
-          getContainerBlockID();
-      // The case of overwriting value should never happen
-      allocatedBlockLocations.put(existingBlockID, existingLocationInfo);
+    for (List<OmKeyLocationInfo> existingLocationInfos :
+        keyLocationInfoGroup.getLocationLists()) {
+      for (OmKeyLocationInfo existingLocationInfo : existingLocationInfos) {
+        ContainerBlockID existingBlockID = existingLocationInfo.getBlockID().
+            getContainerBlockID();
+        // The case of overwriting value should never happen
+        allocatedBlockLocations.put(existingBlockID, existingLocationInfo);
+      }
     }
 
     List<OmKeyLocationInfo> updatedBlockLocations = new ArrayList<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OmKeyInfo.verifyAndGetKeyLocations()` calls `createLocationList()` only to
iterate over the existing block locations and populate
`allocatedBlockLocations`.

This change iterates over `getLocationLists()` directly, avoiding the
intermediate flattened list without changing the resulting block map.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16252

## How was this patch tested?

A local JMH benchmark compared the affected loop with 1, 16, and 128
locations split across 1 or 4 internal lists.

| Locations / lists | `createLocationList()` | `getLocationLists()` |
|---:|---:|---:|
| 1 / 1 | 544 B/op | 160 B/op |
| 1 / 4 | 808 B/op | 160 B/op |
| 16 / 1 | 1,624 B/op | 1,056 B/op |
| 16 / 4 | 1,888 B/op | 1,056 B/op |
| 128 / 1 | 12,280 B/op | 9,904 B/op |
| 128 / 4 | 12,544 B/op | 9,904 B/op |

JMH 1.37, OpenJDK 17.0.17, 1 thread, 2 forks, `-prof gc`.

CI: https://github.com/F64116045/ozone/actions/runs/32586214700