### PR TITLE
HDDS-16175. Do not change usedNamespace on hsync re-commit

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -1289,6 +1289,45 @@ public class TestHSync {
   }
 
   @Test
+  public void testUsedNamespaceWithRepeatedHsync() throws Exception {
+    // Set the fs.defaultFS
+    final String rootPath = String.format("%s://%s/",
+        OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
+    CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName()
+        + OZONE_URI_DELIMITER + bucket.getName();
+    final Path file = new Path(dir, "file-hsync-used-namespace");
+
+    OzoneVolume volume = client.getObjectStore().getVolume(bucket.getVolumeName());
+    final long usedNamespace = volume.getBucket(bucket.getName()).getUsedNamespace();
+
+    try (FileSystem fs = FileSystem.get(CONF)) {
+      try (FSDataOutputStream out = fs.create(file, true)) {
+        // Each new block makes the client send an hsync commit to OM. Only the
+        // first commit adds the key name, the rest re-commit the same key.
+        byte[] blockData = RandomStringUtils.secure().nextAlphabetic(BLOCK_SIZE)
+            .getBytes(UTF_8);
+        for (int i = 0; i < 4; i++) {
+          out.write(blockData);
+          out.hsync();
+        }
+      }
+      // One key name was added, no matter how many commits it took.
+      assertEquals(usedNamespace + 1,
+          volume.getBucket(bucket.getName()).getUsedNamespace());
+
+      assertTrue(fs.delete(file, false));
+      // OzoneBucket reports usedNamespace as live plus pending-delete namespace
+      // (RpcClient sets it from getTotalBucketNamespace), so the refund becomes
+      // visible to the client once the deleting services purge the key.
+      GenericTestUtils.waitFor((CheckedSupplier<Boolean, IOException>) () ->
+          volume.getBucket(bucket.getName()).getUsedNamespace() == usedNamespace,
+          100, 30000);
+    }
+  }
+
+  @Test
   public void testNormalKeyOverwriteHSyncKey() throws Exception {
     // Set the fs.defaultFS
     final String rootPath = String.format("%s://%s/",

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -1298,27 +1298,37 @@ public class TestHSync {
         + OZONE_URI_DELIMITER + bucket.getName();
     final Path file = new Path(dir, "file-hsync-used-namespace");
 
-    OzoneVolume volume = client.getObjectStore().getVolume(bucket.getVolumeName());
-    final long usedNamespace = volume.getBucket(bucket.getName()).getUsedNamespace();
+    OzoneManager ozoneManager = cluster.getOzoneManager();
+    OMMetadataManager metadataManager = ozoneManager.getMetadataManager();
+    String bucketKey = metadataManager.getBucketKey(bucket.getVolumeName(), bucket.getName());
+    final long usedNamespace = metadataManager.getBucketTable().get(bucketKey).getUsedNamespace();
 
     try (FileSystem fs = FileSystem.get(CONF)) {
-      try (FSDataOutputStream out = fs.create(file, true)) {
-        // Each block triggers an hsync commit; only the first adds the key.
-        byte[] blockData = RandomStringUtils.secure().nextAlphabetic(BLOCK_SIZE)
-            .getBytes(UTF_8);
-        for (int i = 0; i < 4; i++) {
-          out.write(blockData);
-          out.hsync();
+      try {
+        try (FSDataOutputStream out = fs.create(file, true)) {
+          // Each block triggers an hsync commit; only the first adds the key.
+          byte[] blockData = RandomStringUtils.secure().nextAlphabetic(BLOCK_SIZE)
+              .getBytes(UTF_8);
+          for (int i = 0; i < 4; i++) {
+            out.write(blockData);
+            out.hsync();
+          }
+        }
+        assertEquals(usedNamespace + 1,
+            metadataManager.getBucketTable().get(bucketKey).getUsedNamespace());
+
+        assertTrue(fs.delete(file, false));
+        GenericTestUtils.waitFor((CheckedSupplier<Boolean, IOException>) () ->
+            metadataManager.getBucketTable().get(bucketKey).getUsedNamespace() == usedNamespace,
+            100, 30000);
+      } finally {
+        try {
+          fs.delete(file, false);
+          waitForEmptyDeletedTable();
+        } finally {
+          cleanupOpenKeyTable(ozoneManager, BUCKET_LAYOUT);
         }
       }
-      assertEquals(usedNamespace + 1,
-          volume.getBucket(bucket.getName()).getUsedNamespace());
-
-      assertTrue(fs.delete(file, false));
-      // Client usage includes pending-delete namespace, so wait for purge.
-      GenericTestUtils.waitFor((CheckedSupplier<Boolean, IOException>) () ->
-          volume.getBucket(bucket.getName()).getUsedNamespace() == usedNamespace,
-          100, 30000);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -1290,7 +1290,6 @@ public class TestHSync {
 
   @Test
   public void testUsedNamespaceWithRepeatedHsync() throws Exception {
-    // Set the fs.defaultFS
     final String rootPath = String.format("%s://%s/",
         OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
     CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
@@ -1304,8 +1303,7 @@ public class TestHSync {
 
     try (FileSystem fs = FileSystem.get(CONF)) {
       try (FSDataOutputStream out = fs.create(file, true)) {
-        // Each new block makes the client send an hsync commit to OM. Only the
-        // first commit adds the key name, the rest re-commit the same key.
+        // Each block triggers an hsync commit; only the first adds the key.
         byte[] blockData = RandomStringUtils.secure().nextAlphabetic(BLOCK_SIZE)
             .getBytes(UTF_8);
         for (int i = 0; i < 4; i++) {
@@ -1313,14 +1311,11 @@ public class TestHSync {
           out.hsync();
         }
       }
-      // One key name was added, no matter how many commits it took.
       assertEquals(usedNamespace + 1,
           volume.getBucket(bucket.getName()).getUsedNamespace());
 
       assertTrue(fs.delete(file, false));
-      // OzoneBucket reports usedNamespace as live plus pending-delete namespace
-      // (RpcClient sets it from getTotalBucketNamespace), so the refund becomes
-      // visible to the client once the deleting services purge the key.
+      // Client usage includes pending-delete namespace, so wait for purge.
       GenericTestUtils.waitFor((CheckedSupplier<Boolean, IOException>) () ->
           volume.getBucket(bucket.getName()).getUsedNamespace() == usedNamespace,
           100, 30000);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -319,8 +319,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       Map<String, RepeatedOmKeyInfo> oldKeyVersionsToDeleteMap = null;
       long correctedSpace = omKeyInfo.getReplicatedSize();
-      // Re-committing a key the same client already hsync'd does not add a
-      // key name, so it does not consume namespace.
+      // Same-client hsync re-commit does not consume namespace.
       if (keyToDelete != null && (isSameHsyncKey)) {
         correctedSpace -= keyToDelete.getReplicatedSize();
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -319,8 +319,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       Map<String, RepeatedOmKeyInfo> oldKeyVersionsToDeleteMap = null;
       long correctedSpace = omKeyInfo.getReplicatedSize();
-      // if keyToDelete isn't null, usedNamespace needn't check and
-      // increase.
+      // Re-committing a key the same client already hsync'd does not add a
+      // key name, so it does not consume namespace.
       if (keyToDelete != null && (isSameHsyncKey)) {
         correctedSpace -= keyToDelete.getReplicatedSize();
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
@@ -367,12 +367,13 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         // Subtract the used namespace of empty overwritten keys.
         omBucketInfo.decrUsedNamespace(filteredUsedBlockCnt.getRight(), false);
         omBucketInfo.decrUsedBytes(totalSize, true);
+        omBucketInfo.incrUsedNamespace(1L);
       } else {
         checkBucketQuotaInNamespace(omBucketInfo, 1L);
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
+        omBucketInfo.incrUsedNamespace(1L);
       }
-      omBucketInfo.incrUsedNamespace(1L);
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
       final OmKeyInfo pseudoKeyInfo = isHSync ? null

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -250,8 +250,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
           .build();
 
       long correctedSpace = omKeyInfo.getReplicatedSize();
-      // Re-committing a key the same client already hsync'd does not add a
-      // key name, so it does not consume namespace.
+      // Same-client hsync re-commit does not consume namespace.
       if (keyToDelete != null && isSameHsyncKey) {
         correctedSpace -= keyToDelete.getReplicatedSize();
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -250,7 +250,8 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
           .build();
 
       long correctedSpace = omKeyInfo.getReplicatedSize();
-      // if keyToDelete isn't null, usedNamespace shouldn't check and increase.
+      // Re-committing a key the same client already hsync'd does not add a
+      // key name, so it does not consume namespace.
       if (keyToDelete != null && isSameHsyncKey) {
         correctedSpace -= keyToDelete.getReplicatedSize();
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
@@ -299,12 +300,13 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         omBucketInfo.decrUsedNamespace(totalNamespace, true);
         omBucketInfo.decrUsedNamespace(filteredUsedBlockCnt.getRight(), false);
         omBucketInfo.decrUsedBytes(totalSize, true);
+        omBucketInfo.incrUsedNamespace(1L);
       } else {
         checkBucketQuotaInNamespace(omBucketInfo, 1L);
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
+        omBucketInfo.incrUsedNamespace(1L);
       }
-      omBucketInfo.incrUsedNamespace(1L);
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -520,8 +520,6 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
         omMetadataManager, bucketLayout);
     List<KeyLocation> allocatedKeyLocationList = getKeyLocation(10);
 
-    // Three commits of the same key by the same client: two hsync re-commits
-    // and the final close. Only one key name is ever added.
     doKeyCommit(true, allocatedKeyLocationList.subList(0, 3));
     doKeyCommit(true, allocatedKeyLocationList.subList(0, 6));
     doKeyCommit(false, allocatedKeyLocationList);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -526,6 +526,15 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
 
     OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
     assertEquals(1, bucketInfo.getUsedNamespace());
+
+    clientID = Time.now();
+    version += 1;
+    Map<String, RepeatedOmKeyInfo> keyToDeleteMap =
+        doKeyCommit(false, getKeyLocation(20).subList(10, 20));
+    assertThat(keyToDeleteMap).isNotEmpty();
+
+    bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    assertEquals(1, bucketInfo.getUsedNamespace());
   }
 
   private Map<String, RepeatedOmKeyInfo> doKeyCommit(boolean isHSync,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -511,6 +511,25 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
     assertEquals(1000, thirdCommitUsedBytes - usedBytes);
   }
 
+  @Test
+  public void testCommitWithHsyncUsedNamespace() throws Exception {
+    BucketLayout bucketLayout = getBucketLayout();
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, bucketLayout);
+    List<KeyLocation> allocatedKeyLocationList = getKeyLocation(10);
+
+    // Three commits of the same key by the same client: two hsync re-commits
+    // and the final close. Only one key name is ever added.
+    doKeyCommit(true, allocatedKeyLocationList.subList(0, 3));
+    doKeyCommit(true, allocatedKeyLocationList.subList(0, 6));
+    doKeyCommit(false, allocatedKeyLocationList);
+
+    OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    assertEquals(1, bucketInfo.getUsedNamespace());
+  }
+
   private Map<String, RepeatedOmKeyInfo> doKeyCommit(boolean isHSync,
       List<KeyLocation> keyLocations) throws Exception {
     // allocated block list


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OMKeyCommitRequest` currently increments `usedNamespace` for every commit, including re-commits of a key that the same client already hsync'd. Because the client commits once per newly allocated block and again on close, a file spanning N blocks can leave N namespace units behind after deletion.

This regressed in c351de9914 (HDDS-13756), which moved the increment outside the branch where a key name is added and unintentionally reverted the namespace accounting from df4df20371 (HDDS-7965).

This change moves `incrUsedNamespace(1L)` back into the branches that add a key name in `OMKeyCommitRequest` and `OMKeyCommitRequestWithFSO`. The overwrite branch still increments the counter because it first refunds the previous key's namespace usage.

Existing incorrect counters are not repaired by this patch and require `ozone repair om quota start`. During a rolling upgrade, old and new OMs account for new commits differently, as they already do after HDDS-13756.

Bucket versioning is out of scope, as discussed in HDDS-16127.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-16175

## How was this patch tested?

Added tests covering:

- Three commits of the same key by one client (two hsync re-commits and close), verifying that `usedNamespace` remains 1. The test runs for both OBS and FSO commit paths.
- A multi-block file written through ofs with hsync, then closed and deleted, verifying that `usedNamespace` returns to 0. This provides cluster-level FSO coverage.

Ran:

```shell
mvn -pl :ozone-manager test \
  -Dtest='TestOMKeyCommitRequest,TestOMKeyCommitRequestWithFSO' \
  -DskipShade -DskipRecon -DskipDocs

mvn -pl :ozone-integration-test test \
  -Dtest=TestHSync#testUsedNamespaceWithRepeatedHsync \
  -DskipShade -DskipRecon -DskipDocs

mvn -pl :ozone-manager,:ozone-integration-test checkstyle:check \
  -DskipShade -DskipRecon -DskipDocs
```

Also ran `author.sh` successfully.

Generated-by: Claude Code (Opus 5)

