### PR TITLE
HDDS-10478. Store full block data as ByteString in MockDatanodeStorage

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
@@ -47,7 +47,7 @@ public class MockDatanodeStorage {
   private final Map<BlockID, BlockData> blocks = new HashedMap();
   private final Map<Long, List<DatanodeBlockID>>
       containerBlocks = new HashedMap();
-  private final Map<BlockID, String> fullBlockData = new HashMap<>();
+  private final Map<BlockID, ByteString> fullBlockData = new HashMap<>();
 
   private final Map<String, ByteString> data = new HashMap<>();
 
@@ -157,20 +157,19 @@ public class MockDatanodeStorage {
       throw exception;
     }
     String blockKey = createKey(blockID);
+    ByteString storedBytes = ByteString.copyFrom(bytes.asReadOnlyByteBuffer());
     ByteString block;
     if (data.containsKey(blockKey)) {
       block = data.get(blockKey);
       assert block.size() == chunkInfo.getOffset();
-      data.put(blockKey, block.concat(ByteString.copyFrom(bytes.asReadOnlyByteBuffer())));
+      data.put(blockKey, block.concat(storedBytes));
     } else {
       assert chunkInfo.getOffset() == 0;
-      data.put(blockKey, ByteString.copyFrom(bytes.asReadOnlyByteBuffer()));
+      data.put(blockKey, storedBytes);
     }
 
-    fullBlockData
-        .put(new BlockID(blockID.getContainerID(), blockID.getLocalID()),
-            fullBlockData.getOrDefault(toBlockID(blockID), "")
-                .concat(bytes.toStringUtf8()));
+    BlockID id = toBlockID(blockID);
+    fullBlockData.put(id, fullBlockData.getOrDefault(id, ByteString.EMPTY).concat(storedBytes));
   }
 
   public ByteString readChunkData(
@@ -195,7 +194,7 @@ public class MockDatanodeStorage {
     return this.data;
   }
 
-  public String getFullBlockData(BlockID blockID) {
+  public ByteString getFullBlockData(BlockID blockID) {
     return this.fullBlockData.get(blockID);
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -160,8 +160,7 @@ public class TestOzoneECClient {
       assertEquals(1, datanodeStorage.getAllBlockData().size());
       ByteString content =
           datanodeStorage.getAllBlockData().values().iterator().next();
-      assertEquals(new String(inputChunks[i], UTF_8),
-          content.toStringUtf8());
+      assertEquals(ByteString.copyFrom(inputChunks[i]), content);
     }
   }
 
@@ -190,9 +189,7 @@ public class TestOzoneECClient {
       assertEquals(1, datanodeStorage.getAllBlockData().size());
       ByteString content =
           datanodeStorage.getAllBlockData().values().iterator().next();
-      assertEquals(
-          new String(parityBuffers[i - dataBlocks].array(), UTF_8),
-          content.toStringUtf8());
+      assertEquals(ByteString.copyFrom(parityBuffers[i - dataBlocks].array()), content);
     }
 
   }
@@ -341,12 +338,11 @@ public class TestOzoneECClient {
           storages.get(getMatchingStorage(storages, DatanodeID.fromProto(member.getId())));
       dns.add(mockDatanodeStorage);
     }
-    String firstBlockData = dns.get(0).getFullBlockData(new BlockID(
+    ByteString firstBlockData = dns.get(0).getFullBlockData(new BlockID(
         keyLocations.getBlockID().getContainerBlockID().getContainerID(),
         keyLocations.getBlockID().getContainerBlockID().getLocalID()));
 
-    assertArrayEquals(
-        firstSmallChunk, firstBlockData.getBytes(UTF_8));
+    assertEquals(ByteString.copyFrom(firstSmallChunk), firstBlockData);
 
     final ByteBuffer[] dataBuffers = new ByteBuffer[dataBlocks];
     dataBuffers[0] = ByteBuffer.wrap(firstSmallChunk);
@@ -364,13 +360,12 @@ public class TestOzoneECClient {
 
     //Lets assert the parity data.
     for (int i = dataBlocks; i < dataBlocks + parityBlocks; i++) {
-      String parityBlockData = dns.get(i).getFullBlockData(new BlockID(
+      ByteString parityBlockData = dns.get(i).getFullBlockData(new BlockID(
           keyLocations.getBlockID().getContainerBlockID().getContainerID(),
           keyLocations.getBlockID().getContainerBlockID().getLocalID()));
-      String expected =
-          new String(parityBuffers[i - dataBlocks].array(), UTF_8);
+      ByteString expected = ByteString.copyFrom(parityBuffers[i - dataBlocks].array());
       assertEquals(expected, parityBlockData);
-      assertEquals(expected.length(), parityBlockData.length());
+      assertEquals(expected.size(), parityBlockData.size());
 
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MockDatanodeStorage` currently stores full block data as `String`, which requires binary chunk data to be decoded as UTF-8. This conversion is lossy for arbitrary binary data, including EC parity data.

This change:

* Stores `fullBlockData` values as `ByteString`.
* Reuses the defensive copy created when chunk data is stored.
* Removes UTF-8 conversions when accumulating full block data.
* Updates `TestOzoneECClient` assertions to compare binary data exactly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10478

## How was this patch tested?

* `mvn -pl :ozone-client test -Dtest=TestOzoneECClient`
  * All 34 tests passed.
* `./hadoop-ozone/dev-support/checks/checkstyle.sh`
  * Passed with no Checkstyle violations.
