### PR TITLE
HDDS-16216. Avoid the flatten-copy in KeyInputStream.getBlockLocationInfo

### DIFF
--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -45,10 +45,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
@@ -100,6 +96,11 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
@@ -108,17 +106,15 @@ public class KeyInputStream extends MultipartInputStream {
 
   private static BlockLocationInfo getBlockLocationInfo(OmKeyInfo newKeyInfo,
       BlockID blockID) {
-    List<OmKeyLocationInfo> collect =
-        newKeyInfo.getLatestVersionLocations()
-            .createLocationList()
-            .stream()
-            .filter(l -> l.getBlockID().equals(blockID))
-            .collect(Collectors.toList());
-    if (CollectionUtils.isNotEmpty(collect)) {
-      return collect.get(0);
-    } else {
-      return null;
+    for (List<OmKeyLocationInfo> locationList
+        : newKeyInfo.getLatestVersionLocations().getLocationLists()) {
+      for (OmKeyLocationInfo location : locationList) {
+        if (location.getBlockID().equals(blockID)) {
+          return location;
+        }
+      }
     }
+    return null;
   }
 
   private static LengthInputStream getFromOmKeyInfo(


### PR DESCRIPTION
## What changes were proposed in this pull request?
`KeyInputStream.getBlockLocationInfo` runs on every per-block pipeline refresh / read retry. It flatten-copies the version map with `createLocationList()`, then does `stream().filter().collect(toList())` just to pick `get(0)`, two throwaway `ArrayList`s per call, no short-circuit.

`OmKeyLocationInfoGroup.createLocationList()` is documented a s`"expensive ... Use getLocationLists() instead"`.

Fix: iterate `getLocationLists()` (the raw uncopied `Collection<List<...>>`) with a nested for-loop, return on first match. Zero allocations, short-circuits, same semantics.
                                                        
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16216                                                                                                                             

## How was this patch tested?

https://github.com/0lai0/ozone/actions/runs/32735325487

  - `mvn -pl :ozone-client install -DskipTests` — pass                                                                                                                           
  - `mvn -pl :ozone-client test -Dtest=TestKeyInputStreamEC` — pass
  - `mvn -pl :ozone-client checkstyle:check` — pass                                                                                                                              
                                                                                                                                                                               
  Local JMH (target at last position → worst-case scan, gains are purely from removed allocations):
                                                                                                                                                                                 
  | N / G     | before ns | after ns | before B/op | after B/op |                                                                                                                
  |---:|---:|---:|---:|---:|
  | 1 / 1     |    91 |   4 |   816 | ≈0 |                                                                                                                                       
  | 1 / 4     |   131 |  11 | 1,080 | ≈0 |                                                                                                                                     
  | 16 / 1    |   144 |   9 | 1,000 | ≈0 |                                                                                                                                       
  | 16 / 4    |   288 |  33 | 1,944 | ≈0 |
  | 128 / 1   |   395 |  40 | 2,808 | ≈0 |                                                                                                                                       
  | 128 / 4   | 1,365 | 158 | 7,760 | ≈0 |
                                                                                                                                       
Generated-by: Claude Code (claude-opus-4-7)