### PR TITLE
HDDS-16255. Avoid the per-group list copy in ContainerMapper.parseOmDB

### DIFF
--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
@@ -93,27 +93,28 @@ public class ContainerMapper {
                 OzoneManagerProtocolProtos.KeyInfo.parseFrom(value));
             for (OmKeyLocationInfoGroup keyLocationInfoGroup : keyInfo
                 .getKeyLocationVersions()) {
-              List<OmKeyLocationInfo> keyLocationInfo = keyLocationInfoGroup
-                  .createLocationList();
-              for (OmKeyLocationInfo keyLocation : keyLocationInfo) {
-                BlockIdDetails blockIdDetails = new BlockIdDetails();
-                Map<Long, BlockIdDetails> innerMap = new HashMap<>();
+              for (List<OmKeyLocationInfo> keyLocationInfo : keyLocationInfoGroup
+                  .getLocationLists()) {
+                for (OmKeyLocationInfo keyLocation : keyLocationInfo) {
+                  BlockIdDetails blockIdDetails = new BlockIdDetails();
+                  Map<Long, BlockIdDetails> innerMap = new HashMap<>();
 
-                long containerID = keyLocation.getBlockID().getContainerID();
-                long blockID = keyLocation.getBlockID().getLocalID();
-                blockIdDetails.setBucketName(keyInfo.getBucketName());
-                blockIdDetails.setBlockVol(keyInfo.getVolumeName());
-                blockIdDetails.setKeyName(keyInfo.getKeyName());
+                  long containerID = keyLocation.getBlockID().getContainerID();
+                  long blockID = keyLocation.getBlockID().getLocalID();
+                  blockIdDetails.setBucketName(keyInfo.getBucketName());
+                  blockIdDetails.setBlockVol(keyInfo.getVolumeName());
+                  blockIdDetails.setKeyName(keyInfo.getKeyName());
 
-                List<Map<Long, BlockIdDetails>> innerList = new ArrayList<>();
-                innerMap.put(blockID, blockIdDetails);
+                  List<Map<Long, BlockIdDetails>> innerList = new ArrayList<>();
+                  innerMap.put(blockID, blockIdDetails);
 
-                if (dataMap.containsKey(containerID)) {
-                  innerList = dataMap.get(containerID);
+                  if (dataMap.containsKey(containerID)) {
+                    innerList = dataMap.get(containerID);
+                  }
+
+                  innerList.add(innerMap);
+                  dataMap.put(containerID, innerList);
                 }
-
-                innerList.add(innerMap);
-                dataMap.put(containerID, innerList);
               }
             }
           }

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
 /**
- * Generates Container Id to Blocks and BlockDetails mapping.
+ * Generates Container Id to Blocks and BlockIdDetails mapping.
  */
 public class ContainerMapper {
 
@@ -61,9 +61,9 @@ public class ContainerMapper {
   }
 
   /**
-   * Generates Container Id to Blocks and BlockDetails mapping.
+   * Generates Container Id to Blocks and BlockIdDetails mapping.
    * @param configuration @{@link OzoneConfiguration}
-   * @return {@code Map<Long, List<Map<Long, BlockDetails>>>
+   * @return {@code Map<Long, List<Map<Long, BlockIdDetails>>>
    *   Map of ContainerId -> (Block, Block info)}
    * @throws IOException
    */
@@ -93,29 +93,7 @@ public class ContainerMapper {
                 OzoneManagerProtocolProtos.KeyInfo.parseFrom(value));
             for (OmKeyLocationInfoGroup keyLocationInfoGroup : keyInfo
                 .getKeyLocationVersions()) {
-              for (List<OmKeyLocationInfo> keyLocationInfo : keyLocationInfoGroup
-                  .getLocationLists()) {
-                for (OmKeyLocationInfo keyLocation : keyLocationInfo) {
-                  BlockIdDetails blockIdDetails = new BlockIdDetails();
-                  Map<Long, BlockIdDetails> innerMap = new HashMap<>();
-
-                  long containerID = keyLocation.getBlockID().getContainerID();
-                  long blockID = keyLocation.getBlockID().getLocalID();
-                  blockIdDetails.setBucketName(keyInfo.getBucketName());
-                  blockIdDetails.setBlockVol(keyInfo.getVolumeName());
-                  blockIdDetails.setKeyName(keyInfo.getKeyName());
-
-                  List<Map<Long, BlockIdDetails>> innerList = new ArrayList<>();
-                  innerMap.put(blockID, blockIdDetails);
-
-                  if (dataMap.containsKey(containerID)) {
-                    innerList = dataMap.get(containerID);
-                  }
-
-                  innerList.add(innerMap);
-                  dataMap.put(containerID, innerList);
-                }
-              }
+              addLocations(dataMap, keyInfo, keyLocationInfoGroup);
             }
           }
         }
@@ -125,6 +103,34 @@ public class ContainerMapper {
 
     } finally {
       metadataManager.stop();
+    }
+  }
+
+  private static void addLocations(
+      Map<Long, List<Map<Long, BlockIdDetails>>> dataMap, OmKeyInfo keyInfo,
+      OmKeyLocationInfoGroup keyLocationInfoGroup) {
+    for (List<OmKeyLocationInfo> keyLocationInfo : keyLocationInfoGroup
+        .getLocationLists()) {
+      for (OmKeyLocationInfo keyLocation : keyLocationInfo) {
+        BlockIdDetails blockIdDetails = new BlockIdDetails();
+        Map<Long, BlockIdDetails> innerMap = new HashMap<>();
+
+        long containerID = keyLocation.getBlockID().getContainerID();
+        long blockID = keyLocation.getBlockID().getLocalID();
+        blockIdDetails.setBucketName(keyInfo.getBucketName());
+        blockIdDetails.setBlockVol(keyInfo.getVolumeName());
+        blockIdDetails.setKeyName(keyInfo.getKeyName());
+
+        List<Map<Long, BlockIdDetails>> innerList = new ArrayList<>();
+        innerMap.put(blockID, blockIdDetails);
+
+        if (dataMap.containsKey(containerID)) {
+          innerList = dataMap.get(containerID);
+        }
+
+        innerList.add(innerMap);
+        dataMap.put(containerID, innerList);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- obsidian --><h3 data-heading="What changes were proposed in this pull request?">What changes were proposed in this pull request?</h3>
<p><code>ContainerMapper.parseOmDB</code> called <code>OmKeyLocationInfoGroup.createLocationList()</code> once per version group of every key, only to iterate the result once. <code>createLocationList()</code> is documented as not O(1).</p>
<p>This PR adds one nested loop over the zero-copy <code>getLocationLists()</code> accessor; the inner loop body that builds <code>BlockIdDetails</code> is unchanged.</p>
<p>Additionally, a throwaway (not committed) JUnit micro-benchmark measured per-traversal thread allocation for both implementations (JDK 21.0.12, 50,000-iteration warmup then 500,000 measured iterations per shape, deterministic checksums asserted equal, <code>volatile</code> sink to block JIT elimination). Results, reproduced across two independent JVM processes:</p>

Key Shape | Before | After | Saved
-- | -- | -- | --
1 group x 1 block | 100 ns / 419 B | 8 ns / 0 B | 419 B
1 group x 4 blocks | 87 ns / 408 B | 13 ns / 0 B | 408 B
1 group x 32 blocks | 242 ns / 744 B | 61 ns / 0 B | 744 B
4 groups x 4 blocks | 242 ns / 1632 B | 52 ns / 0 B | 1632 B
16 groups x 8 blocks | 1303 ns / 6528 B | 312 ns / 0 B | 6528 B


<h3 data-heading="What is the link to the Apache JIRA">What is the link to the Apache JIRA</h3>
<p><a href="https://issues.apache.org/jira/browse/HDDS-16255" class="external-link" target="_blank" rel="noopener nofollow">https://issues.apache.org/jira/browse/HDDS-16255</a></p>
<h3 data-heading="How was this patch tested?">How was this patch tested?</h3>

The following test passed:

- `TestContainerMapper#testContainerMapper`
- ci: https://github.com/shuan1026/ozone/actions/runs/35065482478