### PR TITLE
HDDS-16103. Set version to 2.2.2-SNAPSHOT after 2.2.1 release branch

### DIFF
--- a/dev-support/pom.xml
+++ b/dev-support/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-dev-support</artifactId>
   <name>Apache Ozone Dev Support</name>

--- a/hadoop-hdds/annotations/pom.xml
+++ b/hadoop-hdds/annotations/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdds-annotation-processing</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Annotation Processing</name>
   <description>Apache Ozone annotation processing tools for validating custom

--- a/hadoop-hdds/cli-common/pom.xml
+++ b/hadoop-hdds/cli-common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-cli-common</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Common</name>
   <description>Apache Ozone CLI Common</description>

--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
 
   <artifactId>hdds-client</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Client</name>
   <description>Apache Ozone Distributed Data Store Client Library</description>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-common</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Common</name>
   <description>Apache Ozone Distributed Data Store Common</description>

--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-config</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Config</name>
   <description>Apache Ozone Distributed Data Store Config Tools</description>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-container-service</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Container Service</name>
   <description>Apache Ozone Distributed Data Store Container Service</description>

--- a/hadoop-hdds/crypto-api/pom.xml
+++ b/hadoop-hdds/crypto-api/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdds-crypto-api</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <name>Apache Ozone HDDS Crypto</name>
   <description>Apache Ozone Distributed Data Store cryptographic functions</description>
 

--- a/hadoop-hdds/crypto-default/pom.xml
+++ b/hadoop-hdds/crypto-default/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdds-crypto-default</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <name>Apache Ozone HDDS Crypto - Default</name>
   <description>Default implementation of Apache Ozone Distributed Data Store's cryptographic functions</description>
 

--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-docs</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Documentation</name>
   <description>Apache Ozone Documentation</description>

--- a/hadoop-hdds/erasurecode/pom.xml
+++ b/hadoop-hdds/erasurecode/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-erasurecode</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Erasurecode</name>
   <description>Apache Ozone Distributed Data Store Earsurecode utils</description>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-server-framework</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Server Framework</name>
   <description>Apache Ozone Distributed Data Store Server Framework</description>

--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-hadoop-dependency-client</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone HDDS Hadoop Client dependencies</name>
   <description>Apache Ozone Distributed Data Store Hadoop client dependencies</description>

--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-interface-admin</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Admin Interface</name>
   <description>Apache Ozone Distributed Data Store Admin interface</description>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-interface-client</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Client Interface</name>
   <description>Apache Ozone Distributed Data Store Client interface</description>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-interface-server</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Server Interface</name>
   <description>Apache Ozone Distributed Data Store Server interface</description>

--- a/hadoop-hdds/managed-rocksdb/pom.xml
+++ b/hadoop-hdds/managed-rocksdb/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-managed-rocksdb</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Managed RocksDB</name>
   <description>Apache Ozone Managed RocksDB library</description>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>hdds</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone HDDS</name>
   <description>Apache Ozone Distributed Data Store Project</description>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-rocks-native</artifactId>
   <name>Apache Ozone HDDS RocksDB Tools</name>

--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>rocksdb-checkpoint-differ</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Checkpoint Differ for RocksDB</name>
   <description>Apache Ozone Checkpoint Differ for RocksDB</description>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-server-scm</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS SCM Server</name>
   <description>Apache Ozone Distributed Data Store Storage Container Manager Server</description>

--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>hdds-test-utils</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Test Utils</name>
   <description>Apache Ozone Distributed Data Store Test Utils</description>

--- a/hadoop-ozone/cli-admin/pom.xml
+++ b/hadoop-ozone/cli-admin/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
 
   <artifactId>ozone-cli-admin</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Admin</name>
   <description>Apache Ozone CLI Admin</description>

--- a/hadoop-ozone/cli-debug/pom.xml
+++ b/hadoop-ozone/cli-debug/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-cli-debug</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Debug Tools</name>
   <description>Apache Ozone Debug Tools</description>

--- a/hadoop-ozone/cli-interactive/pom.xml
+++ b/hadoop-ozone/cli-interactive/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-cli-interactive</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Interactive</name>
   <description>Apache Ozone top-level interactive CLI</description>

--- a/hadoop-ozone/cli-repair/pom.xml
+++ b/hadoop-ozone/cli-repair/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-cli-repair</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Repair Tools</name>
   <description>Apache Ozone Repair Tools</description>

--- a/hadoop-ozone/cli-shell/pom.xml
+++ b/hadoop-ozone/cli-shell/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-cli-shell</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Shell</name>
   <description>Apache Ozone CLI Shell</description>

--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-client</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Client</name>
   <description>Apache Ozone Client</description>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-common</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Common</name>
   <description>Apache Ozone Common</description>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-csi</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CSI service</name>
   <description>Apache Ozone CSI service</description>

--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-datanode</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Datanode</name>
 

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-dist</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Distribution</name>
   <properties>

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-fault-injection-test</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>mini-chaos-tests</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <name>Apache Ozone Mini Ozone Chaos Tests</name>
   <description>Apache Ozone Mini Ozone Chaos Tests</description>
 

--- a/hadoop-ozone/fault-injection-test/network-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/network-tests/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-fault-injection-test</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-network-tests</artifactId>
   <packaging>jar</packaging>

--- a/hadoop-ozone/fault-injection-test/pom.xml
+++ b/hadoop-ozone/fault-injection-test/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-fault-injection-test</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone Fault Injection Tests</name>
   <description>Apache Ozone Fault Injection Tests</description>

--- a/hadoop-ozone/freon/pom.xml
+++ b/hadoop-ozone/freon/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-freon</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Freon</name>
   <description>Apache Ozone Freon</description>

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -19,10 +19,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-httpfsgateway</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Apache Ozone HttpFS</name>

--- a/hadoop-ozone/iceberg/pom.xml
+++ b/hadoop-ozone/iceberg/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-iceberg</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Iceberg Integration</name>
   <description>Apache Ozone Iceberg Integration</description>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-insight</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Insight Tool</name>
   <description>Apache Ozone Insight Tool</description>

--- a/hadoop-ozone/integration-test-recon/pom.xml
+++ b/hadoop-ozone/integration-test-recon/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-integration-test-recon</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Recon Integration Tests</name>
   <description>Apache Ozone Integration Tests with Recon</description>

--- a/hadoop-ozone/integration-test-s3/pom.xml
+++ b/hadoop-ozone/integration-test-s3/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-integration-test-s3</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Integration Tests</name>
   <description>Apache Ozone Integration Tests with S3 Gateway</description>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-integration-test</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Integration Tests</name>
   <description>Apache Ozone Integration Tests</description>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-interface-client</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Client Interface</name>
   <description>Apache Ozone Client interface</description>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-interface-storage</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Storage Interface</name>
   <description>Apache Ozone Storage Interface</description>

--- a/hadoop-ozone/mini-cluster/pom.xml
+++ b/hadoop-ozone/mini-cluster/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-mini-cluster</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Mini Cluster</name>
   <description>Apache Ozone Mini Cluster for Integration Tests</description>

--- a/hadoop-ozone/multitenancy-ranger/pom.xml
+++ b/hadoop-ozone/multitenancy-ranger/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-multitenancy-ranger</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Multitenancy with Ranger</name>
   <description>Implementation of multitenancy for Apache Ozone Manager Server using Apache Ranger</description>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-manager</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Manager Server</name>
   <description>Apache Ozone Manager Server</description>

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-filesystem-common</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem Common</name>
   <properties>

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-filesystem-hadoop2</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FS Hadoop 2.x compatibility</name>
   <dependencies>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-filesystem-hadoop3</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FS Hadoop 3.x compatibility</name>
   <properties>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-filesystem-shaded</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem Shaded</name>
 

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-filesystem</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem</name>
   <properties>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone</name>
   <description>Apache Ozone Project</description>

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-reconcodegen</artifactId>
   <name>Apache Ozone Recon CodeGen</name>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-recon</artifactId>
   <name>Apache Ozone Recon</name>

--- a/hadoop-ozone/s3-secret-store/pom.xml
+++ b/hadoop-ozone/s3-secret-store/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-s3-secret-store</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Secret Store</name>
   <properties>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-s3gateway</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Gateway</name>
   <properties>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-tools</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Tools</name>
   <description>Apache Ozone Tools</description>

--- a/hadoop-ozone/vapor/pom.xml
+++ b/hadoop-ozone/vapor/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>ozone-vapor</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Vapor</name>
   <description>Apache Ozone server-side load testing tools</description>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.ozone</groupId>
   <artifactId>ozone-main</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Ozone Main</name>
   <description>Apache Ozone Main</description>
@@ -166,7 +166,7 @@
     <ozone.release>Katmai</ozone.release>
     <ozone.shaded.native.prefix>org_apache_ozone_shaded</ozone.shaded.native.prefix>
     <ozone.shaded.prefix>org.apache.ozone.shaded</ozone.shaded.prefix>
-    <ozone.version>2.2.1-SNAPSHOT</ozone.version>
+    <ozone.version>2.2.2-SNAPSHOT</ozone.version>
     <!--
       4.7.6: https://github.com/remkop/picocli/issues/2309
       4.7.7: https://github.com/remkop/picocli/issues/2407
@@ -174,7 +174,7 @@
     <picocli.version>4.7.5</picocli.version>
     <pmd.version>3.28.0</pmd.version>
     <!-- Enable Reproducible Builds mode -->
-    <project.build.outputTimestamp>2026-08-03T10:05:10Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-08-25T15:10:55Z</project.build.outputTimestamp>
     <!-- platform encoding override -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## Summary
- Set Maven project version to 2.2.2-SNAPSHOT on the `ozone-2.2` maintenance branch after the 2.2.1 release branch is cut

## Jira
https://issues.apache.org/jira/browse/HDDS-16103

## Merge order
1. Create `ozone-2.2.1` release branch on apache (#11107)
2. Merge this PR into `ozone-2.2`

## Deferred
- HDDS-16109 (#11104) xcompat/upgrade test update is deferred until the 2.2.1 Docker image is available (HDDS-16108)

## Test plan
- [ ] CI passes