### PR TITLE
HDDS-16139. Define and enforce OFS and O3FS IPv6 authority contracts

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -617,7 +617,8 @@ public final class OmUtils {
 
     String hostName = bindHost.orElse(addressHost.orElse(omNodeHostAddr));
 
-    return hostName + ":" + addressPort.orElse(OZONE_OM_HTTP_BIND_PORT_DEFAULT);
+    return getHostPortString(hostName,
+        addressPort.orElse(OZONE_OM_HTTP_BIND_PORT_DEFAULT));
   }
 
   /**
@@ -643,8 +644,8 @@ public final class OmUtils {
 
     String hostName = bindHost.orElse(addressHost.orElse(omNodeHostAddr));
 
-    return hostName + ":" +
-        addressPort.orElse(OZONE_OM_HTTPS_BIND_PORT_DEFAULT);
+    return getHostPortString(hostName,
+        addressPort.orElse(OZONE_OM_HTTPS_BIND_PORT_DEFAULT));
   }
 
   public static File createOMDir(String dirPath) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -151,8 +151,8 @@ public final class OmUtils {
     final Optional<String> host = getHostNameFromConfigKeys(conf,
         OZONE_OM_ADDRESS_KEY);
 
-    return host.orElse(OZONE_OM_BIND_HOST_DEFAULT) + ":" +
-        getOmRpcPort(conf);
+    return getHostPortString(host.orElse(OZONE_OM_BIND_HOST_DEFAULT),
+        getOmRpcPort(conf));
   }
 
   /**
@@ -167,8 +167,9 @@ public final class OmUtils {
     final Optional<String> host = getHostNameFromConfigKeys(conf, confKey);
 
     if (host.isPresent()) {
-      return host.get() + ":" + getPortNumberFromConfigKeys(conf, confKey)
-              .orElse(OZONE_OM_PORT_DEFAULT);
+      return getHostPortString(host.get(),
+          getPortNumberFromConfigKeys(conf, confKey)
+              .orElse(OZONE_OM_PORT_DEFAULT));
     } else {
       // The specified confKey is not set
       return null;

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.TreeSet;
@@ -214,6 +215,40 @@ public class TestOmUtils {
     InetSocketAddress addr = OmUtils.getOmAddress(conf);
     assertEquals("1.2.3.4", addr.getHostString());
     assertEquals(100, addr.getPort());
+  }
+
+  @Test
+  void getOmSocketAddressIpv6HostPort() throws UnknownHostException {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_ADDRESS_KEY, "[2001:db8::10]:100");
+
+    assertEquals("[2001:db8::10]:100", OmUtils.getOmRpcAddress(conf));
+    InetSocketAddress addr = OmUtils.getOmAddress(conf);
+    assertEquals(InetAddress.getByName("2001:db8::10"), addr.getAddress());
+    assertEquals(100, addr.getPort());
+  }
+
+  @Test
+  void getOmSocketAddressIpv6Host() throws UnknownHostException {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_ADDRESS_KEY, "[2001:db8::10]");
+
+    int defaultPort = OMConfigKeys.OZONE_OM_PORT_DEFAULT;
+    assertEquals("[2001:db8::10]:" + defaultPort,
+        OmUtils.getOmRpcAddress(conf));
+    InetSocketAddress addr = OmUtils.getOmAddress(conf);
+    assertEquals(InetAddress.getByName("2001:db8::10"), addr.getAddress());
+    assertEquals(defaultPort, addr.getPort());
+  }
+
+  @Test
+  void getOmRpcAddressIpv6ForConfigKey() {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    String addressKey = OZONE_OM_ADDRESS_KEY + ".service.node";
+    conf.set(addressKey, "[2001:db8::10]:100");
+
+    assertEquals("[2001:db8::10]:100",
+        OmUtils.getOmRpcAddress(conf, addressKey));
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -249,6 +250,22 @@ public class TestOmUtils {
 
     assertEquals("[2001:db8::10]:100",
         OmUtils.getOmRpcAddress(conf, addressKey));
+  }
+
+  @Test
+  void getOmPeerHttpAddressesIpv6() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    String serviceId = "service";
+    String nodeId = "node";
+    conf.set(ConfUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, serviceId, nodeId),
+        "[2001:db8::10]:100");
+    conf.set(ConfUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, serviceId, nodeId),
+        "[2001:db8::10]:200");
+
+    assertEquals("[2001:db8::10]:100",
+        OmUtils.getHttpAddressForOMPeerNode(conf, serviceId, nodeId, "fallback"));
+    assertEquals("[2001:db8::10]:200",
+        OmUtils.getHttpsAddressForOMPeerNode(conf, serviceId, nodeId, "fallback"));
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
@@ -178,6 +178,23 @@ public class TestOMFailoverProxyProvider {
   }
 
   @Test
+  public void testConfiguredIpv6Address() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_ADDRESS_KEY, "[2001:db8::10]:9862");
+
+    try (HadoopRpcOMFailoverProxyProvider<OzoneManagerProtocolPB> ipv6Provider =
+             new HadoopRpcOMFailoverProxyProvider<>(conf,
+                 UserGroupInformation.getCurrentUser(), null,
+                 OzoneManagerProtocolPB.class)) {
+      List<OMProxyInfo<OzoneManagerProtocolPB>> proxies =
+          ipv6Provider.getOMProxies();
+      assertEquals(1, proxies.size());
+      assertEquals("[2001:db8::10]:9862",
+          proxies.get(0).getAddressString());
+    }
+  }
+
+  @Test
   public void testOMProxyMap() {
     final String serviceID = "service0";
     final List<OMProxyInfo<Integer>> list = new ArrayList<>();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -33,6 +33,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.net.InetAddresses;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -156,10 +157,6 @@ public class BasicOzoneFileSystem extends FileSystem {
       throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
     }
 
-    if (authority.indexOf(':') != authority.lastIndexOf(':')) {
-      throw new IllegalArgumentException(IPV6_EXCEPTION_TEXT);
-    }
-
     Matcher matcher = URL_SCHEMA_PATTERN.matcher(authority);
 
     if (!matcher.matches()) {
@@ -168,6 +165,10 @@ public class BasicOzoneFileSystem extends FileSystem {
     String bucketStr = matcher.group(1);
     String volumeStr = matcher.group(2);
     String remaining = matcher.groupCount() == 3 ? matcher.group(3) : null;
+
+    if (!isEmpty(remaining) && remaining.contains(":") && InetAddresses.isInetAddress(remaining)) {
+      throw new IllegalArgumentException(IPV6_EXCEPTION_TEXT);
+    }
 
     String omHost = null;
     int omPort = -1;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -129,6 +129,9 @@ public class BasicOzoneFileSystem extends FileSystem {
       "o3fs://bucket.volume.om-host.example.com:5678/key  OR " +
       "o3fs://bucket.volume.omServiceId/key";
 
+  private static final String IPV6_EXCEPTION_TEXT =
+      "Raw IPv6 literals are not supported in O3FS authorities; use an OM service ID or DNS name instead";
+
   private static final int PATH_DEPTH_TO_BUCKET = 0;
 
   @Override
@@ -151,6 +154,10 @@ public class BasicOzoneFileSystem extends FileSystem {
       // authority is null when fs.defaultFS is not a qualified o3fs URI and
       // o3fs:/// is passed to the client. matcher will NPE if authority is null
       throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
+    }
+
+    if (authority.indexOf(':') != authority.lastIndexOf(':')) {
+      throw new IllegalArgumentException(IPV6_EXCEPTION_TEXT);
     }
 
     Matcher matcher = URL_SCHEMA_PATTERN.matcher(authority);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -38,6 +38,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLU
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
+import com.google.common.net.InetAddresses;
 import io.opentelemetry.api.trace.Span;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -165,7 +166,10 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     }
 
     if (authority.indexOf(':') != authority.lastIndexOf(':') && !authority.startsWith("[")) {
-      throw new IllegalArgumentException(UNBRACKETED_IPV6_EXCEPTION_TEXT);
+      if (InetAddresses.isInetAddress(authority)) {
+        throw new IllegalArgumentException(UNBRACKETED_IPV6_EXCEPTION_TEXT);
+      }
+      throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
     }
 
     // Parse hostname and port. HostAndPort is bracket-aware, so IPv6 literal

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -132,7 +132,12 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       "URL should be one of the following formats: " +
       "ofs://om-service-id/path/to/key  OR " +
       "ofs://om-host.example.com/path/to/key  OR " +
-      "ofs://om-host.example.com:5678/path/to/key";
+      "ofs://om-host.example.com:5678/path/to/key  OR " +
+      "ofs://[2001:db8::10]:9862/path/to/key";
+
+  private static final String UNBRACKETED_IPV6_EXCEPTION_TEXT =
+      "IPv6 literals in OFS authorities must be enclosed in brackets, for example " +
+      "ofs://[2001:db8::10]/ or ofs://[2001:db8::10]:9862/";
 
   private static final int PATH_DEPTH_TO_BUCKET = 2;
   private OzoneConfiguration ozoneConfiguration;
@@ -157,6 +162,10 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       // authority is null when fs.defaultFS is not a qualified ofs URI and
       // ofs:/// is passed to the client. matcher will NPE if authority is null
       throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
+    }
+
+    if (authority.indexOf(':') != authority.lastIndexOf(':') && !authority.startsWith("[")) {
+      throw new IllegalArgumentException(UNBRACKETED_IPV6_EXCEPTION_TEXT);
     }
 
     // Parse hostname and port. HostAndPort is bracket-aware, so IPv6 literal

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageSize;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -211,6 +210,14 @@ public class TestBasicOzoneFileSystems {
     assertTrue(exception.getMessage().contains("must be enclosed in brackets"));
   }
 
+  @Test
+  public void testRootedMalformedAuthorityUsesGeneralError() throws Exception {
+    BasicRootedOzoneFileSystem ofs = new BasicRootedOzoneFileSystem();
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> ofs.initialize(new URI("ofs://host:123:456/"), new OzoneConfiguration()));
+    assertTrue(exception.getMessage().contains("URL should be one of the following formats"));
+  }
+
   @ParameterizedTest
   @CsvSource(value = {
       "o3fs://bucket.volume/, NULL, -1",
@@ -234,9 +241,8 @@ public class TestBasicOzoneFileSystems {
   }
 
   @Test
-  public void testO3fsConfiguredIpv6Endpoint() throws Exception {
+  public void testO3fsNullEndpoint() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY, "[2001:db8::10]:9862");
     BasicOzoneFileSystem o3fs = spy(new BasicOzoneFileSystem());
     BasicOzoneClientAdapterImpl adapter = mock(BasicOzoneClientAdapterImpl.class);
     doReturn(adapter).when(o3fs).createAdapter(any(), anyString(), anyString(), nullable(String.class), anyInt());

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAU
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -30,19 +31,24 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageSize;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -176,6 +182,98 @@ public class TestBasicOzoneFileSystems {
 
     // The rebuilt filesystem URI keeps the (bracketed) IPv6 authority intact.
     assertEquals(new URI(uri).getAuthority(), ofs.getUri().getAuthority());
+  }
+
+  @Test
+  public void testRootedIpv6UriConstructionAndRoundTrip() throws Exception {
+    URI uri = new URI("ofs", null, "2001:db8::10", 9862, "/", null, null);
+    assertEquals("ofs://[2001:db8::10]:9862/", uri.toString());
+
+    BasicRootedOzoneFileSystem ofs = spy(new BasicRootedOzoneFileSystem());
+    BasicRootedOzoneClientAdapterImpl adapter = mock(BasicRootedOzoneClientAdapterImpl.class);
+    doReturn(adapter).when(ofs).createAdapter(any(), anyString(), anyInt());
+    ofs.initialize(uri, new OzoneConfiguration());
+
+    Path qualified = ofs.makeQualified(new Path("/volume/bucket/key"));
+    assertEquals("ofs://[2001:db8::10]:9862/volume/bucket/key", qualified.toString());
+    assertEquals(qualified, new Path(qualified.toUri()));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "ofs://2001:db8::10/",
+      "ofs://2001:db8::10:9862/"
+  })
+  public void testRootedAuthorityRejectsUnbracketedIpv6(String uri) throws Exception {
+    BasicRootedOzoneFileSystem ofs = new BasicRootedOzoneFileSystem();
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> ofs.initialize(new URI(uri), new OzoneConfiguration()));
+    assertTrue(exception.getMessage().contains("must be enclosed in brackets"));
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "o3fs://bucket.volume/, NULL, -1",
+      "o3fs://bucket.volume.omservice1/, omservice1, -1",
+      "o3fs://bucket.volume.om.example.com:9862/, om.example.com, 9862",
+      "o3fs://bucket.volume.192.0.2.1:9862/, 192.0.2.1, 9862"
+  }, nullValues = "NULL")
+  public void testO3fsAuthorityParsing(String uri, String expectedHost, int expectedPort) throws Exception {
+    BasicOzoneFileSystem o3fs = spy(new BasicOzoneFileSystem());
+    BasicOzoneClientAdapterImpl adapter = mock(BasicOzoneClientAdapterImpl.class);
+    doReturn(adapter).when(o3fs).createAdapter(any(), anyString(), anyString(), nullable(String.class), anyInt());
+
+    o3fs.initialize(new URI(uri), new OzoneConfiguration());
+
+    ArgumentCaptor<String> hostCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Integer> portCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(o3fs).createAdapter(any(), anyString(), anyString(), hostCaptor.capture(), portCaptor.capture());
+    assertEquals(expectedHost, hostCaptor.getValue());
+    assertEquals(expectedPort, portCaptor.getValue().intValue());
+    assertEquals(new URI(uri).getAuthority(), o3fs.getUri().getAuthority());
+  }
+
+  @Test
+  public void testO3fsConfiguredIpv6Endpoint() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+        "[2001:db8::10]:9862");
+    BasicOzoneFileSystem o3fs = spy(new BasicOzoneFileSystem());
+    BasicOzoneClientAdapterImpl adapter =
+        mock(BasicOzoneClientAdapterImpl.class);
+    doReturn(adapter).when(o3fs).createAdapter(any(), anyString(), anyString(),
+        nullable(String.class), anyInt());
+
+    o3fs.initialize(new URI("o3fs://bucket.volume/"), conf);
+
+    ArgumentCaptor<ConfigurationSource> confCaptor =
+        ArgumentCaptor.forClass(ConfigurationSource.class);
+    ArgumentCaptor<String> hostCaptor = ArgumentCaptor.forClass(String.class);
+    verify(o3fs).createAdapter(confCaptor.capture(), anyString(), anyString(),
+        hostCaptor.capture(), anyInt());
+    assertNull(hostCaptor.getValue());
+    assertEquals("[2001:db8::10]:9862",
+        OmUtils.getOmRpcAddress(confCaptor.getValue()));
+  }
+
+  @Test
+  public void testO3fsDottedIpv6UriCannotBeConstructed() {
+    assertThrows(URISyntaxException.class,
+        () -> new URI("o3fs://bucket.volume.[2001:db8::10]:9862/"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "o3fs://[2001:db8::10]/",
+      "o3fs://[2001:db8::10]:9862/",
+      "o3fs://bucket.volume.2001:db8::10/",
+      "o3fs://bucket.volume.2001:db8::10:9862/"
+  })
+  public void testO3fsInitializationRejectsIpv6LiteralForms(String uri) throws Exception {
+    BasicOzoneFileSystem o3fs = new BasicOzoneFileSystem();
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> o3fs.initialize(new URI(uri), new OzoneConfiguration()));
+    assertTrue(exception.getMessage().contains("use an OM service ID or DNS name instead"));
   }
 
   @Test

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAU
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -30,8 +29,11 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,10 +46,8 @@ import java.util.Collection;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageSize;
-import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -236,24 +236,14 @@ public class TestBasicOzoneFileSystems {
   @Test
   public void testO3fsConfiguredIpv6Endpoint() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
-        "[2001:db8::10]:9862");
+    conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY, "[2001:db8::10]:9862");
     BasicOzoneFileSystem o3fs = spy(new BasicOzoneFileSystem());
-    BasicOzoneClientAdapterImpl adapter =
-        mock(BasicOzoneClientAdapterImpl.class);
-    doReturn(adapter).when(o3fs).createAdapter(any(), anyString(), anyString(),
-        nullable(String.class), anyInt());
+    BasicOzoneClientAdapterImpl adapter = mock(BasicOzoneClientAdapterImpl.class);
+    doReturn(adapter).when(o3fs).createAdapter(any(), anyString(), anyString(), nullable(String.class), anyInt());
 
     o3fs.initialize(new URI("o3fs://bucket.volume/"), conf);
 
-    ArgumentCaptor<ConfigurationSource> confCaptor =
-        ArgumentCaptor.forClass(ConfigurationSource.class);
-    ArgumentCaptor<String> hostCaptor = ArgumentCaptor.forClass(String.class);
-    verify(o3fs).createAdapter(confCaptor.capture(), anyString(), anyString(),
-        hostCaptor.capture(), anyInt());
-    assertNull(hostCaptor.getValue());
-    assertEquals("[2001:db8::10]:9862",
-        OmUtils.getOmRpcAddress(confCaptor.getValue()));
+    verify(o3fs).createAdapter(same(conf), eq("bucket"), eq("volume"), isNull(), eq(-1));
   }
 
   @Test
@@ -264,8 +254,6 @@ public class TestBasicOzoneFileSystems {
 
   @ParameterizedTest
   @CsvSource({
-      "o3fs://[2001:db8::10]/",
-      "o3fs://[2001:db8::10]:9862/",
       "o3fs://bucket.volume.2001:db8::10/",
       "o3fs://bucket.volume.2001:db8::10:9862/"
   })
@@ -274,6 +262,19 @@ public class TestBasicOzoneFileSystems {
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
         () -> o3fs.initialize(new URI(uri), new OzoneConfiguration()));
     assertTrue(exception.getMessage().contains("use an OM service ID or DNS name instead"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "o3fs://[2001:db8::10]/",
+      "o3fs://[2001:db8::10]:9862/",
+      "o3fs://bucket.volume.host:123:456/"
+  })
+  public void testO3fsMalformedAuthoritiesUseGeneralError(String uri) throws Exception {
+    BasicOzoneFileSystem o3fs = new BasicOzoneFileSystem();
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> o3fs.initialize(new URI(uri), new OzoneConfiguration()));
+    assertTrue(exception.getMessage().contains("Ozone file system URL should be one of the following formats"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR defines and enforces the supported IPv6 authority forms for OFS and O3FS following the URI parser changes in HDDS-15775.
* Allow OFS authorities containing bracketed IPv6 literals, with or without an explicit port, such as `ofs://[2001:db8::10]:9862/`.
* Reject all unbracketed IPv6 authorities in OFS with an error explaining that IPv6 literals must be enclosed in brackets.
* Reject raw IPv6 literals in O3FS authorities with an error recommending an OM service ID or DNS name.
* Preserve existing O3FS forms using `bucket.volume`, DNS names, IPv4 addresses, and OM service IDs.
* Preserve support for `o3fs://bucket.volume/` when the OM endpoint is supplied through configuration, including a configured bracketed IPv6 address.
* Construct OM RPC addresses through the existing bracket-aware host-and-port helper so configured IPv6 addresses retain the required brackets.
* Add coverage for URI construction, filesystem initialization, authority parsing, rejection behavior, configured IPv6 endpoints, and qualified-path round trips.

A dotted O3FS authority cannot contain a bracketed IPv6 literal such as `bucket.volume.[2001:db8::10]`, because `java.net.URI` rejects that form before O3FS initialization. Therefore, O3FS requires a DNS name or OM service ID when an IPv6 endpoint must be represented in the dotted authority.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16139

## How was this patch tested?

Local Test
```shell
mvn -pl :ozone-filesystem-common -am test \
  -Dtest=TestBasicOzoneFileSystems,TestOmUtils,TestOMFailoverProxyProvider \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/32799667939

Generated-by: Codex (GPT-5)