### PR TITLE
HDDS-16283. Fix flakiness in trash root prepare failure test.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -2689,9 +2689,10 @@ class TestKeyLifecycleService extends OzoneTestBase {
       final String keyPrefix = "key";
       String bucketOwner = UserGroupInformation.getCurrentUser().getShortUserName() + "-test";
       long initialKeyCount = getKeyCount(FILE_SYSTEM_OPTIMIZED);
-      long initialSuccessTaskCount = metrics.getNumSuccessTask().value();
 
-      createKeys(volumeName, bucketName, FILE_SYSTEM_OPTIMIZED, bucketOwner, 1, 1, keyPrefix, null);
+      List<OmKeyArgs> createdKeys =
+          createKeys(volumeName, bucketName, FILE_SYSTEM_OPTIMIZED, bucketOwner, 1, 1, keyPrefix, null);
+      assertEquals(1, createdKeys.size());
       Thread.sleep(SERVICE_INTERVAL);
       GenericTestUtils.waitFor(() -> getKeyCount(FILE_SYSTEM_OPTIMIZED) - initialKeyCount == 1,
           WAIT_CHECK_INTERVAL, 1000);
@@ -2740,7 +2741,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
 
         assertTrue(log.getOutput().contains("Failed to prepare trash root"));
         assertTrue(log.getOutput().contains("Failed to evaluate lifecycle configuration for bucket"));
-        assertEquals(initialSuccessTaskCount, metrics.getNumSuccessTask().value());
+        // Verify local bucket state instead of global lifecycle metrics, which are shared across parameterized runs.
+        assertNotNull(writeClient.getKeyInfo(createdKeys.get(0), false));
         assertEquals(1, getKeyCount(FILE_SYSTEM_OPTIMIZED) - initialKeyCount);
       } finally {
         ozoneManagerField.set(keyLifecycleService, om);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testMoveToTrashAbortTaskWhenTrashRootPrepareFails` is flaky because it asserts that KeyLifecycleServiceMetrics#getNumSuccessTask() does not change. That metric is globally registered/shared, so concurrent lifecycle task execution in other parameterized runs can increment it, leading to intermittent failures (for example expected: <41> but was: <42>).

The test has been updated to validate deterministic, local behavior instead of shared global metrics:

- capture the created key,

- inject trash-root preparation failure,

- run LifecycleActionTask,

- assert expected failure logs are present,

- assert the original key still exists and key count is unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16283

## How was this patch tested?

Tested Manually.
