### PR TITLE
HDDS-16285. Bump netty to 4.1.137-Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <metainf-services.version>1.11</metainf-services.version>
     <mockito.version>4.11.0</mockito.version>
     <native.lib.tmp.dir />
-    <netty.version>4.1.136.Final</netty.version>
+    <netty.version>4.1.137.Final</netty.version>
     <!-- Node.js version number (without the v prefix required by frontend-maven-plugin) -->
     <nodejs.version>24.17.0</nodejs.version>
     <okhttp3.version>4.12.0</okhttp3.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes CVEs:
- https://app.opencve.io/cve/CVE-2026-75596
- https://app.opencve.io/cve/CVE-2026-75595
- https://app.opencve.io/cve/CVE-2026-62243

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16285

## How was this patch tested?

CI run (https://github.com/krvikash/ozone/actions/runs/32848034171)
