### PR TITLE
HDDS-16206. Start MiniOzoneCluster Datanodes finalized

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone;
 
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_CONTAINER_RATIS_IPC_RANDOM_PORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -41,6 +42,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
@@ -49,6 +51,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test cases for mini ozone cluster.
@@ -101,6 +105,27 @@ public class TestMiniOzoneCluster {
         assertTrue(client.isConnected(pipeline.getFirstNode()));
       }
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testDatanodesStartWithLatestLayoutVersion(boolean withCustomHostnames)
+      throws Exception {
+    MiniOzoneCluster.Builder builder =
+        MiniOzoneCluster.newBuilder(new OzoneConfiguration(conf))
+            .setNumDatanodes(1)
+            .setStartDataNodes(false);
+    if (withCustomHostnames) {
+      builder.setHosts(new String[] {"host0.test"});
+    }
+    cluster = builder.build();
+
+    OzoneConfiguration dnConf = cluster.getHddsDatanodes().get(0).getConf();
+    assertEquals(maxLayoutVersion(),
+        new DatanodeLayoutStorage(dnConf).getLayoutVersion(),
+        "Datanode must start at the latest metadata layout version. A "
+            + "datanode.id file written before the datanode starts makes it "
+            + "come up pre-finalized, as if upgraded from an older install.");
   }
 
   @Test

--- a/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/mini-cluster/src/main/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
 import static org.apache.hadoop.hdds.server.http.BaseHttpServer.SERVER_DIR;
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_RATIS_SNAPSHOT_DIR;
 import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
 import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
@@ -77,6 +78,7 @@ import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.common.Storage.StorageState;
+import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
@@ -774,10 +776,9 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
         OzoneConfiguration dnConf = dnFactory.apply(conf);
         if (hosts != null) {
           dnConf.set(HddsConfigKeys.HDDS_DATANODE_HOST_NAME_KEY, hosts[i]);
+          initializeDatanodeIdentity(dnConf, hosts[i]);
         }
 
-        // Bypass InetAddress.getName() resolution for custom hostnames by starting DN via YAML.
-        confDatanodeViaYaml(dnConf);
         HddsDatanodeService datanode = new HddsDatanodeService(NO_ARGS);
         dnConf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, conf.getStrings(ScmConfigKeys.OZONE_SCM_NAMES));
         datanode.setConfiguration(dnConf);
@@ -787,13 +788,28 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       return hddsDatanodes;
     }
 
-    private void confDatanodeViaYaml(OzoneConfiguration dnConf) throws IOException {
+    /**
+     * Seeds the datanode.id file for a Datanode with a synthetic hostname: such a hostname
+     * cannot be resolved, so the Datanode cannot discover its own IP address, which is a
+     * required field of the registration request.  The layout version is stamped as well,
+     * since a datanode.id file without a VERSION file marks the Datanode as an installation
+     * predating the upgrade framework, which would make it start pre-finalized.
+     */
+    private void initializeDatanodeIdentity(OzoneConfiguration dnConf, String hostName)
+        throws IOException {
       DatanodeDetails datanodeDetails = DatanodeDetails.newBuilder()
           .setID(DatanodeID.randomID())
-          .setHostName(dnConf.get(HddsConfigKeys.HDDS_DATANODE_HOST_NAME_KEY))
+          .setHostName(hostName)
           .setIpAddress("127.0.0.1")
           .build();
       datanodeDetails.setNetworkName(datanodeDetails.getUuidString());
+
+      DatanodeLayoutStorage layoutStorage = new DatanodeLayoutStorage(dnConf,
+          datanodeDetails.getUuidString(), maxLayoutVersion());
+      if (layoutStorage.getState() != StorageState.INITIALIZED) {
+        layoutStorage.initialize();
+      }
+
       String dnFilePath = HddsServerUtil.getDatanodeIdFilePath(dnConf);
       ContainerUtils.writeDatanodeDetailsTo(datanodeDetails, new File(dnFilePath), dnConf);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Every Datanode in a mini cluster starts pre-finalized. `MiniOzoneCluster` pre-creates each Datanode's `datanode.id` file — HDDS-14812 added that so a Datanode given a synthetic hostname can report an IP address it has no way to resolve, `ipAddress` being required at registration — and `DatanodeLayoutStorage` reads a `datanode.id` file with no VERSION file beside it as an upgrade from an install predating the upgrade framework, defaulting to metadata layout version 0. The Datanode reaches the current version only once SCM orders it to finalize, after it registers.

Master hides this, because SCM finalizes those Datanodes before they can satisfy safemode and tests wait on them. Under ZDU a pre-finalized Datanode is valid for existing operations and no longer holds up safemode exit, so a write meant for a finalized Datanode can land on one that has not finalized yet — the intermittent `TestFinalizeBlock` failures.

The identity file is now written only for Datanodes that are given a synthetic hostname, with the layout version stamped beside it; every other cluster builds its Datanodes the way a real one does. Tests that want an older layout version set it through `UniformDatanodesFactory`, which writes the VERSION file itself and takes precedence.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16206

## How was this patch tested?

A new parameterized test in `TestMiniOzoneCluster` builds a cluster with its Datanodes not started and asserts the metadata layout version defaults to the maximum, with and without configured hostnames; both cases fail without the change (`expected: <10> but was: <0>`).

`TestRackAwarePlacement` — added with HDDS-14812, covering every rack and hostname combination — and `TestDNDataDistributionFinalization` pass, as does `checkstyle:check` on both modules. `TestHDDSUpgrade` ran out of memory on this machine before finishing, so it is left to CI.

Generated-by: Claude Code (Claude Opus 5)