### PR TITLE
HDDS-16277. Reuse CharsetEncoder/Decoder in StringCodec

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
@@ -42,6 +42,9 @@ abstract class StringCodecBase implements Codec<String> {
   private final Charset charset;
   private final boolean fixedLength;
   private final int maxBytesPerChar;
+  // CharsetEncoder/CharsetDecoder are stateful and not thread-safe: reuse one per thread.
+  private final ThreadLocal<CharsetEncoder> threadLocalEncoder = ThreadLocal.withInitial(this::newEncoder);
+  private final ThreadLocal<CharsetDecoder> threadLocalDecoder = ThreadLocal.withInitial(this::newDecoder);
 
   StringCodecBase(Charset charset) {
     this.charset = charset;
@@ -97,7 +100,7 @@ abstract class StringCodecBase implements Codec<String> {
   private <E extends Exception> PutToByteBuffer<E> encode(
       String string, Integer serializedSize, Function<String, E> newE) {
     return buffer -> {
-      final CoderResult result = newEncoder().encode(
+      final CoderResult result = threadLocalEncoder.get().reset().encode(
           CharBuffer.wrap(string), buffer, true);
       if (result.isError()) {
         throw newE.apply("Failed to encode with " + charset + ": " + result
@@ -114,7 +117,7 @@ abstract class StringCodecBase implements Codec<String> {
 
   String decodeNoFallback(ByteBuffer buffer) throws CodecException {
     try {
-      return newDecoder().decode(buffer.asReadOnlyBuffer()).toString();
+      return threadLocalDecoder.get().decode(buffer.asReadOnlyBuffer()).toString();
     } catch (Exception e) {
       throw new CodecException("Failed to decode " + buffer, e);
     }
@@ -123,7 +126,7 @@ abstract class StringCodecBase implements Codec<String> {
   String decodeWithFallback(ByteBuffer buffer) {
     Runnable error = null;
     try {
-      return newDecoder().decode(buffer.asReadOnlyBuffer()).toString();
+      return threadLocalDecoder.get().decode(buffer.asReadOnlyBuffer()).toString();
     } catch (Exception e) {
       error = () -> LOG.warn("Failed to decode buffer with {}, buffer = (hex) {}",
           charset, StringUtils.bytes2Hex(buffer, 20), e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`StringCodecBase` (the base of `StringCodec` and `FixedLengthStringCodec`) allocates a fresh `CharsetEncoder` on every encode and a fresh `CharsetDecoder` on every decode:

- `encode(...)` -> `newEncoder().encode(...)`
- `decodeNoFallback(...)` / `decodeWithFallback(...)` -> `newDecoder().decode(...)`

These codecs are singletons on a hot path: every `String` RocksDB key/value (OM/SCM tables, iterators, compaction) is serialized/deserialized through them, so a short-lived coder is created on each call.

`CharsetEncoder`/`CharsetDecoder` are stateful and not thread-safe, so this caches one per thread (`ThreadLocal`) and reuses it:

- the encoder is `reset()` before each use, because the 3-arg `encode(in, out, endOfInput)` does not reset on its own;
- the decoder uses the single-arg `CharsetDecoder.decode(ByteBuffer)`, which resets internally (per its javadoc), so no explicit reset is added there.

The cache is per codec instance rather than `static`, because subclasses use different charsets. `reset()` only clears coding state and keeps `onMalformedInput`/`onUnmappableCharacter(REPORT)`, so behavior is unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16277

## How was this patch tested?

fork CI run：
https://github.com/rich7420/ozone/actions/runs/32851264063

#### Microbenchmark

JMH (out of tree), JDK 21, single thread, `fork=2`. Both variants run the identical encode/decode and differ only in coder acquisition (fresh vs. reused per thread), so the delta is attributable to this change. `gc.alloc.rate.norm` error is +/- 0.001 B/op, i.e. the per-call allocation is exact. that's on my macbook.

encode:

| input | ns/op (old -> new) | B/op (old -> new) |
| --- | --- | --- |
| `/vol1/bucket1/dir1/dir2/object-file-000000123.dat` | 81.7 -> 66.3 (-19%) | 208 -> 112 (-96 B, -46%) |
| `8f14e45f-ceea-467a-9d1b-2f3c4d5e6f70` | 58.7 -> 53.6 (-9%) | 208 -> 112 (-96 B, -46%) |

decode:

| input | ns/op (old -> new) | B/op (old -> new) |
| --- | --- | --- |
| `/vol1/bucket1/dir1/dir2/object-file-000000123.dat` | 29.5 -> 25.5 (-14%) | 368 -> 328 (-40 B, -11%) |
| `8f14e45f-ceea-467a-9d1b-2f3c4d5e6f70` | 28.7 -> 26.5 (-8%) | 320 -> 280 (-40 B, -13%) |
