### PR TITLE
HDDS-16256. Avoid the per-group list copy in OMKeyRequest.filterOutBlocksStillInUse

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1255,7 +1255,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // the referenceKey.
     Map<ContainerBlockID, OmKeyLocationInfo> cbIdSet = referenceKey.getKeyLocationVersions()
         .stream()
-        .flatMap(e -> e.createLocationList().stream())
+        .flatMap(group -> group.getLocationLists().stream())
+        .flatMap(List::stream)
         .collect(Collectors.toMap(omKeyLocationInfo -> omKeyLocationInfo.getBlockID().getContainerBlockID(),
             Function.identity()));
     Map<OmKeyInfo, List<OmKeyLocationInfo>> filteredOutBlocks = new HashMap<>();


### PR DESCRIPTION
<!-- obsidian --><h3 data-heading="What changes were proposed in this pull request?">What changes were proposed in this pull request?</h3>
<p><code>OMKeyRequest.filterOutBlocksStillInUse</code> called <code>OmKeyLocationInfoGroup.createLocationList()</code> on every version group of the reference key just to build a <code>Map&#x3C;ContainerBlockID, OmKeyLocationInfo></code> lookup table, allocating a throwaway flattened <code>List</code> per group that is immediately re-streamed and discarded. </p>
<p>This PR replaces the <code>flatMap(createLocationList().stream())</code> chain with nested stream flattening over <code>getLocationLists()</code>, removing the per-group list allocation while preserving <code>Collectors.toMap</code> duplicate-key semantics.</p>
<p>Additionally, a throwaway (not committed) JUnit micro-benchmark measured per-lookup-map-construction thread allocation for both implementations (JDK21.0.12, 50,000-iteration warmup then 500,000 measured iterations per shape, output maps asserted equal, <code>volatile</code> sink to block JIT elimination):</p>

Key Shape | Before | After | Saved
-- | -- | -- | --
1 group x 1 block | 240 ns / 950 B | 107 ns / 704 B | 246 B
1 group x 4 blocks | 171 ns / 1072 B | 169 ns / 872 B | 200 B
1 group x 32 blocks | 1149 ns / 4736 B | 1014 ns / 4200 B | 536 B
4 groups x 4 blocks | 504 ns / 3648 B | 404 ns / 2608 B | 1040 B
16 groups x 8 blocks | 6973 ns / 21088 B | 6449 ns / 16688 B | 4400 B


<h3 data-heading="What is the link to the Apache JIRA">What is the link to the Apache JIRA</h3>
<p><a href="https://issues.apache.org/jira/browse/HDDS-16256" class="external-link" target="_blank" rel="noopener nofollow">https://issues.apache.org/jira/browse/HDDS-16256</a></p>
<h3 data-heading="How was this patch tested?">How was this patch tested?</h3>
<ul>
<li><code>TestOMKeyCommitRequest#testValidateAndUpdateCacheOnOverwrite</code></li>
<li><code>TestOMKeyCommitRequest#testValidateAndUpdateCacheOnOverwriteWithUncommittedBlocks</code></li>
</ul>