### PR TITLE
HDDS-16100. Parameterize TestChunkInputStream

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/DomainSocketFactory.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/DomainSocketFactory.java
@@ -133,6 +133,10 @@ public final class DomainSocketFactory {
     return instance;
   }
 
+  public static boolean isNativeLibraryLoaded() {
+    return nativeLibraryLoaded;
+  }
+
   private DomainSocketFactory(ConfigurationSource conf) {
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
     boolean shortCircuitEnabled = clientConfig.isShortCircuitEnabled();

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -228,7 +228,7 @@ public abstract class GenericTestUtils {
   /**
    * Class to capture logs for doing assertions.
    */
-  public abstract static class LogCapturer {
+  public abstract static class LogCapturer implements AutoCloseable {
     private final StringWriter sw = new StringWriter();
 
     public static LogCapturer captureLogs(Logger logger) {
@@ -264,6 +264,11 @@ public abstract class GenericTestUtils {
 
     public void clearOutput() {
       writer().getBuffer().setLength(0);
+    }
+
+    @Override
+    public void close() {
+      stopCapturing();
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/InputStreamTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/InputStreamTests.java
@@ -92,10 +92,13 @@ abstract class InputStreamTests {
         .setStreamBufferMaxSize(MAX_FLUSH_SIZE)
         .applyTo(conf);
 
-    enableShortCircuitRead(dir, conf);
+    int datanodeCount = getDatanodeCount();
+    if (datanodeCount == 1) {
+      enableShortCircuitRead(dir, conf);
+    }
 
     return MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(getDatanodeCount())
+        .setNumDatanodes(datanodeCount)
         .build();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/InputStreamTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/InputStreamTests.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_LAYOU
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 
+import java.io.File;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -31,19 +32,25 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
+import org.apache.hadoop.hdds.scm.XceiverClientShortCircuit;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
+import org.apache.hadoop.hdds.scm.storage.LocalChunkInputStream;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.ClientConfigForTesting;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.OzoneTestHelper;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.event.Level;
 
-// TODO remove this class, set config as default in integration tests
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class InputStreamTests {
 
@@ -54,6 +61,9 @@ abstract class InputStreamTests {
   static final int BYTES_PER_CHECKSUM = 256 * 1024;   // 256KB
 
   private MiniOzoneCluster cluster;
+
+  @TempDir
+  private File dir;
 
   protected MiniOzoneCluster newCluster() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
@@ -74,7 +84,6 @@ abstract class InputStreamTests {
         conf.getObject(ReplicationManagerConfiguration.class);
     repConf.setInterval(Duration.ofSeconds(1));
     conf.setFromObject(repConf);
-    setCustomizedProperties(conf);
 
     ClientConfigForTesting.newBuilder(StorageUnit.BYTES)
         .setBlockSize(BLOCK_SIZE)
@@ -82,6 +91,8 @@ abstract class InputStreamTests {
         .setStreamBufferFlushSize(FLUSH_SIZE)
         .setStreamBufferMaxSize(MAX_FLUSH_SIZE)
         .applyTo(conf);
+
+    enableShortCircuitRead(dir, conf);
 
     return MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(getDatanodeCount())
@@ -94,9 +105,6 @@ abstract class InputStreamTests {
 
   int getDatanodeCount() {
     return 5;
-  }
-
-  void setCustomizedProperties(OzoneConfiguration configuration) {
   }
 
   ReplicationConfig getRepConfig() {
@@ -134,5 +142,23 @@ abstract class InputStreamTests {
         }
       }
     });
+  }
+
+  protected static void enableShortCircuitRead(File dir, OzoneConfiguration configuration) {
+    useShortCircuitRead(configuration, true);
+    configuration.set(OzoneClientConfig.OZONE_DOMAIN_SOCKET_PATH, new File(dir, "ozone-socket").getAbsolutePath());
+  }
+
+  protected static void useShortCircuitRead(OzoneConfiguration conf, boolean use) {
+    OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
+    clientConfig.setShortCircuit(use);
+    conf.setFromObject(clientConfig);
+  }
+
+  protected static void debugShortCircuitRead() {
+    GenericTestUtils.setLogLevel(XceiverClientShortCircuit.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(XceiverClientGrpc.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(LocalChunkInputStream.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BlockInputStream.LOG, Level.DEBUG);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/InputStreamTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/InputStreamTests.java
@@ -65,7 +65,7 @@ abstract class InputStreamTests {
   @TempDir
   private File dir;
 
-  protected MiniOzoneCluster newCluster() throws Exception {
+  private MiniOzoneCluster newCluster() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
 
     OzoneClientConfig config = conf.getObject(OzoneClientConfig.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -17,28 +17,78 @@
 
 package org.apache.hadoop.ozone.client.rpc.read;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
+import org.apache.hadoop.hdds.scm.XceiverClientShortCircuit;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
+import org.apache.hadoop.hdds.scm.storage.DomainSocketFactory;
+import org.apache.hadoop.hdds.scm.storage.LocalChunkInputStream;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.om.BucketForTesting;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests {@link ChunkInputStream}.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ParameterizedClass
+@ValueSource(booleans = {true, false})
 class TestChunkInputStream extends InputStreamTests {
+
+  @Parameter
+  private boolean useShortCircuitRead;
+
+  private LogCapturer localChunkInputStreamLog;
+  private LogCapturer shortCircuitClientLog;
+  private LogCapturer blockInputStreamLog;
+  private LogCapturer grpcClientLog;
+
+  @BeforeEach
+  void startCapturing() {
+    localChunkInputStreamLog = LogCapturer.captureLogs(LocalChunkInputStream.LOG);
+    shortCircuitClientLog = LogCapturer.captureLogs(XceiverClientShortCircuit.LOG);
+    blockInputStreamLog = LogCapturer.captureLogs(BlockInputStream.LOG);
+    grpcClientLog = LogCapturer.captureLogs(XceiverClientGrpc.LOG);
+  }
+
+  @AfterEach
+  void stopCapturing() {
+    org.apache.hadoop.hdds.utils.IOUtils.closeQuietly(
+        blockInputStreamLog, grpcClientLog, localChunkInputStreamLog, shortCircuitClientLog);
+  }
+
+  @Override
+  int getDatanodeCount() {
+    return getRepConfig().getRequiredNodes();
+  }
+
+  @Override
+  ReplicationConfig getRepConfig() {
+    return RatisReplicationConfig.getInstance(ONE);
+  }
 
   /**
    * Run the tests as a single test method to avoid needing a new mini-cluster
@@ -46,15 +96,32 @@ class TestChunkInputStream extends InputStreamTests {
    */
   @ContainerLayoutTestInfo.ContainerTest
   void testAll(ContainerLayoutVersion layout) throws Exception {
-    try (OzoneClient client = getCluster().newClient()) {
-      updateConfig(layout);
+    if (useShortCircuitRead) {
+      assumeTrue(DomainSocketFactory.getInstance(getCluster().getConf()).isServiceReady());
+    }
 
+    updateConfig(layout);
+
+    OzoneConfiguration clientConfig = new OzoneConfiguration(getCluster().getConf());
+    useShortCircuitRead(clientConfig, useShortCircuitRead);
+    debugShortCircuitRead();
+
+    try (OzoneClient client = OzoneClientFactory.getRpcClient(clientConfig)) {
       BucketForTesting bucket = BucketForTesting.newBuilder(client).build();
 
       testChunkReadBuffers(bucket);
       testBufferRelease(bucket);
       testCloseReleasesBuffers(bucket);
     }
+
+    assertEquals(useShortCircuitRead, localChunkInputStreamLog.getOutput()
+        .contains("LocalChunkInputStream is created"));
+    assertEquals(useShortCircuitRead, shortCircuitClientLog.getOutput()
+        .contains("XceiverClientShortCircuit is created"));
+    assertEquals(useShortCircuitRead, blockInputStreamLog.getOutput()
+        .contains("Get the FileInputStream of block"));
+    assertEquals(!useShortCircuitRead, grpcClientLog.getOutput()
+        .contains("XceiverClientGrpc is created"));
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestLocalChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestLocalChunkInputStream.java
@@ -18,36 +18,32 @@
 package org.apache.hadoop.ozone.client.rpc.read;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.File;
 import java.io.IOException;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
 import org.apache.hadoop.hdds.scm.XceiverClientShortCircuit;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.DomainSocketFactory;
 import org.apache.hadoop.hdds.scm.storage.LocalChunkInputStream;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
-import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
-import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.om.BucketForTesting;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.event.Level;
 
 /**
  * Tests {@link LocalChunkInputStream}.
@@ -58,27 +54,33 @@ import org.slf4j.event.Level;
  *  to intellij run configuration.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class TestLocalChunkInputStream extends TestChunkInputStream {
+class TestLocalChunkInputStream extends InputStreamTests {
 
-  @TempDir
-  private File dir;
+  private LogCapturer shortCircuitClientLog;
+  private LogCapturer grpcClientLog;
 
+  @BeforeAll
   @Override
-  int getDatanodeCount() {
-    return 1;
+  void setup() throws Exception {
+    assumeTrue(DomainSocketFactory.isNativeLibraryLoaded());
+    super.setup();
+    assumeTrue(DomainSocketFactory.getInstance(getCluster().getConf()).isServiceReady());
+  }
+
+  @BeforeEach
+  void startCapturing() {
+    shortCircuitClientLog = LogCapturer.captureLogs(XceiverClientShortCircuit.LOG);
+    grpcClientLog = LogCapturer.captureLogs(XceiverClientGrpc.LOG);
+  }
+
+  @AfterEach
+  void stopCapturing() {
+    IOUtils.closeQuietly(grpcClientLog, shortCircuitClientLog);
   }
 
   @Override
-  void setCustomizedProperties(OzoneConfiguration configuration) {
-    OzoneClientConfig clientConfig = configuration.getObject(OzoneClientConfig.class);
-    clientConfig.setShortCircuit(true);
-    configuration.setFromObject(clientConfig);
-    configuration.set(OzoneClientConfig.OZONE_DOMAIN_SOCKET_PATH,
-        new File(dir, "ozone-socket").getAbsolutePath());
-    GenericTestUtils.setLogLevel(XceiverClientShortCircuit.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(XceiverClientGrpc.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(LocalChunkInputStream.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(BlockInputStream.LOG, Level.DEBUG);
+  int getDatanodeCount() {
+    return getRepConfig().getRequiredNodes();
   }
 
   @Override
@@ -86,47 +88,12 @@ public class TestLocalChunkInputStream extends TestChunkInputStream {
     return RatisReplicationConfig.getInstance(ONE);
   }
 
-
-  /**
-   * Run the tests as a single test method to avoid needing a new mini-cluster
-   * for each test.
-   */
-  @ContainerLayoutTestInfo.ContainerTest
-  @Override
-  void testAll(ContainerLayoutVersion layout) throws Exception {
-    try (OzoneClient client = getCluster().newClient()) {
-      updateConfig(layout);
-      assumeTrue(DomainSocketFactory.getInstance(getCluster().getConf()).isServiceReady());
-
-      BucketForTesting bucket = BucketForTesting.newBuilder(client).build();
-      GenericTestUtils.LogCapturer logCapturer1 =
-          GenericTestUtils.LogCapturer.captureLogs(LocalChunkInputStream.LOG);
-      GenericTestUtils.LogCapturer logCapturer2 =
-          GenericTestUtils.LogCapturer.captureLogs(XceiverClientShortCircuit.LOG);
-      GenericTestUtils.LogCapturer logCapturer3 =
-          GenericTestUtils.LogCapturer.captureLogs(BlockInputStream.LOG);
-      GenericTestUtils.LogCapturer logCapturer4 =
-          GenericTestUtils.LogCapturer.captureLogs(XceiverClientGrpc.LOG);
-      testChunkReadBuffers(bucket);
-      testBufferRelease(bucket);
-      testCloseReleasesBuffers(bucket);
-      assertTrue(logCapturer1.getOutput().contains("LocalChunkInputStream is created"));
-      assertTrue(logCapturer2.getOutput().contains("XceiverClientShortCircuit is created"));
-      assertTrue((logCapturer3.getOutput().contains("Get the FileInputStream of block")));
-      assertFalse(logCapturer4.getOutput().contains("XceiverClientGrpc is created"));
-    }
-  }
-
   @Test
   void testFallbackToGrpc() throws Exception {
     try (OzoneClient client = getCluster().newClient()) {
-      assumeTrue(DomainSocketFactory.getInstance(getCluster().getConf()).isServiceReady());
-
       BucketForTesting bucket = BucketForTesting.newBuilder(client).build();
-      GenericTestUtils.LogCapturer logCapturer1 =
-          GenericTestUtils.LogCapturer.captureLogs(XceiverClientShortCircuit.LOG);
-      GenericTestUtils.LogCapturer logCapturer2 =
-          GenericTestUtils.LogCapturer.captureLogs(XceiverClientGrpc.LOG);
+
+      debugShortCircuitRead();
 
       // create key
       String keyName = getNewKeyName();
@@ -137,7 +104,7 @@ public class TestLocalChunkInputStream extends TestChunkInputStream {
             (BlockInputStream)keyInputStream.getPartStreams().get(0);
         block0Stream.initialize();
         assertNotNull(block0Stream.getBlockFileInputStream());
-        assertTrue(logCapturer1.getOutput().contains("XceiverClientShortCircuit is created"));
+        assertThat(shortCircuitClientLog.getOutput()).contains("XceiverClientShortCircuit is created");
 
         // stop XceiverServerDomainSocket server before client sends the second getBlockRequest to server
         XceiverServerSpi server = getCluster().getHddsDatanodes().get(0)
@@ -147,8 +114,9 @@ public class TestLocalChunkInputStream extends TestChunkInputStream {
         try {
           block1Stream.initialize();
         } catch (IOException e) {
-          assertTrue(e.getMessage().contains("DomainSocket stream is not open"));
-          assertTrue(logCapturer1.getOutput().contains("ReceiveResponseTask is closed due to java.io.EOFException"));
+          assertThat(e.getMessage()).contains("DomainSocket stream is not open");
+          assertThat(shortCircuitClientLog.getOutput())
+              .contains("ReceiveResponseTask is closed due to java.io.EOFException");
         }
         assertNull(block1Stream.getBlockFileInputStream());
         // read whole key through Grpc channel
@@ -156,7 +124,7 @@ public class TestLocalChunkInputStream extends TestChunkInputStream {
         int readLen = keyInputStream.read(data);
         assertEquals(dataLength, readLen);
         assertArrayEquals(inputData, data);
-        assertTrue(logCapturer2.getOutput().contains("XceiverClientGrpc is created"));
+        assertThat(grpcClientLog.getOutput()).contains("XceiverClientGrpc is created");
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestStreamBlockInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestStreamBlockInputStream.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.storage.StreamBlockInputStream;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
@@ -76,16 +75,12 @@ public class TestStreamBlockInputStream extends InputStreamTests {
 
   @Test
   void testReadKey() throws Exception {
-    try (MiniOzoneCluster cluster = newCluster()) {
-      cluster.waitForClusterToBeReady();
-      LOG.info("cluster ready");
-      OzoneConfiguration conf = cluster.getConf();
+    OzoneConfiguration conf = getCluster().getConf();
 
-      runTestReadKey(DATA_LENGTH, false, conf);
-      for (int i = 0; i < 2; i++) {
-        final int keyLength = DATA_LENGTH + ThreadLocalRandom.current().nextInt(DATA_LENGTH);
-        runTestReadKey(keyLength, true, conf);
-      }
+    runTestReadKey(DATA_LENGTH, false, conf);
+    for (int i = 0; i < 2; i++) {
+      final int keyLength = DATA_LENGTH + ThreadLocalRandom.current().nextInt(DATA_LENGTH);
+      runTestReadKey(keyLength, true, conf);
     }
   }
 
@@ -196,34 +191,30 @@ public class TestStreamBlockInputStream extends InputStreamTests {
   }
 
   void runTestAll(boolean preRead) throws Exception {
-    try (MiniOzoneCluster cluster = newCluster()) {
-      cluster.waitForClusterToBeReady();
-
-      OzoneConfiguration conf = cluster.getConf();
-      OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
-      clientConfig.setStreamReadBlock(true);
-      if (!preRead) {
-        clientConfig.setStreamReadPreReadSize(0);
-      }
-      OzoneConfiguration copy = new OzoneConfiguration(conf);
-      copy.setFromObject(clientConfig);
-      String keyName = getNewKeyName();
-      try (OzoneClient client = OzoneClientFactory.getRpcClient(copy)) {
-        bucket = BucketForTesting.newBuilder(client).build();
-        inputData = bucket.writeRandomBytes(keyName, DATA_LENGTH);
-        testReadKeyFully(keyName);
-        testSeek(keyName);
-        testReadEmptyBlock();
-      }
-      keyName = getNewKeyName();
-      clientConfig.setChecksumType(ContainerProtos.ChecksumType.NONE);
-      copy.setFromObject(clientConfig);
-      try (OzoneClient client = OzoneClientFactory.getRpcClient(copy)) {
-        bucket = BucketForTesting.newBuilder(client).build();
-        inputData = bucket.writeRandomBytes(keyName, DATA_LENGTH);
-        testReadKeyFully(keyName);
-        testSeek(keyName);
-      }
+    OzoneConfiguration conf = getCluster().getConf();
+    OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
+    clientConfig.setStreamReadBlock(true);
+    if (!preRead) {
+      clientConfig.setStreamReadPreReadSize(0);
+    }
+    OzoneConfiguration copy = new OzoneConfiguration(conf);
+    copy.setFromObject(clientConfig);
+    String keyName = getNewKeyName();
+    try (OzoneClient client = OzoneClientFactory.getRpcClient(copy)) {
+      bucket = BucketForTesting.newBuilder(client).build();
+      inputData = bucket.writeRandomBytes(keyName, DATA_LENGTH);
+      testReadKeyFully(keyName);
+      testSeek(keyName);
+      testReadEmptyBlock();
+    }
+    keyName = getNewKeyName();
+    clientConfig.setChecksumType(ContainerProtos.ChecksumType.NONE);
+    copy.setFromObject(clientConfig);
+    try (OzoneClient client = OzoneClientFactory.getRpcClient(copy)) {
+      bucket = BucketForTesting.newBuilder(client).build();
+      inputData = bucket.writeRandomBytes(keyName, DATA_LENGTH);
+      testReadKeyFully(keyName);
+      testSeek(keyName);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Make `TestLocalChunkInputStream` extend `InpuStreamTests` instead of `TestChunkInputStream`
- Parameterize `TestChunkInputStream` to also test with short-circuit read enabled
- Keep only `testFallbackToGrpc` in `TestLocalChunkInputStream`
- Remove unnecessary cluster creation from `TestStreamBlockInputStream`

https://issues.apache.org/jira/browse/HDDS-16100

## How was this patch tested?

Without native lib:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.037 s -- in org.apache.hadoop.ozone.client.rpc.read.TestChunkInputStream
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.91 s -- in org.apache.hadoop.ozone.client.rpc.read.TestChunkInputStream
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.15 s -- in org.apache.hadoop.ozone.client.rpc.read.TestChunkInputStream
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 64.82 s -- in org.apache.hadoop.ozone.client.rpc.read.TestKeyInputStream
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.063 s -- in org.apache.hadoop.ozone.client.rpc.read.TestLocalChunkInputStream
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 52.97 s -- in org.apache.hadoop.ozone.client.rpc.read.TestStreamBlockInputStream
```

With native lib:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.79 s -- in org.apache.hadoop.ozone.client.rpc.read.TestChunkInputStream
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.90 s -- in org.apache.hadoop.ozone.client.rpc.read.TestChunkInputStream
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 55.68 s -- in org.apache.hadoop.ozone.client.rpc.read.TestChunkInputStream
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 87.33 s -- in org.apache.hadoop.ozone.client.rpc.read.TestKeyInputStream
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.89 s -- in org.apache.hadoop.ozone.client.rpc.read.TestLocalChunkInputStream
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 92.17 s -- in org.apache.hadoop.ozone.client.rpc.read.TestStreamBlockInputStream
```

https://github.com/adoroszlai/ozone/actions/runs/32855529592
