### PR TITLE
HDDS-16282. Avoid O(n^2) key removal in S3 DeleteObjects

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -355,6 +355,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     OzoneBucket bucket = getVolume().getBucket(bucketName);
     MultiDeleteResponse result = new MultiDeleteResponse();
     List<String> deleteKeys = new ArrayList<>();
+    List<String> failedDeletes = new ArrayList<>();
 
     if (request.getObjects() != null) {
       Map<String, ErrorInfo> undeletedKeyResultMap;
@@ -371,11 +372,11 @@ public class BucketEndpoint extends BucketOperationHandler {
               // if the key is not found, it is assumed to be successfully deleted
               ResultCodes.KEY_NOT_FOUND.name().equals(error.getCode());
           if (deleted) {
-            deleteKeys.remove(d.getKey());
             if (!request.isQuiet()) {
               result.addDeleted(new DeletedObject(d.getKey()));
             }
           } else {
+            failedDeletes.add(d.getKey());
             result.addError(new Error(d.getKey(), error.getCode(), error.getMessage()));
           }
         }
@@ -383,6 +384,8 @@ public class BucketEndpoint extends BucketOperationHandler {
       } catch (IOException ex) {
         LOG.error("Delete key failed: {}", ex.getMessage());
         getMetrics().updateDeleteKeyFailureStats(startNanos);
+        // the batch delete failed as a whole, so no key is reported as deleted
+        failedDeletes.addAll(deleteKeys);
         result.addError(
             new Error("ALL", "InternalError",
                 ex.getMessage()));
@@ -390,7 +393,7 @@ public class BucketEndpoint extends BucketOperationHandler {
     }
 
     AuditMessage.Builder message = auditMessageFor(s3GAction);
-    message.getParams().put("failedDeletes", deleteKeys.toString());
+    message.getParams().put("failedDeletes", failedDeletes.toString());
 
     if (!result.getErrors().isEmpty()) {
       AUDIT.logWriteFailure(message.withResult(AuditEventStatus.FAILURE)

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
@@ -17,23 +17,39 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointTestUtils.assertErrorResponse;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_XML;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Sets;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.xml.bind.JAXBException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.helpers.ErrorInfo;
 import org.apache.hadoop.ozone.s3.endpoint.MultiDeleteRequest.DeleteObject;
+import org.apache.hadoop.ozone.s3.endpoint.MultiDeleteResponse.DeletedObject;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.Test;
 
@@ -138,6 +154,74 @@ public class TestObjectMultiDelete {
     assertEquals(0, response.getErrors().size());
 
     assertEquals(3, Sets.newHashSet(bucket.listKeys("")).size());
+  }
+
+  @Test
+  public void multiDeleteAuditsOnlyFailedKeys() throws Exception {
+    OzoneBucket bucket = mock(OzoneBucket.class);
+    Map<String, ErrorInfo> undeletedKeys = new HashMap<>();
+    undeletedKeys.put("key2", new ErrorInfo("ACCESS_DENIED", "ACL check failed"));
+    undeletedKeys.put("key3", new ErrorInfo(ResultCodes.KEY_NOT_FOUND.name(), "Key does not exist"));
+    when(bucket.deleteKeys(any(), anyBoolean())).thenReturn(undeletedKeys);
+
+    Map<String, String> auditParams = new HashMap<>();
+    MultiDeleteResponse response =
+        newEndpointFor(bucket, auditParams).multiDelete("b1", "", threeKeyRequest());
+
+    assertEquals(asList("key1", "key3"), response.getDeletedObjects().stream()
+        .map(DeletedObject::getKey)
+        .collect(Collectors.toList()));
+    assertEquals(1, response.getErrors().size());
+    assertEquals("key2", response.getErrors().get(0).getKey());
+    assertEquals("[key2]", auditParams.get("failedDeletes"));
+  }
+
+  @Test
+  public void multiDeleteAuditsAllKeysWhenDeleteFails() throws Exception {
+    OzoneBucket bucket = mock(OzoneBucket.class);
+    when(bucket.deleteKeys(any(), anyBoolean())).thenThrow(new IOException("Ozone Manager is unavailable"));
+
+    Map<String, String> auditParams = new HashMap<>();
+    MultiDeleteResponse response =
+        newEndpointFor(bucket, auditParams).multiDelete("b1", "", threeKeyRequest());
+
+    assertEquals(0, response.getDeletedObjects().size());
+    assertEquals(1, response.getErrors().size());
+    assertEquals("ALL", response.getErrors().get(0).getKey());
+    assertEquals("InternalError", response.getErrors().get(0).getCode());
+    assertEquals("[key1, key2, key3]", auditParams.get("failedDeletes"));
+  }
+
+  private MultiDeleteRequest threeKeyRequest() {
+    MultiDeleteRequest mdr = new MultiDeleteRequest();
+    mdr.getObjects().add(new DeleteObject("key1"));
+    mdr.getObjects().add(new DeleteObject("key2"));
+    mdr.getObjects().add(new DeleteObject("key3"));
+    return mdr;
+  }
+
+  private BucketEndpoint newEndpointFor(OzoneBucket bucket, Map<String, String> auditParams) throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    S3GatewayMetrics.create(conf);
+
+    OzoneClient client = mock(OzoneClient.class);
+    ObjectStore objectStore = mock(ObjectStore.class);
+    OzoneVolume volume = mock(OzoneVolume.class);
+    when(client.getObjectStore()).thenReturn(objectStore);
+    when(client.getConfiguration()).thenReturn(conf);
+    when(objectStore.getClientProxy()).thenReturn(mock(ClientProtocol.class));
+    when(objectStore.getS3Volume()).thenReturn(volume);
+    when(volume.getBucket(anyString())).thenReturn(bucket);
+
+    return EndpointBuilder.newBucketEndpointBuilder()
+        .setBase(new BucketEndpoint() {
+          @Override
+          protected Map<String, String> getAuditParameters() {
+            return auditParams;
+          }
+        })
+        .setClient(client)
+        .build();
   }
 
   private OzoneBucket initTestData(OzoneClient client) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

A multi-object DELETE carries up to 1000 keys, and the `failedDeletes` audit list was derived by removing every successfully deleted key from the request list — quadratic in the size of the request. Building the failure list directly leaves the response and the audit output unchanged.

Timing that loop in isolation at the 1000-key cap, median of 2000 iterations after warmup on JDK 25:

| failed keys | before | after |
|---|---|---|
| 0 | 33 µs | 1.2 µs |
| 1 | 36 µs | 1.9 µs |
| 100 | 150 µs | 2.9 µs |
| 500 | 659 µs | 5.1 µs |
| 900 | 239 µs | 4.2 µs |

The peak sits near a 50% failure rate rather than at either extreme, because failed keys accumulate at the head of the list and every later `remove(Object)` scans past them. Against the OM round trip the saving is small; what it buys is dropping a quadratic term from a capped path.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16282

## How was this patch tested?

Two new unit tests pin the response and the `failedDeletes` audit parameter, for a mixed success/failure request and for a batch delete that fails outright. Both also pass against the previous implementation — that is what they are for. The full `ozone-s3gateway` suite (760 tests) and checkstyle pass locally.

Generated-by: Claude Code (Opus 5)
