### PR TITLE
HDDS-16288. Replace MutableRate with lock-free ConcurrentMutableRate on OM hot-path metrics

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/ConcurrentMutableRate.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/ConcurrentMutableRate.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.util;
+
+import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.metrics2.lib.MutableStat;
+
+/**
+ * A lock-free counterpart of Hadoop's {@link MutableRate}.
+ *
+ * <p>Hadoop's {@link MutableRate} is simply a {@link MutableStat} that fixes the
+ * sample name to {@code "Ops"} and the value name to {@code "Time"}, so it emits
+ * {@code <Name>NumOps} / {@code <Name>AvgTime}. This class mimics that
+ * convenience constructor exactly, but extends {@link ConcurrentMutableStat}
+ * instead of {@link MutableStat} so that the hot-path {@link #add(long)} is
+ * non-blocking under concurrent callers.
+ *
+ * <p>It is a drop-in replacement for {@code MutableRate}: the constructor shape
+ * matches and the emitted metric names and NumOps/AvgTime semantics are
+ * identical. Unlike {@code MutableRate} — whose constructor is package-private
+ * and can only be created reflectively by the {@code @Metric} factory — this
+ * constructor is {@code public} so Ozone metric sources can instantiate it
+ * directly.
+ *
+ * <p>See {@link ConcurrentMutableStat} for the lock-free accumulation details
+ * and the standard-deviation accuracy caveat inherited here.
+ */
+public class ConcurrentMutableRate extends ConcurrentMutableStat {
+
+  public ConcurrentMutableRate(String name, String description,
+      boolean extended) {
+    super(name, description, "Ops", "Time", extended);
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/MetricUtil.java
@@ -25,7 +25,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableQuantiles;
-import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.metrics2.lib.MutableStat;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.util.function.CheckedRunnable;
 import org.apache.ratis.util.function.CheckedSupplier;
@@ -38,7 +38,7 @@ public final class MetricUtil {
   }
 
   public static <T, E extends Exception> T captureLatencyNs(
-      MutableRate metric,
+      MutableStat metric,
       CheckedSupplier<T, E> block) throws E {
     long start = Time.monotonicNowNanos();
     try {
@@ -49,7 +49,7 @@ public final class MetricUtil {
   }
 
   public static <E extends IOException> void captureLatencyNs(
-      MutableRate metric,
+      MutableStat metric,
       CheckedRunnable<E> block) throws IOException {
     long start = Time.monotonicNowNanos();
     try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -17,139 +17,84 @@
 
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableGaugeFloat;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
-import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.util.ConcurrentMutableRate;
 
 /**
  * Including OM performance related metrics.
+ *
+ * <p>The latency counters use {@link ConcurrentMutableRate} so that
+ * {@code add(long)} is non-blocking under concurrent handler threads recording
+ * on the same metric instance. The metric names emitted for each counter
+ * ({@code <Name>NumOps} / {@code <Name>AvgTime}) are unchanged from the
+ * previous {@code MutableRate}-based implementation.
  */
-public class OMPerformanceMetrics {
+@Metrics(about = "OzoneManager Request Performance", context = OzoneConsts.OZONE)
+public class OMPerformanceMetrics implements MetricsSource {
   private static final String SOURCE_NAME =
       OMPerformanceMetrics.class.getSimpleName();
 
-  @Metric(about = "Overall lookupKey in nanoseconds")
-  private MutableRate lookupLatencyNs;
+  // TODO: https://issues.apache.org/jira/browse/HDDS-13555
+  @SuppressWarnings("PMD.SingularField")
+  private final MetricsRegistry registry;
 
-  @Metric(about = "Read key info from meta in nanoseconds")
-  private MutableRate lookupReadKeyInfoLatencyNs;
-
-  @Metric(about = "Block token generation latency in nanoseconds")
-  private MutableRate lookupGenerateBlockTokenLatencyNs;
-
-  @Metric(about = "Refresh location nanoseconds")
-  private MutableRate lookupRefreshLocationLatencyNs;
-
-  @Metric(about = "ACLs check nanoseconds")
-  private MutableRate lookupAclCheckLatencyNs;
-
-  @Metric(about = "resolveBucketLink latency nanoseconds")
-  private MutableRate lookupResolveBucketLatencyNs;
-
-  @Metric(about = "Overall getKeyInfo in nanoseconds")
-  private MutableRate getKeyInfoLatencyNs;
-
-  @Metric(about = "Read key info from db in getKeyInfo")
-  private MutableRate getKeyInfoReadKeyInfoLatencyNs;
-
-  @Metric(about = "Block token generation latency in getKeyInfo")
-  private MutableRate getKeyInfoGenerateBlockTokenLatencyNs;
-
-  @Metric(about = "Refresh location latency in getKeyInfo")
-  private MutableRate getKeyInfoRefreshLocationLatencyNs;
-
-  @Metric(about = "ACLs check in getKeyInfo")
-  private MutableRate getKeyInfoAclCheckLatencyNs;
-
-  @Metric(about = "Sort datanodes latency in getKeyInfo")
-  private MutableRate getKeyInfoSortDatanodesLatencyNs;
-
-  @Metric(about = "Sort datanodes latency in allocateBlock (streaming write)")
-  private MutableRate allocateBlockSortDatanodesLatencyNs;
-
-  @Metric(about = "resolveBucketLink latency in getKeyInfo")
-  private MutableRate getKeyInfoResolveBucketLatencyNs;
-
-  @Metric(about = "s3VolumeInfo latency nanoseconds")
-  private MutableRate s3VolumeContextLatencyNs;
-
-  @Metric(about = "Client requests forcing container info cache refresh")
-  private MutableRate forceContainerCacheRefresh;
-
-  @Metric(about = "checkAccess latency in nanoseconds")
-  private MutableRate checkAccessLatencyNs;
-
-  @Metric(about = "listKeys latency in nanoseconds")
-  private MutableRate listKeysLatencyNs;
-
-  @Metric(about = "Validate request latency in nano seconds")
-  private MutableRate validateRequestLatencyNs;
-
-  @Metric(about = "Validate response latency in nano seconds")
-  private MutableRate validateResponseLatencyNs;
-
-  @Metric(about = "PreExecute latency in nano seconds")
-  private MutableRate preExecuteLatencyNs;
-
-  @Metric(about = "Ratis latency in nano seconds")
-  private MutableRate submitToRatisLatencyNs;
-
-  @Metric(about = "Convert om request to ratis request nano seconds")
-  private MutableRate createRatisRequestLatencyNs;
-
-  @Metric(about = "Convert ratis response to om response nano seconds")
-  private MutableRate createOmResponseLatencyNs;
-
-  @Metric(about = "Ratis local command execution latency in nano seconds")
-  private MutableRate validateAndUpdateCacheLatencyNs;
-
-  @Metric(about = "average pagination for listKeys")
-  private MutableRate listKeysAveragePagination;
+  private final ConcurrentMutableRate lookupLatencyNs;
+  private final ConcurrentMutableRate lookupReadKeyInfoLatencyNs;
+  private final ConcurrentMutableRate lookupGenerateBlockTokenLatencyNs;
+  private final ConcurrentMutableRate lookupRefreshLocationLatencyNs;
+  private final ConcurrentMutableRate lookupAclCheckLatencyNs;
+  private final ConcurrentMutableRate lookupResolveBucketLatencyNs;
+  private final ConcurrentMutableRate getKeyInfoLatencyNs;
+  private final ConcurrentMutableRate getKeyInfoReadKeyInfoLatencyNs;
+  private final ConcurrentMutableRate getKeyInfoGenerateBlockTokenLatencyNs;
+  private final ConcurrentMutableRate getKeyInfoRefreshLocationLatencyNs;
+  private final ConcurrentMutableRate getKeyInfoAclCheckLatencyNs;
+  private final ConcurrentMutableRate getKeyInfoSortDatanodesLatencyNs;
+  private final ConcurrentMutableRate allocateBlockSortDatanodesLatencyNs;
+  private final ConcurrentMutableRate getKeyInfoResolveBucketLatencyNs;
+  private final ConcurrentMutableRate s3VolumeContextLatencyNs;
+  private final ConcurrentMutableRate forceContainerCacheRefresh;
+  private final ConcurrentMutableRate checkAccessLatencyNs;
+  private final ConcurrentMutableRate listKeysLatencyNs;
+  private final ConcurrentMutableRate validateRequestLatencyNs;
+  private final ConcurrentMutableRate validateResponseLatencyNs;
+  private final ConcurrentMutableRate preExecuteLatencyNs;
+  private final ConcurrentMutableRate submitToRatisLatencyNs;
+  private final ConcurrentMutableRate createRatisRequestLatencyNs;
+  private final ConcurrentMutableRate createOmResponseLatencyNs;
+  private final ConcurrentMutableRate validateAndUpdateCacheLatencyNs;
+  private final ConcurrentMutableRate listKeysAveragePagination;
+  private final ConcurrentMutableRate listKeysAclCheckLatencyNs;
+  private final ConcurrentMutableRate listKeysResolveBucketLatencyNs;
+  private final ConcurrentMutableRate deleteKeyFailureLatencyNs;
+  private final ConcurrentMutableRate deleteKeySuccessLatencyNs;
+  private final ConcurrentMutableRate deleteKeysResolveBucketLatencyNs;
+  private final ConcurrentMutableRate deleteKeysAclCheckLatencyNs;
+  private final ConcurrentMutableRate deleteKeyResolveBucketAndAclCheckLatencyNs;
+  private final ConcurrentMutableRate listKeysReadFromRocksDbLatencyNs;
+  private final ConcurrentMutableRate getObjectTaggingResolveBucketLatencyNs;
+  private final ConcurrentMutableRate getObjectTaggingAclCheckLatencyNs;
+  private final ConcurrentMutableRate getBucketTaggingResolveBucketLatencyNs;
+  private final ConcurrentMutableRate getBucketTaggingAclCheckLatencyNs;
+  private final ConcurrentMutableRate getBucketTaggingLatencyNs;
+  private final ConcurrentMutableRate createKeyResolveBucketAndAclCheckLatencyNs;
+  private final ConcurrentMutableRate createKeyQuotaCheckLatencyNs;
+  private final ConcurrentMutableRate createKeyAllocateBlockLatencyNs;
+  private final ConcurrentMutableRate createKeyFailureLatencyNs;
+  private final ConcurrentMutableRate createKeySuccessLatencyNs;
 
   @Metric(about = "ops per second for listKeys")
   private MutableGaugeFloat listKeysOpsPerSec;
-
-  @Metric(about = "ACLs check latency in listKeys")
-  private MutableRate listKeysAclCheckLatencyNs;
-
-  @Metric(about = "resolveBucketLink latency in listKeys")
-  private MutableRate listKeysResolveBucketLatencyNs;
-
-  @Metric(about = "deleteKeyFailure latency in nano seconds")
-  private MutableRate deleteKeyFailureLatencyNs;
-
-  @Metric(about = "deleteKeySuccess latency in nano seconds")
-  private MutableRate deleteKeySuccessLatencyNs;
-
-  @Metric(about = "resolveBucketLink latency in deleteKeys")
-  private MutableRate deleteKeysResolveBucketLatencyNs;
-
-  @Metric(about = "ACLs check latency in deleteKeys")
-  private MutableRate deleteKeysAclCheckLatencyNs;
-
-  @Metric(about = "resolveBucketLink and ACLs check latency in deleteKey")
-  private MutableRate deleteKeyResolveBucketAndAclCheckLatencyNs;
-  
-  @Metric(about = "readFromRockDb latency in listKeys")
-  private MutableRate listKeysReadFromRocksDbLatencyNs;
-
-  @Metric(about = "resolveBucketLink latency in getObjectTagging")
-  private MutableRate getObjectTaggingResolveBucketLatencyNs;
-
-  @Metric(about = "ACLs check in getObjectTagging")
-  private MutableRate getObjectTaggingAclCheckLatencyNs;
-
-  @Metric(about = "resolveBucketLink latency in getBucketTagging")
-  private MutableRate getBucketTaggingResolveBucketLatencyNs;
-
-  @Metric(about = "ACLs check latency in getBucketTagging")
-  private MutableRate getBucketTaggingAclCheckLatencyNs;
-
-  @Metric(about = "End-to-end latency in getBucketTagging")
-  private MutableRate getBucketTaggingLatencyNs;
 
   @Metric(about = "Latency of each iteration of DirectoryDeletingService in ms")
   private MutableGaugeLong directoryDeletingServiceLatencyMs;
@@ -166,20 +111,101 @@ public class OMPerformanceMetrics {
   @Metric(about = "Latency of the last snapshot incremental defragmentation operation in ms")
   private MutableGaugeLong snapshotDefragServiceIncLatencyMs;
 
-  @Metric(about = "ResolveBucketLink and ACL check latency for createKey in nanoseconds")
-  private MutableRate createKeyResolveBucketAndAclCheckLatencyNs;
-  
-  @Metric(about = "check quota for createKey in nanoseconds")
-  private MutableRate createKeyQuotaCheckLatencyNs;
+  public OMPerformanceMetrics() {
+    registry = new MetricsRegistry(SOURCE_NAME);
+    lookupLatencyNs = stat("LookupLatencyNs",
+        "Overall lookupKey in nanoseconds");
+    lookupReadKeyInfoLatencyNs = stat("LookupReadKeyInfoLatencyNs",
+        "Read key info from meta in nanoseconds");
+    lookupGenerateBlockTokenLatencyNs = stat("LookupGenerateBlockTokenLatencyNs",
+        "Block token generation latency in nanoseconds");
+    lookupRefreshLocationLatencyNs = stat("LookupRefreshLocationLatencyNs",
+        "Refresh location nanoseconds");
+    lookupAclCheckLatencyNs = stat("LookupAclCheckLatencyNs",
+        "ACLs check nanoseconds");
+    lookupResolveBucketLatencyNs = stat("LookupResolveBucketLatencyNs",
+        "resolveBucketLink latency nanoseconds");
+    getKeyInfoLatencyNs = stat("GetKeyInfoLatencyNs",
+        "Overall getKeyInfo in nanoseconds");
+    getKeyInfoReadKeyInfoLatencyNs = stat("GetKeyInfoReadKeyInfoLatencyNs",
+        "Read key info from db in getKeyInfo");
+    getKeyInfoGenerateBlockTokenLatencyNs = stat("GetKeyInfoGenerateBlockTokenLatencyNs",
+        "Block token generation latency in getKeyInfo");
+    getKeyInfoRefreshLocationLatencyNs = stat("GetKeyInfoRefreshLocationLatencyNs",
+        "Refresh location latency in getKeyInfo");
+    getKeyInfoAclCheckLatencyNs = stat("GetKeyInfoAclCheckLatencyNs",
+        "ACLs check in getKeyInfo");
+    getKeyInfoSortDatanodesLatencyNs = stat("GetKeyInfoSortDatanodesLatencyNs",
+        "Sort datanodes latency in getKeyInfo");
+    allocateBlockSortDatanodesLatencyNs = stat("AllocateBlockSortDatanodesLatencyNs",
+        "Sort datanodes latency in allocateBlock (streaming write)");
+    getKeyInfoResolveBucketLatencyNs = stat("GetKeyInfoResolveBucketLatencyNs",
+        "resolveBucketLink latency in getKeyInfo");
+    s3VolumeContextLatencyNs = stat("S3VolumeContextLatencyNs",
+        "s3VolumeInfo latency nanoseconds");
+    forceContainerCacheRefresh = stat("ForceContainerCacheRefresh",
+        "Client requests forcing container info cache refresh");
+    checkAccessLatencyNs = stat("CheckAccessLatencyNs",
+        "checkAccess latency in nanoseconds");
+    listKeysLatencyNs = stat("ListKeysLatencyNs",
+        "listKeys latency in nanoseconds");
+    validateRequestLatencyNs = stat("ValidateRequestLatencyNs",
+        "Validate request latency in nano seconds");
+    validateResponseLatencyNs = stat("ValidateResponseLatencyNs",
+        "Validate response latency in nano seconds");
+    preExecuteLatencyNs = stat("PreExecuteLatencyNs",
+        "PreExecute latency in nano seconds");
+    submitToRatisLatencyNs = stat("SubmitToRatisLatencyNs",
+        "Ratis latency in nano seconds");
+    createRatisRequestLatencyNs = stat("CreateRatisRequestLatencyNs",
+        "Convert om request to ratis request nano seconds");
+    createOmResponseLatencyNs = stat("CreateOmResponseLatencyNs",
+        "Convert ratis response to om response nano seconds");
+    validateAndUpdateCacheLatencyNs = stat("ValidateAndUpdateCacheLatencyNs",
+        "Ratis local command execution latency in nano seconds");
+    listKeysAveragePagination = stat("ListKeysAveragePagination",
+        "average pagination for listKeys");
+    listKeysAclCheckLatencyNs = stat("ListKeysAclCheckLatencyNs",
+        "ACLs check latency in listKeys");
+    listKeysResolveBucketLatencyNs = stat("ListKeysResolveBucketLatencyNs",
+        "resolveBucketLink latency in listKeys");
+    deleteKeyFailureLatencyNs = stat("DeleteKeyFailureLatencyNs",
+        "deleteKeyFailure latency in nano seconds");
+    deleteKeySuccessLatencyNs = stat("DeleteKeySuccessLatencyNs",
+        "deleteKeySuccess latency in nano seconds");
+    deleteKeysResolveBucketLatencyNs = stat("DeleteKeysResolveBucketLatencyNs",
+        "resolveBucketLink latency in deleteKeys");
+    deleteKeysAclCheckLatencyNs = stat("DeleteKeysAclCheckLatencyNs",
+        "ACLs check latency in deleteKeys");
+    deleteKeyResolveBucketAndAclCheckLatencyNs = stat("DeleteKeyResolveBucketAndAclCheckLatencyNs",
+        "resolveBucketLink and ACLs check latency in deleteKey");
+    listKeysReadFromRocksDbLatencyNs = stat("ListKeysReadFromRocksDbLatencyNs",
+        "readFromRockDb latency in listKeys");
+    getObjectTaggingResolveBucketLatencyNs = stat("GetObjectTaggingResolveBucketLatencyNs",
+        "resolveBucketLink latency in getObjectTagging");
+    getObjectTaggingAclCheckLatencyNs = stat("GetObjectTaggingAclCheckLatencyNs",
+        "ACLs check in getObjectTagging");
+    getBucketTaggingResolveBucketLatencyNs = stat("GetBucketTaggingResolveBucketLatencyNs",
+        "resolveBucketLink latency in getBucketTagging");
+    getBucketTaggingAclCheckLatencyNs = stat("GetBucketTaggingAclCheckLatencyNs",
+        "ACLs check latency in getBucketTagging");
+    getBucketTaggingLatencyNs = stat("GetBucketTaggingLatencyNs",
+        "End-to-end latency in getBucketTagging");
+    createKeyResolveBucketAndAclCheckLatencyNs = stat("CreateKeyResolveBucketAndAclCheckLatencyNs",
+        "ResolveBucketLink and ACL check latency for createKey in nanoseconds");
+    createKeyQuotaCheckLatencyNs = stat("CreateKeyQuotaCheckLatencyNs",
+        "check quota for createKey in nanoseconds");
+    createKeyAllocateBlockLatencyNs = stat("CreateKeyAllocateBlockLatencyNs",
+        "Block allocation latency for createKey in nanoseconds");
+    createKeyFailureLatencyNs = stat("CreateKeyFailureLatencyNs",
+        "createKeyFailure latency in nanoseconds");
+    createKeySuccessLatencyNs = stat("CreateKeySuccessLatencyNs",
+        "creteKeySuccess latency in nanoseconds");
+  }
 
-  @Metric(about = "Block allocation latency for createKey in nanoseconds")
-  private MutableRate createKeyAllocateBlockLatencyNs;
-
-  @Metric(about = "createKeyFailure latency in nanoseconds")
-  private MutableRate createKeyFailureLatencyNs;
-
-  @Metric(about = "creteKeySuccess latency in nanoseconds")
-  private MutableRate createKeySuccessLatencyNs;
+  private static ConcurrentMutableRate stat(String name, String description) {
+    return new ConcurrentMutableRate(name, description, false);
+  }
 
   public static OMPerformanceMetrics register() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
@@ -193,23 +219,78 @@ public class OMPerformanceMetrics {
     ms.unregisterSource(SOURCE_NAME);
   }
 
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder builder = collector.addRecord(SOURCE_NAME);
+    lookupLatencyNs.snapshot(builder, all);
+    lookupReadKeyInfoLatencyNs.snapshot(builder, all);
+    lookupGenerateBlockTokenLatencyNs.snapshot(builder, all);
+    lookupRefreshLocationLatencyNs.snapshot(builder, all);
+    lookupAclCheckLatencyNs.snapshot(builder, all);
+    lookupResolveBucketLatencyNs.snapshot(builder, all);
+    getKeyInfoLatencyNs.snapshot(builder, all);
+    getKeyInfoReadKeyInfoLatencyNs.snapshot(builder, all);
+    getKeyInfoGenerateBlockTokenLatencyNs.snapshot(builder, all);
+    getKeyInfoRefreshLocationLatencyNs.snapshot(builder, all);
+    getKeyInfoAclCheckLatencyNs.snapshot(builder, all);
+    getKeyInfoSortDatanodesLatencyNs.snapshot(builder, all);
+    allocateBlockSortDatanodesLatencyNs.snapshot(builder, all);
+    getKeyInfoResolveBucketLatencyNs.snapshot(builder, all);
+    s3VolumeContextLatencyNs.snapshot(builder, all);
+    forceContainerCacheRefresh.snapshot(builder, all);
+    checkAccessLatencyNs.snapshot(builder, all);
+    listKeysLatencyNs.snapshot(builder, all);
+    validateRequestLatencyNs.snapshot(builder, all);
+    validateResponseLatencyNs.snapshot(builder, all);
+    preExecuteLatencyNs.snapshot(builder, all);
+    submitToRatisLatencyNs.snapshot(builder, all);
+    createRatisRequestLatencyNs.snapshot(builder, all);
+    createOmResponseLatencyNs.snapshot(builder, all);
+    validateAndUpdateCacheLatencyNs.snapshot(builder, all);
+    listKeysAveragePagination.snapshot(builder, all);
+    listKeysAclCheckLatencyNs.snapshot(builder, all);
+    listKeysResolveBucketLatencyNs.snapshot(builder, all);
+    deleteKeyFailureLatencyNs.snapshot(builder, all);
+    deleteKeySuccessLatencyNs.snapshot(builder, all);
+    deleteKeysResolveBucketLatencyNs.snapshot(builder, all);
+    deleteKeysAclCheckLatencyNs.snapshot(builder, all);
+    deleteKeyResolveBucketAndAclCheckLatencyNs.snapshot(builder, all);
+    listKeysReadFromRocksDbLatencyNs.snapshot(builder, all);
+    getObjectTaggingResolveBucketLatencyNs.snapshot(builder, all);
+    getObjectTaggingAclCheckLatencyNs.snapshot(builder, all);
+    getBucketTaggingResolveBucketLatencyNs.snapshot(builder, all);
+    getBucketTaggingAclCheckLatencyNs.snapshot(builder, all);
+    getBucketTaggingLatencyNs.snapshot(builder, all);
+    createKeyResolveBucketAndAclCheckLatencyNs.snapshot(builder, all);
+    createKeyQuotaCheckLatencyNs.snapshot(builder, all);
+    createKeyAllocateBlockLatencyNs.snapshot(builder, all);
+    createKeyFailureLatencyNs.snapshot(builder, all);
+    createKeySuccessLatencyNs.snapshot(builder, all);
+    listKeysOpsPerSec.snapshot(builder, all);
+    directoryDeletingServiceLatencyMs.snapshot(builder, all);
+    keyDeletingServiceLatencyMs.snapshot(builder, all);
+    openKeyCleanupServiceLatencyMs.snapshot(builder, all);
+    snapshotDefragServiceFullLatencyMs.snapshot(builder, all);
+    snapshotDefragServiceIncLatencyMs.snapshot(builder, all);
+  }
+
   public void addLookupLatency(long latencyInNs) {
     lookupLatencyNs.add(latencyInNs);
   }
 
-  MutableRate getLookupRefreshLocationLatencyNs() {
+  ConcurrentMutableRate getLookupRefreshLocationLatencyNs() {
     return lookupRefreshLocationLatencyNs;
   }
 
-  MutableRate getLookupGenerateBlockTokenLatencyNs() {
+  ConcurrentMutableRate getLookupGenerateBlockTokenLatencyNs() {
     return lookupGenerateBlockTokenLatencyNs;
   }
 
-  MutableRate getLookupReadKeyInfoLatencyNs() {
+  ConcurrentMutableRate getLookupReadKeyInfoLatencyNs() {
     return lookupReadKeyInfoLatencyNs;
   }
 
-  MutableRate getLookupAclCheckLatencyNs() {
+  ConcurrentMutableRate getLookupAclCheckLatencyNs() {
     return lookupAclCheckLatencyNs;
   }
 
@@ -217,7 +298,7 @@ public class OMPerformanceMetrics {
     s3VolumeContextLatencyNs.add(latencyInNs);
   }
 
-  MutableRate getLookupResolveBucketLatencyNs() {
+  ConcurrentMutableRate getLookupResolveBucketLatencyNs() {
     return lookupResolveBucketLatencyNs;
   }
 
@@ -225,31 +306,31 @@ public class OMPerformanceMetrics {
     getKeyInfoLatencyNs.add(value);
   }
 
-  MutableRate getGetKeyInfoAclCheckLatencyNs() {
+  ConcurrentMutableRate getGetKeyInfoAclCheckLatencyNs() {
     return getKeyInfoAclCheckLatencyNs;
   }
 
-  MutableRate getGetKeyInfoGenerateBlockTokenLatencyNs() {
+  ConcurrentMutableRate getGetKeyInfoGenerateBlockTokenLatencyNs() {
     return getKeyInfoGenerateBlockTokenLatencyNs;
   }
 
-  MutableRate getGetKeyInfoReadKeyInfoLatencyNs() {
+  ConcurrentMutableRate getGetKeyInfoReadKeyInfoLatencyNs() {
     return getKeyInfoReadKeyInfoLatencyNs;
   }
 
-  MutableRate getGetKeyInfoRefreshLocationLatencyNs() {
+  ConcurrentMutableRate getGetKeyInfoRefreshLocationLatencyNs() {
     return getKeyInfoRefreshLocationLatencyNs;
   }
 
-  MutableRate getGetKeyInfoResolveBucketLatencyNs() {
+  ConcurrentMutableRate getGetKeyInfoResolveBucketLatencyNs() {
     return getKeyInfoResolveBucketLatencyNs;
   }
 
-  MutableRate getGetKeyInfoSortDatanodesLatencyNs() {
+  ConcurrentMutableRate getGetKeyInfoSortDatanodesLatencyNs() {
     return getKeyInfoSortDatanodesLatencyNs;
   }
 
-  MutableRate getAllocateBlockSortDatanodesLatencyNs() {
+  ConcurrentMutableRate getAllocateBlockSortDatanodesLatencyNs() {
     return allocateBlockSortDatanodesLatencyNs;
   }
 
@@ -265,31 +346,31 @@ public class OMPerformanceMetrics {
     listKeysLatencyNs.add(latencyInNs);
   }
 
-  public MutableRate getValidateRequestLatencyNs() {
+  public ConcurrentMutableRate getValidateRequestLatencyNs() {
     return validateRequestLatencyNs;
   }
 
-  public MutableRate getValidateResponseLatencyNs() {
+  public ConcurrentMutableRate getValidateResponseLatencyNs() {
     return validateResponseLatencyNs;
   }
 
-  public MutableRate getPreExecuteLatencyNs() {
+  public ConcurrentMutableRate getPreExecuteLatencyNs() {
     return preExecuteLatencyNs;
   }
 
-  public MutableRate getSubmitToRatisLatencyNs() {
+  public ConcurrentMutableRate getSubmitToRatisLatencyNs() {
     return submitToRatisLatencyNs;
   }
 
-  public MutableRate getCreateRatisRequestLatencyNs() {
+  public ConcurrentMutableRate getCreateRatisRequestLatencyNs() {
     return createRatisRequestLatencyNs;
   }
 
-  public MutableRate getCreateOmResponseLatencyNs() {
+  public ConcurrentMutableRate getCreateOmResponseLatencyNs() {
     return createOmResponseLatencyNs;
   }
 
-  public MutableRate getValidateAndUpdateCacheLatencyNs() {
+  public ConcurrentMutableRate getValidateAndUpdateCacheLatencyNs() {
     return validateAndUpdateCacheLatencyNs;
   }
 
@@ -301,11 +382,11 @@ public class OMPerformanceMetrics {
     listKeysOpsPerSec.set(opsPerSec);
   }
 
-  MutableRate getListKeysAclCheckLatencyNs() {
+  ConcurrentMutableRate getListKeysAclCheckLatencyNs() {
     return listKeysAclCheckLatencyNs;
   }
 
-  MutableRate getListKeysResolveBucketLatencyNs() {
+  ConcurrentMutableRate getListKeysResolveBucketLatencyNs() {
     return listKeysResolveBucketLatencyNs;
   }
 
@@ -325,11 +406,11 @@ public class OMPerformanceMetrics {
     deleteKeysAclCheckLatencyNs.add(latencyInNs);
   }
 
-  public MutableRate getDeleteKeyResolveBucketAndAclCheckLatencyNs() {
+  public ConcurrentMutableRate getDeleteKeyResolveBucketAndAclCheckLatencyNs() {
     return deleteKeyResolveBucketAndAclCheckLatencyNs;
   }
 
-  public MutableRate getCreateKeyResolveBucketAndAclCheckLatencyNs() {
+  public ConcurrentMutableRate getCreateKeyResolveBucketAndAclCheckLatencyNs() {
     return createKeyResolveBucketAndAclCheckLatencyNs;
   }
 
@@ -337,7 +418,7 @@ public class OMPerformanceMetrics {
     createKeyQuotaCheckLatencyNs.add(latencyInNs);
   }
 
-  public MutableRate getCreateKeyAllocateBlockLatencyNs() {
+  public ConcurrentMutableRate getCreateKeyAllocateBlockLatencyNs() {
     return createKeyAllocateBlockLatencyNs;
   }
 
@@ -348,16 +429,16 @@ public class OMPerformanceMetrics {
   public void addCreateKeySuccessLatencyNs(long latencyInNs) {
     createKeySuccessLatencyNs.add(latencyInNs);
   }
-    
+
   public void addListKeysReadFromRocksDbLatencyNs(long latencyInNs) {
     listKeysReadFromRocksDbLatencyNs.add(latencyInNs);
   }
 
-  public MutableRate getGetObjectTaggingResolveBucketLatencyNs() {
+  public ConcurrentMutableRate getGetObjectTaggingResolveBucketLatencyNs() {
     return getObjectTaggingResolveBucketLatencyNs;
   }
 
-  public MutableRate getGetObjectTaggingAclCheckLatencyNs() {
+  public ConcurrentMutableRate getGetObjectTaggingAclCheckLatencyNs() {
     return getObjectTaggingAclCheckLatencyNs;
   }
 
@@ -365,11 +446,11 @@ public class OMPerformanceMetrics {
     getObjectTaggingAclCheckLatencyNs.add(latencyInNs);
   }
 
-  public MutableRate getGetBucketTaggingResolveBucketLatencyNs() {
+  public ConcurrentMutableRate getGetBucketTaggingResolveBucketLatencyNs() {
     return getBucketTaggingResolveBucketLatencyNs;
   }
 
-  public MutableRate getGetBucketTaggingAclCheckLatencyNs() {
+  public ConcurrentMutableRate getGetBucketTaggingAclCheckLatencyNs() {
     return getBucketTaggingAclCheckLatencyNs;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleServiceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyLifecycleServiceMetrics.java
@@ -17,19 +17,22 @@
 
 package org.apache.hadoop.ozone.om.service;
 
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
-import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.util.ConcurrentMutableRate;
 
 /**
  * Class contains metrics related to the OM KeyLifeCycle services.
  */
 @Metrics(about = "Lifecycle Service Metrics", context = OzoneConsts.OZONE)
-public final class KeyLifecycleServiceMetrics {
+public final class KeyLifecycleServiceMetrics implements MetricsSource {
 
   public static final String METRICS_SOURCE_NAME =
       KeyLifecycleServiceMetrics.class.getSimpleName();
@@ -42,8 +45,7 @@ public final class KeyLifecycleServiceMetrics {
   @Metric("Total no. of tasks failed")
   private MutableGaugeLong numFailureTask;
 
-  @Metric("Execution time of a success task for a bucket")
-  private MutableRate taskLatencyMs;
+  private final ConcurrentMutableRate taskLatencyMs;
 
   // following metrics are updated by both success and failure tasks
   @Metric("Number of key iterated")
@@ -70,10 +72,31 @@ public final class KeyLifecycleServiceMetrics {
 
   private KeyLifecycleServiceMetrics() {
     this.registry = new MetricsRegistry(METRICS_SOURCE_NAME);
+    this.taskLatencyMs = new ConcurrentMutableRate("TaskLatencyMs",
+        "Execution time of a success task for a bucket", false);
   }
 
   public MetricsRegistry getRegistry() {
     return registry;
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder builder = collector.addRecord(METRICS_SOURCE_NAME);
+    numSkippedTask.snapshot(builder, all);
+    numSuccessTask.snapshot(builder, all);
+    numFailureTask.snapshot(builder, all);
+    taskLatencyMs.snapshot(builder, all);
+    numKeyIterated.snapshot(builder, all);
+    numDirIterated.snapshot(builder, all);
+    numDirDeleted.snapshot(builder, all);
+    numKeyDeleted.snapshot(builder, all);
+    numKeyRenamed.snapshot(builder, all);
+    numDirRenamed.snapshot(builder, all);
+    sizeKeyDeleted.snapshot(builder, all);
+    sizeKeyRenamed.snapshot(builder, all);
+    numMultipartUploadsIterated.snapshot(builder, all);
+    numMultipartUploadsAborted.snapshot(builder, all);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMPerformanceMetrics.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.apache.ozone.test.MetricsAsserts.assertCounter;
+import static org.apache.ozone.test.MetricsAsserts.assertGauge;
+import static org.apache.ozone.test.MetricsAsserts.getMetrics;
+
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OMPerformanceMetrics}.
+ */
+public class TestOMPerformanceMetrics {
+
+  /**
+   * Base names of every {@link org.apache.hadoop.ozone.util.ConcurrentMutableRate}
+   * latency counter in {@link OMPerformanceMetrics}. Each emits a
+   * {@code <Name>NumOps} counter and a {@code <Name>AvgTime} gauge. This list
+   * must mirror the {@code stat(...)} names in the metrics source one-for-one:
+   * the parity test below fails if a hand-typed literal is renamed or dropped
+   * (e.g. by a typo), which would otherwise silently rename a published metric.
+   */
+  private static final String[] LATENCY_STAT_NAMES = {
+      "LookupLatencyNs",
+      "LookupReadKeyInfoLatencyNs",
+      "LookupGenerateBlockTokenLatencyNs",
+      "LookupRefreshLocationLatencyNs",
+      "LookupAclCheckLatencyNs",
+      "LookupResolveBucketLatencyNs",
+      "GetKeyInfoLatencyNs",
+      "GetKeyInfoReadKeyInfoLatencyNs",
+      "GetKeyInfoGenerateBlockTokenLatencyNs",
+      "GetKeyInfoRefreshLocationLatencyNs",
+      "GetKeyInfoAclCheckLatencyNs",
+      "GetKeyInfoSortDatanodesLatencyNs",
+      "AllocateBlockSortDatanodesLatencyNs",
+      "GetKeyInfoResolveBucketLatencyNs",
+      "S3VolumeContextLatencyNs",
+      "ForceContainerCacheRefresh",
+      "CheckAccessLatencyNs",
+      "ListKeysLatencyNs",
+      "ValidateRequestLatencyNs",
+      "ValidateResponseLatencyNs",
+      "PreExecuteLatencyNs",
+      "SubmitToRatisLatencyNs",
+      "CreateRatisRequestLatencyNs",
+      "CreateOmResponseLatencyNs",
+      "ValidateAndUpdateCacheLatencyNs",
+      "ListKeysAveragePagination",
+      "ListKeysAclCheckLatencyNs",
+      "ListKeysResolveBucketLatencyNs",
+      "DeleteKeyFailureLatencyNs",
+      "DeleteKeySuccessLatencyNs",
+      "DeleteKeysResolveBucketLatencyNs",
+      "DeleteKeysAclCheckLatencyNs",
+      "DeleteKeyResolveBucketAndAclCheckLatencyNs",
+      "ListKeysReadFromRocksDbLatencyNs",
+      "GetObjectTaggingResolveBucketLatencyNs",
+      "GetObjectTaggingAclCheckLatencyNs",
+      "GetBucketTaggingResolveBucketLatencyNs",
+      "GetBucketTaggingAclCheckLatencyNs",
+      "GetBucketTaggingLatencyNs",
+      "CreateKeyResolveBucketAndAclCheckLatencyNs",
+      "CreateKeyQuotaCheckLatencyNs",
+      "CreateKeyAllocateBlockLatencyNs",
+      "CreateKeyFailureLatencyNs",
+      "CreateKeySuccessLatencyNs",
+  };
+
+  @AfterEach
+  public void cleanUp() {
+    OMPerformanceMetrics.unregister();
+  }
+
+  /**
+   * Registers the source and asserts that every latency counter publishes the
+   * expected {@code NumOps}/{@code AvgTime} metric names, guarding the 44
+   * hand-typed name literals against a typo silently renaming a metric.
+   */
+  @Test
+  public void testLatencyMetricNames() {
+    OMPerformanceMetrics metrics = OMPerformanceMetrics.register();
+    MetricsRecordBuilder rb = getMetrics(metrics);
+    for (String name : LATENCY_STAT_NAMES) {
+      assertCounter(name + "NumOps", 0L, rb);
+      assertGauge(name + "AvgTime", 0.0, rb);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/protocolPB/TestOzoneManagerRequestHandler.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.fs.FileEncryptionInfo;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
@@ -46,6 +45,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.util.ConcurrentMutableRate;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.jupiter.api.Assertions;
@@ -352,7 +352,7 @@ public class TestOzoneManagerRequestHandler {
     // Set up perf metrics (needed by captureLatencyNs)
     OMPerformanceMetrics perfMetrics = Mockito.mock(OMPerformanceMetrics.class);
     Mockito.when(perfMetrics.getValidateAndUpdateCacheLatencyNs())
-        .thenReturn(Mockito.mock(MutableRate.class));
+        .thenReturn(Mockito.mock(ConcurrentMutableRate.class));
     Mockito.when(ozoneManager.getPerfMetrics()).thenReturn(perfMetrics);
 
     // Disable ACLs so preExecute doesn't need ACL setup


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem 

OM request-latency metrics are recorded as Hadoop `@Metric` MutableRate counters. MutableRate extends MutableStat, and MutableStat.add(long) is synchronized(this). On the OM hot path many handler threads record a measurement on the same metric instance, so they serialize on that per-counter monitor — a lock convoy that appears under concurrent load. A single getKeyInfo touches 6–7 of these counters in sequence, so the effect compounds on the read path.

HDDS-9377 (already merged) introduced the lock-free ConcurrentMutableStat (striped LongAdder/LongAccumulator, drained lazily at snapshot) and applied it to OMLockMetrics and the PerformanceMetrics wrapper. The remaining MutableRate counters in OMPerformanceMetrics and KeyLifecycleServiceMetrics are the gap this PR closes, scoped deliberately to OM hot-path classes only.

### Approach 

New ConcurrentMutableRate (hadoop-hdds/common) — a lock-free counterpart of Hadoop's MutableRate, extending ConcurrentMutableStat with a public constructor that fixes sampleName="Ops" / valueName="Time". Hadoop's MutableRate constructor is package-private and only instantiable reflectively by the `@Metric` factory; this public ctor lets OM metric sources build it directly. Semantics and emitted names (<Name>NumOps / <Name>AvgTime) are identical.

OMPerformanceMetrics — converted all 44 `@Metric` MutableRate latency counters to ConcurrentMutableRate. Because `@Metric` fields are instantiated reflectively (the factory always builds a real MutableRate, so a field cannot simply be retyped), the class is reworked into a hand-rolled MetricsSource following the OMLockMetrics / S3GatewayMetrics template: stats built in the constructor, getMetrics() snapshots all 44 stats plus the 6 surviving `@Metric` gauges. The single-writer gauges (listKeysOpsPerSec + 5 *ServiceLatencyMs) stay `@Metric.`

KeyLifecycleServiceMetrics — taskLatencyMs (written concurrently by the lifecycle BackgroundService pool, per bucket) converted to ConcurrentMutableRate; the class becomes a hand-rolled MetricsSource. Its 13 MutableGaugeLong gauges remain `@Metric`.

MetricUtil.captureLatencyNs — the two overload parameters widened from MutableRate to its superclass MutableStat. The body already only calls add(long). This is source-compatible (MutableRate and ConcurrentMutableStat both extend MutableStat) and lets all existing captureLatencyNs(getter(), block) call sites in ozone-manager compile unchanged.

### Metric-name compatibility

All emitted metric names are preserved byte-identically: the capitalized field name plus extended=false reproduces exactly the <Name>NumOps / <Name>AvgTime pairs the `@Metric` factory generated. No dashboard or alert names change. Caveat: standard deviation is slightly underestimated under concurrent batched adds (documented on ConcurrentMutableStat, inherited here) — acceptable for these latency stats.

### Not converted (deliberately)

OzoneManagerDoubleBufferMetrics (flushTime, queueSize) — written only by the single OMDoubleBufferFlushThread daemon, so there is no cross-thread contention and lock-free would only add churn. The MutableGaugeLong/Float gauges throughout are single-writer and left as `@Metric`.

The genuinely-contended per-RPC MutableRate counters in the shared ipc_ fork (RpcMetrics) are out of OM scope and tracked separately (HDDS-16304).

Generated-by: Claude Code (Opus 4.8)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16288

## How was this patch tested?

CI: https://github.com/yandrey321/ozone/actions/runs/33043941610/job/98425998600

Unit tests
Integration tests