### PR TITLE
HDDS-16307. Construct listeners from separate host and port values

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -244,6 +244,19 @@ public final class HddsUtils {
   }
 
   /**
+   * Render an address as a "host:port" string, wrapping the host in square
+   * brackets when it is an IPv6 literal. Hadoop's
+   * {@code NetUtils.getHostPortString(InetSocketAddress)} joins the two with a
+   * plain colon, which yields an ambiguous authority for IPv6.
+   *
+   * @param addr the address to render
+   * @return the combined address, bracketed for IPv6 literals
+   */
+  public static String getHostPortString(InetSocketAddress addr) {
+    return getHostPortString(addr.getHostName(), addr.getPort());
+  }
+
+  /**
    * Parse a Ratis role string produced by
    * {@code SCMRatisServerImpl.getRatisRoles()} into its constituent fields.
    * The format is {@code [host]:port:ROLE:id:hostIP} where host and hostIP
@@ -403,7 +416,7 @@ public final class HddsUtils {
         .orElse(conf.getInt(HDDS_DATANODE_CLIENT_PORT_KEY,
             HDDS_DATANODE_CLIENT_PORT_DEFAULT));
 
-    return NetUtils.createSocketAddr(host + ":" + port);
+    return NetUtils.createSocketAddr(getHostPortString(host, port));
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -244,19 +244,6 @@ public final class HddsUtils {
   }
 
   /**
-   * Render an address as a "host:port" string, wrapping the host in square
-   * brackets when it is an IPv6 literal. Hadoop's
-   * {@code NetUtils.getHostPortString(InetSocketAddress)} joins the two with a
-   * plain colon, which yields an ambiguous authority for IPv6.
-   *
-   * @param addr the address to render
-   * @return the combined address, bracketed for IPv6 literals
-   */
-  public static String getHostPortString(InetSocketAddress addr) {
-    return getHostPortString(addr.getHostName(), addr.getPort());
-  }
-
-  /**
    * Parse a Ratis role string produced by
    * {@code SCMRatisServerImpl.getRatisRoles()} into its constituent fields.
    * The format is {@code [host]:port:ROLE:id:hostIP} where host and hostIP

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -17,12 +17,16 @@
 
 package org.apache.hadoop.hdds;
 
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_BIND_HOST_KEY;
 import static org.apache.hadoop.hdds.HddsUtils.processForLogging;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -100,6 +104,31 @@ public class TestHddsUtils {
 
     // Already-bracketed IPv6 literals keep a single pair of brackets.
     assertEquals("[2001:db8::1]:9858", HddsUtils.getHostPortString("[2001:db8::1]", 9858));
+  }
+
+  @Test
+  void testGetHostPortStringFromAddress() {
+    assertEquals("1.2.3.4:9858",
+        HddsUtils.getHostPortString(new InetSocketAddress("1.2.3.4", 9858)));
+
+    // Hadoop's NetUtils.getHostPortString joins these with a plain colon, which
+    // is ambiguous; the host must come back bracketed.
+    assertEquals("[2001:db8:0:0:0:0:0:1]:9858",
+        HddsUtils.getHostPortString(new InetSocketAddress("2001:db8::1", 9858)));
+    assertEquals("[0:0:0:0:0:0:0:0]:9858",
+        HddsUtils.getHostPortString(new InetSocketAddress("::", 9858)));
+  }
+
+  @Test
+  void testGetDatanodeRpcAddressWithIPv6BindHost() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HDDS_DATANODE_CLIENT_BIND_HOST_KEY, "::");
+    conf.set(HDDS_DATANODE_CLIENT_ADDRESS_KEY, "[2001:db8::1]:100");
+
+    InetSocketAddress addr = HddsUtils.getDatanodeRpcAddress(conf);
+
+    assertEquals(InetAddress.getByName("::"), addr.getAddress());
+    assertEquals(100, addr.getPort());
   }
 
   @Test

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -107,19 +107,6 @@ public class TestHddsUtils {
   }
 
   @Test
-  void testGetHostPortStringFromAddress() {
-    assertEquals("1.2.3.4:9858",
-        HddsUtils.getHostPortString(new InetSocketAddress("1.2.3.4", 9858)));
-
-    // Hadoop's NetUtils.getHostPortString joins these with a plain colon, which
-    // is ambiguous; the host must come back bracketed.
-    assertEquals("[2001:db8:0:0:0:0:0:1]:9858",
-        HddsUtils.getHostPortString(new InetSocketAddress("2001:db8::1", 9858)));
-    assertEquals("[0:0:0:0:0:0:0:0]:9858",
-        HddsUtils.getHostPortString(new InetSocketAddress("::", 9858)));
-  }
-
-  @Test
   void testGetDatanodeRpcAddressWithIPv6BindHost() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HDDS_DATANODE_CLIENT_BIND_HOST_KEY, "::");

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -26,6 +26,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collection;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
@@ -120,7 +121,7 @@ public final class ServerUtils {
     InetSocketAddress updatedAddr = new InetSocketAddress(addr.getHostString(),
         listenAddr.getPort());
     conf.set(addressKey,
-        addr.getHostString() + ":" + listenAddr.getPort());
+        HddsUtils.getHostPortString(addr.getHostString(), listenAddr.getPort()));
     return updatedAddr;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -224,7 +224,7 @@ public abstract class BaseHttpServer implements AutoCloseable {
         builder.setFindPort(true);
       }
 
-      URI uri = URI.create("http://" + getHostPortString(httpAddr));
+      URI uri = newEndpointUri("http", httpAddr);
       builder.addEndpoint(uri);
       LOG.info("Starting Web-server for {} at: {}", name, uri);
     }
@@ -237,7 +237,7 @@ public abstract class BaseHttpServer implements AutoCloseable {
         builder.setFindPort(true);
       }
 
-      URI uri = URI.create("https://" + getHostPortString(httpsAddr));
+      URI uri = newEndpointUri("https", httpsAddr);
       builder.addEndpoint(uri);
       LOG.info("Starting Web-server for {} at: {}", name, uri);
     }
@@ -280,6 +280,17 @@ public abstract class BaseHttpServer implements AutoCloseable {
    */
   protected WebAppContext getWebAppContext() {
     return httpServer.getWebAppContext();
+  }
+
+  /**
+   * Build a listener endpoint URI. Jetty reads the host and port straight off
+   * this URI, and an unbracketed IPv6 authority parses to a null host and a
+   * port of -1 without raising, which binds the server to every interface on
+   * an ephemeral port.
+   */
+  static URI newEndpointUri(String scheme, InetSocketAddress addr) {
+    return URI.create(scheme + "://"
+        + getHostPortString(addr.getHostName(), addr.getPort()));
   }
 
   protected InetSocketAddress getBindAddress(String bindHostKey,
@@ -359,14 +370,16 @@ public abstract class BaseHttpServer implements AutoCloseable {
     int connIdx = 0;
     if (policy.isHttpEnabled()) {
       httpAddress = httpServer.getConnectorAddress(connIdx++);
-      String realAddress = getHostPortString(NetUtils.getConnectAddress(httpAddress));
+      InetSocketAddress connectAddress = NetUtils.getConnectAddress(httpAddress);
+      String realAddress = getHostPortString(connectAddress.getHostName(), connectAddress.getPort());
       conf.set(getHttpAddressKey(), realAddress);
       LOG.info("HTTP server of {} listening at http://{}", name, realAddress);
     }
 
     if (policy.isHttpsEnabled()) {
       httpsAddress = httpServer.getConnectorAddress(connIdx);
-      String realAddress = getHostPortString(NetUtils.getConnectAddress(httpsAddress));
+      InetSocketAddress connectAddress = NetUtils.getConnectAddress(httpsAddress);
+      String realAddress = getHostPortString(connectAddress.getHostName(), connectAddress.getPort());
       conf.set(getHttpsAddressKey(), realAddress);
       LOG.info("HTTPS server of {} listening at https://{}", name, realAddress);
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.server.http;
 
 import static org.apache.hadoop.hdds.HddsUtils.createDir;
 import static org.apache.hadoop.hdds.HddsUtils.getHostNameFromConfigKeys;
+import static org.apache.hadoop.hdds.HddsUtils.getHostPortString;
 import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.hdds.server.ServerUtils.getOzoneMetaDirPath;
 import static org.apache.hadoop.hdds.server.http.HttpConfig.getHttpPolicy;
@@ -223,7 +224,7 @@ public abstract class BaseHttpServer implements AutoCloseable {
         builder.setFindPort(true);
       }
 
-      URI uri = URI.create("http://" + NetUtils.getHostPortString(httpAddr));
+      URI uri = URI.create("http://" + getHostPortString(httpAddr));
       builder.addEndpoint(uri);
       LOG.info("Starting Web-server for {} at: {}", name, uri);
     }
@@ -236,7 +237,7 @@ public abstract class BaseHttpServer implements AutoCloseable {
         builder.setFindPort(true);
       }
 
-      URI uri = URI.create("https://" + NetUtils.getHostPortString(httpsAddr));
+      URI uri = URI.create("https://" + getHostPortString(httpsAddr));
       builder.addEndpoint(uri);
       LOG.info("Starting Web-server for {} at: {}", name, uri);
     }
@@ -295,7 +296,7 @@ public abstract class BaseHttpServer implements AutoCloseable {
     String hostName = bindHost.orElse(addressHost.orElse(bindHostDefault));
 
     return NetUtils.createSocketAddr(
-        hostName + ":" + addressPort.orElse(bindPortdefault));
+        getHostPortString(hostName, addressPort.orElse(bindPortdefault)));
   }
 
   /**
@@ -358,14 +359,14 @@ public abstract class BaseHttpServer implements AutoCloseable {
     int connIdx = 0;
     if (policy.isHttpEnabled()) {
       httpAddress = httpServer.getConnectorAddress(connIdx++);
-      String realAddress = NetUtils.getHostPortString(NetUtils.getConnectAddress(httpAddress));
+      String realAddress = getHostPortString(NetUtils.getConnectAddress(httpAddress));
       conf.set(getHttpAddressKey(), realAddress);
       LOG.info("HTTP server of {} listening at http://{}", name, realAddress);
     }
 
     if (policy.isHttpsEnabled()) {
       httpsAddress = httpServer.getConnectorAddress(connIdx);
-      String realAddress = NetUtils.getHostPortString(NetUtils.getConnectAddress(httpsAddress));
+      String realAddress = getHostPortString(NetUtils.getConnectAddress(httpsAddress));
       conf.set(getHttpsAddressKey(), realAddress);
       LOG.info("HTTPS server of {} listening at https://{}", name, realAddress);
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -28,6 +28,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_RECON_INITIAL_HEARTBEAT
 import static org.apache.hadoop.hdds.HddsUtils.getHostName;
 import static org.apache.hadoop.hdds.HddsUtils.getHostNameFromConfigKeys;
 import static org.apache.hadoop.hdds.HddsUtils.getHostPort;
+import static org.apache.hadoop.hdds.HddsUtils.getHostPortString;
 import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.hdds.HddsUtils.getScmServiceId;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
@@ -268,7 +269,7 @@ public final class HddsServerUtil {
         .orElse(conf.getInt(ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY,
             ScmConfigKeys.OZONE_SCM_CLIENT_PORT_DEFAULT));
 
-    return NetUtils.createSocketAddr(host + ":" + port);
+    return NetUtils.createSocketAddr(getHostPortString(host, port));
   }
 
   /**
@@ -289,7 +290,7 @@ public final class HddsServerUtil {
         .orElse(conf.getInt(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
             ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT));
 
-    return NetUtils.createSocketAddr(host + ":" + port);
+    return NetUtils.createSocketAddr(getHostPortString(host, port));
   }
 
   /**
@@ -308,12 +309,10 @@ public final class HddsServerUtil {
     final OptionalInt port = getPortNumberFromConfigKeys(conf,
         ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY);
 
-    return NetUtils.createSocketAddr(
-        host
-            + ":" + port
-            .orElse(conf.getInt(ScmConfigKeys
-                    .OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
-                ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT)));
+    return NetUtils.createSocketAddr(getHostPortString(host,
+        port.orElse(conf.getInt(
+            ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
+            ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT))));
   }
 
   /**
@@ -331,10 +330,10 @@ public final class HddsServerUtil {
     final OptionalInt port = getPortNumberFromConfigKeys(conf,
         ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY);
 
-    return NetUtils.createSocketAddr(
-        host.orElse(ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_DEFAULT) + ":" +
-            port.orElse(conf.getInt(OZONE_SCM_DATANODE_PORT_KEY,
-                ScmConfigKeys.OZONE_SCM_DATANODE_PORT_DEFAULT)));
+    return NetUtils.createSocketAddr(getHostPortString(
+        host.orElse(ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_DEFAULT),
+        port.orElse(conf.getInt(OZONE_SCM_DATANODE_PORT_KEY,
+            ScmConfigKeys.OZONE_SCM_DATANODE_PORT_DEFAULT))));
   }
 
   /**
@@ -352,10 +351,9 @@ public final class HddsServerUtil {
     final OptionalInt port = getPortNumberFromConfigKeys(conf,
         ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY);
 
-    return NetUtils.createSocketAddr(
-        host.orElse(
-            ReconConfigKeys.OZONE_RECON_DATANODE_BIND_HOST_DEFAULT) + ":" +
-            port.orElse(ReconConfigKeys.OZONE_RECON_DATANODE_PORT_DEFAULT));
+    return NetUtils.createSocketAddr(getHostPortString(
+        host.orElse(ReconConfigKeys.OZONE_RECON_DATANODE_BIND_HOST_DEFAULT),
+        port.orElse(ReconConfigKeys.OZONE_RECON_DATANODE_PORT_DEFAULT)));
   }
 
   /**

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -57,6 +58,21 @@ public class TestServerUtils {
    * Test case for {@link ServerUtils#getPermissions}.
    * Verifies the retrieval of permissions for different configs.
    */
+  /**
+   * The address written back after a server binds must stay parseable, so an
+   * IPv6 listen address is bracketed rather than joined with a plain colon.
+   */
+  @Test
+  public void testUpdateListenAddressBracketsIPv6() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    InetSocketAddress bindAddr = new InetSocketAddress("2001:db8::1", 0);
+    InetSocketAddress listenAddr = new InetSocketAddress("2001:db8::1", 9860);
+
+    ServerUtils.updateListenAddress(conf, "test.address.key", bindAddr, listenAddr);
+
+    assertEquals("[2001:db8:0:0:0:0:0:1]:9860", conf.get("test.address.key"));
+  }
+
   @Test
   public void testGetPermissions() {
     // Create an OzoneConfiguration object and set the permissions

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
@@ -55,10 +55,6 @@ public class TestServerUtils {
   private Path folder;
 
   /**
-   * Test case for {@link ServerUtils#getPermissions}.
-   * Verifies the retrieval of permissions for different configs.
-   */
-  /**
    * The address written back after a server binds must stay parseable, so an
    * IPv6 listen address is bracketed rather than joined with a plain colon.
    */
@@ -73,6 +69,10 @@ public class TestServerUtils {
     assertEquals("[2001:db8:0:0:0:0:0:1]:9860", conf.get("test.address.key"));
   }
 
+  /**
+   * Test case for {@link ServerUtils#getPermissions}.
+   * Verifies the retrieval of permissions for different configs.
+   */
   @Test
   public void testGetPermissions() {
     // Create an OzoneConfiguration object and set the permissions

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.file.Path;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
@@ -155,6 +156,17 @@ class TestBaseHttpServer {
         .getBindAddress("bindhostkey", "addresskey", "default", 65);
     assertEquals(InetAddress.getByName("2001:db8::1"), literal.getAddress());
     assertEquals(1234, literal.getPort());
+  }
+
+  @Test
+  void endpointUriKeepsHostAndPort() {
+    URI ipv4 = BaseHttpServer.newEndpointUri("http", new InetSocketAddress("192.0.2.1", 9874));
+    assertEquals("192.0.2.1", ipv4.getHost());
+    assertEquals(9874, ipv4.getPort());
+
+    URI ipv6 = BaseHttpServer.newEndpointUri("https", new InetSocketAddress("2001:db8::1", 9875));
+    assertEquals("[2001:db8:0:0:0:0:0:1]", ipv6.getHost());
+    assertEquals(9875, ipv6.getPort());
   }
 
   @ParameterizedTest

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
@@ -137,6 +138,23 @@ class TestBaseHttpServer {
     assertEquals("/1.2.3.4:1234", baseHttpServer
         .getBindAddress("bindhostkey", "addresskey",
             "default", 65).toString());
+
+    // An IPv6 bind host, wildcard or literal, must survive being combined with
+    // the port. Assert on the address rather than toString(), whose bracketing
+    // of IPv6 literals is a JDK detail.
+    conf.set("bindhostkey", "::");
+
+    InetSocketAddress wildcard = baseHttpServer
+        .getBindAddress("bindhostkey", "addresskey", "default", 65);
+    assertEquals(InetAddress.getByName("::"), wildcard.getAddress());
+    assertEquals(1234, wildcard.getPort());
+
+    conf.set("bindhostkey", "2001:db8::1");
+
+    InetSocketAddress literal = baseHttpServer
+        .getBindAddress("bindhostkey", "addresskey", "default", 65);
+    assertEquals(InetAddress.getByName("2001:db8::1"), literal.getAddress());
+    assertEquals(1234, literal.getPort());
   }
 
   @ParameterizedTest

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ScmUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ScmUtils.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm;
 
 import static org.apache.hadoop.hdds.HddsUtils.getHostNameFromConfigKeys;
+import static org.apache.hadoop.hdds.HddsUtils.getHostPortString;
 import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_DEFAULT;
@@ -85,14 +86,13 @@ public final class ScmUtils {
       logWarn(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
           OZONE_SCM_BLOCK_CLIENT_PORT_KEY);
     }
-    return NetUtils.createSocketAddr(
-        host.orElse(
-            OZONE_SCM_BLOCK_CLIENT_BIND_HOST_DEFAULT) + ":" +
-            port.orElse(conf.getInt(
-                ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
-                    localScmServiceId, nodeId),
-                conf.getInt(OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
-                    OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT))));
+    return NetUtils.createSocketAddr(getHostPortString(
+        host.orElse(OZONE_SCM_BLOCK_CLIENT_BIND_HOST_DEFAULT),
+        port.orElse(conf.getInt(
+            ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
+                localScmServiceId, nodeId),
+            conf.getInt(OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
+                OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT)))));
   }
 
   public static String getScmBlockProtocolServerAddressKey(
@@ -118,12 +118,12 @@ public final class ScmUtils {
       logWarn(OZONE_SCM_CLIENT_ADDRESS_KEY, OZONE_SCM_CLIENT_PORT_KEY);
     }
 
-    return NetUtils.createSocketAddr(host + ":" +
+    return NetUtils.createSocketAddr(getHostPortString(host,
         port.orElse(
             conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_PORT_KEY,
                 localScmServiceId, nodeId),
             conf.getInt(OZONE_SCM_CLIENT_PORT_KEY,
-                OZONE_SCM_CLIENT_PORT_DEFAULT))));
+                OZONE_SCM_CLIENT_PORT_DEFAULT)))));
   }
 
   public static String getClientProtocolServerAddressKey(
@@ -145,12 +145,13 @@ public final class ScmUtils {
       logWarn(OZONE_SCM_DATANODE_ADDRESS_KEY, OZONE_SCM_DATANODE_PORT_KEY);
     }
 
-    return NetUtils.createSocketAddr(
-        host.orElse(OZONE_SCM_DATANODE_BIND_HOST_DEFAULT) + ":" +
-            port.orElse(conf.getInt(ConfUtils.addKeySuffixes(
-                OZONE_SCM_DATANODE_PORT_KEY, localScmServiceId, nodeId),
-                conf.getInt(OZONE_SCM_DATANODE_PORT_KEY,
-                    OZONE_SCM_DATANODE_PORT_DEFAULT))));
+    return NetUtils.createSocketAddr(getHostPortString(
+        host.orElse(OZONE_SCM_DATANODE_BIND_HOST_DEFAULT),
+        port.orElse(conf.getInt(
+            ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
+                localScmServiceId, nodeId),
+            conf.getInt(OZONE_SCM_DATANODE_PORT_KEY,
+                OZONE_SCM_DATANODE_PORT_DEFAULT)))));
   }
 
   public static String getScmDataNodeBindAddressKey(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestHddsServerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestHddsServerUtil.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.recon.ReconConfigKeys;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
 import org.apache.hadoop.hdds.scm.net.HostAndPort;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
@@ -178,6 +180,43 @@ public class TestHddsServerUtil {
     addr = HddsServerUtil.getScmDataNodeBindAddress(conf);
     assertEquals("5.6.7.8", addr.getHostString());
     assertEquals(200, addr.getPort());
+  }
+
+  /**
+   * Verify that a bind host holding an IPv6 literal, including the wildcard
+   * {@code ::}, yields a usable listener address.
+   */
+  @Test
+  void testBindAddressesAcceptIPv6BindHost() throws Exception {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY, "::");
+    conf.set(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY, "::");
+    conf.set(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY, "::");
+    conf.set(ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY, "2001:db8::1");
+    conf.set(ReconConfigKeys.OZONE_RECON_DATANODE_BIND_HOST_KEY, "2001:db8::1");
+
+    final InetAddress wildcard = InetAddress.getByName("::");
+    final InetAddress literal = InetAddress.getByName("2001:db8::1");
+
+    InetSocketAddress addr = HddsServerUtil.getScmClientBindAddress(conf);
+    assertEquals(wildcard, addr.getAddress());
+    assertEquals(ScmConfigKeys.OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+
+    addr = HddsServerUtil.getScmBlockClientBindAddress(conf);
+    assertEquals(wildcard, addr.getAddress());
+    assertEquals(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT, addr.getPort());
+
+    addr = HddsServerUtil.getScmSecurityInetAddress(conf);
+    assertEquals(wildcard, addr.getAddress());
+    assertEquals(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT, addr.getPort());
+
+    addr = HddsServerUtil.getScmDataNodeBindAddress(conf);
+    assertEquals(literal, addr.getAddress());
+    assertEquals(ScmConfigKeys.OZONE_SCM_DATANODE_PORT_DEFAULT, addr.getPort());
+
+    addr = HddsServerUtil.getReconDataNodeBindAddress(conf);
+    assertEquals(literal, addr.getAddress());
+    assertEquals(ReconConfigKeys.OZONE_RECON_DATANODE_PORT_DEFAULT, addr.getPort());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestScmUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestScmUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test the SCM utility class.
+ */
+public class TestScmUtils {
+
+  private static final String SERVICE_ID = "scmservice";
+  private static final String NODE_ID = "scm1";
+
+  /**
+   * Verify that a per-node bind host holding an IPv6 literal, including the
+   * wildcard {@code ::}, yields a usable listener address.
+   */
+  @Test
+  void testHaBindAddressesAcceptIPv6BindHost() throws Exception {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY, SERVICE_ID, NODE_ID), "::");
+    conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY, SERVICE_ID, NODE_ID), "::");
+    conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY, SERVICE_ID, NODE_ID),
+        "2001:db8::1");
+
+    final InetAddress wildcard = InetAddress.getByName("::");
+    final InetAddress literal = InetAddress.getByName("2001:db8::1");
+
+    InetSocketAddress addr = ScmUtils.getClientProtocolServerAddress(conf, SERVICE_ID, NODE_ID);
+    assertEquals(wildcard, addr.getAddress());
+    assertEquals(ScmConfigKeys.OZONE_SCM_CLIENT_PORT_DEFAULT, addr.getPort());
+
+    addr = ScmUtils.getScmBlockProtocolServerAddress(conf, SERVICE_ID, NODE_ID);
+    assertEquals(wildcard, addr.getAddress());
+    assertEquals(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT, addr.getPort());
+
+    addr = ScmUtils.getScmDataNodeBindAddress(conf, SERVICE_ID, NODE_ID);
+    assertEquals(literal, addr.getAddress());
+    assertEquals(ScmConfigKeys.OZONE_SCM_DATANODE_PORT_DEFAULT, addr.getPort());
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -151,8 +151,8 @@ public final class OmUtils {
     final Optional<String> host = getHostNameFromConfigKeys(conf,
         OZONE_OM_ADDRESS_KEY);
 
-    return host.orElse(OZONE_OM_BIND_HOST_DEFAULT) + ":" +
-        getOmRpcPort(conf);
+    return getHostPortString(host.orElse(OZONE_OM_BIND_HOST_DEFAULT),
+        getOmRpcPort(conf));
   }
 
   /**
@@ -167,8 +167,9 @@ public final class OmUtils {
     final Optional<String> host = getHostNameFromConfigKeys(conf, confKey);
 
     if (host.isPresent()) {
-      return host.get() + ":" + getPortNumberFromConfigKeys(conf, confKey)
-              .orElse(OZONE_OM_PORT_DEFAULT);
+      return getHostPortString(host.get(),
+          getPortNumberFromConfigKeys(conf, confKey)
+              .orElse(OZONE_OM_PORT_DEFAULT));
     } else {
       // The specified confKey is not set
       return null;
@@ -616,7 +617,8 @@ public final class OmUtils {
 
     String hostName = bindHost.orElse(addressHost.orElse(omNodeHostAddr));
 
-    return hostName + ":" + addressPort.orElse(OZONE_OM_HTTP_BIND_PORT_DEFAULT);
+    return getHostPortString(hostName,
+        addressPort.orElse(OZONE_OM_HTTP_BIND_PORT_DEFAULT));
   }
 
   /**
@@ -642,8 +644,8 @@ public final class OmUtils {
 
     String hostName = bindHost.orElse(addressHost.orElse(omNodeHostAddr));
 
-    return hostName + ":" +
-        addressPort.orElse(OZONE_OM_HTTPS_BIND_PORT_DEFAULT);
+    return getHostPortString(hostName,
+        addressPort.orElse(OZONE_OM_HTTPS_BIND_PORT_DEFAULT));
   }
 
   public static File createOMDir(String dirPath) {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -386,6 +386,24 @@ public class TestOmUtils {
   }
 
   @Test
+  void testOmAddressesBracketIPv6Literals() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_ADDRESS_KEY, "[2001:db8::1]:9999");
+
+    assertEquals("[2001:db8::1]:9999", OmUtils.getOmRpcAddress(conf));
+
+    String peerAddressKey = OZONE_OM_ADDRESS_KEY + ".omservice.om1";
+    conf.set(peerAddressKey, "2001:db8::2");
+    assertEquals("[2001:db8::2]:" + OMConfigKeys.OZONE_OM_PORT_DEFAULT,
+        OmUtils.getOmRpcAddress(conf, peerAddressKey));
+
+    assertEquals("[2001:db8::3]:" + OMConfigKeys.OZONE_OM_HTTP_BIND_PORT_DEFAULT,
+        OmUtils.getHttpAddressForOMPeerNode(conf, "omservice", "om1", "2001:db8::3"));
+    assertEquals("[2001:db8::3]:" + OMConfigKeys.OZONE_OM_HTTPS_BIND_PORT_DEFAULT,
+        OmUtils.getHttpsAddressForOMPeerNode(conf, "omservice", "om1", "2001:db8::3"));
+  }
+
+  @Test
   public void testResolveOmHostAcceptsIpv6Literal() {
     // A bracketed or bare IPv6 literal must parse into a host:port authority.
     // Before HDDS-15775 the bare form made createSocketAddr throw


### PR DESCRIPTION
## What changes were proposed in this pull request?

A bind-host property set to an IPv6 literal, including `::`, prevents the service from starting.

Ozone currently joins the host and port by string concatenation before parsing the result. For example, `::` and port `9860` become `:::9860`. This is not an unambiguous host:port authority, causing `NetUtils.createSocketAddr` to throw `"Does not contain a valid host:port authority"`.

This patch updates every listener-construction site to use `HddsUtils.getHostPortString`, the bracket-aware helper introduced by HDDS-15768, as required by the IPv6 OEP.

Three of the affected sites re-serialize an address that was already constructed correctly, so fixing the initial construction alone is not sufficient. One is the Jetty endpoint URI. The other two write the server's actual listen address back to configuration after binding. Without brackets, the address is later parsed as a bare host and the port is silently dropped.

All three currently use Hadoop's `NetUtils.getHostPortString(InetSocketAddress)`, which does not add brackets around IPv6 literals.

IPv4 and DNS behavior remains unchanged: the host is bracketed only when it contains a colon. No configuration properties or bind defaults are changed.

Advertised-address validation remains part of HDDS-16308, together with the four remaining call sites that render advertised peer identities.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-16307

## How was this patch tested?

Unit tests were added or updated across the six affected helper classes. Each test was confirmed to fail without the production change, while the existing IPv4 and DNS assertions remain unchanged.

The endpoint URI is tested through `newEndpointUri`. Without the fix, an unbracketed IPv6 authority causes the resulting URI to have a null host.

`updateConnectorAddress` is not directly tested because doing so requires a server actually bound to `::`. The accepted address families depend on the operating system's `IPV6_V6ONLY` behavior, so this is better covered by the IPv6 test environment described in HDDS-15779.


Generated-by: Claude Code (Opus 5)
