### PR TITLE
HDDS-16109. Update upgrade/xcompat tests to use 2.2.1

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -33,8 +33,8 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-run_test ha     non-rolling-upgrade 2.2.0 "$OZONE_CURRENT_VERSION"
-# run_test ha     non-rolling-upgrade 2.1.1 "$OZONE_CURRENT_VERSION"
+run_test ha     non-rolling-upgrade 2.2.1 "$OZONE_CURRENT_VERSION"
+# run_test ha     non-rolling-upgrade 2.2.0 "$OZONE_CURRENT_VERSION"
 # run_test ha     non-rolling-upgrade 2.0.0 "$OZONE_CURRENT_VERSION"
 # run_test non-ha non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"
 # run_test ha     non-rolling-upgrade 1.4.1 "$OZONE_CURRENT_VERSION"

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -77,6 +77,10 @@ services:
     image: ${OZONE_IMAGE}:2.2.0${OZONE_IMAGE_FLAVOR}
     <<: *old-config
 
+  old_client_2_2_1:
+    image: ${OZONE_IMAGE}:2.2.1${OZONE_IMAGE_FLAVOR}
+    <<: *old-config
+
   new_client:
     <<: *new-config
     environment:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/lib.sh
@@ -24,7 +24,7 @@ source "${COMPOSE_DIR}/../testlib.sh"
 
 current_version="${OZONE_CURRENT_VERSION}"
 # TODO: debug acceptance test failures for client versions 1.0.0 on secure clusters
-old_versions="1.1.0 1.2.1 1.3.0 1.4.1 2.0.0 2.1.1 2.2.0" # container is needed for each version in clients.yaml
+old_versions="1.1.0 1.2.1 1.3.0 1.4.1 2.0.0 2.1.1 2.2.0 2.2.1" # container is needed for each version in clients.yaml
 
 export SECURITY_ENABLED=true
 : ${OZONE_BUCKET_KEY_NAME:=key1}


### PR DESCRIPTION
## Summary
- Add `old_client_2_2_1` to xcompat `clients.yaml`
- Append `2.2.1` to `old_versions` in `lib.sh`
- Run upgrade test from 2.2.1 instead of 2.2.0

## Jira
https://issues.apache.org/jira/browse/HDDS-16109

Depends on HDDS-16108 / apache/ozone-docker#96 for `apache/ozone:2.2.1-rocky` image.

## Test plan
- [ ] xcompat CI passes after Docker image is published


Made with [Cursor](https://cursor.com)