### PR TITLE
HDDS-16315. Skip MD5 recomputation in CopyObject when source ETag can be reused

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -1087,8 +1087,14 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     }
   }
 
+  /**
+   * Writes the source object content to the destination key. When
+   * {@code reusedETag} is null, {@code src} must be a {@link DigestInputStream} and the MD5 digest
+   * computed during the copy becomes the destination ETag; otherwise {@code reusedETag} is stored
+   * as-is and the content is not re-hashed.
+   */
   @SuppressWarnings("checkstyle:ParameterNumber")
-  void copy(OzoneVolume volume, DigestInputStream src, long srcKeyLen,
+  void copy(OzoneVolume volume, InputStream src, String reusedETag, long srcKeyLen,
       String destKey, String destBucket,
       ReplicationConfig replication,
       Map<String, String> metadata,
@@ -1104,7 +1110,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       perf.appendStreamMode();
       copyLength = ObjectEndpointStreaming
           .copyKeyWithStream(volume.getBucket(destBucket), destKey, srcKeyLen,
-              getChunkSize(), replication, metadata, src, perf, startNanos, tags,
+              getChunkSize(), replication, metadata, src, reusedETag, perf, startNanos, tags,
               writeConditions);
     } else {
       final long expectedLength = srcKeyLen;
@@ -1115,8 +1121,9 @@ public class ObjectEndpoint extends ObjectOperationHandler {
             getMetrics().updateCopyKeyMetadataStats(startNanos);
         perf.appendMetaLatencyNanos(metadataLatencyNs);
         copyLength = dest.copyFrom(src, getIOBufferSize(expectedLength));
-        String md5Hash = DatatypeConverter.printHexBinary(src.getMessageDigest().digest()).toLowerCase();
-        dest.getMetadata().put(OzoneConsts.ETAG, md5Hash);
+        String eTag = reusedETag != null ? reusedETag
+            : DatatypeConverter.printHexBinary(((DigestInputStream) src).getMessageDigest().digest()).toLowerCase();
+        dest.getMetadata().put(OzoneConsts.ETAG, eTag);
       }
     }
     getMetrics().incCopyObjectSuccessLength(copyLength);
@@ -1221,11 +1228,25 @@ public class ObjectEndpoint extends ObjectOperationHandler {
         throw ex;
       }
 
+      // A whole-object copy writes byte-identical content, so a plain (non-multipart) MD5 ETag
+      // stored on the source is also the correct content MD5 for the destination and the data does
+      // not need to be re-hashed during the copy. An aggregate "-N" ETag of an MPU-created source
+      // is not a content MD5, so a fresh digest is still computed for it.
+      final String sourceETag = sourceKeyDetails.getMetadata().get(OzoneConsts.ETAG);
+      final String reusedETag = StringUtils.isNotEmpty(sourceETag) && !sourceETag.contains("-")
+          ? stripQuotes(sourceETag) : null;
+
       try (OzoneInputStream src = getClientProtocol().getKey(volume.getName(),
           sourceBucket, sourceKey)) {
         getMetrics().updateCopyKeyMetadataStats(startNanos);
-        sourceDigestInputStream = new DigestInputStream(src, getMD5DigestInstance());
-        copy(volume, sourceDigestInputStream, sourceKeyLen, destkey, destBucket, replicationConfig,
+        final InputStream copySource;
+        if (reusedETag != null) {
+          copySource = src;
+        } else {
+          sourceDigestInputStream = new DigestInputStream(src, getMD5DigestInstance());
+          copySource = sourceDigestInputStream;
+        }
+        copy(volume, copySource, reusedETag, sourceKeyLen, destkey, destBucket, replicationConfig,
                 customMetadata, perf, startNanos, tags, writeConditions);
       }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -1088,13 +1088,13 @@ public class ObjectEndpoint extends ObjectOperationHandler {
   }
 
   /**
-   * Writes the source object content to the destination key. When
-   * {@code reusedETag} is null, {@code src} must be a {@link DigestInputStream} and the MD5 digest
-   * computed during the copy becomes the destination ETag; otherwise {@code reusedETag} is stored
-   * as-is and the content is not re-hashed.
+   * Writes the source object content to the destination key. When {@code reusedETag} is null the
+   * MD5 digest {@code src} computes during the copy becomes the destination ETag; otherwise
+   * {@code reusedETag} is stored as-is and {@code src} has digesting switched off, so the content
+   * is not re-hashed.
    */
   @SuppressWarnings("checkstyle:ParameterNumber")
-  void copy(OzoneVolume volume, InputStream src, String reusedETag, long srcKeyLen,
+  void copy(OzoneVolume volume, DigestInputStream src, String reusedETag, long srcKeyLen,
       String destKey, String destBucket,
       ReplicationConfig replication,
       Map<String, String> metadata,
@@ -1122,7 +1122,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
         perf.appendMetaLatencyNanos(metadataLatencyNs);
         copyLength = dest.copyFrom(src, getIOBufferSize(expectedLength));
         String eTag = reusedETag != null ? reusedETag
-            : DatatypeConverter.printHexBinary(((DigestInputStream) src).getMessageDigest().digest()).toLowerCase();
+            : DatatypeConverter.printHexBinary(src.getMessageDigest().digest()).toLowerCase();
         dest.getMetadata().put(OzoneConsts.ETAG, eTag);
       }
     }
@@ -1239,14 +1239,12 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       try (OzoneInputStream src = getClientProtocol().getKey(volume.getName(),
           sourceBucket, sourceKey)) {
         getMetrics().updateCopyKeyMetadataStats(startNanos);
-        final InputStream copySource;
+        sourceDigestInputStream = new DigestInputStream(src, getMD5DigestInstance());
         if (reusedETag != null) {
-          copySource = src;
-        } else {
-          sourceDigestInputStream = new DigestInputStream(src, getMD5DigestInstance());
-          copySource = sourceDigestInputStream;
+          // Nothing reads the digest in this case, so do not hash the copied bytes at all.
+          sourceDigestInputStream.on(false);
         }
-        copy(volume, copySource, reusedETag, sourceKeyLen, destkey, destBucket, replicationConfig,
+        copy(volume, sourceDigestInputStream, reusedETag, sourceKeyLen, destkey, destBucket, replicationConfig,
                 customMetadata, perf, startNanos, tags, writeConditions);
       }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Utils.validateSignatureHeader;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapInQuotes;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.util.Map;
@@ -169,6 +170,12 @@ final class ObjectEndpointStreaming {
         keyMetadata, tags);
   }
 
+  /**
+   * Writes the copy source stream to the destination key. When {@code reusedETag} is null,
+   * {@code body} must be a {@link DigestInputStream} and the MD5 digest computed during the copy
+   * becomes the destination ETag; otherwise {@code reusedETag} is stored as-is and the content is
+   * not re-hashed.
+   */
   @SuppressWarnings("checkstyle:ParameterNumber")
   public static long copyKeyWithStream(
       OzoneBucket bucket,
@@ -177,7 +184,7 @@ final class ObjectEndpointStreaming {
       int bufferSize,
       ReplicationConfig replicationConfig,
       Map<String, String> keyMetadata,
-      DigestInputStream body, PerformanceStringBuilder perf, long startNanos,
+      InputStream body, String reusedETag, PerformanceStringBuilder perf, long startNanos,
       Map<String, String> tags,
       S3ConditionalRequest.WriteConditions writeConditions)
       throws IOException {
@@ -189,8 +196,8 @@ final class ObjectEndpointStreaming {
       long metadataLatencyNs =
           METRICS.updateCopyKeyMetadataStats(startNanos);
       writeLen = writeGuard.copyFrom(body, bufferSize);
-      String eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
-          .toLowerCase();
+      String eTag = reusedETag != null ? reusedETag
+          : DatatypeConverter.printHexBinary(((DigestInputStream) body).getMessageDigest().digest()).toLowerCase();
       perf.appendMetaLatencyNanos(metadataLatencyNs);
       writeGuard.getMetadata().put(OzoneConsts.ETAG, eTag);
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -24,7 +24,6 @@ import static org.apache.hadoop.ozone.s3.util.S3Utils.validateSignatureHeader;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapInQuotes;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.util.Map;
@@ -171,10 +170,10 @@ final class ObjectEndpointStreaming {
   }
 
   /**
-   * Writes the copy source stream to the destination key. When {@code reusedETag} is null,
-   * {@code body} must be a {@link DigestInputStream} and the MD5 digest computed during the copy
-   * becomes the destination ETag; otherwise {@code reusedETag} is stored as-is and the content is
-   * not re-hashed.
+   * Writes the copy source stream to the destination key. When {@code reusedETag} is null the MD5
+   * digest {@code body} computes during the copy becomes the destination ETag; otherwise
+   * {@code reusedETag} is stored as-is and {@code body} has digesting switched off, so the content
+   * is not re-hashed.
    */
   @SuppressWarnings("checkstyle:ParameterNumber")
   public static long copyKeyWithStream(
@@ -184,7 +183,7 @@ final class ObjectEndpointStreaming {
       int bufferSize,
       ReplicationConfig replicationConfig,
       Map<String, String> keyMetadata,
-      InputStream body, String reusedETag, PerformanceStringBuilder perf, long startNanos,
+      DigestInputStream body, String reusedETag, PerformanceStringBuilder perf, long startNanos,
       Map<String, String> tags,
       S3ConditionalRequest.WriteConditions writeConditions)
       throws IOException {
@@ -197,7 +196,7 @@ final class ObjectEndpointStreaming {
           METRICS.updateCopyKeyMetadataStats(startNanos);
       writeLen = writeGuard.copyFrom(body, bufferSize);
       String eTag = reusedETag != null ? reusedETag
-          : DatatypeConverter.printHexBinary(((DigestInputStream) body).getMessageDigest().digest()).toLowerCase();
+          : DatatypeConverter.printHexBinary(body.getMessageDigest().digest()).toLowerCase();
       perf.appendMetaLatencyNanos(metadataLatencyNs);
       writeGuard.getMetadata().put(OzoneConsts.ETAG, eTag);
     }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -58,10 +58,12 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 import javax.ws.rs.HttpMethod;
@@ -69,6 +71,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -87,6 +90,7 @@ import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -105,6 +109,7 @@ class TestObjectPut {
   private static final String DEST_BUCKET_NAME = "b2";
   private static final String DEST_KEY = "key=value/2";
   private static final String NONEXISTENT_BUCKET = "nonexist";
+  private static final String MULTIPART_ETAG = "9b2cf535f27731c974343645a3985328-2";
 
   private ObjectEndpoint objectEndpoint;
   private HttpHeaders headers;
@@ -507,11 +512,8 @@ class TestObjectPut {
 
   @Test
   public void testCopyObjectMessageDigestResetDuringException() throws Exception {
-    assertSucceeds(() -> putObject(CONTENT));
-
-    OzoneKeyDetails keyDetails = assertKeyContent(bucket, KEY_NAME, CONTENT);
-    assertNotNull(keyDetails.getMetadata());
-    assertThat(keyDetails.getMetadata().get(OzoneConsts.ETAG)).isNotEmpty();
+    // A multipart-style "-N" source ETag keeps the copy on the digesting path
+    createSourceKeyWithETag(KEY_NAME, MULTIPART_ETAG);
 
     MessageDigest messageDigest = mock(MessageDigest.class);
     try (MockedStatic<EndpointBase> endpoint =
@@ -533,6 +535,58 @@ class TestObjectPut {
       // next request in the same thread
       verify(messageDigest, times(1)).reset();
     }
+  }
+
+  @Test
+  void testCopyObjectReusesSourceETagWithoutRehashing() throws Exception {
+    assertSucceeds(() -> putObject(CONTENT));
+    String sourceETag = bucket.getKey(KEY_NAME).getMetadata().get(OzoneConsts.ETAG);
+    assertThat(sourceETag).isNotEmpty();
+
+    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
+        BUCKET_NAME + "/" + urlEncode(KEY_NAME));
+
+    MessageDigest messageDigest = mock(MessageDigest.class);
+    try (MockedStatic<EndpointBase> endpoint =
+        mockStatic(EndpointBase.class, CALLS_REAL_METHODS)) {
+      // The copy must reuse the source's plain MD5 ETag: fail loudly if it re-hashes the content
+      endpoint.when(EndpointBase::getMD5DigestInstance).thenReturn(messageDigest);
+      doThrow(new RuntimeException("digest should not be used"))
+          .when(messageDigest).update(any(byte[].class), anyInt(), anyInt());
+
+      Response response = put(objectEndpoint, DEST_BUCKET_NAME, DEST_KEY, CONTENT);
+      assertEquals(HttpStatus.SC_OK, response.getStatus());
+      CopyObjectResponse copyObjectResponse = (CopyObjectResponse) response.getEntity();
+      assertEquals("\"" + sourceETag + "\"", copyObjectResponse.getETag());
+    }
+
+    OzoneKeyDetails destKeyDetails = assertKeyContent(destBucket, DEST_KEY, CONTENT);
+    assertEquals(sourceETag, destKeyDetails.getMetadata().get(OzoneConsts.ETAG));
+  }
+
+  @Test
+  void testCopyObjectRecomputesETagForMultipartSource() throws Exception {
+    createSourceKeyWithETag(KEY_NAME, MULTIPART_ETAG);
+
+    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
+        BUCKET_NAME + "/" + urlEncode(KEY_NAME));
+    assertSucceeds(() -> put(objectEndpoint, DEST_BUCKET_NAME, DEST_KEY, CONTENT));
+
+    // The aggregate "-N" ETag is not a content MD5, so the destination gets a fresh digest
+    OzoneKeyDetails destKeyDetails = assertKeyContent(destBucket, DEST_KEY, CONTENT);
+    assertEquals(contentMd5Hex(), destKeyDetails.getMetadata().get(OzoneConsts.ETAG));
+  }
+
+  @Test
+  void testCopyObjectComputesETagWhenSourceHasNoETag() throws Exception {
+    createSourceKeyWithETag(KEY_NAME, null);
+
+    when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
+        BUCKET_NAME + "/" + urlEncode(KEY_NAME));
+    assertSucceeds(() -> put(objectEndpoint, DEST_BUCKET_NAME, DEST_KEY, CONTENT));
+
+    OzoneKeyDetails destKeyDetails = assertKeyContent(destBucket, DEST_KEY, CONTENT);
+    assertEquals(contentMd5Hex(), destKeyDetails.getMetadata().get(OzoneConsts.ETAG));
   }
 
   @Test
@@ -930,6 +984,26 @@ class TestObjectPut {
     assertEquals("abc123", parseETag("abc123"));
     assertEquals("abc123", parseETag("  \"abc123\"  "));
     assertEquals(null, parseETag(null));
+  }
+
+  /**
+   * Create {@code keyName} with pre-defined {@link #CONTENT} directly through the client stub,
+   * with the given ETag stored in the key metadata ({@code null} for no ETag).
+   */
+  private void createSourceKeyWithETag(String keyName, String eTag) throws IOException {
+    Map<String, String> metadata = new HashMap<>();
+    if (eTag != null) {
+      metadata.put(OzoneConsts.ETAG, eTag);
+    }
+    try (OutputStream out = bucket.createKey(keyName, CONTENT.length(),
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), metadata)) {
+      out.write(CONTENT.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  private static String contentMd5Hex() throws NoSuchAlgorithmException {
+    return DatatypeConverter.printHexBinary(
+        MessageDigest.getInstance("MD5").digest(CONTENT.getBytes(StandardCharsets.UTF_8))).toLowerCase();
   }
 
   /** Put object at {@code bucketName}/{@code keyName} with pre-defined {@link #CONTENT}. */

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.ws.rs.core.HttpHeaders;
+import javax.xml.bind.DatatypeConverter;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -155,5 +156,55 @@ public class TestUploadWithStream {
 
     final long newDataSize = bucket.getKey(S3KEY).getDataSize();
     assertEquals(dataSize, newDataSize);
+  }
+
+  @Test
+  public void testUploadWithCopyReusesSourceETag() throws Exception {
+    // A deliberately fake plain (non-multipart) ETag: if the copy re-hashed the
+    // content, the destination would get the real MD5 instead of this value
+    String sourceETag = "00000000000000000000000000000000";
+    createCopySourceKey(sourceETag);
+    setCopyHeaders();
+
+    assertSucceeds(() -> put(rest, S3BUCKET, S3KEY, null));
+
+    OzoneBucket bucket = client.getObjectStore().getS3Bucket(S3BUCKET);
+    assertEquals(sourceETag, bucket.getKey(S3KEY).getMetadata().get(OzoneConsts.ETAG));
+  }
+
+  @Test
+  public void testUploadWithCopyRecomputesETagForMultipartSource() throws Exception {
+    // An aggregate "-N" ETag of an MPU-created source is not a content MD5, so
+    // the copy computes a fresh digest for the destination
+    createCopySourceKey("9b2cf535f27731c974343645a3985328-2");
+    setCopyHeaders();
+
+    assertSucceeds(() -> put(rest, S3BUCKET, S3KEY, null));
+
+    String expectedETag = DatatypeConverter.printHexBinary(
+        MessageDigest.getInstance("MD5").digest(S3_COPY_EXISTING_KEY_CONTENT.getBytes(UTF_8))).toLowerCase();
+    OzoneBucket bucket = client.getObjectStore().getS3Bucket(S3BUCKET);
+    assertEquals(expectedETag, bucket.getKey(S3KEY).getMetadata().get(OzoneConsts.ETAG));
+  }
+
+  private void createCopySourceKey(String eTag) throws IOException {
+    OzoneBucket bucket = client.getObjectStore().getS3Bucket(S3BUCKET);
+    byte[] keyContent = S3_COPY_EXISTING_KEY_CONTENT.getBytes(UTF_8);
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put(OzoneConsts.ETAG, eTag);
+    try (OutputStream stream = bucket
+        .createStreamKey(S3_COPY_EXISTING_KEY, keyContent.length,
+            ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                ReplicationFactor.THREE), metadata)) {
+      stream.write(keyContent);
+    }
+  }
+
+  private void setCopyHeaders() {
+    HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn("STANDARD");
+    when(headers.getHeaderString(COPY_SOURCE_HEADER))
+        .thenReturn(S3BUCKET + "/" + S3_COPY_EXISTING_KEY);
+    rest.setHeaders(headers);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When copying an object, the S3 Gateway always re-hashed the copied bytes to compute the destination key's ETag. A whole-object copy writes byte-identical content, so when the source key's stored ETag is a plain (non-multipart) MD5, it is also the correct content MD5 for the destination: the copy now stores the source's ETag on the destination key as-is and switches digesting off, skipping the MD5 pass entirely. A multipart source (aggregate `-N` ETag) is not a content MD5, so the copy still computes a fresh MD5 for the destination, unchanged from before; the same applies to a source with no stored ETag. The `CopyObjectResponse` ETag is the value the copy stores on the destination key (since HDDS-15182 it is returned by the write rather than re-read from the key), so the two always match. The same behavior applies to both write variants (regular and datastream paths).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16315

## How was this patch tested?

The s3gateway tests pass. New tests show that a non-multipart copy reuses the source ETag without re-hashing (a mocked digest fails loudly if it is fed any bytes) and returns that same ETag in the `CopyObjectResponse`, and that a multipart (`-N`) source, or a source with no stored ETag, still gets a freshly computed plain MD5 on the destination. The repository checkstyle.sh reports 0 violations.

### Benchmark

Measured on an Apple M4 / JDK 21 with an off-tree harness driving `ObjectEndpoint` against the
in-memory client stub. The A/B is driven by the shipped code rather than by two builds: a source
whose stored ETag is a plain MD5 takes the new path, a source whose ETag ends in `-N` takes the
digesting path. Arms are interleaved in one JVM, medians over >= 12 iterations after warmup.

| object | digesting (before) | ETag reused (after) | saved |
|---|---|---|---|
| 1 MiB | 3.78 ms | 1.54 ms | 2.24 ms (59%) |
| 8 MiB | 14.78 ms | 2.35 ms | 12.43 ms (84%) |
| 64 MiB | 95.98 ms | 8.76 ms | 87.22 ms (91%) |
| 256 MiB | 407.32 ms | 46.22 ms | 361.09 ms (89%) |

Path selection was confirmed by injecting a counting `MessageDigest` into
`EndpointBase.getMD5DigestInstance()`: the digesting arm feeds exactly 67,108,864 bytes to MD5 for
a 64 MiB object (16 reads at the 4 MiB `ozone.s3g.client.buffer.size`), the reuse arm feeds 0.

The stub holds everything in memory, so these percentages are an upper bound and not end-to-end
cluster numbers. The portable result is the absolute one: the change removes roughly **1.2-1.4 s
of S3 Gateway CPU per GiB copied** (JDK MD5 measures 0.72-0.81 GiB/s here; `openssl speed md5`
independently reports 0.85 GiB/s). Because MD5 is serial and runs on the request thread, that is
also ~1.2 core-seconds freed per GiB of copy throughput on a loaded gateway.

Generated-by: Claude Code (claude-fable-5)
