### PR TITLE
HDDS-16310. Avoid allocating a comparator per HeapEntry comparison in ListIterator

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -56,6 +56,10 @@ public class ListIterator {
    * Entry to be added to the heap.
    */
   public static class HeapEntry implements Comparable<HeapEntry> {
+    private static final Comparator<HeapEntry> COMPARATOR =
+        Comparator.comparing(HeapEntry::getKey)
+            .thenComparingInt(HeapEntry::getEntryIteratorId);
+
     private final int entryIteratorId;
     private final String tableName;
     private final String key;
@@ -87,8 +91,7 @@ public class ListIterator {
 
     @Override
     public int compareTo(HeapEntry other) {
-      return Comparator.comparing(HeapEntry::getKey)
-          .thenComparing(HeapEntry::getEntryIteratorId).compare(this, other);
+      return COMPARATOR.compare(this, other);
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ListIterator.HeapEntry.compareTo` builds a new composed `Comparator` on every call. `HeapEntry` is the element type of the `PriorityQueue<HeapEntry>` min-heap that merges the cache and table iterators for `listStatus`, so draining a listing of N entries allocates a fresh comparator (a couple of short-lived objects) on each of the O(N log N) comparisons.

This hoists the comparator to a `private static final Comparator<HeapEntry>` constant so it is built once instead of per comparison, and switches the secondary key to `thenComparingInt` since `getEntryIteratorId()` returns an `int` (which also avoids the per-comparison `Integer` boxing of `thenComparing`). The ordering is unchanged, so the change is behavior-preserving.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16310

## How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/33090788532
