### PR TITLE
HDDS-15125. MVCC-style snapshot reclaimability using seqNumMin/seqNumMax

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -690,6 +690,12 @@ public final class OmUtils {
     // Set the updateID
     builder.setUpdateID(trxnLogIndex);
 
+    // Close the visibility interval. toBuilder() carries seqNumMin over; leaving seqNumMax unset
+    // when there is no seqNumMin keeps such versions on the previous-snapshot lookup path.
+    if (keyInfo.getSeqNumMin() != null) {
+      builder.setSeqNumMax(trxnLogIndex);
+    }
+
     //The key doesn't exist in deletedTable, so create a new instance.
     return new RepeatedOmKeyInfo(builder.build(), bucketId);
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -112,6 +112,11 @@ public final class OmKeyInfo extends WithParentObjectId
   // been modified.
   private final Long expectedDataGeneration;
 
+  // Visibility interval; see KeyInfo.seqNumMin in OmClientProtocol.proto. Null means the version
+  // predates HDDS-15125 and falls back to previous-snapshot lookups.
+  private final Long seqNumMin;
+  private final Long seqNumMax;
+
   private OmKeyInfo(Builder b) {
     super(b);
     this.volumeName = b.volumeName;
@@ -130,6 +135,8 @@ public final class OmKeyInfo extends WithParentObjectId
     this.ownerName = b.ownerName;
     this.tags = b.tags.build();
     this.expectedDataGeneration = b.expectedDataGeneration;
+    this.seqNumMin = b.seqNumMin;
+    this.seqNumMax = b.seqNumMax;
   }
 
   /**
@@ -206,6 +213,14 @@ public final class OmKeyInfo extends WithParentObjectId
 
   public Long getExpectedDataGeneration() {
     return expectedDataGeneration;
+  }
+
+  public Long getSeqNumMin() {
+    return seqNumMin;
+  }
+
+  public Long getSeqNumMax() {
+    return seqNumMax;
   }
 
   public String getOwnerName() {
@@ -513,6 +528,8 @@ public final class OmKeyInfo extends WithParentObjectId
     private boolean isFile;
     private final MapBuilder<String, String> tags;
     private Long expectedDataGeneration = null;
+    private Long seqNumMin = null;
+    private Long seqNumMax = null;
 
     public Builder() {
       this.acls = AclListBuilder.empty();
@@ -535,6 +552,8 @@ public final class OmKeyInfo extends WithParentObjectId
       this.fileChecksum = obj.fileChecksum;
       this.isFile = obj.isFile;
       this.expectedDataGeneration = obj.expectedDataGeneration;
+      this.seqNumMin = obj.seqNumMin;
+      this.seqNumMax = obj.seqNumMax;
       this.tags = MapBuilder.of(obj.tags);
       obj.keyLocationVersions.forEach(keyLocationVersion ->
           this.omKeyLocationInfoGroups.add(
@@ -706,6 +725,16 @@ public final class OmKeyInfo extends WithParentObjectId
       return this;
     }
 
+    public Builder setSeqNumMin(Long minSeqNum) {
+      this.seqNumMin = minSeqNum;
+      return this;
+    }
+
+    public Builder setSeqNumMax(Long maxSeqNum) {
+      this.seqNumMax = maxSeqNum;
+      return this;
+    }
+
     @Override
     protected void validate() {
       super.validate();
@@ -857,6 +886,12 @@ public final class OmKeyInfo extends WithParentObjectId
     if (ownerName != null) {
       kb.setOwnerName(ownerName);
     }
+    if (seqNumMin != null) {
+      kb.setSeqNumMin(seqNumMin);
+    }
+    if (seqNumMax != null) {
+      kb.setSeqNumMax(seqNumMax);
+    }
     return kb.build();
   }
 
@@ -910,6 +945,12 @@ public final class OmKeyInfo extends WithParentObjectId
 
     if (keyInfo.hasOwnerName()) {
       builder.setOwnerName(keyInfo.getOwnerName());
+    }
+    if (keyInfo.hasSeqNumMin()) {
+      builder.setSeqNumMin(keyInfo.getSeqNumMin());
+    }
+    if (keyInfo.hasSeqNumMax()) {
+      builder.setSeqNumMax(keyInfo.getSeqNumMax());
     }
     return builder;
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -114,6 +115,53 @@ public class TestOmKeyInfo {
         (ECReplicationConfig) recovered.getReplicationConfig();
     assertEquals(3, config.getData());
     assertEquals(2, config.getParity());
+  }
+
+  @Test
+  public void visibilityIntervalProtobufConversion() throws IOException {
+    OmKeyInfo key = createOmKeyInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE)).toBuilder()
+        .setSeqNumMin(42L)
+        .setSeqNumMax(99L)
+        .build();
+
+    OmKeyInfo recovered = OmKeyInfo.getFromProtobuf(key.getProtobuf(ClientVersion.CURRENT_VERSION));
+    assertEquals(42L, recovered.getSeqNumMin());
+    assertEquals(99L, recovered.getSeqNumMax());
+
+    // Key table entries use isOpenKey=false; the interval must survive that codec.
+    OmKeyInfo fromKeyTableCodec = OmKeyInfo.getFromProtobuf(
+        key.getProtobuf(true, ClientVersion.CURRENT_VERSION, false));
+    assertEquals(42L, fromKeyTableCodec.getSeqNumMin());
+    assertEquals(99L, fromKeyTableCodec.getSeqNumMax());
+
+    assertEquals(42L, key.copyObject().getSeqNumMin());
+    assertEquals(99L, key.copyObject().getSeqNumMax());
+  }
+
+  @Test
+  public void visibilityIntervalAbsentByDefault() throws IOException {
+    OmKeyInfo key = createOmKeyInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+    assertNull(key.getSeqNumMin());
+    assertNull(key.getSeqNumMax());
+
+    OmKeyInfo recovered = OmKeyInfo.getFromProtobuf(key.getProtobuf(ClientVersion.CURRENT_VERSION));
+    assertNull(recovered.getSeqNumMin());
+    assertNull(recovered.getSeqNumMax());
+  }
+
+  /** seqNumMin alone must round-trip as such: prepareKeyForDelete keys off its presence. */
+  @Test
+  public void visibilityIntervalPartiallyPopulated() throws IOException {
+    OmKeyInfo key = createOmKeyInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE)).toBuilder()
+        .setSeqNumMin(0L)
+        .build();
+
+    OmKeyInfo recovered = OmKeyInfo.getFromProtobuf(key.getProtobuf(ClientVersion.CURRENT_VERSION));
+    assertEquals(0L, recovered.getSeqNumMin());
+    assertNull(recovered.getSeqNumMax());
   }
 
   private OmKeyInfo createOmKeyInfo(ReplicationConfig replicationConfig) {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1226,6 +1226,12 @@ message KeyInfo {
   // This allows a key to be created an committed atomically if the original has not
   // been modified.
     optional uint64 expectedDataGeneration = 22;
+  // Visibility interval in OM transaction indexes: a snapshot sees this version when
+  // seqNumMin <= snapshotCreateTxnIndex < seqNumMax. Either field absent means the version
+  // predates HDDS-15125 and falls back to previous-snapshot lookups.
+  // 23 is retired (was expectedETag, removed by HDDS-13919).
+    optional uint64 seqNumMin = 24;
+    optional uint64 seqNumMax = 25;
 }
 
 // KeyInfoProtoLight is a lightweight subset of KeyInfo message containing

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeletingServiceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeletingServiceMetrics.java
@@ -70,6 +70,13 @@ public final class DeletingServiceMetrics {
   private MutableGaugeLong numKeysPurged;
   @Metric("Total no. of rename entries purged")
   private MutableGaugeLong numRenameEntriesPurged;
+  /*
+   * Which path decided reclaimability: the visibility interval, or the previous snapshot lookup.
+   */
+  @Metric("Total no. of deleted key versions reclaimed from their visibility interval")
+  private MutableGaugeLong numReclaimDecisionsFromInterval;
+  @Metric("Total no. of deleted key versions that fell back to the previous snapshot lookup path")
+  private MutableGaugeLong numReclaimDecisionsFromSnapshotLookup;
 
   /*
    * Key deletion metrics in the last 24 hours.
@@ -196,6 +203,22 @@ public final class DeletingServiceMetrics {
 
   public void incrNumKeysSentForPurge(long keysPurge) {
     this.numKeysSentForPurge.incr(keysPurge);
+  }
+
+  public void incrNumReclaimDecisionsFromInterval() {
+    this.numReclaimDecisionsFromInterval.incr();
+  }
+
+  public void incrNumReclaimDecisionsFromSnapshotLookup() {
+    this.numReclaimDecisionsFromSnapshotLookup.incr();
+  }
+
+  public long getNumReclaimDecisionsFromInterval() {
+    return numReclaimDecisionsFromInterval.value();
+  }
+
+  public long getNumReclaimDecisionsFromSnapshotLookup() {
+    return numReclaimDecisionsFromSnapshotLookup.value();
   }
 
   public void incrNumDirPurged(long dirPurged) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -309,6 +309,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           .addAllMetadata(KeyValueUtil.getFromProtobuf(
                 commitKeyArgs.getMetadataList()))
           .setUpdateID(trxnLogIndex)
+          .setSeqNumMin(resolveSeqNumMin(ozoneManager, keyToDelete, omKeyInfo, trxnLogIndex))
           .setDataSize(commitKeyArgs.getDataSize())
           .build();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -231,6 +231,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
               commitKeyArgs.getMetadataList()))
           .setDataSize(commitKeyArgs.getDataSize())
           .setUpdateID(trxnLogIndex)
+          .setSeqNumMin(resolveSeqNumMin(ozoneManager, keyToDelete, omKeyInfo, trxnLogIndex))
           .build();
 
       List<OmKeyLocationInfo> uncommitted =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -97,6 +97,7 @@ import org.apache.hadoop.ozone.om.lock.OzoneLockStrategy;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.OMClientRequestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserInfo;
@@ -1172,6 +1173,27 @@ public abstract class OMKeyRequest extends OMClientRequest {
 
     return omMetadataManager
         .getMultipartKey(volumeName, bucketName, keyName, uploadID);
+  }
+
+  /**
+   * Start of the visibility interval for the version being committed; null before the layout feature
+   * is finalized. hsync re-commits and MPU overwrite reuse the existing objectID, so the interval
+   * must start where that objectID first became visible, or a snapshot taken between two commits
+   * falls outside it and its blocks could be reclaimed.
+   *
+   * <p>When the objectID is carried over from a version written before finalization its first
+   * visible transaction is unknown, so this returns null and the version stays on the
+   * previous-snapshot lookup path rather than getting an interval that starts too late.
+   */
+  protected static Long resolveSeqNumMin(OzoneManager ozoneManager, OmKeyInfo keyToDelete,
+      OmKeyInfo committedKeyInfo, long trxnLogIndex) {
+    if (!ozoneManager.getVersionManager().isAllowed(OMLayoutFeature.SNAPSHOT_RECLAIM_SEQ_NUM)) {
+      return null;
+    }
+    if (keyToDelete != null && keyToDelete.getObjectID() == committedKeyInfo.getObjectID()) {
+      return keyToDelete.getSeqNumMin();
+    }
+    return trxnLogIndex;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -337,6 +337,9 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         // creation after the knob turned on.
         OmKeyInfo keyToDelete =
             omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
+        omKeyInfo = omKeyInfo.toBuilder()
+            .setSeqNumMin(resolveSeqNumMin(ozoneManager, keyToDelete, omKeyInfo, trxnLogIndex))
+            .build();
         boolean isNamespaceUpdate = false;
         if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
           RepeatedOmKeyInfo oldKeyVersionsToDelete = getOldVersionsToCleanUp(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/filter/ReclaimableKeyFilter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/filter/ReclaimableKeyFilter.java
@@ -24,7 +24,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.DeletingServiceMetrics;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
@@ -34,6 +36,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.lock.IOzoneManagerLock;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.ratis.util.MemoizedCheckedSupplier;
 import org.apache.ratis.util.function.CheckedSupplier;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
@@ -45,6 +48,11 @@ import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
   private final Map<UUID, Long> exclusiveSizeMap;
   private final Map<UUID, Long> exclusiveReplicatedSizeMap;
+  private final boolean intervalOptimizationEnabled;
+  private final DeletingServiceMetrics metrics;
+  // Decoded once per bucket rather than once per deleted key version.
+  private UUID cachedPreviousSnapshotId;
+  private Long cachedPreviousSnapshotCreateIndex;
 
   /**
    * @param currentSnapshotInfo  : If null the deleted keys in AOS needs to be processed, hence the latest snapshot
@@ -59,6 +67,9 @@ public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
     super(ozoneManager, omSnapshotManager, snapshotChainManager, currentSnapshotInfo, keyManager, lock, 2);
     this.exclusiveSizeMap = new HashMap<>();
     this.exclusiveReplicatedSizeMap = new HashMap<>();
+    this.intervalOptimizationEnabled =
+        ozoneManager.getVersionManager().isAllowed(OMLayoutFeature.SNAPSHOT_RECLAIM_SEQ_NUM);
+    this.metrics = ozoneManager.getDeletionMetrics();
   }
 
   @Override
@@ -71,26 +82,33 @@ public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
     return keyValue.getValue().getBucketName();
   }
 
-  @Override
   /**
-   * Determines whether a deleted key entry is reclaimable by checking its presence in prior snapshots.
+   * Determines whether a deleted key version is reclaimable, preferring its visibility interval and
+   * falling back to reading the previous snapshot when the interval is absent.
    *
-   * This method validates the existence of the deleted key in the previous snapshot's key table or file table.
-   * If the key is not found in the previous snapshot, it is marked as reclaimable. Otherwise, additional checks
-   * are performed using the previous-to-previous snapshot to confirm if the key is exclusively present in the
-   * previous snapshot and accounted in the previous snapshot's exclusive size.
-   *
-   * @param deletedKeyInfo The key-value pair representing the deleted key information.
-   * @return {@code true} if the key is reclaimable (not present in prior snapshots), {@code false} otherwise.
-   * @throws IOException If an error occurs while accessing snapshot data or key information.
+   * @return {@code true} if no snapshot references the version, {@code false} otherwise.
    */
+  @Override
   protected Boolean isReclaimable(Table.KeyValue<String, OmKeyInfo> deletedKeyInfo) throws IOException {
+    if (Boolean.TRUE.equals(isReclaimableByVisibilityInterval(deletedKeyInfo.getValue()))) {
+      metrics.incrNumReclaimDecisionsFromInterval();
+      return true;
+    }
+    metrics.incrNumReclaimDecisionsFromSnapshotLookup();
+    return isReclaimableByPreviousSnapshotLookup(deletedKeyInfo);
+  }
+
+  /**
+   * Determines reclaimability by looking the key up in the previous snapshot's key table or file
+   * table. A key absent there is reclaimable; a key present there is not, and is additionally
+   * checked against the previous-to-previous snapshot to attribute it to the previous snapshot's
+   * exclusive size.
+   */
+  private Boolean isReclaimableByPreviousSnapshotLookup(Table.KeyValue<String, OmKeyInfo> deletedKeyInfo)
+      throws IOException {
     UncheckedAutoCloseableSupplier<OmSnapshot> previousSnapshot = getPreviousOmSnapshot(1);
-
-
     KeyManager previousKeyManager = Optional.ofNullable(previousSnapshot)
         .map(i -> i.get().getKeyManager()).orElse(null);
-
 
     // Getting keyInfo from prev snapshot's keyTable/fileTable
     CheckedSupplier<Optional<OmKeyInfo>, IOException> previousKeyInfo =
@@ -110,10 +128,54 @@ public class ReclaimableKeyFilter extends ReclaimableFilter<OmKeyInfo> {
         MemoizedCheckedSupplier.valueOf(() -> getPreviousSnapshotKeyInfo(
             getVolumeId(), getBucketInfo(), previousKeyInfo.get().orElse(null), previousKeyManager,
             previousToPreviousKeyManager));
-    SnapshotInfo previousSnapshotInfo = getPreviousSnapshotInfo(1);
-    calculateExclusiveSize(previousSnapshotInfo, previousKeyInfo, previousPrevKeyInfo,
+    calculateExclusiveSize(getPreviousSnapshotInfo(1), previousKeyInfo, previousPrevKeyInfo,
         exclusiveSizeMap, exclusiveReplicatedSizeMap);
     return false;
+  }
+
+  /**
+   * Decides reclaimability from the version's visibility interval, reading no snapshot DB.
+   *
+   * <p>Only the previous snapshot needs checking: {@link OmSnapshotManager#createOmSnapshotCheckpoint}
+   * drains the bucket's deletedTable from the active DB when a checkpoint is taken, so every entry
+   * here has {@code seqNumMax} above the previous snapshot's create index. Any older snapshot inside
+   * the interval therefore implies the previous one is too. That invariant is asserted rather than
+   * assumed: an entry violating it falls back instead of being reclaimed.
+   *
+   * @return TRUE if no snapshot can see this version, FALSE if the previous snapshot can, null if
+   *         the interval is absent and the caller must fall back to a snapshot lookup.
+   */
+  private Boolean isReclaimableByVisibilityInterval(OmKeyInfo deletedKeyInfo) throws IOException {
+    Long seqNumMin = deletedKeyInfo.getSeqNumMin();
+    Long seqNumMax = deletedKeyInfo.getSeqNumMax();
+    if (!intervalOptimizationEnabled || seqNumMin == null || seqNumMax == null) {
+      return null;
+    }
+    SnapshotInfo previousSnapshotInfo = getPreviousSnapshotInfo(1);
+    if (previousSnapshotInfo == null) {
+      // No previous snapshot, so nothing can reference this version.
+      return true;
+    }
+    Long previousSnapshotCreateIndex = getPreviousSnapshotCreateIndex(previousSnapshotInfo);
+    if (previousSnapshotCreateIndex == null) {
+      // Snapshot predates createTransactionInfo being recorded.
+      return null;
+    }
+    if (seqNumMax <= previousSnapshotCreateIndex) {
+      // The invariant above says this cannot happen. If it ever does, an older snapshot could sit
+      // inside the interval without being checked, so fall back rather than reclaim on our own.
+      return null;
+    }
+    return seqNumMin > previousSnapshotCreateIndex;
+  }
+
+  private Long getPreviousSnapshotCreateIndex(SnapshotInfo previousSnapshotInfo) throws IOException {
+    if (!previousSnapshotInfo.getSnapshotId().equals(cachedPreviousSnapshotId)) {
+      cachedPreviousSnapshotId = previousSnapshotInfo.getSnapshotId();
+      cachedPreviousSnapshotCreateIndex = previousSnapshotInfo.getCreateTransactionInfo() == null ? null
+          : TransactionInfo.fromByteString(previousSnapshotInfo.getCreateTransactionInfo()).getTransactionIndex();
+    }
+    return cachedPreviousSnapshotCreateIndex;
   }
 
   public Map<UUID, Long> getExclusiveSizeMap() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
@@ -46,7 +46,8 @@ public enum OMLayoutFeature implements LayoutFeature {
   DELEGATION_TOKEN_SYMMETRIC_SIGN(8, "Delegation token signed by symmetric key"),
   SNAPSHOT_DEFRAG(9, "Supporting defragmentation of snapshot"),
   S3_LIFECYCLE_SUPPORT(10, "S3 bucket lifecycle configuration support"),
-  MPU_PARTS_TABLE_SPLIT(11, "Split multipart table into separate table for parts and key");
+  MPU_PARTS_TABLE_SPLIT(11, "Split multipart table into separate table for parts and key"),
+  SNAPSHOT_RECLAIM_SEQ_NUM(12, "Visibility interval on key versions for snapshot reclaimability");
 
   ///////////////////////////////  /////////////////////////////
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequestTests.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequestTests.java
@@ -83,6 +83,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotCreateRequest;
 import org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest;
 import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotCreateResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
@@ -156,6 +157,7 @@ public class OMKeyRequestTests {
     when(ozoneManager.getConfig()).thenReturn(ozoneConfiguration.getObject(OmConfig.class));
     OMLayoutVersionManager lvm = mock(OMLayoutVersionManager.class);
     when(lvm.isAllowed(anyString())).thenReturn(true);
+    when(lvm.isAllowed(any(OMLayoutFeature.class))).thenReturn(true);
     when(ozoneManager.getVersionManager()).thenReturn(lvm);
     when(ozoneManager.isFilesystemSnapshotEnabled()).thenReturn(true);
     auditLogger = mock(AuditLogger.class);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
@@ -58,6 +59,7 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCommitResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
@@ -805,6 +807,74 @@ public class TestOMKeyCommitRequest extends OMKeyRequestTests {
     List<OmKeyInfo> omKeyInfoList = keyValue.getValue().getOmKeyInfoList();
     assertEquals(1, omKeyInfoList.size());
     assertThat(key).doesNotEndWith(String.valueOf(omKeyInfoList.get(0).getObjectID()));
+  }
+
+  @Test
+  public void testCommitOpensVisibilityInterval() throws Exception {
+    testValidateAndUpdateCache();
+
+    OmKeyInfo committed = omMetadataManager.getKeyTable(getBucketLayout()).get(getOzonePathKey());
+    assertEquals(100L, committed.getSeqNumMin());
+    assertNull(committed.getSeqNumMax());
+  }
+
+  @Test
+  public void testOverwriteClosesVisibilityInterval() throws Exception {
+    testValidateAndUpdateCacheOnOverwrite();
+
+    String deletedKeyPrefix = omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
+    List<Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs =
+        omMetadataManager.getDeletedTable().getRangeKVs(null, 100, deletedKeyPrefix);
+    assertThat(rangeKVs.size()).isGreaterThan(0);
+    OmKeyInfo deletedVersion = rangeKVs.get(0).getValue().getOmKeyInfoList().get(0);
+    assertEquals(100L, deletedVersion.getSeqNumMin());
+    assertEquals(102L, deletedVersion.getSeqNumMax());
+
+    OmKeyInfo current = omMetadataManager.getKeyTable(getBucketLayout()).get(getOzonePathKey());
+    assertNull(current.getSeqNumMax());
+    // The harness gives every open key objectID 0, so this also covers the same-objectID rule:
+    // the replacing version keeps the interval start of the version it replaced.
+    assertEquals(100L, current.getSeqNumMin());
+  }
+
+  @Test
+  public void testNoVisibilityIntervalBeforeLayoutFeatureFinalization() throws Exception {
+    when(ozoneManager.getVersionManager().isAllowed(any(OMLayoutFeature.class))).thenReturn(false);
+    testValidateAndUpdateCache();
+
+    OmKeyInfo committed = omMetadataManager.getKeyTable(getBucketLayout()).get(getOzonePathKey());
+    assertNull(committed.getSeqNumMin());
+    assertNull(committed.getSeqNumMax());
+  }
+
+  /**
+   * hsync re-commits and MPU overwrite reuse the existing objectID, so the interval must keep the
+   * transaction where that objectID first became visible.
+   */
+  @Test
+  public void testSeqNumMinPreservedAcrossCommitsOfSameObjectId() {
+    OmKeyInfo committing = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+        replicationConfig).setObjectID(1L).build();
+
+    OmKeyInfo sameObjectIdWithInterval = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+        replicationConfig).setObjectID(1L).setSeqNumMin(50L).build();
+    assertEquals(50L,
+        OMKeyRequest.resolveSeqNumMin(ozoneManager, sameObjectIdWithInterval, committing, 200L));
+
+    // An objectID carried over from before finalization has no known first-visible transaction, so
+    // no interval may be opened: a snapshot taken before this commit could still reference it.
+    OmKeyInfo sameObjectIdWithoutInterval = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+        replicationConfig).setObjectID(1L).build();
+    assertNull(OMKeyRequest.resolveSeqNumMin(ozoneManager, sameObjectIdWithoutInterval, committing, 200L));
+
+    OmKeyInfo differentObjectId = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+        replicationConfig).setObjectID(2L).setSeqNumMin(50L).build();
+    assertEquals(200L, OMKeyRequest.resolveSeqNumMin(ozoneManager, differentObjectId, committing, 200L));
+
+    assertEquals(200L, OMKeyRequest.resolveSeqNumMin(ozoneManager, null, committing, 200L));
+
+    when(ozoneManager.getVersionManager().isAllowed(any(OMLayoutFeature.class))).thenReturn(false);
+    assertNull(OMKeyRequest.resolveSeqNumMin(ozoneManager, sameObjectIdWithInterval, committing, 200L));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/AbstractReclaimableFilterTest.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.om.BucketManager;
+import org.apache.hadoop.ozone.om.DeletingServiceMetrics;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -67,6 +68,8 @@ import org.apache.hadoop.ozone.om.snapshot.OmSnapshotLocalDataManager;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotDiffManager;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 import org.junit.jupiter.api.AfterEach;
@@ -103,6 +106,7 @@ public abstract class AbstractReclaimableFilterTest {
   private Path testDir;
   private SnapshotChainManager snapshotChainManager;
   private KeyManager keyManager;
+  private boolean layoutFeatureAllowed = true;
 
   protected abstract ReclaimableFilter initializeFilter(
       OzoneManager om, OmSnapshotManager snapshotManager, SnapshotChainManager chainManager,
@@ -158,8 +162,18 @@ public abstract class AbstractReclaimableFilterTest {
 
   @AfterEach
   protected void teardown() throws IOException {
+    this.layoutFeatureAllowed = true;
     this.mockedSnapshotUtils.close();
     this.reclaimableFilter.close();
+  }
+
+  /**
+   * Controls what the mocked {@link OMLayoutVersionManager} reports for every layout feature. Must
+   * be called before {@code setup(...)}, since filters read the flag when they are constructed. It
+   * is reset to {@code true} after each test.
+   */
+  protected void setLayoutFeatureAllowed(boolean allowed) {
+    this.layoutFeatureAllowed = allowed;
   }
 
   private void mockOzoneManager(BucketLayout bucketLayout) throws IOException {
@@ -167,6 +181,10 @@ public abstract class AbstractReclaimableFilterTest {
     BucketManager bucketManager = mock(BucketManager.class);
     when(ozoneManager.getMetadataManager()).thenReturn(metadataManager);
     when(ozoneManager.getBucketManager()).thenReturn(bucketManager);
+    when(ozoneManager.getDeletionMetrics()).thenReturn(mock(DeletingServiceMetrics.class));
+    OMLayoutVersionManager versionManager = mock(OMLayoutVersionManager.class);
+    when(versionManager.isAllowed(any(OMLayoutFeature.class))).thenReturn(layoutFeatureAllowed);
+    when(ozoneManager.getVersionManager()).thenReturn(versionManager);
     when(metadataManager.getSnapshotChainManager()).thenReturn(snapshotChainManager);
     long volumeCount = 0;
     for (String volume : volumes) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/TestReclaimableKeyFilter.java
@@ -19,15 +19,22 @@ package org.apache.hadoop.ozone.om.snapshot.filter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -35,6 +42,7 @@ import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -149,6 +157,147 @@ public class TestReclaimableKeyFilter extends AbstractReclaimableFilterTest {
       assertTrue(keyFilter.getExclusiveSizeMap().isEmpty());
     }
 
+  }
+
+  // Snapshot "snapN" gets create transaction index (N + 1) * SNAPSHOT_CREATE_INDEX_STEP.
+  private static final long SNAPSHOT_CREATE_INDEX_STEP = 100;
+
+  private static final Function<SnapshotInfo, SnapshotInfo> WITH_CREATE_TRANSACTION_INFO = info -> {
+    long ordinal = Long.parseLong(info.getName().substring("snap".length()));
+    try {
+      info.setCreateTransactionInfo(
+          TransactionInfo.valueOf(1, (ordinal + 1) * SNAPSHOT_CREATE_INDEX_STEP).toByteString());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return info;
+  };
+
+  private OmKeyInfo getMockedOmKeyInfoWithInterval(Long seqNumMin, Long seqNumMax) {
+    OmKeyInfo keyInfo = getMockedOmKeyInfo(1);
+    when(keyInfo.getSeqNumMin()).thenReturn(seqNumMin);
+    when(keyInfo.getSeqNumMax()).thenReturn(seqNumMax);
+    return keyInfo;
+  }
+
+  /**
+   * Runs the filter over the active object store and asserts both the verdict and whether the
+   * previous snapshot was read. The previous snapshot's create index is
+   * {@code numberOfSnapshots * SNAPSHOT_CREATE_INDEX_STEP}.
+   */
+  private void assertIntervalVerdict(int numberOfSnapshots, OmKeyInfo keyInfo, boolean expectedReclaimable,
+      boolean expectPreviousSnapshotRead) throws IOException, RocksDBException {
+    assertIntervalVerdict(numberOfSnapshots, keyInfo, expectedReclaimable, expectPreviousSnapshotRead,
+        WITH_CREATE_TRANSACTION_INFO);
+  }
+
+  private void assertIntervalVerdict(int numberOfSnapshots, OmKeyInfo keyInfo, boolean expectedReclaimable,
+      boolean expectPreviousSnapshotRead, Function<SnapshotInfo, SnapshotInfo> snapshotProps)
+      throws IOException, RocksDBException {
+    setup(2, numberOfSnapshots, numberOfSnapshots, 1, 1, snapshotProps, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    String volume = getVolumes().get(0);
+    String bucket = getBuckets().get(0);
+    when(keyInfo.getVolumeName()).thenReturn(volume);
+    when(keyInfo.getBucketName()).thenReturn(bucket);
+
+    // The lookup path reports "still present", so a "reclaimable" verdict can only come from
+    // the interval.
+    OmKeyInfo prevKeyInfo = getMockedOmKeyInfo(1);
+    for (SnapshotInfo info : getLastSnapshotInfos(volume, bucket, 2, numberOfSnapshots)) {
+      if (info != null) {
+        KeyManager snapshotKeyManager =
+            mockOmSnapshot(getOmSnapshotManager().getActiveSnapshot(volume, bucket, info.getName()));
+        when(snapshotKeyManager.getPreviousSnapshotOzoneKeyInfo(anyLong(), any(), any()))
+            .thenReturn(km -> null);
+      }
+    }
+    when(getKeyManager().getPreviousSnapshotOzoneKeyInfo(anyLong(), any(), eq(keyInfo)))
+        .thenReturn(km -> prevKeyInfo);
+    getMockedSnapshotUtils().when(() -> SnapshotUtils.isBlockLocationInfoSame(eq(prevKeyInfo), eq(keyInfo)))
+        .thenReturn(true);
+
+    assertEquals(expectedReclaimable, getReclaimableFilter().apply(Table.newKeyValue("key", keyInfo)));
+    if (expectPreviousSnapshotRead) {
+      verify(getKeyManager()).getPreviousSnapshotOzoneKeyInfo(anyLong(), any(), eq(keyInfo));
+    } else {
+      verify(getKeyManager(), never()).getPreviousSnapshotOzoneKeyInfo(anyLong(), any(), eq(keyInfo));
+    }
+  }
+
+  /** The case the optimization exists for. */
+  @Test
+  public void testVersionCreatedAfterPreviousSnapshotSkipsSnapshotLookup()
+      throws IOException, RocksDBException {
+    // Previous snapshot snap2 has create index 300; the key lived entirely in [310, 320).
+    assertIntervalVerdict(3, getMockedOmKeyInfoWithInterval(310L, 320L), true, false);
+  }
+
+  /**
+   * An interval closing at or before the previous snapshot's create index cannot occur while the
+   * deletedTable is drained at checkpoint time. If one shows up anyway, an older snapshot could sit
+   * inside it unchecked, so the filter must fall back rather than reclaim.
+   */
+  @ParameterizedTest
+  @MethodSource("intervalsClosingBeforePreviousSnapshot")
+  public void testIntervalClosingBeforePreviousSnapshotFallsBackToSnapshotLookup(
+      Long seqNumMin, Long seqNumMax) throws IOException, RocksDBException {
+    assertIntervalVerdict(3, getMockedOmKeyInfoWithInterval(seqNumMin, seqNumMax), false, true);
+  }
+
+  static List<Arguments> intervalsClosingBeforePreviousSnapshot() {
+    List<Arguments> arguments = new ArrayList<>();
+    // Closes well before the previous snapshot (create index 300).
+    arguments.add(Arguments.of(120L, 250L));
+    // Closes exactly at it.
+    arguments.add(Arguments.of(250L, 300L));
+    // Empty interval.
+    arguments.add(Arguments.of(300L, 300L));
+    return arguments;
+  }
+
+  /** Falls through to the lookup path, which is also what computes exclusive sizes. */
+  @Test
+  public void testVersionVisibleToPreviousSnapshotIsNotReclaimable() throws IOException, RocksDBException {
+    assertIntervalVerdict(3, getMockedOmKeyInfoWithInterval(250L, 350L), false, true);
+  }
+
+  @Test
+  public void testSeqNumMinBoundaryIsInclusive() throws IOException, RocksDBException {
+    assertIntervalVerdict(3, getMockedOmKeyInfoWithInterval(300L, 350L), false, true);
+  }
+
+  @Test
+  public void testNoPreviousSnapshotIsReclaimable() throws IOException, RocksDBException {
+    assertIntervalVerdict(0, getMockedOmKeyInfoWithInterval(310L, 320L), true, false);
+  }
+
+  /** Missing metadata must mean "look it up", never "safe to reclaim". */
+  @ParameterizedTest
+  @MethodSource("incompleteIntervals")
+  public void testMissingIntervalFallsBackToSnapshotLookup(Long seqNumMin, Long seqNumMax)
+      throws IOException, RocksDBException {
+    assertIntervalVerdict(3, getMockedOmKeyInfoWithInterval(seqNumMin, seqNumMax), false, true);
+  }
+
+  static List<Arguments> incompleteIntervals() {
+    List<Arguments> arguments = new ArrayList<>();
+    arguments.add(Arguments.of(null, null));
+    arguments.add(Arguments.of(310L, null));
+    arguments.add(Arguments.of(null, 320L));
+    return arguments;
+  }
+
+  @Test
+  public void testMissingSnapshotCreateTransactionInfoFallsBackToSnapshotLookup()
+      throws IOException, RocksDBException {
+    assertIntervalVerdict(3, getMockedOmKeyInfoWithInterval(310L, 320L), false, true, info -> info);
+  }
+
+  @Test
+  public void testOptimizationDisabledBeforeLayoutFeatureFinalization()
+      throws IOException, RocksDBException {
+    setLayoutFeatureAllowed(false);
+    assertIntervalVerdict(3, getMockedOmKeyInfoWithInterval(310L, 320L), false, true);
   }
 
   private OmKeyInfo getMockedOmKeyInfo(long objectId, long size, long replicatedSize) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Deciding whether a deleted key version's blocks can be reclaimed currently requires reading the previous snapshot's RocksDB. For every entry in `deletedTable`, `ReclaimableKeyFilter.isReclaimable` performs a `getIfExist` on the active store's `snapshotRenamedTable`, a `get` on the previous snapshot's `keyTable` (including a full `KeyInfo` parse), and a block-location comparison — all to produce the answer "yes, reclaimable" in the overwhelmingly common case.

This PR records an MVCC visibility interval on each key version so the decision becomes a sequence-number comparison instead of a storage lookup. Two optional fields are added to `KeyInfo`:

- `seqNumMin` — the OM transaction index at which the objectID first became visible in the key table
- `seqNumMax` — the transaction index at which the version moved to the deleted table (exclusive)

A version is visible to a snapshot when `seqNumMin <= snapshotCreateTxnIndex < seqNumMax`.

### Only the previous snapshot has to be checked

The Jira proposes an `O(S)` sorted array of every active snapshot's create sequence per bucket plus `O(D log S)` binary searches. That turns out to be unnecessary: the check is exact against the *immediately previous* snapshot alone, making it `O(1)` with no per-bucket state.

`OmSnapshotManager.createOmSnapshotCheckpoint` range-deletes the bucket's `deletedTable`, `deletedDirTable` and `snapshotRenamedTable` from the active DB as soon as a checkpoint is taken. So, inductively, for any store `X` with immediately-previous path snapshot `P`, every entry in `X.deletedTable` has `seqNumMax > P.createSeq` — entries older than `P` were drained into `P`'s own copy, and entries moved in later by `SnapshotDeletingService` came from snapshots newer than `P`, which satisfy the same invariant.

Given `seqNumMax > P.createSeq`, if any snapshot `S_i` satisfies `seqNumMin <= S_i.createSeq < seqNumMax`, then `S_i.createSeq < P.createSeq < seqNumMax` and `seqNumMin <= S_i.createSeq <= P.createSeq`, so `P` satisfies it too. This is also why the existing filter only consults the previous snapshot.

The decision therefore reduces to, with no DB access:

```java
referenced = seqNumMin <= prevSnapCreateTxnIndex && prevSnapCreateTxnIndex < seqNumMax;
```

The Jira description should be updated to drop the sorted-array design.

### Why seqNumMin is preserved rather than re-stamped

The Jira's fill rule sets `seqNumMin = currentTransactionIndex` on every data-changing commit. This PR instead *preserves* `seqNumMin` when a commit reuses the existing objectID.

hsync commits the same objectID repeatedly while appending blocks, and an MPU overwrite reuses the existing key's objectID. Re-stamping would let a snapshot taken between two commits fall outside the interval, and the blocks it references could then be reclaimed. Preserving the first-visible transaction of the objectID is what makes the safety argument below hold.

### Safety

The fast path only short-circuits on "reclaimable". A "referenced" verdict falls through to the existing logic, which is also what computes `exclusiveSizeMap` / `exclusiveReplicatedSizeMap`, so exclusive-size accounting is byte-for-byte unchanged. The only possible behavioural delta is therefore "the interval path reclaims something the lookup path would keep".

That cannot happen. If the lookup path says "not reclaimable", the key is live in `P.keyTable` with a matching objectID, so it became visible at or before `P.createSeq` — hence `seqNumMin <= P.createSeq` — and `seqNumMax`, the delete transaction, is greater than `P.createSeq`. The interval path also says "referenced".

### Scope and rollout

Phase 1 covers committed key versions in `deletedTable` only. Directory reclamation, rename entries and snapshot-deletion movement are unchanged, per the Jira. MPU part deletes and the `wrapUncommittedBlocksAsPseudoKey` reclaim marker carry no `seqNumMin`, so they keep falling back; giving them empty intervals is a follow-up.

Both writing the fields and using them are gated on a new `OMLayoutFeature.SNAPSHOT_RECLAIM_SEQ_NUM(12)`. Adding optional protobuf fields is wire-compatible, field presence is used rather than a `0` sentinel, and any missing metadata falls back to current behaviour — never to "safe to reclaim". No in-place migration is needed. Field 23 is deliberately skipped: it is retired (it was `expectedETag`, removed by HDDS-13919).

Two counters are added to `DeletingServiceMetrics` so the optimized-versus-fallback hit rate is observable in production.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15125

## How was this patch tested?

**Unit and integration tests.** 2219 existing `ozone-manager` tests and the `ozone-common` helper tests pass unchanged. New coverage:

- `TestOmKeyInfo` — proto round-trip with both fields present, both absent, and partially populated, including the key-table codec path (`isOpenKey=false`) where the interval must not be dropped
- `TestReclaimableKeyFilter` — interval boundaries (before, inside, exactly at `seqNumMin`, exactly at `seqNumMax`, empty interval, no previous snapshot), fallback when either field or `createTransactionInfo` is missing, and fallback before layout-feature finalization. The reclaimable cases assert via `verify(..., never())` that the previous snapshot is not read at all
- `TestOMKeyCommitRequest` / `...WithFSO` — commit opens the interval, overwrite closes the previous version's interval in `deletedTable`, no interval is written before finalization, and `seqNumMin` is preserved across commits of the same objectID

`checkstyle.sh` and `rat.sh` are clean.

**Benchmarks.** Two harnesses were used to produce the numbers below. They are deliberately **not** part of this patch — their sources are inlined at the end of this description so the results can be reproduced without carrying benchmark code in the tree.

The first harness times the two decision procedures against real RocksDB stores (median of 9 rounds, keys visited in key order to match how the service iterates; Apple Silicon laptop):

| deleted versions | referenced | lookup | interval | ratio |
|---|---|---|---|---|
| 10 000 | 0 % | 2.8 µs | 1.9 ns | 1445x |
| 10 000 | 50 % | 7.5 µs | 2.0 ns | 3757x |
| 10 000 | 100 % | 6.3 µs | 7.6 ns | 823x |
| 50 000 | 0 % | 1.9 µs | 9.3 ns | 207x |
| 50 000 | 50 % | 5.5 µs | 11.5 ns | 477x |
| 50 000 | 100 % | 6.3 µs | 7.8 ns | 805x |

The second times a whole `getPendingDeletionKeys` pass on `MiniOzoneCluster` at the batch size the service actually uses: 50 000 deleted key versions, the default of `ozone.key.deleting.limit.per.task`. Both arms run the same binary and differ only in the OM layout version they were initialized at. Below `SNAPSHOT_RECLAIM_SEQ_NUM` nothing carries an interval, so every decision falls back to `isReclaimableByPreviousSnapshotLookup` — which this PR moved but did not modify, so it is master's `isReclaimable` line for line. Arms are interleaved, three clusters each, median of three passes within a cluster. 16-core x86_64 Linux, JDK 21, one datanode, FSO bucket.

Two dimensions are swept. The interval only short-circuits a *reclaimable* verdict, so the saving scales with the reclaimable fraction; and a fallback costs one point lookup into the previous snapshot, so its cost depends on how large that snapshot is.

| previous snapshot | referenced | lookup | interval | ratio | saved per batch |
|---|---|---|---|---|---|
| ~0 MB | 0 % | 36 057 ms | 28 780 ms | 1.25x | 7.3 s |
| 2 MB | 50 % | 29 291 ms | 23 859 ms | 1.23x | 5.4 s |
| 43 MB (1 M keys) | 0 % | 33 968 ms | 23 644 ms | 1.44x | 10.3 s |
| 43 MB (1 M keys) | 50 % | 30 275 ms | 24 088 ms | 1.26x | 6.2 s |
| 346 MB (8 M keys) | 0 % | 32 888 ms | 23 985 ms | 1.37x | 8.9 s |

The last row is a single cluster per arm — staging eight million keys takes ~19 minutes per cluster — so read it as corroboration rather than a measurement of the same weight as the rows above it. Its snapshot exceeds the 256 MB RocksDB block cache.

The interval arm sits at ~24 s whatever the snapshot size, while the lookup arm ranges 29–36 s, which is what a decision that reads no storage should look like. `KeyDeletingService` wakes once a minute, so on master a full batch spends 30–36 s of a 60 s duty cycle deciding what may be reclaimed; with the interval that drops to about 24.

**Null control.** The same harness was built and run against upstream master (`d959514a97`, this PR's merge base), where `maxLayoutVersion()` is 11 and both arms therefore boot identically and run identical code. It reports **1.06x** at the 43 MB / 0 % configuration. That is the harness's noise floor, and every row above clears it.

**Verification.** The two `DeletingServiceMetrics` counters were read after every cluster's warmup. Across all 24 clusters of the matrix the fallback arm reported `0 from interval, 50000 from snapshot lookup` in all 12 of its clusters; the interval arm reported `50000 / 0` at 0 % referenced and `25000 / 25000` at 50 %. Both arms also asserted the same purged-key count on every warmup pass — 50 000 of 50 000 at 0 % referenced, 25 000 of 50 000 at 50 % — so the two paths reach identical verdicts on a live cluster and the timings compare like for like.

Snapshot ballast is written straight into the fileTable rather than through the client, which at eight million keys would take hours. It is never read by the filter; it exists only to give the previous snapshot a realistic size. The keys under test all go through the real commit and delete path, so their intervals are stamped by production code.

The ratio is capped by cost both arms pay, which is worth flagging for a follow-up. `ReclaimableFilter.apply()` calls `validateExistingLastNSnapshotsInChain` **twice per key**, and each call walks two snapshots doing `SnapshotUtils.getSnapshotInfo` plus `TransactionInfo.readTransactionInfo` — the latter uses `getSkipCache`, which bypasses the table cache and reads RocksDB directly. That is roughly four uncached reads per deleted key version for chain revalidation, against the two reads this PR removes, and it leaves a ~480 µs/key floor on both arms. It is why a decision three orders of magnitude faster in isolation shows up here as 1.3x. The chain cannot change between keys within a single iteration, so hoisting that revalidation is likely worth more than this change.

## Follow-ups

Deliberately out of scope here, to keep this PR to the reclaimability decision:

* **Interval-based exclusive sizing, and retiring the lookup path** — filed as
  [HDDS-16321](https://issues.apache.org/jira/browse/HDDS-16321). Exclusive size credits a
  version to snapshot P iff it is present in P and absent from P-1. With the guard above
  establishing `seqNumMax > P.createSeq`, and `Pprev.createSeq < P.createSeq`, that reduces on the
  "referenced" branch to a single comparison, `seqNumMin > previousToPreviousCreateIndex` — no
  snapshot reads at all. Doing so changes reported exclusive sizes for hsync keys whose blocks grew
  after the snapshot was taken (the lookup path treats those as absent from P), so it deserves
  review on its own. Once that lands and the fallback can be retired post-upgrade,
  `isReclaimableByPreviousSnapshotLookup`, `calculateExclusiveSize`, `getPreviousSnapshotKeyInfo`
  and the snapshot handles they need — roughly 100 lines — come out of `ReclaimableKeyFilter`, and
  the filter no longer has to open previous snapshots at all.
* **Empty intervals for versions never visible to a snapshot**, so MPU part deletes and the
  `wrapUncommittedBlocksAsPseudoKey` reclaim marker stop falling back.
* **The chain revalidation cost measured above.** `ReclaimableFilter.apply()` revalidates the
  snapshot chain twice per key, each revalidation reading the transactionInfo table via
  `getSkipCache`. The chain cannot change between keys within one iteration, so hoisting it is
  likely worth more than this change.
* **Updating the Jira description** to drop the sorted-array design, which the drain-at-checkpoint
  invariant makes unnecessary.

## Benchmark harnesses

These are not included in the patch. Drop each file at the path shown, run it, then remove it.
Both carry `@Tag("benchmark")`, which the default test groups exclude, so `-Dexcluded-test-groups=`
is needed to make them run. Results print to `target/surefire-reports/*-output.txt`.

<details>
<summary><code>hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/filter/ReclaimableKeyFilterBenchmark.java</code></summary>

Run with:

```
mvn test -pl hadoop-ozone/ozone-manager \
  -Dtest=ReclaimableKeyFilterBenchmark -Dexcluded-test-groups= \
  -Dsurefire.failIfNoSpecifiedTests=false
```

```java
/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements. See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.
 * The ASF licenses this file to You under the Apache License, Version 2.0
 * (the "License"); you may not use this file except in compliance with
 * the License. You may obtain a copy of the License at
 *
 *      http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

package org.apache.hadoop.ozone.om.snapshot.filter;

import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
import static org.junit.jupiter.api.Assertions.assertEquals;

import java.io.File;
import java.io.IOException;
import java.nio.file.Path;
import java.util.ArrayList;
import java.util.Arrays;
import java.util.Collections;
import java.util.List;
import org.apache.hadoop.hdds.client.BlockID;
import org.apache.hadoop.hdds.client.RatisReplicationConfig;
import org.apache.hadoop.hdds.client.ReplicationConfig;
import org.apache.hadoop.hdds.conf.OzoneConfiguration;
import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
import org.apache.hadoop.hdds.utils.IOUtils;
import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
import org.apache.hadoop.ozone.om.helpers.BucketLayout;
import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
import org.junit.jupiter.api.AfterEach;
import org.junit.jupiter.api.Tag;
import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.io.TempDir;

/**
 * Per-key cost of {@link ReclaimableKeyFilter}'s reclaimability decision: previous-snapshot lookup
 * versus the visibility interval of HDDS-15125.
 *
 * <p>Both run against real RocksDB, one store standing in for the active object store and one for
 * the previous snapshot. The lookup arm does what
 * {@code KeyManagerImpl.getPreviousSnapshotOzonePathInfo} and
 * {@code ReclaimableKeyFilter.getPreviousSnapshotKeyInfo} do: a {@code getIfExist} on
 * snapshotRenamedTable, a {@code get} on the snapshot's keyTable including the KeyInfo parse, then
 * objectID and block-location comparisons. The interval arm does the two long comparisons.
 *
 * <p>Keys are visited in key order, as KeyDeletingService iterates them -- the pattern most
 * favourable to the lookup arm, so the ratios are conservative. Work shared by both arms
 * (deletedTable iteration, chain validation, GC locking) is outside the measured window; see
 * KeyDeletingServiceBenchmark for a whole-pass number.
 *
 * <p>Run with:
 * <pre>
 *   mvn test -pl hadoop-ozone/ozone-manager \
 *     -Dtest=ReclaimableKeyFilterBenchmark -Dexcluded-test-groups= \
 *     -Dsurefire.failIfNoSpecifiedTests=false
 * </pre>
 * Results print to {@code target/surefire-reports/*ReclaimableKeyFilterBenchmark-output.txt}.
 */
@Tag("benchmark")
public class ReclaimableKeyFilterBenchmark {

  private static final String VOLUME = "vol1";
  private static final String BUCKET = "bucket1";
  private static final BucketLayout LAYOUT = BucketLayout.OBJECT_STORE;
  private static final ReplicationConfig REPLICATION =
      RatisReplicationConfig.getInstance(ReplicationFactor.THREE);

  private static final int[] DELETED_VERSION_COUNTS = {10_000, 50_000};
  /** Default of {@code ozone.key.deleting.limit.per.task}, used to scale the per-run cost. */
  private static final int KEYS_PER_KDS_TASK = 50_000;
  /** Fraction still live in the previous snapshot, i.e. not reclaimable. */
  private static final double[] REFERENCED_RATIOS = {0.0, 0.5, 1.0};
  private static final int BLOCKS_PER_KEY = 4;
  private static final int WARMUP_ROUNDS = 5;
  private static final int MEASURED_ROUNDS = 9;
  private static final int JIT_WARMUP_VERSIONS = 20_000;

  /** Create transaction index of the previous snapshot. */
  private static final long PREVIOUS_SNAPSHOT_CREATE_INDEX = 1_000_000L;

  @TempDir
  private Path testDir;

  private OmMetadataManagerImpl activeObjectStore;
  private OmMetadataManagerImpl previousSnapshot;

  @AfterEach
  public void teardown() {
    IOUtils.closeQuietly(activeObjectStore, previousSnapshot);
    activeObjectStore = null;
    previousSnapshot = null;
  }

  @Test
  public void runBenchmark() throws Exception {
    // Reach steady-state JIT before any measurement.
    openStores("jit-warmup");
    List<OmKeyInfo> warmupVersions = populate(JIT_WARMUP_VERSIONS, 0.5);
    for (int i = 0; i < WARMUP_ROUNDS; i++) {
      timePreviousSnapshotLookup(warmupVersions);
      timeVisibilityInterval(warmupVersions);
    }
    teardown();

    System.out.println();
    System.out.println("ReclaimableKeyFilter decision cost, median of " + MEASURED_ROUNDS
        + " rounds over real RocksDB");
    System.out.printf("%-9s %-11s %11s %12s %14s %8s %16s%n",
        "versions", "referenced", "cold ns/op", "lookup ns/op", "interval ns/op", "speedup",
        "saved ms/KDS run");
    System.out.println("-------------------------------------------------------------------"
        + "--------------------------");

    for (int versionCount : DELETED_VERSION_COUNTS) {
      for (double referencedRatio : REFERENCED_RATIOS) {
        openStores("v" + versionCount + "-r" + (int) (referencedRatio * 100));
        List<OmKeyInfo> deletedVersions = populate(versionCount, referencedRatio);

        // Both arms must agree, or the timings are not comparable. Also the cold pass: nothing
        // has read the previous snapshot's SST files yet.
        long coldStart = System.nanoTime();
        for (OmKeyInfo deletedVersion : deletedVersions) {
          assertEquals(reclaimableByPreviousSnapshotLookup(deletedVersion),
              reclaimableByVisibilityInterval(deletedVersion),
              "verdict mismatch for " + deletedVersion.getKeyName());
        }
        double coldPerOp = (double) (System.nanoTime() - coldStart) / versionCount;

        for (int i = 0; i < WARMUP_ROUNDS; i++) {
          timePreviousSnapshotLookup(deletedVersions);
          timeVisibilityInterval(deletedVersions);
        }

        // Group each arm's rounds so the lookup arm's garbage (one OmKeyInfo per referenced key)
        // is collected in its own window, not the interval arm's.
        long[] lookupRounds = new long[MEASURED_ROUNDS];
        long[] intervalRounds = new long[MEASURED_ROUNDS];
        settle();
        for (int i = 0; i < MEASURED_ROUNDS; i++) {
          lookupRounds[i] = timePreviousSnapshotLookup(deletedVersions);
        }
        settle();
        for (int i = 0; i < MEASURED_ROUNDS; i++) {
          intervalRounds[i] = timeVisibilityInterval(deletedVersions);
        }

        double lookupPerOp = (double) median(lookupRounds) / versionCount;
        double intervalPerOp = (double) median(intervalRounds) / versionCount;
        double savedMillisPerRun =
            (lookupPerOp - intervalPerOp) * KEYS_PER_KDS_TASK / 1_000_000;
        System.out.printf("%-9d %-10.0f%% %11.1f %12.1f %14.1f %7.0fx %16.1f%n",
            versionCount, referencedRatio * 100, coldPerOp, lookupPerOp, intervalPerOp,
            lookupPerOp / intervalPerOp, savedMillisPerRun);

        teardown();
      }
    }
    System.out.println();
  }

  private static void settle() throws InterruptedException {
    System.gc();
    Thread.sleep(200);
  }

  private static long median(long[] values) {
    long[] sorted = values.clone();
    Arrays.sort(sorted);
    return sorted[sorted.length / 2];
  }

  private long timePreviousSnapshotLookup(List<OmKeyInfo> deletedVersions) throws IOException {
    long start = System.nanoTime();
    boolean sink = false;
    for (OmKeyInfo deletedVersion : deletedVersions) {
      sink ^= reclaimableByPreviousSnapshotLookup(deletedVersion);
    }
    long elapsed = System.nanoTime() - start;
    consume(sink);
    return elapsed;
  }

  private long timeVisibilityInterval(List<OmKeyInfo> deletedVersions) {
    long start = System.nanoTime();
    boolean sink = false;
    for (OmKeyInfo deletedVersion : deletedVersions) {
      sink ^= reclaimableByVisibilityInterval(deletedVersion);
    }
    long elapsed = System.nanoTime() - start;
    consume(sink);
    return elapsed;
  }

  /** Two RocksDB point lookups, a KeyInfo parse, an objectID and a block-location comparison. */
  private boolean reclaimableByPreviousSnapshotLookup(OmKeyInfo deletedVersion) throws IOException {
    String renameKey =
        activeObjectStore.getRenameKey(VOLUME, BUCKET, deletedVersion.getObjectID());
    String renamedKey = activeObjectStore.getSnapshotRenamedTable().getIfExist(renameKey);
    String currentKeyPath =
        activeObjectStore.getOzoneKey(VOLUME, BUCKET, deletedVersion.getKeyName());
    OmKeyInfo previousKeyInfo = previousSnapshot.getKeyTable(LAYOUT)
        .get(renamedKey != null ? renamedKey : currentKeyPath);
    if (previousKeyInfo == null || previousKeyInfo.getObjectID() != deletedVersion.getObjectID()) {
      return true;
    }
    return !SnapshotUtils.isBlockLocationInfoSame(previousKeyInfo, deletedVersion);
  }

  /** Mirrors {@code ReclaimableKeyFilter.isReclaimableByVisibilityInterval}. */
  private boolean reclaimableByVisibilityInterval(OmKeyInfo deletedVersion) {
    long seqNumMin = deletedVersion.getSeqNumMin();
    long seqNumMax = deletedVersion.getSeqNumMax();
    return !(seqNumMin <= PREVIOUS_SNAPSHOT_CREATE_INDEX
        && PREVIOUS_SNAPSHOT_CREATE_INDEX < seqNumMax);
  }

  private void openStores(String label) throws IOException {
    OzoneConfiguration activeConf = new OzoneConfiguration();
    activeConf.set(OZONE_OM_DB_DIRS, newDir("aos-" + label).getAbsolutePath());
    activeObjectStore = new OmMetadataManagerImpl(activeConf, null);

    OzoneConfiguration snapshotConf = new OzoneConfiguration();
    snapshotConf.set(OZONE_OM_DB_DIRS, newDir("snapshot-" + label).getAbsolutePath());
    previousSnapshot = new OmMetadataManagerImpl(snapshotConf, null);
  }

  private File newDir(String name) throws IOException {
    File dir = testDir.resolve(name).toFile();
    if (!dir.mkdirs()) {
      throw new IOException("Could not create " + dir);
    }
    return dir;
  }

  /**
   * Writes {@code versionCount} keys, {@code referencedRatio} of them live in the previous
   * snapshot's keyTable, and returns the matching deletedTable versions in key order. Referenced
   * ones get an interval spanning the snapshot's create index; the rest open after it.
   */
  private List<OmKeyInfo> populate(int versionCount, double referencedRatio) throws IOException {
    int referencedStride = referencedRatio == 0 ? Integer.MAX_VALUE : (int) Math.round(1 / referencedRatio);
    List<OmKeyInfo> deletedVersions = new ArrayList<>(versionCount);
    for (int i = 0; i < versionCount; i++) {
      boolean referenced = i % referencedStride == 0;
      String keyName = String.format("key-%08d", i);
      long objectId = i + 1L;
      long seqNumMin = referenced
          ? PREVIOUS_SNAPSHOT_CREATE_INDEX - 10
          : PREVIOUS_SNAPSHOT_CREATE_INDEX + 10;
      OmKeyInfo deletedVersion = buildKey(keyName, objectId, seqNumMin,
          PREVIOUS_SNAPSHOT_CREATE_INDEX + 20);
      deletedVersions.add(deletedVersion);
      if (referenced) {
        previousSnapshot.getKeyTable(LAYOUT)
            .put(previousSnapshot.getOzoneKey(VOLUME, BUCKET, keyName), deletedVersion);
      }
    }
    // Flush so lookups read SST files, as they would against a snapshot checkpoint.
    previousSnapshot.getStore().flushDB();
    activeObjectStore.getStore().flushDB();
    return deletedVersions;
  }

  private OmKeyInfo buildKey(String keyName, long objectId, long seqNumMin, long seqNumMax) {
    List<OmKeyLocationInfo> blocks = new ArrayList<>(BLOCKS_PER_KEY);
    for (int i = 0; i < BLOCKS_PER_KEY; i++) {
      blocks.add(new OmKeyLocationInfo.Builder()
          .setBlockID(new BlockID(objectId, i))
          .setLength(1024L)
          .setOffset(i * 1024L)
          .build());
    }
    return new OmKeyInfo.Builder()
        .setVolumeName(VOLUME)
        .setBucketName(BUCKET)
        .setKeyName(keyName)
        .setObjectID(objectId)
        .setUpdateID(objectId)
        .setCreationTime(1L)
        .setModificationTime(1L)
        .setDataSize(BLOCKS_PER_KEY * 1024L)
        .setReplicationConfig(REPLICATION)
        .setOmKeyLocationInfos(
            Collections.singletonList(new OmKeyLocationInfoGroup(0L, blocks, false)))
        .setSeqNumMin(seqNumMin)
        .setSeqNumMax(seqNumMax)
        .build();
  }

  private static void consume(boolean sink) {
    // Keeps the loops from being optimised away.

    if (sink && System.nanoTime() == 0) {
      throw new IllegalStateException();
    }
  }
}
```

</details>

<details>
<summary><code>hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/KeyDeletingScaleBenchmark.java</code></summary>

Run with:

```
mvn test -pl :ozone-integration-test \
  -Dtest=KeyDeletingScaleBenchmark -Dexcluded-test-groups= \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dsurefire.fork.timeout=86400 -Djacoco.skip=true \
  -Dbench.deleted=50000 -Dbench.ballast=0,1000000 \
  -Dbench.referenced=0,50 -Dbench.reps=3 -Dbench.writers=64
```

Two of those flags are load-bearing. `-Djacoco.skip=true` removes coverage instrumentation, which
otherwise inflates every measurement and penalises the call-heavy fallback path unevenly.
`-Dsurefire.fork.timeout` overrides the repository's 1200-second default, which otherwise kills the
forked JVM mid-run and reports zero tests.

```java
/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements. See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.
 * The ASF licenses this file to You under the Apache License, Version 2.0
 * (the "License"); you may not use this file except in compliance with
 * the License. You may obtain a copy of the License at
 *
 *      http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

package org.apache.hadoop.ozone.om.service;

import static java.nio.charset.StandardCharsets.UTF_8;
import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
import static org.junit.jupiter.api.Assertions.assertEquals;

import java.io.File;
import java.io.IOException;
import java.util.ArrayList;
import java.util.Arrays;
import java.util.Collections;
import java.util.List;
import java.util.concurrent.ExecutorService;
import java.util.concurrent.Executors;
import java.util.concurrent.Future;
import java.util.concurrent.TimeUnit;
import org.apache.commons.io.FileUtils;
import org.apache.hadoop.hdds.client.BlockID;
import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
import org.apache.hadoop.hdds.client.RatisReplicationConfig;
import org.apache.hadoop.hdds.client.ReplicationConfig;
import org.apache.hadoop.hdds.conf.OzoneConfiguration;
import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
import org.apache.hadoop.hdds.utils.IOUtils;
import org.apache.hadoop.hdds.utils.db.BatchOperation;
import org.apache.hadoop.hdds.utils.db.Table;
import org.apache.hadoop.ozone.DataTestUtil;
import org.apache.hadoop.ozone.MiniOzoneCluster;
import org.apache.hadoop.ozone.client.OzoneBucket;
import org.apache.hadoop.ozone.client.OzoneClient;
import org.apache.hadoop.ozone.om.OMConfigKeys;
import org.apache.hadoop.ozone.om.OMMetadataManager;
import org.apache.hadoop.ozone.om.OMStorage;
import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
import org.apache.hadoop.ozone.om.OzoneManager;
import org.apache.hadoop.ozone.om.PendingKeysDeletion;
import org.apache.hadoop.ozone.om.helpers.BucketLayout;
import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
import org.apache.hadoop.ozone.om.snapshot.filter.ReclaimableKeyFilter;
import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
import org.junit.jupiter.api.Tag;
import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.Timeout;

/**
 * Whole-pass, production-scale A/B of the HDDS-15125 visibility interval against the
 * previous-snapshot lookup it replaces.
 *
 * <p>Measures {@code KeyManager.getPendingDeletionKeys} -- the scan-and-filter phase a
 * KeyDeletingService run spends almost all of its time in -- on a real {@link MiniOzoneCluster},
 * over a batch the size of {@code ozone.key.deleting.limit.per.task} (50 000 by default).
 *
 * <p>Both arms run the same binary and differ only in the OM layout version the cluster was
 * initialized at: below {@link OMLayoutFeature#SNAPSHOT_RECLAIM_SEQ_NUM} nothing carries an
 * interval, so every decision reads the previous snapshot, which is exactly what master does --
 * the PR leaves that fallback code path untouched. At the maximum layout version the interval is
 * used.
 *
 * <p>Two dimensions matter and both are swept:
 * <ul>
 *   <li><b>referenced ratio</b> -- the interval only short-circuits a <em>reclaimable</em>
 *       verdict; a referenced version still falls through to the lookup (it is what computes
 *       exclusive sizes). So the saving is proportional to the reclaimable fraction.</li>
 *   <li><b>previous snapshot size</b> -- a fallback costs one point lookup into the previous
 *       snapshot's fileTable, so its cost grows with that table. A bucket holding only the keys
 *       under test is far smaller than any real one, and makes the lookup look free.</li>
 * </ul>
 *
 * <p>Snapshot ballast is written straight into the fileTable before the checkpoint is taken rather
 * than through the client, which would dominate the runtime. The ballast is never read by the
 * filter; it only gives the previous snapshot a realistic size. Ballast and measured keys share one
 * name space and are interleaved, so consecutive lookups land in different SST blocks the way they
 * would in a real bucket.
 *
 * <p>Run with:
 * <pre>
 *   mvn test -pl hadoop-ozone/integration-test \
 *     -Dtest=KeyDeletingScaleBenchmark -Dexcluded-test-groups= \
 *     -Dsurefire.failIfNoSpecifiedTests=false
 * </pre>
 */
@Tag("benchmark")
public class KeyDeletingScaleBenchmark {

  private static final String VOLUME = "benchvol";
  private static final String BUCKET = "benchbucket";
  private static final byte[] CONTENT = "x".getBytes(UTF_8);
  /** Reclaimability does not depend on replication; ONE keeps the write phase cheap. */
  private static final ReplicationConfig ONE_REPLICA =
      RatisReplicationConfig.getInstance(ReplicationFactor.ONE);
  private static final BucketLayout LAYOUT = BucketLayout.FILE_SYSTEM_OPTIMIZED;
  /** Blocks per ballast key, matching a multi-block key in a real bucket. */
  private static final int BALLAST_BLOCKS_PER_KEY = 4;

  private static final int DELETED_KEY_COUNT = Integer.getInteger("bench.deleted", 50_000);
  private static final int CLUSTER_PASSES_PER_ARM = Integer.getInteger("bench.reps", 3);
  private static final int WARMUP_ROUNDS = Integer.getInteger("bench.warmup", 2);
  private static final int MEASURED_ROUNDS = Integer.getInteger("bench.rounds", 5);
  private static final int WRITER_THREADS = Integer.getInteger("bench.writers", 16);
  private static final int DELETE_BATCH = Integer.getInteger("bench.deleteBatch", 500);
  /** Live keys the previous snapshot holds beyond the ones under test. */
  private static final int[] BALLAST_KEYS = parseInts("bench.ballast", "0,1000000");
  /** Fraction of deleted versions still referenced by the snapshot, i.e. still falling back. */
  private static final int[] REFERENCED_PERCENTS = parseInts("bench.referenced", "0,10,50");

  private static int[] parseInts(String property, String defaultValue) {
    String[] parts = System.getProperty(property, defaultValue).split(",");
    int[] values = new int[parts.length];
    for (int i = 0; i < parts.length; i++) {
      values[i] = Integer.parseInt(parts[i].trim());
    }
    return values;
  }

  @Test
  @Timeout(value = 12, unit = TimeUnit.HOURS)
  public void runBenchmark() throws Exception {
    int legacyVersion = OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion();
    int intervalVersion = OMLayoutVersionManager.maxLayoutVersion();
    List<String> report = new ArrayList<>();

    for (int ballast : BALLAST_KEYS) {
      for (int referencedPercent : REFERENCED_PERCENTS) {
        long[] legacy = new long[CLUSTER_PASSES_PER_ARM];
        long[] interval = new long[CLUSTER_PASSES_PER_ARM];
        // Each pass boots its own cluster, so a fixed ordering would let the later arm run on a
        // warmer JVM. Interleave the arms instead.
        for (int i = 0; i < CLUSTER_PASSES_PER_ARM; i++) {
          if (i % 2 == 0) {
            legacy[i] = measure(legacyVersion, ballast, referencedPercent);
            interval[i] = measure(intervalVersion, ballast, referencedPercent);
          } else {
            interval[i] = measure(intervalVersion, ballast, referencedPercent);
            legacy[i] = measure(legacyVersion, ballast, referencedPercent);
          }
        }
        Arrays.sort(legacy);
        Arrays.sort(interval);
        int mid = CLUSTER_PASSES_PER_ARM / 2;
        double legacyMs = legacy[mid] / 1_000_000.0;
        double intervalMs = interval[mid] / 1_000_000.0;
        report.add(String.format(
            "%9d %9d%% %11.0f %11.0f %8.2fx %10.1f %10.1f %11.0f %11.0f %9.0f-%.0f",
            ballast, referencedPercent, legacyMs, intervalMs, legacyMs / intervalMs,
            legacyMs * 1000 / DELETED_KEY_COUNT, intervalMs * 1000 / DELETED_KEY_COUNT,
            DELETED_KEY_COUNT / (legacyMs / 1000), DELETED_KEY_COUNT / (intervalMs / 1000),
            legacy[0] / 1_000_000.0, legacy[legacy.length - 1] / 1_000_000.0));
        printReport(report);
      }
    }
    printReport(report);
  }

  private void printReport(List<String> rows) {
    System.out.println();
    System.out.println("getPendingDeletionKeys over " + DELETED_KEY_COUNT
        + " deleted key versions, " + CLUSTER_PASSES_PER_ARM + " clusters per arm, median of "
        + MEASURED_ROUNDS + " rounds within each cluster");
    System.out.printf("%9s %10s %11s %11s %9s %10s %10s %11s %11s %12s%n",
        "ballast", "referenced", "lookup ms", "interval ms", "speedup",
        "lookup us/k", "intvl us/k", "lookup k/s", "intvl k/s", "lookup range");
    System.out.println("---------------------------------------------------------"
        + "--------------------------------------------------------------");
    rows.forEach(System.out::println);
    System.out.println();
    System.out.flush();
  }

  /**
   * Boots a cluster at the given layout version, stages the deleted versions and the snapshot
   * ballast, and returns the median wall time of a {@code getPendingDeletionKeys} pass.
   */
  private long measure(int initLayoutVersion, int ballast, int referencedPercent) throws Exception {
    OzoneConfiguration conf = new OzoneConfiguration();
    conf.setInt(OMStorage.TESTING_INIT_LAYOUT_VERSION_KEY, initLayoutVersion);
    conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);

    MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1).build();
    OzoneClient client = null;
    ExecutorService writers = Executors.newFixedThreadPool(WRITER_THREADS);
    try {
      cluster.waitForClusterToBeReady();
      client = cluster.newClient();
      OzoneManager om = cluster.getOzoneManager();

      // Stop the background services draining the deletedTable mid-measurement.
      om.getKeyManager().getDeletingService().suspend();
      om.getKeyManager().getDirDeletingService().suspend();
      om.getKeyManager().getSnapshotDeletingService().suspend();

      OzoneBucket bucket = DataTestUtil.createVolumeAndBucket(
          client, VOLUME, BUCKET, LAYOUT, new DefaultReplicationConfig(ONE_REPLICA));

      // Measured keys are spread evenly through the ballast's name space, so the lookups a pass
      // makes walk the whole previous snapshot rather than one corner of it.
      int stride = ballast == 0 ? 1 : (ballast + DELETED_KEY_COUNT) / DELETED_KEY_COUNT;
      int referencedCount = (int) ((long) DELETED_KEY_COUNT * referencedPercent / 100);

      // Referenced versions exist when the snapshot is taken and stay visible to it; the rest are
      // written afterwards and are reclaimable.
      long staged = System.nanoTime();
      writeKeys(writers, bucket, 0, referencedCount, stride);
      stageBallast(om, ballast, stride);
      client.getObjectStore().createSnapshot(VOLUME, BUCKET, "snap1");
      writeKeys(writers, bucket, referencedCount, DELETED_KEY_COUNT, stride);
      deleteKeys(writers, bucket, 0, DELETED_KEY_COUNT, stride);
      om.awaitDoubleBufferFlush();
      om.getMetadataManager().getStore().flushDB();
      System.out.printf("  [lv=%d ballast=%d referenced=%d%%] staged in %.0f s, snapshot db %d MB%n",
          initLayoutVersion, ballast, referencedPercent,
          (System.nanoTime() - staged) / 1e9, snapshotDbSizeMb(om));

      for (int i = 0; i < WARMUP_ROUNDS; i++) {
        assertEquals(DELETED_KEY_COUNT - referencedCount, onePass(om).getPurgedKeys().size());
      }
      System.out.println("  " + reclaimDecisionCounts(om));
      System.out.flush();

      long[] rounds = new long[MEASURED_ROUNDS];
      for (int i = 0; i < MEASURED_ROUNDS; i++) {
        long start = System.nanoTime();
        onePass(om);
        rounds[i] = System.nanoTime() - start;
      }
      Arrays.sort(rounds);
      return rounds[rounds.length / 2];
    } finally {
      writers.shutdownNow();
      IOUtils.closeQuietly(client);
      cluster.shutdown();
    }
  }

  private static String keyName(int index, int stride) {
    return String.format("key-%09d", (long) index * stride);
  }

  private void writeKeys(ExecutorService writers, OzoneBucket bucket, int from, int to, int stride)
      throws Exception {
    runSharded(writers, from, to, (start, end) -> {
      for (int i = start; i < end; i++) {
        DataTestUtil.createKey(bucket, keyName(i, stride), ONE_REPLICA, CONTENT);
      }
      return null;
    });
  }

  private void deleteKeys(ExecutorService writers, OzoneBucket bucket, int from, int to, int stride)
      throws Exception {
    runSharded(writers, from, to, (start, end) -> {
      List<String> batch = new ArrayList<>(DELETE_BATCH);
      for (int i = start; i < end; i++) {
        batch.add(keyName(i, stride));
        if (batch.size() == DELETE_BATCH) {
          bucket.deleteKeys(batch);
          batch.clear();
        }
      }
      if (!batch.isEmpty()) {
        bucket.deleteKeys(batch);
      }
      return null;
    });
  }

  /** Splits [from, to) across the writer pool and rethrows the first failure. */
  private void runSharded(ExecutorService writers, int from, int to, Shard shard) throws Exception {
    if (to <= from) {
      return;
    }
    int shardSize = Math.max(1, (to - from + WRITER_THREADS - 1) / WRITER_THREADS);
    List<Future<Void>> futures = new ArrayList<>();
    for (int start = from; start < to; start += shardSize) {
      int end = Math.min(start + shardSize, to);
      int shardStart = start;
      futures.add(writers.submit(() -> shard.run(shardStart, end)));
    }
    for (Future<Void> future : futures) {
      future.get();
    }
  }

  /** A contiguous slice of the key index range, run on one writer thread. */
  private interface Shard {
    Void run(int start, int end) throws Exception;
  }

  /**
   * Fills the bucket's fileTable with {@code count} live keys occupying the index slots the
   * measured keys do not, then flushes and compacts so the checkpoint the snapshot takes has the
   * LSM shape of a real store rather than one big memtable.
   */
  private void stageBallast(OzoneManager om, int count, int stride) throws IOException {
    if (count == 0) {
      om.getMetadataManager().getStore().flushDB();
      return;
    }
    OMMetadataManager mm = om.getMetadataManager();
    long volumeId = mm.getVolumeId(VOLUME);
    OmBucketInfo bucketInfo = mm.getBucketTable().get(mm.getBucketKey(VOLUME, BUCKET));
    long bucketId = bucketInfo.getObjectID();
    Table<String, OmKeyInfo> fileTable = mm.getKeyTable(LAYOUT);

    long objectId = 1L << 40;
    int written = 0;
    int slot = 0;
    while (written < count) {
      try (BatchOperation batch = mm.getStore().initBatchOperation()) {
        for (int inBatch = 0; written < count && inBatch < 10_000; slot++) {
          if (stride > 1 && slot % stride == 0) {
            // Reserved for a measured key.
            continue;
          }
          String fileName = String.format("key-%09d", slot);
          fileTable.putWithBatch(batch, mm.getOzonePathKey(volumeId, bucketId, bucketId, fileName),
              ballastKeyInfo(fileName, bucketId, ++objectId));
          written++;
          inBatch++;
        }
        mm.getStore().commitBatchOperation(batch);
      }
    }
    mm.getStore().flushDB();
    mm.getStore().compactDB();
  }

  private OmKeyInfo ballastKeyInfo(String fileName, long parentObjectId, long objectId) {
    List<OmKeyLocationInfo> blocks = new ArrayList<>(BALLAST_BLOCKS_PER_KEY);
    for (int i = 0; i < BALLAST_BLOCKS_PER_KEY; i++) {
      blocks.add(new OmKeyLocationInfo.Builder()
          .setBlockID(new BlockID(objectId, i))
          .setLength(1024L)
          .setOffset(i * 1024L)
          .build());
    }
    return new OmKeyInfo.Builder()
        .setVolumeName(VOLUME)
        .setBucketName(BUCKET)
        .setKeyName(fileName)
        .setObjectID(objectId)
        .setUpdateID(objectId)
        .setParentObjectID(parentObjectId)
        .setCreationTime(1L)
        .setModificationTime(1L)
        .setDataSize(BALLAST_BLOCKS_PER_KEY * 1024L)
        .setReplicationConfig(ONE_REPLICA)
        .setOmKeyLocationInfos(
            Collections.singletonList(new OmKeyLocationInfoGroup(0L, blocks, false)))
        .build();
  }

  /** On-disk size of the snapshot checkpoints, i.e. what a fallback lookup has to search. */
  private static long snapshotDbSizeMb(OzoneManager om) {
    File snapshotDir = new File(OMStorage.getOmDbDir(om.getConfiguration()), OM_SNAPSHOT_CHECKPOINT_DIR);
    return FileUtils.sizeOfDirectory(snapshotDir) / (1024 * 1024);
  }

  /**
   * Fast-path versus fallback counts from DeletingServiceMetrics, read reflectively so the same
   * source also compiles against a master that does not have those counters.
   */
  private static String reclaimDecisionCounts(OzoneManager om) {
    try {
      Object metrics = OzoneManager.class.getMethod("getDeletionMetrics").invoke(om);
      long viaInterval = (long) metrics.getClass()
          .getMethod("getNumReclaimDecisionsFromInterval").invoke(metrics);
      long viaLookup = (long) metrics.getClass()
          .getMethod("getNumReclaimDecisionsFromSnapshotLookup").invoke(metrics);
      return String.format("decisions: %d from interval, %d from snapshot lookup", viaInterval, viaLookup);
    } catch (ReflectiveOperationException e) {
      return "decisions: counters absent (pre-HDDS-15125 binary)";
    }
  }

  /** One pass of the work KeyDeletingService does before submitting a purge, fresh filter and all. */
  private PendingKeysDeletion onePass(OzoneManager om) throws Exception {
    try (ReclaimableKeyFilter filter = new ReclaimableKeyFilter(om, om.getOmSnapshotManager(),
        ((OmMetadataManagerImpl) om.getMetadataManager()).getSnapshotChainManager(),
        null, om.getKeyManager(), om.getMetadataManager().getLock())) {
      return om.getKeyManager().getPendingDeletionKeys(filter, DELETED_KEY_COUNT);
    }
  }
}
```

</details>

Generated-by: Claude Code (Opus 5)

