### PR TITLE
HDDS-11130. Intermittent failure in TestSnapshotDeletingService#testSnapshotSplitAndMove

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingServiceIntegrationTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingServiceIntegrationTest.java
@@ -177,7 +177,6 @@ public class TestSnapshotDeletingServiceIntegrationTest {
 
   @Test
   @Order(2)
-  @Flaky("HDDS-11130")
   public void testSnapshotSplitAndMove() throws Exception {
 
     if (runIndividualTest) {
@@ -200,6 +199,9 @@ public class TestSnapshotDeletingServiceIntegrationTest {
             .getDeletedTable().getRangeKVs(null, 100,
                 "/vol1/bucket1/bucket1key1");
     assertEquals(1, omKeyInfos.size());
+
+    client.getProxy().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap1");
+    client.getProxy().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap3");
   }
 
   @Test
@@ -250,8 +252,6 @@ public class TestSnapshotDeletingServiceIntegrationTest {
     assertEquals(2, om.getOmSnapshotManager().getSnapshotCacheSize());
 
     // cleaning up the data
-    client.getProxy().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap1");
-    client.getProxy().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap3");
     client.getProxy().deleteBucket(VOLUME_NAME, BUCKET_NAME_TWO);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
`testMultipleSnapshotKeyReclaim` and `testSnapshotSplitAndMove` share the snapshot state created for `bucket1` and run in a fixed order.

Previously, `testMultipleSnapshotKeyReclaim` deleted `bucket1snap1` and `bucket1snap3` during its cleanup, even though `testSnapshotSplitAndMove` still needed `bucket1snap3` to verify that the deleted key had been moved to the next non-deleted snapshot. The background SnapshotDeletingService could process the deleted snapshot before this verification, causing the intermittent `expected: <1> but was: <0>` failure.

This change moves the snapshot cleanup to the end of `testSnapshotSplitAndMove`, after the snapshot contents have been verified. It also removes the `@Flaky` annotation associated with HDDS-11130.

This patch only changes integration test cleanup ordering. It does not affect production behavior or public interfaces.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11130

## How was this patch tested?

Local Test
```
mvn -pl :ozone-integration-test -am test \
  -Dtest='TestSnapshotDeletingServiceIntegrationTest#testMultipleSnapshotKeyReclaim+testSnapshotSplitAndMove' \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dexcluded-test-groups=benchmark \
  -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/33147737544

> The GitHub Actions flaky test check was also run with the class-level `@Unhealthy` annotation temporarily removed so that the workflow would not exclude the test class. The temporary enabling commit is not part of this patch.
Flaky-test-check: https://github.com/echonesis/ozone/actions/runs/33145334806

Generated-by: Codex (GPT-5)