### PR TITLE
HDDS-15225. Fix BlockDataStreamOutput.hsync() exception handling

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -541,12 +541,10 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
       if (!isClosed()) {
         handleFlush(false);
       }
-    } catch (IOException e) {
-      throw e;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       handleInterruptedException(e, false);
-    } catch (ExecutionException | RuntimeException e) {
+    } catch (ExecutionException e) {
       handleExecutionException(e);
     }
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -541,8 +541,13 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
       if (!isClosed()) {
         handleFlush(false);
       }
-    } catch (Exception e) {
-
+    } catch (IOException e) {
+      throw e;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      handleInterruptedException(e, false);
+    } catch (ExecutionException e) {
+      handleExecutionException(e);
     }
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -546,7 +546,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       handleInterruptedException(e, false);
-    } catch (ExecutionException e) {
+    } catch (ExecutionException | RuntimeException e) {
       handleExecutionException(e);
     }
   }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockDataStreamOutput.java
@@ -171,7 +171,6 @@ class TestBlockDataStreamOutput {
 
     // hsync should propagate the IOException from the failed putBlock
     assertThrows(IOException.class, stream::hsync, "hsync() must propagate IOException from failed putBlock");
-//    stream.cleanup(false);
     assertThrows(IOException.class, stream::close);
   }
 
@@ -188,7 +187,6 @@ class TestBlockDataStreamOutput {
 
     // hsync should propagate the watch failure
     assertThrows(IOException.class, stream::hsync, "hsync() must propagate IOException from failed watchForCommit");
-//    stream.cleanup(false);
     assertThrows(IOException.class, stream::close);
   }
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockDataStreamOutput.java
@@ -159,7 +159,7 @@ class TestBlockDataStreamOutput {
     }
   }
 
-  //@Test - skipped as it fails now.
+  @Test
   void hsyncPropagatesIOException() throws Exception {
     MockDatanodePipeline pipeline = new MockDatanodePipeline();
     // Fail the first putBlock
@@ -174,7 +174,7 @@ class TestBlockDataStreamOutput {
     stream.close();
   }
 
-  //@Test - skipped as it fails now
+  @Test
   void hsyncPropagatesWatchFailure() throws Exception {
     MockDatanodePipeline pipeline = new MockDatanodePipeline();
     // Fail the first watchForCommit

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockDataStreamOutput.java
@@ -171,7 +171,7 @@ class TestBlockDataStreamOutput {
 
     // hsync should propagate the IOException from the failed putBlock
     assertThrows(IOException.class, stream::hsync, "hsync() must propagate IOException from failed putBlock");
-    stream.close();
+    stream.cleanup(false);
   }
 
   @Test
@@ -187,7 +187,7 @@ class TestBlockDataStreamOutput {
 
     // hsync should propagate the watch failure
     assertThrows(IOException.class, stream::hsync, "hsync() must propagate IOException from failed watchForCommit");
-    stream.close();
+    stream.cleanup(false);
   }
 
   @Test

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockDataStreamOutput.java
@@ -171,7 +171,8 @@ class TestBlockDataStreamOutput {
 
     // hsync should propagate the IOException from the failed putBlock
     assertThrows(IOException.class, stream::hsync, "hsync() must propagate IOException from failed putBlock");
-    stream.cleanup(false);
+//    stream.cleanup(false);
+    assertThrows(IOException.class, stream::close);
   }
 
   @Test
@@ -187,7 +188,8 @@ class TestBlockDataStreamOutput {
 
     // hsync should propagate the watch failure
     assertThrows(IOException.class, stream::hsync, "hsync() must propagate IOException from failed watchForCommit");
-    stream.cleanup(false);
+//    stream.cleanup(false);
+    assertThrows(IOException.class, stream::close);
   }
 
   @Test

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -389,9 +389,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
             try {
               handleStreamAction(entry, op);
             } catch (IOException ioe) {
-              if (op == StreamAction.HSYNC) {
-                throw ioe;
-              }
               handleException(entry, ioe);
               continue;
             }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -389,6 +389,9 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
             try {
               handleStreamAction(entry, op);
             } catch (IOException ioe) {
+              if (op == StreamAction.HSYNC) {
+                throw ioe;
+              }
               handleException(entry, ioe);
               continue;
             }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyDataStreamOutput.java
@@ -229,12 +229,19 @@ class TestKeyDataStreamOutput {
 
   @Test
   void hsyncWithBlockErrorDoesNotCallOmHsync() throws Exception {
-    MockDatanodePipeline pipeline1 = new MockDatanodePipeline(new BlockID(1, 1));
-    MockDatanodePipeline pipeline2 = new MockDatanodePipeline(new BlockID(2, 2));
+//    MockDatanodePipeline pipeline1 = new MockDatanodePipeline(new BlockID(1, 1));
+//    MockDatanodePipeline pipeline2 = new MockDatanodePipeline(new BlockID(2, 2));
+//    // First putBlock will fail
+//    pipeline1.failPutBlockAfter(0, () -> new IOException("putBlock failed"));
+//    OzoneManagerProtocol omClient = createOmClient(pipeline1, pipeline2);
+//    KeyDataStreamOutput stream = createKeyStream(omClient, pipeline1, pipeline2);
+    MockDatanodePipeline pipeline = new MockDatanodePipeline();
     // First putBlock will fail
-    pipeline1.failPutBlockAfter(0, () -> new IOException("putBlock failed"));
-    OzoneManagerProtocol omClient = createOmClient(pipeline1, pipeline2);
-    KeyDataStreamOutput stream = createKeyStream(omClient, pipeline1, pipeline2);
+    pipeline.failPutBlockAfter(0, () -> new IOException("putBlock failed"));
+
+    OzoneManagerProtocol omClient = createOmClient(pipeline);
+
+    KeyDataStreamOutput stream = createKeyStream(omClient, pipeline);
     writeRandom(stream, 200);
 
     // hsync should throw because the block-level flush failed

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyDataStreamOutput.java
@@ -229,13 +229,12 @@ class TestKeyDataStreamOutput {
 
   @Test
   void hsyncWithBlockErrorDoesNotCallOmHsync() throws Exception {
-    MockDatanodePipeline pipeline = new MockDatanodePipeline();
+    MockDatanodePipeline pipeline1 = new MockDatanodePipeline(new BlockID(1, 1));
+    MockDatanodePipeline pipeline2 = new MockDatanodePipeline(new BlockID(2, 2));
     // First putBlock will fail
-    pipeline.failPutBlockAfter(0, () -> new IOException("putBlock failed"));
-
-    OzoneManagerProtocol omClient = createOmClient(pipeline);
-
-    KeyDataStreamOutput stream = createKeyStream(omClient, pipeline);
+    pipeline1.failPutBlockAfter(0, () -> new IOException("putBlock failed"));
+    OzoneManagerProtocol omClient = createOmClient(pipeline1, pipeline2);
+    KeyDataStreamOutput stream = createKeyStream(omClient, pipeline1, pipeline2);
     writeRandom(stream, 200);
 
     // hsync should throw because the block-level flush failed

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyDataStreamOutput.java
@@ -229,12 +229,6 @@ class TestKeyDataStreamOutput {
 
   @Test
   void hsyncWithBlockErrorDoesNotCallOmHsync() throws Exception {
-//    MockDatanodePipeline pipeline1 = new MockDatanodePipeline(new BlockID(1, 1));
-//    MockDatanodePipeline pipeline2 = new MockDatanodePipeline(new BlockID(2, 2));
-//    // First putBlock will fail
-//    pipeline1.failPutBlockAfter(0, () -> new IOException("putBlock failed"));
-//    OzoneManagerProtocol omClient = createOmClient(pipeline1, pipeline2);
-//    KeyDataStreamOutput stream = createKeyStream(omClient, pipeline1, pipeline2);
     MockDatanodePipeline pipeline = new MockDatanodePipeline();
     // First putBlock will fail
     pipeline.failPutBlockAfter(0, () -> new IOException("putBlock failed"));

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyDataStreamOutput.java
@@ -227,7 +227,7 @@ class TestKeyDataStreamOutput {
     }
   }
 
-//  @Test - skipped as it fails now
+  @Test
   void hsyncWithBlockErrorDoesNotCallOmHsync() throws Exception {
     MockDatanodePipeline pipeline = new MockDatanodePipeline();
     // First putBlock will fail


### PR DESCRIPTION
## What changes were proposed in this pull request?
`BlockDataStreamOutputhsync()` has an empty catch block that discards all exceptions from `handleFlush()`. This means a failed `putBlock` or `watchForCommit` during hsync is silently ignored, and the caller believes the sync succeeded. `KeyDataStreamOutput` then proceeds to call OM `hsyncKey`() for data that was never acknowledged by datanodes.

The Ratis path (`RatisBlockOutputStream.hsync()`) correctly propagates exceptions. The fix aligns the `DataStream` hsync with the Ratis behavior, propagate `IOException` directly, wrap checked exceptions in `IOException`.

At the key level, `KeyDataStreamOutput.handleFlushOrClose()` treat HSYNC like WRITE/FLUSH/CLOSE. All of failures go through `handleException`, which could:
1. Clean up the failed block stream.
2. Loop and call `hsync()` again on a closed stream.
3. Return to `KeyDataStreamOutput.hsync()` and call OM `hsyncKey()` for data never committed via putBlock.

To prevent that, this fix inserted in catch block of `KeyDataStreamOutput.handleFlushOrClose()`:
```
if (op == StreamAction.HSYNC) {
  throw ioe;
}
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15225

## How was this patch tested?

Unit tests skipped in #10230 turn green.