### PR TITLE
HDDS-16322. ConfigurationSource.getClass loads property key instead of configured class name

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
@@ -237,7 +237,7 @@ public interface ConfigurationSource {
       return defaultValue;
     }
     try {
-      return Class.forName(name);
+      return Class.forName(valueString);
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationSource.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationSource.java
@@ -35,6 +35,14 @@ class TestConfigurationSource {
   }
 
   @Test
+  void getClassUsesConfiguredValueNotKey() {
+    MutableConfigurationSource c = new InMemoryConfigurationForTesting();
+    c.set("some.config.key", String.class.getName());
+
+    assertEquals(String.class, c.getClass("some.config.key", null));
+  }
+
+  @Test
   void getPropsMatchPrefix() {
     MutableConfigurationSource c = new InMemoryConfigurationForTesting();
     c.set("somePrefix.key", "value");


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ConfigurationSource.getClass` called `Class.forName(name)` on the property key after reading the configured class name into `valueString`. Implementations that do not inherit Hadoop `Configuration.getClass` therefore failed to load the configured class. Use `valueString`, matching `getClasses` and Hadoop `Configuration.getClass`.

Added `getClassUsesConfiguredValueNotKey` in `TestConfigurationSource`, using `InMemoryConfigurationForTesting` (hits the default method, not Hadoop `Configuration.getClass`).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16322

## How was this patch tested?

- `mvn -pl :hdds-config test -Dtest=TestConfigurationSource`