### PR TITLE
HDDS-16033. Fix intermittent failures in TestKeyLifecycleService

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/FaultInjectorImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/FaultInjectorImpl.java
@@ -67,18 +67,13 @@ public class FaultInjectorImpl extends FaultInjector {
     wait.countDown();
   }
 
-  /**
-   * Wait until someone is paused here, without letting them through.
-   */
+  /** Wait until someone is paused here, without letting them through. */
   public void awaitPaused(long timeoutMillis) throws InterruptedException {
     Assertions.assertTrue(ready.await(timeoutMillis, TimeUnit.MILLISECONDS),
         "Timed out waiting for the injector to be reached");
   }
 
-  /**
-   * Let anyone waiting in {@link #pause()} through without waiting for the pause to happen, so an
-   * injector can be discarded without leaving a background thread parked in it forever.
-   */
+  /** Unlike {@link #resume()}, does not wait for a pause first, so a discarded injector cannot park a thread. */
   public void release() {
     wait.countDown();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/FaultInjectorImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/FaultInjectorImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.utils.FaultInjector;
 import org.assertj.core.api.Fail;
@@ -63,6 +64,22 @@ public class FaultInjectorImpl extends FaultInjector {
       e.printStackTrace();
       Assertions.assertTrue(Fail.fail("resume interrupted"));
     }
+    wait.countDown();
+  }
+
+  /**
+   * Wait until someone is paused here, without letting them through.
+   */
+  public void awaitPaused(long timeoutMillis) throws InterruptedException {
+    Assertions.assertTrue(ready.await(timeoutMillis, TimeUnit.MILLISECONDS),
+        "Timed out waiting for the injector to be reached");
+  }
+
+  /**
+   * Let anyone waiting in {@link #pause()} through without waiting for the pause to happen, so an
+   * injector can be discarded without leaving a background thread parked in it forever.
+   */
+  public void release() {
     wait.countDown();
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -116,7 +116,6 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -1751,24 +1750,21 @@ class TestKeyLifecycleService extends OzoneTestBase {
 
     public Stream<Arguments> parameters4() {
       return Stream.of(
-          arguments("dir1/dir2/dir3//", "dir1/dir2/dir3/", 3, true, false),
-          arguments("dir1/dir2/dir3//", "dir1/dir2/dir3/", 3, false, true),
-          arguments("dir1/dir2//", "dir1/dir2/", 2, true, false),
-          arguments("dir1/dir2//", "dir1/dir2/", 2, false, true),
-          arguments("dir1//", "dir1/", 1, true, false),
-          arguments("dir1//", "dir1/", 1, false, true)
+          arguments("dir1/dir2/dir3//", "dir1/dir2/dir3/", true, false),
+          arguments("dir1/dir2/dir3//", "dir1/dir2/dir3/", false, true),
+          arguments("dir1/dir2//", "dir1/dir2/", true, false),
+          arguments("dir1/dir2//", "dir1/dir2/", false, true),
+          arguments("dir1//", "dir1/", true, false),
+          arguments("dir1//", "dir1/", false, true)
       );
     }
 
     @ParameterizedTest
     @MethodSource("parameters4")
-    void testPrefixDirectoryNotExpired(String dirName, String prefix, int dirDepth, boolean createPrefix,
+    void testPrefixDirectoryNotExpired(String dirName, String prefix, boolean createPrefix,
         boolean createFilterPrefix) throws IOException, TimeoutException, InterruptedException {
       final String volumeName = getTestName();
       final String bucketName = uniqueObjectName("bucket");
-      long initialDeletedDirCount = getDeletedDirectoryCount();
-      long initialDirCount = getDirCount();
-      long initialNumDeletedDir = metrics.getNumDirDeleted().value();
 
       // Create the directory
       createVolumeAndBucket(volumeName, bucketName, FILE_SYSTEM_OPTIMIZED,
@@ -1777,10 +1773,6 @@ class TestKeyLifecycleService extends OzoneTestBase {
       KeyInfoWithVolumeContext keyInfo = getDirectory(volumeName, bucketName, dirName);
       assertFalse(keyInfo.getKeyInfo().isFile());
       Thread.sleep(SERVICE_INTERVAL);
-
-      GenericTestUtils.waitFor(() -> dirDepth == getDirCount() - initialDirCount,
-          WAIT_CHECK_INTERVAL, 5000);
-      assertEquals(0, getDeletedDirectoryCount() - initialDeletedDirCount);
 
       GenericTestUtils.LogCapturer log =
           GenericTestUtils.LogCapturer.captureLogs(
@@ -1800,8 +1792,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
 
       GenericTestUtils.waitFor(() -> log.getOutput().contains("Prefix directory " + prefix + " doesn't get expired"),
           WAIT_CHECK_INTERVAL, 10000);
-      assertEquals(dirDepth, getDirCount() - initialDirCount);
-      assertEquals(0, metrics.getNumDirDeleted().value() - initialNumDeletedDir);
+      // getKeyInfo resolves the whole path, so this fails if any level of the directory was expired
+      assertFalse(getDirectory(volumeName, bucketName, dirName).getKeyInfo().isFile());
       deleteLifecyclePolicy(volumeName, bucketName);
     }
 
@@ -3572,16 +3564,6 @@ class TestKeyLifecycleService extends OzoneTestBase {
       return metadataManager.countRowsInTable(table);
     } catch (IOException e) {
       fail("Failed to count deleted directories " + e.getMessage());
-      return -1;
-    }
-  }
-
-  private long getDirCount() {
-    final Table<String, OmDirectoryInfo> table = metadataManager.getDirectoryTable();
-    try {
-      return metadataManager.countRowsInTable(table);
-    } catch (IOException e) {
-      fail("Failed to count directories " + e.getMessage());
       return -1;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -854,14 +854,19 @@ class TestKeyLifecycleService extends OzoneTestBase {
       createLifecyclePolicy(volumeName, bucketName, bucketLayout, prefix, null, date.toString(), true);
 
       // Inject to cause resume case for FSO with nested directory
+      FaultInjectorImpl firstTaskStart = new FaultInjectorImpl();
+      FaultInjectorImpl firstDelete = new FaultInjectorImpl();
       FaultInjectorImpl lastFaultInjector = new FaultInjectorImpl();
       lastFaultInjector.setException(new IOException("Injected exception for testing"));
-      KeyLifecycleService.setInjectors(
-          Arrays.asList(new FaultInjectorImpl(), new FaultInjectorImpl(), lastFaultInjector));
+      KeyLifecycleService.setInjectors(Arrays.asList(firstTaskStart, firstDelete, lastFaultInjector));
       // Resume the service
       keyLifecycleService.resume();
-      KeyLifecycleService.getInjector(0).resume();
-      KeyLifecycleService.getInjector(1).resume();
+      // Returns once the aborted task is past its start, so it keeps using the injectors below
+      firstTaskStart.resume();
+      // Hold the follow-up task at its start, otherwise it overwrites the scan state asserted below
+      FaultInjectorImpl nextTaskStart = new FaultInjectorImpl();
+      KeyLifecycleService.setInjectors(Arrays.asList(nextTaskStart, firstDelete, lastFaultInjector));
+      firstDelete.resume();
 
       // wait for scanState to be updated
       String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
@@ -903,6 +908,9 @@ class TestKeyLifecycleService extends OzoneTestBase {
           }
         }
       }
+
+      // Let the follow-up task resume from the saved state and finish the scan
+      nextTaskStart.resume();
 
       GenericTestUtils.waitFor(() ->
           (getDeletedKeyCount() - initialDeletedKeyCount) == testKeyCount, WAIT_CHECK_INTERVAL, 10000);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -3496,20 +3496,26 @@ class TestKeyLifecycleService extends OzoneTestBase {
   // scanned, so both have to be cleared for the next test to start from a quiet service.
   private void cleanUpService() throws Exception {
     try {
-      for (String policyKey : new ArrayList<>(createdLifecyclePolicies)) {
-        deleteLifecyclePolicy(policyKey);
-      }
-    } finally {
+      // Suspending first closes the window where a cycle has already read the policies but has not
+      // registered its task yet, which would let that task run into the next test.
+      keyLifecycleService.suspend();
       installedInjectors.forEach(FaultInjectorImpl::release);
-      installedInjectors.clear();
-      KeyLifecycleService.setInjectors(null);
-      keyLifecycleService.setOzoneTrash(null);
-      keyLifecycleService.setMoveToTrashEnabled(true);
-      keyLifecycleService.setListMaxSize(conf.getInt(OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE,
-          OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE_DEFAULT));
-      keyLifecycleService.resume();
       GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().isEmpty(),
           WAIT_CHECK_INTERVAL, 30000);
+    } finally {
+      try {
+        for (String policyKey : new ArrayList<>(createdLifecyclePolicies)) {
+          deleteLifecyclePolicy(policyKey);
+        }
+      } finally {
+        installedInjectors.clear();
+        KeyLifecycleService.setInjectors(null);
+        keyLifecycleService.setOzoneTrash(null);
+        keyLifecycleService.setMoveToTrashEnabled(true);
+        keyLifecycleService.setListMaxSize(conf.getInt(OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE,
+            OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE_DEFAULT));
+        keyLifecycleService.resume();
+      }
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -868,13 +868,17 @@ class TestKeyLifecycleService extends OzoneTestBase {
       // Resume the service
       keyLifecycleService.resume();
       // Returns once the aborted task is past its start, so it keeps using the injectors below
-      firstTaskStart.resume();
+      firstTaskStart.awaitPaused(10000);
+      firstTaskStart.release();
       // Hold the follow-up task at its start, otherwise it overwrites the scan state asserted below
       FaultInjectorImpl nextTaskStart = new FaultInjectorImpl();
       installInjectors(nextTaskStart, firstDelete, lastFaultInjector);
-      firstDelete.resume();
+      firstDelete.awaitPaused(10000);
+      firstDelete.release();
+      // BackgroundService waits for the previous batch, so the follow-up task reaching its start means
+      // the first task is done
+      nextTaskStart.awaitPaused(10000);
 
-      // wait for scanState to be updated
       String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
       try {
         GenericTestUtils.waitFor(() -> {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -3264,11 +3264,9 @@ class TestKeyLifecycleService extends OzoneTestBase {
       String expectedString = "Received a request to delete a Key does not exist /" + key.getVolumeName() + "/" +
           key.getBucketName() + "/" + key.getKeyName();
       GenericTestUtils.waitFor(() -> requestLog.getOutput().contains(expectedString), WAIT_CHECK_INTERVAL, 10000);
-      if (!deleted) {
-        // Since expiration action is an absolute timestamp, so the renamed key will expire in next evaluation task
-        GenericTestUtils.waitFor(() -> log.getOutput().contains("1 expired keys and 0 expired dirs found"),
-            SERVICE_INTERVAL, 10000);
-      }
+      // The expiration action is an absolute timestamp, so a renamed key still expires and a later task
+      // deletes it. How many candidates a single task reports depends on whether the in-flight delete has
+      // landed when it starts, so assert on the outcome instead.
       GenericTestUtils.waitFor(() -> getKeyCount(bucketLayout) - initialKeyCount == 0, WAIT_CHECK_INTERVAL, 10000);
       assertEquals(KEY_COUNT, getDeletedKeyCount() - initialDeletedKeyCount);
       deleteLifecyclePolicy(volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -77,9 +77,12 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -96,6 +99,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
+import org.apache.hadoop.hdds.utils.FaultInjector;
 import org.apache.hadoop.hdds.utils.db.DBConfigFromFile;
 import org.apache.hadoop.hdds.utils.db.RocksDatabaseException;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -140,7 +144,6 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.key.OMKeysDeleteRequest;
 import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LifecycleConfiguration;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
@@ -207,6 +210,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
   private ScmBlockLocationTestingClient scmBlockTestingClient;
   private KeyLifecycleServiceMetrics metrics;
   private long bucketObjectID;
+  private final List<FaultInjectorImpl> installedInjectors = new ArrayList<>();
+  private final Set<String> createdLifecyclePolicies = new HashSet<>();
 
   @Parameter(0)
   private long stateSaveInternal;
@@ -275,12 +280,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
     }
 
     @AfterEach
-    void resume() {
-      keyLifecycleService.setOzoneTrash(null);
-      keyLifecycleService.setMoveToTrashEnabled(true);
-      KeyLifecycleService.setInjectors(null);
-      keyLifecycleService.setListMaxSize(conf.getInt(OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE,
-          OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE_DEFAULT));
+    void resume() throws Exception {
+      cleanUpService();
     }
 
     @AfterAll
@@ -402,6 +403,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertEquals(testKeyCount, keyList.size());
       GenericTestUtils.waitFor(() -> getKeyCount(bucketLayout) - initialKeyCount == testKeyCount,
           WAIT_CHECK_INTERVAL, 1000);
+      awaitKeyCacheDrained(bucketLayout, volumeName, bucketName);
 
       // Inject spy to LifecycleScanStateTable to count put operations
       Field tableField = OmMetadataManagerImpl.class.getDeclaredField("lifecycleScanStateTable");
@@ -471,6 +473,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertEquals(testKeyCount, keyList.size());
       GenericTestUtils.waitFor(() -> getKeyCount(bucketLayout) - initialKeyCount == testKeyCount,
           WAIT_CHECK_INTERVAL, 1000);
+      awaitKeyCacheDrained(bucketLayout, volumeName, bucketName);
 
       // determine db keys
       List<String> dbKeys = new ArrayList<>();
@@ -584,7 +587,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
       int testKeyCount = 3;
 
       keyLifecycleService.setListMaxSize(1);
-      KeyLifecycleService.setInjectors(Arrays.asList(new FaultInjectorImpl()));
+      FaultInjectorImpl taskStart = new FaultInjectorImpl();
+      installInjectors(taskStart);
 
       List<OmKeyArgs> keyList =
           createKeys(volumeName, bucketName, bucketLayout, testKeyCount, 1, keyPrefix, null);
@@ -600,13 +604,14 @@ class TestKeyLifecycleService extends OzoneTestBase {
       }
 
       String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
-      GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().contains(bucketKey),
-          WAIT_CHECK_INTERVAL, 10000);
+      // The in-flight list is filled when the task is scheduled, so wait on the injector instead:
+      // suspending before the task actually starts makes it skip its run and never pause here.
+      taskStart.awaitPaused(10000);
 
       GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.captureLogs(
           LoggerFactory.getLogger(KeyLifecycleService.class));
       keyLifecycleService.suspend();
-      KeyLifecycleService.getInjector(0).resume();
+      taskStart.release();
       GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().isEmpty(),
           WAIT_CHECK_INTERVAL, 10000);
 
@@ -847,6 +852,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertEquals(testKeyCount, keyList.size());
       GenericTestUtils.waitFor(
           () -> getKeyCount(bucketLayout) - initialKeyCount == testKeyCount, WAIT_CHECK_INTERVAL, 1000);
+      awaitKeyCacheDrained(bucketLayout, volumeName, bucketName);
 
       // Create Lifecycle configuration
       ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
@@ -858,59 +864,61 @@ class TestKeyLifecycleService extends OzoneTestBase {
       FaultInjectorImpl firstDelete = new FaultInjectorImpl();
       FaultInjectorImpl lastFaultInjector = new FaultInjectorImpl();
       lastFaultInjector.setException(new IOException("Injected exception for testing"));
-      KeyLifecycleService.setInjectors(Arrays.asList(firstTaskStart, firstDelete, lastFaultInjector));
+      installInjectors(firstTaskStart, firstDelete, lastFaultInjector);
       // Resume the service
       keyLifecycleService.resume();
       // Returns once the aborted task is past its start, so it keeps using the injectors below
       firstTaskStart.resume();
       // Hold the follow-up task at its start, otherwise it overwrites the scan state asserted below
       FaultInjectorImpl nextTaskStart = new FaultInjectorImpl();
-      KeyLifecycleService.setInjectors(Arrays.asList(nextTaskStart, firstDelete, lastFaultInjector));
+      installInjectors(nextTaskStart, firstDelete, lastFaultInjector);
       firstDelete.resume();
 
       // wait for scanState to be updated
       String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
-      GenericTestUtils.waitFor(() -> {
-        try {
-          OmLifecycleScanState scanState = metadataManager.getLifecycleScanStateTable().get(bucketKey);
-          if (bucketLayout == FILE_SYSTEM_OPTIMIZED) {
-            return scanState != null && scanState.getLastScannedDir() != null && scanState.getLastScannedKey() != null;
-          } else {
-            return scanState != null && scanState.getLastScannedKey() != null;
+      try {
+        GenericTestUtils.waitFor(() -> {
+          try {
+            OmLifecycleScanState state = metadataManager.getLifecycleScanStateTable().get(bucketKey);
+            if (bucketLayout == FILE_SYSTEM_OPTIMIZED) {
+              return state != null && state.getLastScannedDir() != null && state.getLastScannedKey() != null;
+            } else {
+              return state != null && state.getLastScannedKey() != null;
+            }
+          } catch (IOException e) {
+            return false;
           }
-        } catch (IOException e) {
-          return false;
-        }
-      }, WAIT_CHECK_INTERVAL, 10000);
+        }, WAIT_CHECK_INTERVAL, 10000);
 
-      OmLifecycleScanState scanState = metadataManager.getLifecycleScanStateTable().get(bucketKey);
-      if (stateSaveInternal != -1) {
-        if (maxSize == 2) {
-          if (bucketLayout == FILE_SYSTEM_OPTIMIZED) {
-            assertEquals("dir3/dir6/dir9", scanState.getLastScannedDir());
-            assertTrue(scanState.getLastScannedKey().endsWith("key8"));
+        OmLifecycleScanState scanState = metadataManager.getLifecycleScanStateTable().get(bucketKey);
+        if (stateSaveInternal != -1) {
+          if (maxSize == 2) {
+            if (bucketLayout == FILE_SYSTEM_OPTIMIZED) {
+              assertEquals("dir3/dir6/dir9", scanState.getLastScannedDir());
+              assertTrue(scanState.getLastScannedKey().endsWith("key8"));
+            } else {
+              assertTrue(scanState.getLastScannedKey().endsWith("key1"));
+            }
+          } else if (maxSize == 3) {
+            if (bucketLayout == FILE_SYSTEM_OPTIMIZED) {
+              assertEquals("dir3/dir6/dir8", scanState.getLastScannedDir());
+              assertTrue(scanState.getLastScannedKey().endsWith("key6"));
+            } else {
+              assertTrue(scanState.getLastScannedKey().endsWith("key2"));
+            }
           } else {
-            assertTrue(scanState.getLastScannedKey().endsWith("key1"));
-          }
-        } else if (maxSize == 3) {
-          if (bucketLayout == FILE_SYSTEM_OPTIMIZED) {
-            assertEquals("dir3/dir6/dir8", scanState.getLastScannedDir());
-            assertTrue(scanState.getLastScannedKey().endsWith("key6"));
-          } else {
-            assertTrue(scanState.getLastScannedKey().endsWith("key2"));
-          }
-        } else {
-          if (bucketLayout == FILE_SYSTEM_OPTIMIZED) {
-            assertEquals("dir1/dir5", scanState.getLastScannedDir());
-            assertTrue(scanState.getLastScannedKey().endsWith("key3"));
-          } else {
-            assertTrue(scanState.getLastScannedKey().endsWith("key7"));
+            if (bucketLayout == FILE_SYSTEM_OPTIMIZED) {
+              assertEquals("dir1/dir5", scanState.getLastScannedDir());
+              assertTrue(scanState.getLastScannedKey().endsWith("key3"));
+            } else {
+              assertTrue(scanState.getLastScannedKey().endsWith("key7"));
+            }
           }
         }
+      } finally {
+        // Let the follow-up task resume from the saved state and finish the scan
+        nextTaskStart.release();
       }
-
-      // Let the follow-up task resume from the saved state and finish the scan
-      nextTaskStart.resume();
 
       GenericTestUtils.waitFor(() ->
           (getDeletedKeyCount() - initialDeletedKeyCount) == testKeyCount, WAIT_CHECK_INTERVAL, 10000);
@@ -1071,6 +1079,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertEquals(4, keyList.size());
       GenericTestUtils.waitFor(() -> getKeyCount(BucketLayout.FILE_SYSTEM_OPTIMIZED) - initialKeyCount == 4,
           WAIT_CHECK_INTERVAL, 1000);
+      awaitKeyCacheDrained(BucketLayout.FILE_SYSTEM_OPTIMIZED, volumeName, bucketName);
 
       long bucketId =
           metadataManager.getBucketTable().get(metadataManager.getBucketKey(volumeName, bucketName)).getObjectID();
@@ -1158,6 +1167,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertEquals(3, keyList.size());
       GenericTestUtils.waitFor(() -> getKeyCount(layout) - initialKeyCount == 3,
           WAIT_CHECK_INTERVAL, 1000);
+      awaitKeyCacheDrained(layout, volumeName, bucketName);
 
       long bucketId =
           metadataManager.getBucketTable().get(metadataManager.getBucketKey(volumeName, bucketName)).getObjectID();
@@ -1727,8 +1737,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       KeyInfoWithVolumeContext keyInfo = getDirectory(volumeName, bucketName, dirName);
       assertFalse(keyInfo.getKeyInfo().isFile());
 
-      KeyLifecycleService.setInjectors(
-          Arrays.asList(new FaultInjectorImpl(), new FaultInjectorImpl()));
+      installInjectors(new FaultInjectorImpl(), new FaultInjectorImpl());
 
       // create Lifecycle configuration
       ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
@@ -1934,6 +1943,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
             .build());
         keyList.add(createAndCommitKey(volumeName, bucketName, dir4 + "key4", 1, null));
       }
+      awaitKeyCacheDrained(FILE_SYSTEM_OPTIMIZED, volumeName, bucketName);
       createLifecyclePolicy(volumeName, bucketName, FILE_SYSTEM_OPTIMIZED, ruleList);
 
       try {
@@ -2087,8 +2097,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       List<OmKeyArgs> keyList =
           createKeys(volumeName, bucketName, bucketLayout, KEY_COUNT, 1, keyPrefix, null);
 
-      KeyLifecycleService.setInjectors(
-          Arrays.asList(new FaultInjectorImpl(), new FaultInjectorImpl()));
+      installInjectors(new FaultInjectorImpl(), new FaultInjectorImpl());
 
       // create Lifecycle configuration
       ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
@@ -2121,10 +2130,9 @@ class TestKeyLifecycleService extends OzoneTestBase {
           key.getBucketName() + "/" + key.getKeyName() + " whose updateID not match or null";
       GenericTestUtils.waitFor(() -> requestLog.getOutput().contains(expectedString), WAIT_CHECK_INTERVAL, 10000);
 
-      // rename will change object's modificationTime. But since expiration action is an absolute timestamp, so
-      // the renamed key will expire in next evaluation task
-      GenericTestUtils.waitFor(() -> log.getOutput().contains("1 expired keys and 0 expired dirs found"),
-          WAIT_CHECK_INTERVAL, 10000);
+      // The update changes the key's modificationTime, but the expiration action is an absolute timestamp,
+      // so the key still expires and a later task deletes it. How many candidates a single task reports
+      // depends on when it starts relative to the in-flight delete, so assert on the outcome instead.
       GenericTestUtils.waitFor(() -> getKeyCount(bucketLayout) - initialKeyCount == 0, WAIT_CHECK_INTERVAL, 10000);
       assertEquals(KEY_COUNT, getDeletedKeyCount() - initialDeletedKeyCount);
       deleteLifecyclePolicy(volumeName, bucketName);
@@ -2565,8 +2573,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       KeyInfoWithVolumeContext keyInfo = getDirectory(volumeName, bucketName, dirName);
       assertFalse(keyInfo.getKeyInfo().isFile());
 
-      KeyLifecycleService.setInjectors(
-          Arrays.asList(new FaultInjectorImpl(), new FaultInjectorImpl()));
+      installInjectors(new FaultInjectorImpl(), new FaultInjectorImpl());
 
       // create Lifecycle configuration
       ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
@@ -2622,8 +2629,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       // Create and inject for test
       createKeys(volumeName, bucketName, FILE_SYSTEM_OPTIMIZED, KEY_COUNT, 1, prefix, null);
       ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(EXPIRE_SECONDS);
-      KeyLifecycleService.setInjectors(
-          Arrays.asList(new FaultInjectorImpl(), new FaultInjectorImpl()));
+      installInjectors(new FaultInjectorImpl(), new FaultInjectorImpl());
       createLifecyclePolicy(volumeName, bucketName, FILE_SYSTEM_OPTIMIZED, "", null, date.toString(), true);
       Thread.sleep(SERVICE_INTERVAL + 100);
       
@@ -3137,7 +3143,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
     }
 
     @AfterEach
-    void resume() {
+    void resume() throws Exception {
+      cleanUpService();
     }
 
     @AfterAll
@@ -3181,7 +3188,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       ZonedDateTime date = now.plusSeconds(EXPIRE_SECONDS);
 
       FaultInjectorImpl injector = new FaultInjectorImpl();
-      KeyLifecycleService.setInjectors(Arrays.asList(injector));
+      installInjectors(injector);
       createLifecyclePolicy(volumeName, bucketName, bucketLayout, "", null, date.toString(), true);
 
       Thread.sleep(1000);
@@ -3230,8 +3237,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       List<OmKeyArgs> keyList =
           createKeys(volumeName, bucketName, bucketLayout, KEY_COUNT, 1, keyPrefix, null);
 
-      KeyLifecycleService.setInjectors(
-          Arrays.asList(new FaultInjectorImpl(), new FaultInjectorImpl()));
+      installInjectors(new FaultInjectorImpl(), new FaultInjectorImpl());
 
       // create Lifecycle configuration
       ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
@@ -3382,13 +3388,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       }
       throw e;
     }
-    String key = "/" + volume + "/" + bucket;
-    LifecycleConfiguration lcProto = lcc.getProtobuf();
-    OmLifecycleConfiguration canonicalLcc = OmLifecycleConfiguration.getFromProtobuf(lcProto);
-    canonicalLcc.valid();
-    metadataManager.getLifecycleConfigurationTable().put(key, lcc);
-    metadataManager.getLifecycleConfigurationTable().addCacheEntry(
-        new CacheKey<>(key), CacheValue.get(1L, canonicalLcc));
+    putLifecyclePolicy(volume, bucket, lcc, true);
   }
 
   private void createLifecyclePolicy(String volume, String bucket, BucketLayout layout, List<OmLCRule> ruleList)
@@ -3408,20 +3408,87 @@ class TestKeyLifecycleService extends OzoneTestBase {
       }
       throw e;
     }
-    String key = "/" + volume + "/" + bucket;
-    LifecycleConfiguration lcProto = lcc.getProtobuf();
-    OmLifecycleConfiguration canonicalLcc = OmLifecycleConfiguration.getFromProtobuf(lcProto);
+    putLifecyclePolicy(volume, bucket, lcc, false);
+  }
+
+  /**
+   * Track policies created by the test helpers so that @AfterEach can drop the ones a test leaves behind.
+   */
+  private void putLifecyclePolicy(String volume, String bucket, OmLifecycleConfiguration lcc, boolean validate)
+      throws IOException {
+    String key = metadataManager.getBucketKey(volume, bucket);
+    OmLifecycleConfiguration canonicalLcc = OmLifecycleConfiguration.getFromProtobuf(lcc.getProtobuf());
+    if (validate) {
+      canonicalLcc.valid();
+    }
     metadataManager.getLifecycleConfigurationTable().put(key, lcc);
     metadataManager.getLifecycleConfigurationTable().addCacheEntry(
         new CacheKey<>(key), CacheValue.get(1L, canonicalLcc));
+    createdLifecyclePolicies.add(key);
   }
 
   private void deleteLifecyclePolicy(String volume, String bucket)
       throws IOException {
-    String key = "/" + volume + "/" + bucket;
-    metadataManager.getLifecycleConfigurationTable().delete(key);
+    deleteLifecyclePolicy(metadataManager.getBucketKey(volume, bucket));
+  }
+
+  private void deleteLifecyclePolicy(String policyKey) throws IOException {
+    metadataManager.getLifecycleConfigurationTable().delete(policyKey);
     metadataManager.getLifecycleConfigurationTable().addCacheEntry(
-        new CacheKey<>(key), CacheValue.get(1L));
+        new CacheKey<>(policyKey), CacheValue.get(1L));
+    createdLifecyclePolicies.remove(policyKey);
+  }
+
+  /**
+   * Wait until the bucket's keys are only in the DB. A scan reads keys still in the key table cache
+   * from an unordered map, skips them in the sorted table iterator and does not count them, so
+   * lastScannedKey and numKeyIterated are not stable until the cache entries are gone. The cache is
+   * cleaned up asynchronously after the write, so being able to read a key back is not enough.
+   */
+  private void awaitKeyCacheDrained(BucketLayout layout, String volume, String bucket)
+      throws TimeoutException, InterruptedException {
+    Table<String, OmKeyInfo> keyTable = metadataManager.getKeyTable(layout);
+    GenericTestUtils.waitFor(() -> {
+      Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>> cacheIter = keyTable.cacheIterator();
+      while (cacheIter.hasNext()) {
+        OmKeyInfo key = cacheIter.next().getValue().getCacheValue();
+        if (key != null && volume.equals(key.getVolumeName()) && bucket.equals(key.getBucketName())) {
+          return false;
+        }
+      }
+      return true;
+    }, WAIT_CHECK_INTERVAL, 10000);
+  }
+
+  // Tracks every injector installed, not just the current set, so a replaced one is still released
+  private void installInjectors(FaultInjectorImpl... injectors) {
+    installedInjectors.addAll(Arrays.asList(injectors));
+    KeyLifecycleService.setInjectors(new ArrayList<FaultInjector>(Arrays.asList(injectors)));
+  }
+
+  /**
+   * Leave the service usable for the next test. A task parked in an injector blocks every following
+   * cycle, because BackgroundService waits for the previous batch before scheduling a new one, so
+   * injectors must be released rather than just dropped. Policies left behind keep their bucket
+   * scanned for the rest of the run, which shifts the global counters other tests assert on.
+   */
+  private void cleanUpService() throws Exception {
+    try {
+      for (String policyKey : new ArrayList<>(createdLifecyclePolicies)) {
+        deleteLifecyclePolicy(policyKey);
+      }
+    } finally {
+      installedInjectors.forEach(FaultInjectorImpl::release);
+      installedInjectors.clear();
+      KeyLifecycleService.setInjectors(null);
+      keyLifecycleService.setOzoneTrash(null);
+      keyLifecycleService.setMoveToTrashEnabled(true);
+      keyLifecycleService.setListMaxSize(conf.getInt(OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE,
+          OZONE_KEY_LIFECYCLE_SERVICE_DELETE_BATCH_SIZE_DEFAULT));
+      keyLifecycleService.resume();
+      GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().isEmpty(),
+          WAIT_CHECK_INTERVAL, 30000);
+    }
   }
 
   /**
@@ -3432,17 +3499,16 @@ class TestKeyLifecycleService extends OzoneTestBase {
    */
   private void runSingleLifecycleScan(String volume, String bucket)
       throws IOException, TimeoutException, InterruptedException {
-    String bucketKey = metadataManager.getBucketKey(volume, bucket);
-    // injector 0 holds the task at its start, injector 1 holds the first delete request,
-    // injector 2 is only read for an injected exception but must exist
-    KeyLifecycleService.setInjectors(
-        Arrays.asList(new FaultInjectorImpl(), new FaultInjectorImpl(), new FaultInjectorImpl()));
+    FaultInjectorImpl taskStart = new FaultInjectorImpl();
+    FaultInjectorImpl firstDelete = new FaultInjectorImpl();
+    // The third injector is only read for an injected exception, but the scan expects it to exist
+    installInjectors(taskStart, firstDelete, new FaultInjectorImpl());
     keyLifecycleService.resume();
-    GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().contains(bucketKey),
-        WAIT_CHECK_INTERVAL, 10000);
+    // The in-flight list is filled at schedule time, so wait for the task to reach the injector
+    taskStart.awaitPaused(10000);
     deleteLifecyclePolicy(volume, bucket);
-    KeyLifecycleService.getInjector(0).resume();
-    KeyLifecycleService.getInjector(1).resume();
+    taskStart.release();
+    firstDelete.release();
     GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().isEmpty(),
         WAIT_CHECK_INTERVAL, 10000);
   }
@@ -3759,6 +3825,11 @@ class TestKeyLifecycleService extends OzoneTestBase {
       createSubject();
       keyDeletingService.suspend();
       directoryDeletingService.suspend();
+    }
+
+    @AfterEach
+    void resume() throws Exception {
+      cleanUpService();
     }
 
     @AfterAll

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -191,6 +191,9 @@ class TestKeyLifecycleService extends OzoneTestBase {
   private static final AtomicInteger OBJECT_ID_COUNTER = new AtomicInteger();
   private static final int KEY_COUNT = 2;
   private static final int EXPIRE_SECONDS = 2;
+  // Date-based expiration compares the key's modificationTime against the date, so tests that rename or
+  // update a key after it was scanned need a date that stays in the future for the whole test.
+  private static final int LONG_EXPIRE_SECONDS = 600;
   private static final int SERVICE_INTERVAL = 300;
   private static final int WAIT_CHECK_INTERVAL = 50;
 
@@ -2092,7 +2095,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
 
       // create Lifecycle configuration
       ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-      ZonedDateTime date = now.plusSeconds(EXPIRE_SECONDS);
+      ZonedDateTime date = now.plusSeconds(LONG_EXPIRE_SECONDS);
       createLifecyclePolicy(volumeName, bucketName, bucketLayout, rulePrefix, null, date.toString(), true);
       Thread.sleep(SERVICE_INTERVAL);
       KeyLifecycleService.getInjector(0).resume();
@@ -3235,7 +3238,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
 
       // create Lifecycle configuration
       ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-      ZonedDateTime date = now.plusSeconds(EXPIRE_SECONDS);
+      ZonedDateTime date = now.plusSeconds(LONG_EXPIRE_SECONDS);
       createLifecyclePolicy(volumeName, bucketName, bucketLayout, rulePrefix, null, date.toString(), true);
       Thread.sleep(SERVICE_INTERVAL);
       KeyLifecycleService.getInjector(0).resume();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -645,6 +645,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertEquals(testKeyCount, keyList.size());
       GenericTestUtils.waitFor(() -> getKeyCount(bucketLayout) - initialKeyCount == testKeyCount,
           WAIT_CHECK_INTERVAL, 1000);
+      awaitKeyCacheDrained(bucketLayout, volumeName, bucketName);
 
       // determine db keys
       List<String> dbKeys = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -120,6 +120,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -854,6 +855,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       GenericTestUtils.waitFor(
           () -> getKeyCount(bucketLayout) - initialKeyCount == testKeyCount, WAIT_CHECK_INTERVAL, 1000);
       awaitKeyCacheDrained(bucketLayout, volumeName, bucketName);
+      awaitDirCacheDrained(volumeName, bucketName);
 
       // Create Lifecycle configuration
       ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
@@ -3445,6 +3447,25 @@ class TestKeyLifecycleService extends OzoneTestBase {
       while (cacheIter.hasNext()) {
         OmKeyInfo key = cacheIter.next().getValue().getCacheValue();
         if (key != null && volume.equals(key.getVolumeName()) && bucket.equals(key.getBucketName())) {
+          return false;
+        }
+      }
+      return true;
+    }, WAIT_CHECK_INTERVAL, 10000);
+  }
+
+  // getSubDirectory evaluates directories still in the cache and adds them again from the table iterator,
+  // so a scan sees them twice until they drain.
+  private void awaitDirCacheDrained(String volume, String bucket)
+      throws IOException, TimeoutException, InterruptedException {
+    long volumeId = metadataManager.getVolumeTable().get(metadataManager.getVolumeKey(volume)).getObjectID();
+    long bucketId = metadataManager.getBucketTable().get(metadataManager.getBucketKey(volume, bucket)).getObjectID();
+    String bucketPrefix = OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId + OM_KEY_PREFIX;
+    Table<String, OmDirectoryInfo> dirTable = metadataManager.getDirectoryTable();
+    GenericTestUtils.waitFor(() -> {
+      Iterator<Map.Entry<CacheKey<String>, CacheValue<OmDirectoryInfo>>> cacheIter = dirTable.cacheIterator();
+      while (cacheIter.hasNext()) {
+        if (cacheIter.next().getKey().getCacheKey().startsWith(bucketPrefix)) {
           return false;
         }
       }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -1205,7 +1205,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
       metadataManager.getLifecycleScanStateTable().addCacheEntry(new CacheKey<>(bucketKey),
           CacheValue.get(1L, scanState));
           
-      keyLifecycleService.resume();
+      runSingleLifecycleScan(volumeName, bucketName);
 
       // It should seek to key2. key1 is skipped, key2 is skipped too.
       // So key1 and key2 are skipped, key3 is deleted.
@@ -1216,7 +1216,6 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertEquals(2, getKeyCount(layout) - initialKeyCount);
       GenericTestUtils.waitFor(() ->
           expectedDeleted == metrics.getNumKeyIterated().value() - keyIterated, WAIT_CHECK_INTERVAL, 5000);
-      deleteLifecyclePolicy(volumeName, bucketName);
     }
 
     @ParameterizedTest

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -920,7 +920,6 @@ class TestKeyLifecycleService extends OzoneTestBase {
           }
         }
       } finally {
-        // Let the follow-up task resume from the saved state and finish the scan
         nextTaskStart.release();
       }
 
@@ -2134,9 +2133,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
           key.getBucketName() + "/" + key.getKeyName() + " whose updateID not match or null";
       GenericTestUtils.waitFor(() -> requestLog.getOutput().contains(expectedString), WAIT_CHECK_INTERVAL, 10000);
 
-      // The update changes the key's modificationTime, but the expiration action is an absolute timestamp,
-      // so the key still expires and a later task deletes it. How many candidates a single task reports
-      // depends on when it starts relative to the in-flight delete, so assert on the outcome instead.
+      // How many candidates a task reports depends on whether the in-flight delete has landed when it
+      // starts, so assert on the outcome instead.
       GenericTestUtils.waitFor(() -> getKeyCount(bucketLayout) - initialKeyCount == 0, WAIT_CHECK_INTERVAL, 10000);
       assertEquals(KEY_COUNT, getDeletedKeyCount() - initialDeletedKeyCount);
       deleteLifecyclePolicy(volumeName, bucketName);
@@ -3268,9 +3266,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
       String expectedString = "Received a request to delete a Key does not exist /" + key.getVolumeName() + "/" +
           key.getBucketName() + "/" + key.getKeyName();
       GenericTestUtils.waitFor(() -> requestLog.getOutput().contains(expectedString), WAIT_CHECK_INTERVAL, 10000);
-      // The expiration action is an absolute timestamp, so a renamed key still expires and a later task
-      // deletes it. How many candidates a single task reports depends on whether the in-flight delete has
-      // landed when it starts, so assert on the outcome instead.
+      // How many candidates a task reports depends on whether the in-flight delete has landed when it
+      // starts, so assert on the outcome instead.
       GenericTestUtils.waitFor(() -> getKeyCount(bucketLayout) - initialKeyCount == 0, WAIT_CHECK_INTERVAL, 10000);
       assertEquals(KEY_COUNT, getDeletedKeyCount() - initialDeletedKeyCount);
       deleteLifecyclePolicy(volumeName, bucketName);
@@ -3413,9 +3410,6 @@ class TestKeyLifecycleService extends OzoneTestBase {
     putLifecyclePolicy(volume, bucket, lcc, false);
   }
 
-  /**
-   * Track policies created by the test helpers so that @AfterEach can drop the ones a test leaves behind.
-   */
   private void putLifecyclePolicy(String volume, String bucket, OmLifecycleConfiguration lcc, boolean validate)
       throws IOException {
     String key = metadataManager.getBucketKey(volume, bucket);
@@ -3441,12 +3435,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
     createdLifecyclePolicies.remove(policyKey);
   }
 
-  /**
-   * Wait until the bucket's keys are only in the DB. A scan reads keys still in the key table cache
-   * from an unordered map, skips them in the sorted table iterator and does not count them, so
-   * lastScannedKey and numKeyIterated are not stable until the cache entries are gone. The cache is
-   * cleaned up asynchronously after the write, so being able to read a key back is not enough.
-   */
+  // A scan reads keys still in the cache from an unordered map and skips them in the sorted table
+  // iterator without counting them, so lastScannedKey and numKeyIterated are unstable until they drain.
   private void awaitKeyCacheDrained(BucketLayout layout, String volume, String bucket)
       throws TimeoutException, InterruptedException {
     Table<String, OmKeyInfo> keyTable = metadataManager.getKeyTable(layout);
@@ -3462,11 +3452,6 @@ class TestKeyLifecycleService extends OzoneTestBase {
     }, WAIT_CHECK_INTERVAL, 10000);
   }
 
-  /**
-   * Wait until the multipart upload is only in the DB, so a direct write to the table is not undone by
-   * the pending flush of its creation. The cache is cleaned up asynchronously after the write, so being
-   * able to read the upload back is not enough.
-   */
   private void awaitMultipartCacheDrained(String dbKey) throws TimeoutException, InterruptedException {
     Table<String, OmMultipartKeyInfo> mpuTable = metadataManager.getMultipartInfoTable();
     GenericTestUtils.waitFor(() -> {
@@ -3486,12 +3471,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
     KeyLifecycleService.setInjectors(new ArrayList<FaultInjector>(Arrays.asList(injectors)));
   }
 
-  /**
-   * Leave the service usable for the next test. A task parked in an injector blocks every following
-   * cycle, because BackgroundService waits for the previous batch before scheduling a new one, so
-   * injectors must be released rather than just dropped. Policies left behind keep their bucket
-   * scanned for the rest of the run, which shifts the global counters other tests assert on.
-   */
+  // A task parked in an injector blocks every following cycle, and a policy left behind keeps its bucket
+  // scanned, so both have to be cleared for the next test to start from a quiet service.
   private void cleanUpService() throws Exception {
     try {
       for (String policyKey : new ArrayList<>(createdLifecyclePolicies)) {
@@ -3511,12 +3492,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
     }
   }
 
-  /**
-   * Resume the service and let exactly one lifecycle scan run for the bucket: the task is held at
-   * its start, the policy is dropped so the periodic service does not schedule a follow-up scan,
-   * then the task is released and waited for. Without this the next scan starts SERVICE_INTERVAL
-   * after the first one finished and deletes the objects the caller expects to remain.
-   */
+  // Runs exactly one scan: without dropping the policy first, the next scan starts SERVICE_INTERVAL
+  // later and deletes the objects the caller expects to remain.
   private void runSingleLifecycleScan(String volume, String bucket)
       throws IOException, TimeoutException, InterruptedException {
     FaultInjectorImpl taskStart = new FaultInjectorImpl();
@@ -3697,9 +3674,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
       String keyName, String uploadId, long newCreationTime)
       throws IOException, TimeoutException, InterruptedException {
     String dbKey = metadataManager.getMultipartKey(volumeName, bucketName, keyName, uploadId);
-    // The upload was created through the request pipeline, which flushes to the DB asynchronously.
-    // Writing straight to the table before that flush lands lets the flush overwrite the new creation
-    // time, so the upload never looks expired. Wait for the entry to leave the cache first.
+    // The create is flushed to the DB asynchronously, and that flush would overwrite the new creation
+    // time, leaving the upload looking fresh. Wait for the entry to leave the cache first.
     awaitMultipartCacheDrained(dbKey);
     OmMultipartKeyInfo existingInfo = metadataManager.getMultipartInfoTable().get(dbKey);
     if (existingInfo == null) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -524,18 +524,16 @@ class TestKeyLifecycleService extends OzoneTestBase {
       assertNotNull(state);
 
       // resume the service
-      keyLifecycleService.resume();
+      runSingleLifecycleScan(volumeName, bucketName);
 
-      // wait for it to process
       // it should skip the first 3 keys (index 0, 1, 2) since we set lastScannedDbKey as index 2.
       // So it deletes only the last 2 keys (index 3 and 4).
       int expectedDeleted = 2;
       GenericTestUtils.waitFor(() ->
-          (getDeletedKeyCount() - initialDeletedKeyCount) >= expectedDeleted, WAIT_CHECK_INTERVAL, 10000);
+          (getDeletedKeyCount() - initialDeletedKeyCount) == expectedDeleted, WAIT_CHECK_INTERVAL, 10000);
       
       // confirm it hasn't deleted all keys
       assertEquals(testKeyCount - expectedDeleted, getKeyCount(bucketLayout) - initialKeyCount);
-      deleteLifecyclePolicy(volumeName, bucketName);
     }
 
     @Test
@@ -1028,9 +1026,8 @@ class TestKeyLifecycleService extends OzoneTestBase {
       GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.captureLogs(
           LoggerFactory.getLogger(KeyLifecycleService.class));
       // Resume the service
-      keyLifecycleService.resume();
+      runSingleLifecycleScan(volumeName, bucketName);
 
-      // Wait for it to process
       GenericTestUtils.waitFor(() ->
           (getDeletedKeyCount() - initialDeletedKeyCount) == expectedDeleted, WAIT_CHECK_INTERVAL, 10000);
       
@@ -1041,8 +1038,6 @@ class TestKeyLifecycleService extends OzoneTestBase {
             d -> assertTrue(logCapturer.getOutput().contains("Skip " + d)));
         logCapturer.clearOutput();
       }
-
-      deleteLifecyclePolicy(volumeName, bucketName);
     }
 
     @ParameterizedTest
@@ -1113,22 +1108,24 @@ class TestKeyLifecycleService extends OzoneTestBase {
 
       GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.captureLogs(
           LoggerFactory.getLogger(KeyLifecycleService.class));
-      keyLifecycleService.resume();
+      runSingleLifecycleScan(volumeName, bucketName);
 
-      // dir1 can be fully evaluated depending on whether lastScannedKey belong to it (no seek) or not
-      // dir2 should be skipped dir2 > dir1
-      int expectedDeleted = 2;
+      // dir2 is skipped since dir2 > dir1. dir1 is fully evaluated only when lastScannedKey does not
+      // belong to it, otherwise the scan seeks past its last key and nothing is left to expire.
+      int expectedDeleted = keyBelongToDir ? 0 : 2;
       GenericTestUtils.waitFor(() ->
-          (getDeletedKeyCount() - initialDeletedKeyCount) >= expectedDeleted, WAIT_CHECK_INTERVAL, 5000);
+          (getDeletedKeyCount() - initialDeletedKeyCount) == expectedDeleted, WAIT_CHECK_INTERVAL, 5000);
       assertEquals(keyList.size() - expectedDeleted, getKeyCount(BucketLayout.FILE_SYSTEM_OPTIMIZED) - initialKeyCount);
+      // The task drops the bucket from the in-flight list before it updates the metrics
       GenericTestUtils.waitFor(() ->
           expectedDeleted == metrics.getNumKeyIterated().value() - keyIterated, WAIT_CHECK_INTERVAL, 5000);
+      // dir2 sorts after the resumed dir1, so it is skipped in both cases
+      assertTrue(logCapturer.getOutput().contains("Skip dir2"));
       if (keyBelongToDir) {
         assertTrue(logCapturer.getOutput().contains("Seek to key"));
       } else {
         assertFalse(logCapturer.getOutput().contains("Seek to key"));
       }
-      deleteLifecyclePolicy(volumeName, bucketName);
     }
 
     @ParameterizedTest
@@ -3425,6 +3422,29 @@ class TestKeyLifecycleService extends OzoneTestBase {
     metadataManager.getLifecycleConfigurationTable().delete(key);
     metadataManager.getLifecycleConfigurationTable().addCacheEntry(
         new CacheKey<>(key), CacheValue.get(1L));
+  }
+
+  /**
+   * Resume the service and let exactly one lifecycle scan run for the bucket: the task is held at
+   * its start, the policy is dropped so the periodic service does not schedule a follow-up scan,
+   * then the task is released and waited for. Without this the next scan starts SERVICE_INTERVAL
+   * after the first one finished and deletes the objects the caller expects to remain.
+   */
+  private void runSingleLifecycleScan(String volume, String bucket)
+      throws IOException, TimeoutException, InterruptedException {
+    String bucketKey = metadataManager.getBucketKey(volume, bucket);
+    // injector 0 holds the task at its start, injector 1 holds the first delete request,
+    // injector 2 is only read for an injected exception but must exist
+    KeyLifecycleService.setInjectors(
+        Arrays.asList(new FaultInjectorImpl(), new FaultInjectorImpl(), new FaultInjectorImpl()));
+    keyLifecycleService.resume();
+    GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().contains(bucketKey),
+        WAIT_CHECK_INTERVAL, 10000);
+    deleteLifecyclePolicy(volume, bucket);
+    KeyLifecycleService.getInjector(0).resume();
+    KeyLifecycleService.getInjector(1).resume();
+    GenericTestUtils.waitFor(() -> keyLifecycleService.status().getRunningBucketsList().isEmpty(),
+        WAIT_CHECK_INTERVAL, 10000);
   }
 
   private void createVolumeAndBucket(String volumeName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -3462,6 +3462,24 @@ class TestKeyLifecycleService extends OzoneTestBase {
     }, WAIT_CHECK_INTERVAL, 10000);
   }
 
+  /**
+   * Wait until the multipart upload is only in the DB, so a direct write to the table is not undone by
+   * the pending flush of its creation. The cache is cleaned up asynchronously after the write, so being
+   * able to read the upload back is not enough.
+   */
+  private void awaitMultipartCacheDrained(String dbKey) throws TimeoutException, InterruptedException {
+    Table<String, OmMultipartKeyInfo> mpuTable = metadataManager.getMultipartInfoTable();
+    GenericTestUtils.waitFor(() -> {
+      Iterator<Map.Entry<CacheKey<String>, CacheValue<OmMultipartKeyInfo>>> cacheIter = mpuTable.cacheIterator();
+      while (cacheIter.hasNext()) {
+        if (dbKey.equals(cacheIter.next().getKey().getCacheKey())) {
+          return false;
+        }
+      }
+      return true;
+    }, WAIT_CHECK_INTERVAL, 10000);
+  }
+
   // Tracks every injector installed, not just the current set, so a replaced one is still released
   private void installInjectors(FaultInjectorImpl... injectors) {
     installedInjectors.addAll(Arrays.asList(injectors));
@@ -3676,8 +3694,13 @@ class TestKeyLifecycleService extends OzoneTestBase {
   }
 
   private void updateMultipartUploadCreationTime(String volumeName, String bucketName,
-      String keyName, String uploadId, long newCreationTime) throws IOException {
+      String keyName, String uploadId, long newCreationTime)
+      throws IOException, TimeoutException, InterruptedException {
     String dbKey = metadataManager.getMultipartKey(volumeName, bucketName, keyName, uploadId);
+    // The upload was created through the request pipeline, which flushes to the DB asynchronously.
+    // Writing straight to the table before that flush lands lets the flush overwrite the new creation
+    // time, so the upload never looks expired. Wait for the entry to leave the cache first.
+    awaitMultipartCacheDrained(dbKey);
     OmMultipartKeyInfo existingInfo = metadataManager.getMultipartInfoTable().get(dbKey);
     if (existingInfo == null) {
       fail("Multipart upload not found: " + dbKey);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestKeyLifecycleService` intermittently reports failures in bursts: once one test leaves the shared lifecycle service in a bad state, dozens of later tests can time out. 

The tests share one `OzoneManager`, one continuously running `KeyLifecycleService`, and a static list of fault injectors. This patch isolates that shared state between tests and replaces timing-dependent checks with synchronization on the events the tests actually need.

### Root causes and fixes

<details>


| Root cause | Failure mode | Fix |
| --- | --- | --- |
| **Leaked test state** | An unreleased injector blocks later scans; a leftover policy changes later tests' counters and consumes their injectors. | Clean up all injectors and policies after each test, restore service settings, and wait for the service to become idle. |
| **Uncontrolled follow-up scans** | A second periodic scan overwrites scan state or deletes objects that a resume test expects to remain. | Remove the policy before releasing the resumed task so exactly one scan runs; hold follow-up tasks while scan state is asserted. |
| **Scheduled was treated as running** | A task appears in the in-flight list before reaching its injector, so the test can suspend it too early and wait indefinitely. | Use a bounded `awaitPaused` to confirm that the task actually started. |
| **Cache/DB visibility races** | Cached keys produce unstable scan positions and counts; a pending multipart-upload flush can overwrite the creation time set by the test. | Wait for the relevant cache entries to drain before asserting scan state or updating the table directly. |
| **Timing-dependent or global assertions** | A two-second expiration date, exact intermediate log counts, and OM-wide directory counts are not stable invariants. | Use a sufficiently future date and assert final key or directory outcomes scoped to the test. |

</details>

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-16033

## How was this patch tested?

The complete `TestKeyLifecycleService` class passes locally with both parameter sets:

```text
Tests run: 368, Failures: 0, Errors: 0, Skipped: 18
```


The individual races were also reproduced before applying their fixes:

* Delaying a resume test consistently reproduced the follow-up-scan race. The fixed test passes with the same delay.
* The multipart-upload race occurred in 2 of 7 runs before the fix and 0 of 6 runs after it. Logs confirmed that a pending flush had restored the original creation time.
* `flaky-test-check` ran the whole class with 10 splits and 10 iterations. The results progressed from cascading failures to isolated failures to all splits passing:
  https://github.com/chihsuan/ozone/actions/runs/33180409064

Checkstyle and RAT report no errors.

Generated-by: Claude Code (Opus 5)
