### PR TITLE
HDDS-16317. Rename TestKeyValueContainerIntegrityChecks for naming convention

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerIntegrityTestBase.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerIntegrityTestBase.java
@@ -53,10 +53,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Base class for tests identifying issues with key value container contents.
  */
-public class TestKeyValueContainerIntegrityChecks {
+public class KeyValueContainerIntegrityTestBase {
 
   static final Logger LOG =
-      LoggerFactory.getLogger(TestKeyValueContainerIntegrityChecks.class);
+      LoggerFactory.getLogger(KeyValueContainerIntegrityTestBase.class);
 
   private ContainerLayoutTestInfo containerLayoutTestInfo;
   private MutableVolumeSet volumeSet;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
  * Test the KeyValueContainerCheck class's ability to detect container errors.
  */
 public class TestKeyValueContainerCheck
-    extends TestKeyValueContainerIntegrityChecks {
+    extends KeyValueContainerIntegrityTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestKeyValueContainerCheck.class);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -49,7 +49,7 @@ import org.apache.ozone.test.GenericTestUtils;
 /**
  * Tests for {@link KeyValueContainerMetadataInspector}.
  */
-public class TestKeyValueContainerMetadataInspector extends TestKeyValueContainerIntegrityChecks {
+public class TestKeyValueContainerMetadataInspector extends KeyValueContainerIntegrityTestBase {
   private static final long CONTAINER_ID = 102;
 
   static final DeletedBlocksTransactionGeneratorForTesting GENERATOR =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename the test base class `TestKeyValueContainerIntegrityChecks` to `KeyValueContainerIntegrityTestBase` so test tooling does not mistake it for a test class.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-16317

## How was this patch tested?

- TestKeyValueContainerCheck — tests passed
- TestKeyValueContainerMetadataInspector — tests passed
- `checkstyle.sh`, `rat.sh`, and `author.sh` passed