### PR TITLE
HDDS-16326. Cache the container chunks directory instead of stat-ing it on every chunk operation

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -308,6 +308,11 @@ public final class ContainerUtils {
       throws StorageContainerException {
     Objects.requireNonNull(containerData, "containerData == null");
 
+    File chunksDir = containerData.getChunksDirFile();
+    if (chunksDir != null) {
+      return chunksDir;
+    }
+
     String chunksPath = containerData.getChunksPath();
     if (chunksPath == null) {
       LOG.error("Chunks path is null in the container data");
@@ -315,13 +320,14 @@ public final class ContainerUtils {
           UNABLE_TO_FIND_DATA_DIR);
     }
 
-    File chunksDir = new File(chunksPath);
+    chunksDir = new File(chunksPath);
     if (!chunksDir.exists()) {
       LOG.error("Chunks dir {} does not exist", chunksDir.getAbsolutePath());
       throw new StorageContainerException("Chunks directory " +
           chunksDir.getAbsolutePath() + " does not exist.",
           UNABLE_TO_FIND_DATA_DIR);
     }
+    containerData.setChunksDirFile(chunksDir);
     return chunksDir;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -298,7 +298,10 @@ public final class ContainerUtils {
   }
 
   /**
-   * Get the chunk directory from the containerData.
+   * Resolve and validate the chunk directory from the containerData. The
+   * directory's existence is checked on every call, so a chunk operation
+   * against a failed volume surfaces as a storage failure; write paths rely on
+   * this to mark the container unhealthy.
    *
    * @param containerData {@link ContainerData}
    * @return the file of chunk directory
@@ -308,11 +311,6 @@ public final class ContainerUtils {
       throws StorageContainerException {
     Objects.requireNonNull(containerData, "containerData == null");
 
-    File chunksDir = containerData.getChunksDirFile();
-    if (chunksDir != null) {
-      return chunksDir;
-    }
-
     String chunksPath = containerData.getChunksPath();
     if (chunksPath == null) {
       LOG.error("Chunks path is null in the container data");
@@ -320,13 +318,35 @@ public final class ContainerUtils {
           UNABLE_TO_FIND_DATA_DIR);
     }
 
-    chunksDir = new File(chunksPath);
+    File chunksDir = new File(chunksPath);
     if (!chunksDir.exists()) {
       LOG.error("Chunks dir {} does not exist", chunksDir.getAbsolutePath());
       throw new StorageContainerException("Chunks directory " +
           chunksDir.getAbsolutePath() + " does not exist.",
           UNABLE_TO_FIND_DATA_DIR);
     }
+    return chunksDir;
+  }
+
+  /**
+   * Read-path variant of {@link #getChunkDir(ContainerData)} that resolves and
+   * validates the directory once, then returns the cached result on later calls
+   * to skip the per-read stat. Unlike a write, a read does not need the eager
+   * storage-failure probe: a directory that disappears after caching is caught
+   * by the read's own open(), and read failures do not mark the container
+   * unhealthy.
+   *
+   * @param containerData {@link ContainerData}
+   * @return the file of chunk directory
+   * @throws StorageContainerException
+   */
+  public static File getChunkDirForRead(ContainerData containerData)
+      throws StorageContainerException {
+    File cached = containerData.getChunksDirFile();
+    if (cached != null) {
+      return cached;
+    }
+    File chunksDir = getChunkDir(containerData);
     containerData.setChunksDirFile(chunksDir);
     return chunksDir;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -298,10 +298,7 @@ public final class ContainerUtils {
   }
 
   /**
-   * Resolve and validate the chunk directory from the containerData. The
-   * directory's existence is checked on every call, so a chunk operation
-   * against a failed volume surfaces as a storage failure; write paths rely on
-   * this to mark the container unhealthy.
+   * Resolve and validate the chunk directory from the container data.
    *
    * @param containerData {@link ContainerData}
    * @return the file of chunk directory

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -329,29 +329,6 @@ public final class ContainerUtils {
   }
 
   /**
-   * Read-path variant of {@link #getChunkDir(ContainerData)} that resolves and
-   * validates the directory once, then returns the cached result on later calls
-   * to skip the per-read stat. Unlike a write, a read does not need the eager
-   * storage-failure probe: a directory that disappears after caching is caught
-   * by the read's own open(), and read failures do not mark the container
-   * unhealthy.
-   *
-   * @param containerData {@link ContainerData}
-   * @return the file of chunk directory
-   * @throws StorageContainerException
-   */
-  public static File getChunkDirForRead(ContainerData containerData)
-      throws StorageContainerException {
-    File cached = containerData.getChunksDirFile();
-    if (cached != null) {
-      return cached;
-    }
-    File chunksDir = getChunkDir(containerData);
-    containerData.setChunksDirFile(chunksDir);
-    return chunksDir;
-  }
-
-  /**
    * ContainerID can be decoded from the container base directory name.
    */
   public static long getContainerID(File containerBaseDir) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import jakarta.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -76,6 +77,10 @@ public abstract class ContainerData {
 
   // Path to Physical file system where chunks are stored.
   private String chunksPath;
+
+  // Chunks directory resolved and validated once from chunksPath, cached to
+  // avoid re-stat-ing it on every chunk operation. Not serialized.
+  private transient volatile File chunksDirFile;
 
   // State of the Container
   private ContainerDataProto.State state;
@@ -263,6 +268,21 @@ public abstract class ContainerData {
    */
   public void setChunksPath(String chunkPath) {
     this.chunksPath = chunkPath;
+    this.chunksDirFile = null;
+  }
+
+  /**
+   * @return the chunks directory resolved and validated once from
+   *         {@link #getChunksPath()} and cached for the container's lifetime,
+   *         or {@code null} if it has not been resolved yet.
+   */
+  public File getChunksDirFile() {
+    return chunksDirFile;
+  }
+
+  /** Caches the chunks directory resolved by {@code ContainerUtils#getChunkDir}. */
+  public void setChunksDirFile(File chunksDirFile) {
+    this.chunksDirFile = chunksDirFile;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -282,6 +282,7 @@ public abstract class ContainerData {
    * @return the resolved chunks directory
    * @throws StorageContainerException if the chunks directory cannot be resolved
    */
+  @JsonIgnore
   public File getChunksDirForRead() throws StorageContainerException {
     File dir = chunksDirFile;
     if (dir == null) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerType;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.ratis.util.Preconditions;
@@ -272,17 +273,22 @@ public abstract class ContainerData {
   }
 
   /**
-   * @return the chunks directory resolved and validated once from
-   *         {@link #getChunksPath()} and cached for the container's lifetime,
-   *         or {@code null} if it has not been resolved yet.
+   * Read-path accessor for the chunks directory. Resolves and validates it once
+   * via {@link ContainerUtils#getChunkDir(ContainerData)}, then returns the
+   * cached result on later calls to skip the per-read stat. Writes and other
+   * callers use {@code ContainerUtils.getChunkDir} directly, so a missing
+   * directory still surfaces as a storage failure on every operation.
+   *
+   * @return the resolved chunks directory
+   * @throws StorageContainerException if the chunks directory cannot be resolved
    */
-  public File getChunksDirFile() {
-    return chunksDirFile;
-  }
-
-  /** Caches the chunks directory resolved by {@code ContainerUtils#getChunkDir}. */
-  public void setChunksDirFile(File chunksDirFile) {
-    this.chunksDirFile = chunksDirFile;
+  public File getChunksDirForRead() throws StorageContainerException {
+    File dir = chunksDirFile;
+    if (dir == null) {
+      dir = ContainerUtils.getChunkDir(this);
+      chunksDirFile = dir;
+    }
+    return dir;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerLayoutVersion.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerLayoutVersion.java
@@ -116,6 +116,18 @@ public enum ContainerLayoutVersion {
     return getChunkFile(chunkDir, blockID, chunkName);
   }
 
+  /**
+   * Read-path variant that resolves the chunk file from the cached chunks
+   * directory ({@link ContainerUtils#getChunkDirForRead}) to avoid a per-read
+   * stat. Write and other paths keep using {@link #getChunkFile} so a missing
+   * directory still surfaces as a storage failure.
+   */
+  public File getChunkFileForRead(ContainerData containerData, BlockID blockID,
+      String chunkName) throws StorageContainerException {
+    File chunkDir = ContainerUtils.getChunkDirForRead(containerData);
+    return getChunkFile(chunkDir, blockID, chunkName);
+  }
+
   @Override
   public String toString() {
     return "ContainerLayout:v" + version;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerLayoutVersion.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerLayoutVersion.java
@@ -116,18 +116,6 @@ public enum ContainerLayoutVersion {
     return getChunkFile(chunkDir, blockID, chunkName);
   }
 
-  /**
-   * Read-path variant that resolves the chunk file from the cached chunks
-   * directory ({@link ContainerUtils#getChunkDirForRead}) to avoid a per-read
-   * stat. Write and other paths keep using {@link #getChunkFile} so a missing
-   * directory still surfaces as a storage failure.
-   */
-  public File getChunkFileForRead(ContainerData containerData, BlockID blockID,
-      String chunkName) throws StorageContainerException {
-    File chunkDir = ContainerUtils.getChunkDirForRead(containerData);
-    return getChunkFile(chunkDir, blockID, chunkName);
-  }
-
   @Override
   public String toString() {
     return "ContainerLayout:v" + version;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -237,7 +237,9 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     HddsVolume volume = containerData.getVolume();
 
-    final File chunkFile = getChunkFileForRead(container, blockID);
+    // Reads use the cached chunks directory to skip the per-read stat; writes
+    // keep validating via getChunkFile so a missing directory is still detected.
+    final File chunkFile = FILE_PER_BLOCK.getChunkFile(containerData.getChunksDirForRead(), blockID, null);
 
     final long len = info.getLen();
     long offset = info.getOffset();
@@ -339,10 +341,6 @@ public class FilePerBlockStrategy implements ChunkManager {
 
   private static File getChunkFile(Container container, BlockID blockID) throws StorageContainerException {
     return FILE_PER_BLOCK.getChunkFile(container.getContainerData(), blockID, null);
-  }
-
-  private static File getChunkFileForRead(Container container, BlockID blockID) throws StorageContainerException {
-    return FILE_PER_BLOCK.getChunkFileForRead(container.getContainerData(), blockID, null);
   }
 
   private static void checkFullDelete(ChunkInfo info, File chunkFile)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.ozone.common.ChunkBufferToByteString;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
+import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -246,11 +247,16 @@ public class FilePerBlockStrategy implements ChunkManager {
     int bufferCapacity = ChunkManager.getBufferCapacityForChunkRead(info,
         defaultReadBufferCapacity);
 
-    if (readNettyChunkedNioFile && dispatcherContext != null && dispatcherContext.isReleaseSupported()) {
-      return ChunkUtils.readData(chunkFile, bufferCapacity, offset, len, volume, dispatcherContext);
+    try {
+      if (readNettyChunkedNioFile && dispatcherContext != null && dispatcherContext.isReleaseSupported()) {
+        return ChunkUtils.readData(chunkFile, bufferCapacity, offset, len, volume, dispatcherContext);
+      }
+      return ChunkUtils.readData(len, bufferCapacity, chunkFile, offset, volume,
+          readMappedBufferThreshold, readMappedBufferMaxCount > 0, mappedBufferManager);
+    } catch (StorageContainerException ex) {
+      ContainerUtils.getChunkDir(containerData);
+      throw ex;
     }
-    return ChunkUtils.readData(len, bufferCapacity, chunkFile, offset, volume,
-        readMappedBufferThreshold, readMappedBufferMaxCount > 0, mappedBufferManager);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -237,7 +237,7 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     HddsVolume volume = containerData.getVolume();
 
-    final File chunkFile = getChunkFile(container, blockID);
+    final File chunkFile = getChunkFileForRead(container, blockID);
 
     final long len = info.getLen();
     long offset = info.getOffset();
@@ -339,6 +339,10 @@ public class FilePerBlockStrategy implements ChunkManager {
 
   private static File getChunkFile(Container container, BlockID blockID) throws StorageContainerException {
     return FILE_PER_BLOCK.getChunkFile(container.getContainerData(), blockID, null);
+  }
+
+  private static File getChunkFileForRead(Container container, BlockID blockID) throws StorageContainerException {
+    return FILE_PER_BLOCK.getChunkFileForRead(container.getContainerData(), blockID, null);
   }
 
   private static void checkFullDelete(ChunkInfo info, File chunkFile)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -224,8 +224,10 @@ public class FilePerChunkStrategy implements ChunkManager {
     HddsVolume volume = containerData.getVolume();
 
     // In version1, we verify checksum if it is available and return data
-    // of the chunk file.
-    File finalChunkFile = getChunkFileForRead(kvContainer, blockID, info);
+    // of the chunk file. Reads use the cached chunks directory to skip the
+    // per-read stat; writes keep validating so a missing directory is detected.
+    File finalChunkFile = FILE_PER_CHUNK.getChunkFile(
+        containerData.getChunksDirForRead(), blockID, info.getChunkName());
 
     List<File> possibleFiles = new ArrayList<>();
     possibleFiles.add(finalChunkFile);
@@ -353,11 +355,6 @@ public class FilePerChunkStrategy implements ChunkManager {
   private static File getChunkFile(KeyValueContainer container, BlockID blockID,
       ChunkInfo info) throws StorageContainerException {
     return FILE_PER_CHUNK.getChunkFile(container.getContainerData(), blockID, info.getChunkName());
-  }
-
-  private static File getChunkFileForRead(KeyValueContainer container, BlockID blockID,
-      ChunkInfo info) throws StorageContainerException {
-    return FILE_PER_CHUNK.getChunkFileForRead(container.getContainerData(), blockID, info.getChunkName());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -225,7 +225,7 @@ public class FilePerChunkStrategy implements ChunkManager {
 
     // In version1, we verify checksum if it is available and return data
     // of the chunk file.
-    File finalChunkFile = getChunkFile(kvContainer, blockID, info);
+    File finalChunkFile = getChunkFileForRead(kvContainer, blockID, info);
 
     List<File> possibleFiles = new ArrayList<>();
     possibleFiles.add(finalChunkFile);
@@ -353,6 +353,11 @@ public class FilePerChunkStrategy implements ChunkManager {
   private static File getChunkFile(KeyValueContainer container, BlockID blockID,
       ChunkInfo info) throws StorageContainerException {
     return FILE_PER_CHUNK.getChunkFile(container.getContainerData(), blockID, info.getChunkName());
+  }
+
+  private static File getChunkFileForRead(KeyValueContainer container, BlockID blockID,
+      ChunkInfo info) throws StorageContainerException {
+    return FILE_PER_CHUNK.getChunkFileForRead(container.getContainerData(), blockID, info.getChunkName());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.ChunkBufferToByteString;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
+import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -287,6 +288,7 @@ public class FilePerChunkStrategy implements ChunkManager {
         }
       }
     }
+    ContainerUtils.getChunkDir(containerData);
     throw new StorageContainerException(
         "Chunk file can't be found " + possibleFiles.toString(),
         UNABLE_TO_FIND_CHUNK);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
@@ -26,6 +26,7 @@ import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuil
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getDummyCommandRequestProto;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -55,8 +56,10 @@ import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
+import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeInfoMetrics;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.ratis.thirdparty.com.google.protobuf.TextFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,6 +77,45 @@ public class TestContainerUtils {
   void setup(@TempDir File dir) {
     conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, dir.toString());
+  }
+
+  @Test
+  void getChunkDirCachesResolvedDirectory(@TempDir File dir) throws Exception {
+    File chunks = new File(dir, "chunks");
+    assertTrue(chunks.mkdirs());
+
+    KeyValueContainerData data = new KeyValueContainerData(1L,
+        ContainerLayoutVersion.FILE_PER_BLOCK, 1024L * 1024 * 1024,
+        UUID.randomUUID().toString(), UUID.randomUUID().toString());
+    data.setChunksPath(chunks.getAbsolutePath());
+
+    // Resolved and validated once, then cached: same instance on every call.
+    File first = ContainerUtils.getChunkDir(data);
+    assertSame(first, ContainerUtils.getChunkDir(data));
+
+    // Cache survives the directory disappearing; a mid-life disappearance is
+    // caught later by open(), not by getChunkDir.
+    assertTrue(chunks.delete());
+    assertSame(first, ContainerUtils.getChunkDir(data));
+
+    // Changing the path invalidates the cache and re-resolves.
+    File other = new File(dir, "chunks2");
+    assertTrue(other.mkdirs());
+    data.setChunksPath(other.getAbsolutePath());
+    assertEquals(other.getAbsolutePath(),
+        ContainerUtils.getChunkDir(data).getAbsolutePath());
+  }
+
+  @Test
+  void getChunkDirThrowsWhenChunksDirMissing(@TempDir File dir) {
+    KeyValueContainerData data = new KeyValueContainerData(1L,
+        ContainerLayoutVersion.FILE_PER_BLOCK, 1024L * 1024 * 1024,
+        UUID.randomUUID().toString(), UUID.randomUUID().toString());
+    data.setChunksPath(new File(dir, "missing").getAbsolutePath());
+
+    StorageContainerException e = assertThrows(StorageContainerException.class,
+        () -> ContainerUtils.getChunkDir(data));
+    assertEquals(Result.UNABLE_TO_FIND_DATA_DIR, e.getResult());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
@@ -80,7 +80,7 @@ public class TestContainerUtils {
   }
 
   @Test
-  void getChunkDirCachesResolvedDirectory(@TempDir File dir) throws Exception {
+  void getChunkDirReDetectsMissingDirectory(@TempDir File dir) throws Exception {
     File chunks = new File(dir, "chunks");
     assertTrue(chunks.mkdirs());
 
@@ -89,21 +89,41 @@ public class TestContainerUtils {
         UUID.randomUUID().toString(), UUID.randomUUID().toString());
     data.setChunksPath(chunks.getAbsolutePath());
 
-    // Resolved and validated once, then cached: same instance on every call.
-    File first = ContainerUtils.getChunkDir(data);
-    assertSame(first, ContainerUtils.getChunkDir(data));
-
-    // Cache survives the directory disappearing; a mid-life disappearance is
-    // caught later by open(), not by getChunkDir.
+    // getChunkDir validates on every call, so a write against a failed volume
+    // is detected even after the directory was resolved once.
+    assertEquals(chunks.getAbsolutePath(),
+        ContainerUtils.getChunkDir(data).getAbsolutePath());
     assertTrue(chunks.delete());
-    assertSame(first, ContainerUtils.getChunkDir(data));
+    StorageContainerException e = assertThrows(StorageContainerException.class,
+        () -> ContainerUtils.getChunkDir(data));
+    assertEquals(Result.UNABLE_TO_FIND_DATA_DIR, e.getResult());
+  }
+
+  @Test
+  void getChunkDirForReadCachesResolvedDirectory(@TempDir File dir) throws Exception {
+    File chunks = new File(dir, "chunks");
+    assertTrue(chunks.mkdirs());
+
+    KeyValueContainerData data = new KeyValueContainerData(1L,
+        ContainerLayoutVersion.FILE_PER_BLOCK, 1024L * 1024 * 1024,
+        UUID.randomUUID().toString(), UUID.randomUUID().toString());
+    data.setChunksPath(chunks.getAbsolutePath());
+
+    // Resolved and validated once, then cached: same instance on every read.
+    File first = ContainerUtils.getChunkDirForRead(data);
+    assertSame(first, ContainerUtils.getChunkDirForRead(data));
+
+    // The read cache survives the directory disappearing; a mid-life
+    // disappearance is caught by the read's own open(), not by this method.
+    assertTrue(chunks.delete());
+    assertSame(first, ContainerUtils.getChunkDirForRead(data));
 
     // Changing the path invalidates the cache and re-resolves.
     File other = new File(dir, "chunks2");
     assertTrue(other.mkdirs());
     data.setChunksPath(other.getAbsolutePath());
     assertEquals(other.getAbsolutePath(),
-        ContainerUtils.getChunkDir(data).getAbsolutePath());
+        ContainerUtils.getChunkDirForRead(data).getAbsolutePath());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
@@ -100,7 +100,7 @@ public class TestContainerUtils {
   }
 
   @Test
-  void getChunkDirForReadCachesResolvedDirectory(@TempDir File dir) throws Exception {
+  void getChunksDirForReadCachesResolvedDirectory(@TempDir File dir) throws Exception {
     File chunks = new File(dir, "chunks");
     assertTrue(chunks.mkdirs());
 
@@ -110,20 +110,20 @@ public class TestContainerUtils {
     data.setChunksPath(chunks.getAbsolutePath());
 
     // Resolved and validated once, then cached: same instance on every read.
-    File first = ContainerUtils.getChunkDirForRead(data);
-    assertSame(first, ContainerUtils.getChunkDirForRead(data));
+    File first = data.getChunksDirForRead();
+    assertSame(first, data.getChunksDirForRead());
 
     // The read cache survives the directory disappearing; a mid-life
     // disappearance is caught by the read's own open(), not by this method.
     assertTrue(chunks.delete());
-    assertSame(first, ContainerUtils.getChunkDirForRead(data));
+    assertSame(first, data.getChunksDirForRead());
 
     // Changing the path invalidates the cache and re-resolves.
     File other = new File(dir, "chunks2");
     assertTrue(other.mkdirs());
     data.setChunksPath(other.getAbsolutePath());
     assertEquals(other.getAbsolutePath(),
-        ContainerUtils.getChunkDirForRead(data).getAbsolutePath());
+        data.getChunksDirForRead().getAbsolutePath());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.COMBINED_STAGE;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.WRITE_STAGE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -186,6 +187,23 @@ public abstract class CommonChunkManagerTestCases extends AbstractTestChunkManag
     } catch (StorageContainerException ex) {
       assertEquals(ContainerProtos.Result.UNABLE_TO_FIND_CHUNK, ex.getResult());
     }
+  }
+
+  @Test
+  public void testReadChunkWithMissingChunksDirectory() throws Exception {
+    ChunkManager chunkManager = createTestSubject();
+    KeyValueContainer container = getKeyValueContainer();
+    BlockID blockID = getBlockID();
+    ChunkInfo chunkInfo = getChunkInfo();
+
+    chunkManager.writeChunk(container, blockID, chunkInfo, getData(), COMBINED_STAGE);
+    chunkManager.finishWriteChunks(container, new BlockData(blockID));
+    chunkManager.readChunk(container, blockID, chunkInfo, null);
+    FileUtils.deleteDirectory(new File(getKeyValueContainerData().getChunksPath()));
+
+    assertThatThrownBy(() -> chunkManager.readChunk(container, blockID, chunkInfo, null))
+        .isInstanceOfSatisfying(StorageContainerException.class,
+            ex -> assertThat(ex.getResult()).isEqualTo(ContainerProtos.Result.UNABLE_TO_FIND_DATA_DIR));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ContainerUtils.getChunkDir` built a `new File(chunksPath)` and called `exists()` on the container's chunks directory on every WriteChunk and ReadChunk (reached via `ContainerLayoutVersion.getChunkFile`). The chunks directory is fixed for the container's lifetime, so on the read path this stat is pure added work.

The read path now resolves the directory once and caches it: `ContainerData.getChunksDirForRead()` validates via `getChunkDir` on first use, stores the result in a `transient volatile File` field, and reuses it for the container's lifetime. `ReadChunk` in both layout strategies uses it.

Writes and every other caller keep going through `getChunkDir`, which still stats on every call. That per-op check is load-bearing: it is how a WriteChunk against a failed volume surfaces as `UNABLE_TO_FIND_DATA_DIR` so the container is marked UNHEALTHY (covered by `TestContainerStateMachineFailures#testUnhealthyContainer`). An earlier revision cached it away for writes too and broke that detection; keeping the stat on writes preserves it.

On the read path the eager probe is not needed: a directory that disappears after it was cached is caught by the read's own `open()`, and a failed read does not mark the container UNHEALTHY (read-side volume failures are handled out of band by the volume checker). `setChunksPath` invalidates the cache so create / import / move re-resolve, and the field is `transient`, so it is never serialized to the container YAML. The container scanner (`KeyValueContainerCheck`) stats the path independently and is unaffected.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16326

## How was this patch tested?

`TestContainerUtils` (read cache + write re-validation) and `TestContainerStateMachineFailures#testUnhealthyContainer` (storage-failure detection on write), plus a green fork CI run: https://github.com/rich7420/ozone/actions/runs/33411361078
