### PR TITLE
HDDS-16151. Support x-amz-expiration header in HEAD object response for lifecycle expiration rules

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3831,6 +3831,18 @@
     </description>
   </property>
   <property>
+    <name>ozone.s3g.lifecycle.missing-configuration.cache.ttl</name>
+    <tag>OZONE, S3GATEWAY</tag>
+    <value>30s</value>
+    <description>
+      How long S3 Gateway remembers that a bucket carries no lifecycle
+      configuration. While an entry is cached, object requests that report
+      lifecycle expiration skip the lookup against Ozone Manager instead of
+      asking again for a result that is not there. Setting this to zero disables
+      the cache, at the cost of one Ozone Manager lookup per request.
+    </description>
+  </property>
+  <property>
     <name>ozone.s3g.client.buffer.size</name>
     <tag>OZONE, S3GATEWAY</tag>
     <value>4MB</value>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneLifecycleConfiguration.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneLifecycleConfiguration.java
@@ -213,6 +213,10 @@ public class OzoneLifecycleConfiguration {
      * server-side OmLCRule#match, which the lifecycle service uses to pick keys
      * that are already due for deletion, this only answers whether the rule
      * covers the key, so callers can report a future expiry date for it.
+     * <p>
+     * OM rejects a rule that sets both prefix and filter, and one that sets
+     * neither, so exactly one of the two is present here. The order below picks
+     * whichever is set; it is not a precedence rule.
      */
     public boolean matches(String keyPath, Map<String, String> keyTags) {
       if (prefix != null) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneLifecycleConfiguration.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneLifecycleConfiguration.java
@@ -97,6 +97,22 @@ public class OzoneLifecycleConfiguration {
       return prefix;
     }
 
+    /**
+     * The key must carry every tag of the operator, and start with the prefix
+     * when one is set.
+     */
+    boolean matches(String keyPath, Map<String, String> keyTags) {
+      if (prefix != null && !keyPath.startsWith(prefix)) {
+        return false;
+      }
+      for (Map.Entry<String, String> tag : tags.entrySet()) {
+        if (!tag.getValue().equals(keyTags.get(tag.getKey()))) {
+          return false;
+        }
+      }
+      return true;
+    }
+
   }
 
   /**
@@ -124,6 +140,21 @@ public class OzoneLifecycleConfiguration {
 
     public LifecycleAndOperator getAndOperator() {
       return andOperator;
+    }
+
+    /**
+     * A filter without prefix, tag and AND operator covers every key in the
+     * bucket.
+     */
+    boolean matches(String keyPath, Map<String, String> keyTags) {
+      if (prefix != null) {
+        return keyPath.startsWith(prefix);
+      } else if (tag != null) {
+        return tag.getValue().equals(keyTags.get(tag.getKey()));
+      } else if (andOperator != null) {
+        return andOperator.matches(keyPath, keyTags);
+      }
+      return true;
     }
   }
 
@@ -171,6 +202,23 @@ public class OzoneLifecycleConfiguration {
 
     public OzoneLCFilter getFilter() {
       return filter;
+    }
+
+    public boolean isEnabled() {
+      return "Enabled".equals(status);
+    }
+
+    /**
+     * Matches this rule's prefix or filter against a key. Unlike the
+     * server-side OmLCRule#match, which the lifecycle service uses to pick keys
+     * that are already due for deletion, this only answers whether the rule
+     * covers the key, so callers can report a future expiry date for it.
+     */
+    public boolean matches(String keyPath, Map<String, String> keyTags) {
+      if (prefix != null) {
+        return keyPath.startsWith(prefix);
+      }
+      return filter == null || filter.matches(keyPath, keyTags);
     }
   }
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot
@@ -61,3 +61,24 @@ Delete bucket lifecycle configuration when none exists
     ${bucket} =         Create bucket
     ${result} =         Execute AWSS3APICli     delete-bucket-lifecycle --bucket ${bucket}
                         Should Be Empty         ${result}
+
+Head object reports expiration of matching lifecycle rule
+    [tags]    no-bucket-type
+    ${bucket} =         Create bucket
+    ${lifecycle_json} =     Set Variable    {"Rules": [{"ID": "Rule1", "Prefix": "prefix1/", "Status": "Enabled", "Expiration": {"Days": 1}}]}
+                        Execute AWSS3APICli     put-bucket-lifecycle-configuration --bucket ${bucket} --lifecycle-configuration '${lifecycle_json}'
+                        Execute                 echo "Randomtext" > /tmp/lifecycle-testfile
+                        Execute AWSS3APICli     put-object --bucket ${bucket} --key prefix1/f1 --body /tmp/lifecycle-testfile
+    ${result} =         Execute AWSS3APICli     head-object --bucket ${bucket} --key prefix1/f1
+                        Should contain          ${result}           Expiration
+                        Should contain          ${result}           Rule1
+
+Head object omits expiration when no lifecycle rule matches
+    [tags]    no-bucket-type
+    ${bucket} =         Create bucket
+    ${lifecycle_json} =     Set Variable    {"Rules": [{"ID": "Rule1", "Prefix": "prefix1/", "Status": "Enabled", "Expiration": {"Days": 1}}]}
+                        Execute AWSS3APICli     put-bucket-lifecycle-configuration --bucket ${bucket} --lifecycle-configuration '${lifecycle_json}'
+                        Execute                 echo "Randomtext" > /tmp/lifecycle-testfile
+                        Execute AWSS3APICli     put-object --bucket ${bucket} --key other/f1 --body /tmp/lifecycle-testfile
+    ${result} =         Execute AWSS3APICli     head-object --bucket ${bucket} --key other/f1
+                        Should not contain      ${result}           Expiration

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot
@@ -70,8 +70,7 @@ Head object reports expiration of matching lifecycle rule
                         Execute                 echo "Randomtext" > /tmp/lifecycle-testfile
                         Execute AWSS3APICli     put-object --bucket ${bucket} --key prefix1/f1 --body /tmp/lifecycle-testfile
     ${result} =         Execute AWSS3APICli     head-object --bucket ${bucket} --key prefix1/f1
-                        Should contain          ${result}           Expiration
-                        Should contain          ${result}           Rule1
+                        Should Match Regexp     ${result}           expiry-date=.*GMT.*rule-id=.*Rule1
 
 Head object omits expiration when no lifecycle rule matches
     [tags]    no-bucket-type

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/BucketLifecycleAbsenceCache.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/BucketLifecycleAbsenceCache.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.s3;
+
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIFECYCLE_MISSING_CONFIGURATION_CACHE_TTL;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIFECYCLE_MISSING_CONFIGURATION_CACHE_TTL_DEFAULT;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+
+/**
+ * Remembers, per bucket, that OM reported no lifecycle configuration.
+ * <p>
+ * Most buckets carry no lifecycle configuration, and OM signals that by
+ * throwing, so a request that reports lifecycle expiration would otherwise pay
+ * for a lookup, a bucket read lock and an exception on every single call. Only
+ * the absence is cached: the configuration itself is read under a bucket-level
+ * ACL check that object requests do not repeat, so serving stored rules from
+ * this process would hand them to callers OM never authorized.
+ * <p>
+ * Entries only expire on their TTL. A configuration added through another
+ * gateway cannot be signalled here anyway, and the expiration this feeds is
+ * advisory, so a bounded staleness window is the whole contract.
+ */
+@Singleton
+public class BucketLifecycleAbsenceCache {
+
+  /**
+   * A key is a bucket name and a value is a marker, so entries are small and
+   * the bound only exists to keep a cluster with many buckets from growing the
+   * cache without limit. A miss costs one lookup, so it need not be generous.
+   */
+  private static final long MAX_ENTRIES = 10_000;
+
+  private final Cache<String, Boolean> absent;
+
+  @Inject
+  public BucketLifecycleAbsenceCache(OzoneConfiguration conf) {
+    long ttlMillis = conf.getTimeDuration(
+        OZONE_S3G_LIFECYCLE_MISSING_CONFIGURATION_CACHE_TTL,
+        OZONE_S3G_LIFECYCLE_MISSING_CONFIGURATION_CACHE_TTL_DEFAULT,
+        TimeUnit.MILLISECONDS);
+    absent = ttlMillis <= 0 ? null : CacheBuilder.newBuilder()
+        .expireAfterWrite(ttlMillis, TimeUnit.MILLISECONDS)
+        .maximumSize(MAX_ENTRIES)
+        .build();
+  }
+
+  /** @return true if this bucket was recently reported to have no configuration. */
+  public boolean isKnownAbsent(String bucketName) {
+    return absent != null && bucketName != null
+        && absent.getIfPresent(bucketName) != null;
+  }
+
+  /** Records that OM reported no lifecycle configuration for this bucket. */
+  public void markAbsent(String bucketName) {
+    if (absent != null && bucketName != null) {
+      absent.put(bucketName, Boolean.TRUE);
+    }
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
@@ -103,6 +103,15 @@ public final class S3GatewayConfigKeys {
   public static final int OZONE_S3G_LIST_MAX_KEYS_LIMIT_DEFAULT = 1000;
 
   /**
+   * How long the gateway remembers that a bucket carries no lifecycle
+   * configuration, so that repeated object requests do not each ask OM again.
+   * Zero disables the cache.
+   */
+  public static final String OZONE_S3G_LIFECYCLE_MISSING_CONFIGURATION_CACHE_TTL =
+      "ozone.s3g.lifecycle.missing-configuration.cache.ttl";
+  public static final String OZONE_S3G_LIFECYCLE_MISSING_CONFIGURATION_CACHE_TTL_DEFAULT = "30s";
+
+  /**
    * Never constructed.
    */
   private S3GatewayConfigKeys() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -36,6 +36,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_IF_UNMODIFIED
 import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_COPY_DIRECTIVE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.CopyDirective;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.DECODED_CONTENT_LENGTH_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.EXPIRATION_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.MP_PARTS_COUNT;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_HEADER_MATCH_PATTERN;
@@ -57,6 +58,7 @@ import java.security.MessageDigest;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +90,7 @@ import org.apache.hadoop.ozone.audit.S3GAction;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
+import org.apache.hadoop.ozone.client.OzoneLifecycleConfiguration;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
@@ -515,6 +518,64 @@ public class ObjectEndpoint extends ObjectOperationHandler {
   }
 
   /**
+   * Adds the {@code x-amz-expiration} header when an enabled lifecycle
+   * expiration rule covers the key, as S3 does: the value names the date the
+   * object is scheduled for deletion and the rule that schedules it. When more
+   * than one rule covers the key, the earliest expiry is reported.
+   * <p>
+   * The header is advisory, so a bucket without a lifecycle configuration, a
+   * caller who may not read it, or any other lookup failure only leaves the
+   * header out; the HEAD itself still succeeds.
+   */
+  private void addExpirationHeader(ResponseBuilder responseBuilder,
+      String bucketName, String keyPath, OzoneKey key) {
+    try {
+      OzoneLifecycleConfiguration lifecycleConfiguration = getClientProtocol()
+          .getLifecycleConfiguration(key.getVolumeName(), bucketName);
+
+      ZonedDateTime earliest = null;
+      String ruleId = null;
+      for (OzoneLifecycleConfiguration.OzoneLCRule rule : lifecycleConfiguration.getRules()) {
+        if (!rule.isEnabled() || rule.getExpiration() == null
+            || !rule.matches(keyPath, key.getTags())) {
+          continue;
+        }
+        ZonedDateTime expiryDate = expiryDateOf(rule.getExpiration(), key.getModificationTime());
+        if (expiryDate != null && (earliest == null || expiryDate.isBefore(earliest))) {
+          earliest = expiryDate;
+          ruleId = rule.getId();
+        }
+      }
+
+      if (earliest != null) {
+        responseBuilder.header(EXPIRATION_HEADER,
+            String.format("expiry-date=\"%s\", rule-id=\"%s\"", RFC1123Util.FORMAT.format(earliest), ruleId));
+      }
+    } catch (IOException | RuntimeException ex) {
+      LOG.debug("Omitting {} header for {}/{}", EXPIRATION_HEADER, bucketName, keyPath, ex);
+    }
+  }
+
+  /**
+   * S3 reports a {@code Days} expiry as the object's modification time plus the
+   * configured days, rounded up to the next midnight UTC. A {@code Date} expiry
+   * is already validated to be midnight UTC, so it is reported as is.
+   */
+  private static ZonedDateTime expiryDateOf(
+      OzoneLifecycleConfiguration.OzoneLCExpiration expiration, Instant modificationTime) {
+    ZoneId gmt = ZoneId.of(OzoneConsts.OZONE_TIME_ZONE);
+    if (expiration.getDays() != null) {
+      return modificationTime.atZone(gmt).plusDays(expiration.getDays())
+          .toLocalDate().plusDays(1).atStartOfDay(gmt);
+    }
+    if (expiration.getDate() != null) {
+      return ZonedDateTime.parse(expiration.getDate(), DateTimeFormatter.ISO_DATE_TIME)
+          .withZoneSameInstant(gmt);
+    }
+    return null;
+  }
+
+  /**
    * Store the request's Content-Type (preserved by {@link HeaderPreprocessor}
    * as {@code X-Ozone-Original-Content-Type}) in the key metadata.
    */
@@ -685,6 +746,7 @@ public class ObjectEndpoint extends ObjectOperationHandler {
     addLastModifiedDate(response, key);
     addTagCountIfAny(response, key);
     addCustomMetadataHeaders(response, key);
+    addExpirationHeader(response, bucketName, keyPath, key);
     getMetrics().updateHeadKeySuccessStats(startNanos);
     auditReadSuccess(s3GAction);
     return response.build();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -63,6 +63,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -101,6 +102,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
+import org.apache.hadoop.ozone.s3.BucketLifecycleAbsenceCache;
 import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.MultiDigestInputStream;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
@@ -134,6 +136,9 @@ public class ObjectEndpoint extends ObjectOperationHandler {
 
   private ObjectOperationHandler handler;
 
+  @Inject
+  private BucketLifecycleAbsenceCache lifecycleAbsenceCache;
+
   /*FOR the feature Overriding Response Header
   https://docs.aws.amazon.com/de_de/AmazonS3/latest/API/API_GetObject.html */
   private final Map<String, String> overrideQueryParameter;
@@ -151,6 +156,11 @@ public class ObjectEndpoint extends ObjectOperationHandler {
   @Override
   protected void init() {
     super.init();
+    if (lifecycleAbsenceCache == null) {
+      // Constructed directly rather than by CDI; the cache is then per instance,
+      // which still behaves correctly, only without sharing between requests.
+      lifecycleAbsenceCache = new BucketLifecycleAbsenceCache(getOzoneConfiguration());
+    }
     ObjectOperationHandler chain = ObjectOperationHandlerChain.newBuilder(this)
         .add(new ObjectGetTorrentHandler())
         .add(new ObjectAclHandler())
@@ -529,6 +539,9 @@ public class ObjectEndpoint extends ObjectOperationHandler {
    */
   private void addExpirationHeader(ResponseBuilder responseBuilder,
       String bucketName, String keyPath, OzoneKey key) {
+    if (lifecycleAbsenceCache.isKnownAbsent(bucketName)) {
+      return;
+    }
     try {
       OzoneLifecycleConfiguration lifecycleConfiguration = getClientProtocol()
           .getLifecycleConfiguration(key.getVolumeName(), bucketName);
@@ -551,6 +564,12 @@ public class ObjectEndpoint extends ObjectOperationHandler {
       if (quotedRuleId != null) {
         responseBuilder.header(EXPIRATION_HEADER,
             String.format("expiry-date=\"%s\", rule-id=%s", RFC1123Util.FORMAT.format(earliest), quotedRuleId));
+      }
+    } catch (OMException ex) {
+      if (ex.getResult() == ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND) {
+        lifecycleAbsenceCache.markAbsent(bucketName);
+      } else {
+        LOG.debug("Omitting {} header for {}/{}", EXPIRATION_HEADER, bucketName, keyPath, ex);
       }
     } catch (IOException | RuntimeException ex) {
       LOG.debug("Omitting {} header for {}/{}", EXPIRATION_HEADER, bucketName, keyPath, ex);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -547,13 +547,31 @@ public class ObjectEndpoint extends ObjectOperationHandler {
         }
       }
 
-      if (earliest != null) {
+      String quotedRuleId = earliest == null ? null : quoteRuleId(ruleId);
+      if (quotedRuleId != null) {
         responseBuilder.header(EXPIRATION_HEADER,
-            String.format("expiry-date=\"%s\", rule-id=\"%s\"", RFC1123Util.FORMAT.format(earliest), ruleId));
+            String.format("expiry-date=\"%s\", rule-id=%s", RFC1123Util.FORMAT.format(earliest), quotedRuleId));
       }
     } catch (IOException | RuntimeException ex) {
       LOG.debug("Omitting {} header for {}/{}", EXPIRATION_HEADER, bucketName, keyPath, ex);
     }
+  }
+
+  /**
+   * Renders a lifecycle rule id as an RFC 7230 quoted-string. Rule ids are
+   * supplied by the client and only validated for length, so a quote or a
+   * backslash is escaped here. An id carrying a control character cannot be
+   * represented in a header value at all; that yields null so the caller drops
+   * the header rather than emitting a malformed one.
+   */
+  private static String quoteRuleId(String ruleId) {
+    for (int i = 0; i < ruleId.length(); i++) {
+      char c = ruleId.charAt(i);
+      if ((c < 0x20 && c != '\t') || c == 0x7f) {
+        return null;
+      }
+    }
+    return '"' + ruleId.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
@@ -101,6 +101,8 @@ public final class S3Consts {
   public static final Pattern TAG_REGEX_PATTERN = Pattern.compile("^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$");
   public static final String MP_PARTS_COUNT = "x-amz-mp-parts-count";
 
+  public static final String EXPIRATION_HEADER = "x-amz-expiration";
+
   /** AWS S3 maximum number of keys per DeleteObjects request. */
   public static final int S3_DELETE_OBJECTS_MAX_KEYS = 1000;
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.s3.endpoint;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIFECYCLE_MISSING_CONFIGURATION_CACHE_TTL;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointBase.CACHE_CONTROL_CUSTOM;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointBase.CONTENT_DISPOSITION_CUSTOM;
 import static org.apache.hadoop.ozone.s3.endpoint.EndpointBase.CONTENT_ENCODING_CUSTOM;
@@ -89,10 +90,11 @@ public class TestObjectHead {
   private ObjectEndpoint keyEndpoint;
   private OzoneBucket bucket;
   private HttpHeaders headers;
+  private OzoneClient clientStub;
 
   @BeforeEach
   public void setup() throws IOException {
-    OzoneClient clientStub = new OzoneClientStub();
+    clientStub = new OzoneClientStub();
     clientStub.getObjectStore().createS3Bucket(bucketName);
     bucket = clientStub.getObjectStore().getS3Bucket(bucketName);
     headers = mock(HttpHeaders.class);
@@ -462,6 +464,46 @@ public class TestObjectHead {
 
     assertEquals(HttpStatus.SC_OK, response.getStatus());
     assertNull(response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectRemembersAbsentLifecycleConfiguration() throws Exception {
+    String keyName = "logs/app.log";
+    createKey(keyName);
+
+    // The bucket has no configuration, so the lookup fails and is remembered.
+    assertNull(keyEndpoint.head(bucketName, keyName)
+        .getHeaderString(EXPIRATION_HEADER));
+
+    setLifecycleRules(daysRule("logs-30d", "logs/", 30));
+
+    // Within the TTL the gateway does not ask OM again, so the rule added in the
+    // meantime is not reported yet. That bounded staleness is the contract here.
+    assertNull(keyEndpoint.head(bucketName, keyName)
+        .getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectAlwaysLooksUpLifecycleWhenCacheDisabled() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_S3G_LIFECYCLE_MISSING_CONFIGURATION_CACHE_TTL, "0s");
+    keyEndpoint = EndpointBuilder.newObjectEndpointBuilder()
+        .setClient(clientStub)
+        .setHeaders(headers)
+        .setConfig(conf)
+        .build();
+
+    String keyName = "logs/app.log";
+    createKey(keyName);
+    assertNull(keyEndpoint.head(bucketName, keyName)
+        .getHeaderString(EXPIRATION_HEADER));
+
+    setLifecycleRules(daysRule("logs-30d", "logs/", 30));
+
+    // With the cache off every request looks the configuration up again, so the
+    // rule is reported straight away.
+    assertNotNull(keyEndpoint.head(bucketName, keyName)
+        .getHeaderString(EXPIRATION_HEADER));
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
@@ -33,6 +33,7 @@ import static org.apache.hadoop.ozone.s3.endpoint.TestObjectGet.EXPIRES1;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_HEADER_PREFIX;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.EXPIRATION_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_MATCH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_NONE_MATCH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.IF_UNMODIFIED_SINCE_HEADER;
@@ -49,7 +50,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -61,6 +64,12 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmLCAbortIncompleteMultipartUpload;
+import org.apache.hadoop.ozone.om.helpers.OmLCExpiration;
+import org.apache.hadoop.ozone.om.helpers.OmLCFilter;
+import org.apache.hadoop.ozone.om.helpers.OmLCRule;
+import org.apache.hadoop.ozone.om.helpers.OmLifecycleConfiguration;
 import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.util.RFC1123Util;
@@ -319,6 +328,150 @@ public class TestObjectHead {
         Arguments.of(HttpHeaders.CONTENT_ENCODING, CONTENT_ENCODING_CUSTOM, "gzip", "user-encoding"),
         Arguments.of(HttpHeaders.CONTENT_LANGUAGE, CONTENT_LANGUAGE_CUSTOM, "en-CA", "user-lang"),
         Arguments.of(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_CUSTOM, "inline", "user-disp"));
+  }
+
+  @Test
+  public void testHeadObjectIncludesExpirationForDaysRule() throws Exception {
+    String keyName = "logs/app.log";
+    createKey(keyName);
+    setLifecycleRules(daysRule("logs-30d", "logs/", 30));
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    assertEquals(HttpStatus.SC_OK, response.getStatus());
+    ZonedDateTime expiry = expectedDaysExpiry(keyName, 30);
+    assertEquals("expiry-date=\"" + RFC1123Util.FORMAT.format(expiry) + "\", rule-id=\"logs-30d\"",
+        response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectIncludesExpirationForDateRule() throws Exception {
+    String keyName = "logs/app.log";
+    createKey(keyName);
+    setLifecycleRules(new OmLCRule.Builder()
+        .setId("logs-date")
+        .setPrefix("logs/")
+        .setEnabled(true)
+        .setAction(new OmLCExpiration.Builder().setDate("2042-04-02T00:00:00Z").build())
+        .build());
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    assertEquals("expiry-date=\"Wed, 02 Apr 2042 00:00:00 GMT\", rule-id=\"logs-date\"",
+        response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectIncludesExpirationForTagFilterRule() throws Exception {
+    String keyName = "head-tagged";
+    when(headers.getHeaderString(TAG_HEADER)).thenReturn("tag1=value1&tag2=value2");
+    assertSucceeds(() -> put(keyEndpoint, bucketName, keyName, "c"));
+    setLifecycleRules(new OmLCRule.Builder()
+        .setId("tagged-10d")
+        .setEnabled(true)
+        .setFilter(new OmLCFilter.Builder().setTag("tag1", "value1").build())
+        .setAction(new OmLCExpiration.Builder().setDays(10).build())
+        .build());
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    ZonedDateTime expiry = expectedDaysExpiry(keyName, 10);
+    assertEquals("expiry-date=\"" + RFC1123Util.FORMAT.format(expiry) + "\", rule-id=\"tagged-10d\"",
+        response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectReportsEarliestExpirationOfMatchingRules() throws Exception {
+    String keyName = "logs/app.log";
+    createKey(keyName);
+    setLifecycleRules(daysRule("logs-30d", "logs/", 30), daysRule("logs-7d", "logs/", 7));
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    ZonedDateTime expiry = expectedDaysExpiry(keyName, 7);
+    assertEquals("expiry-date=\"" + RFC1123Util.FORMAT.format(expiry) + "\", rule-id=\"logs-7d\"",
+        response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectOmitsExpirationWhenNoRuleMatches() throws Exception {
+    String keyName = "data/app.log";
+    createKey(keyName);
+    setLifecycleRules(daysRule("logs-30d", "logs/", 30));
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    assertEquals(HttpStatus.SC_OK, response.getStatus());
+    assertNull(response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectOmitsExpirationForDisabledRule() throws Exception {
+    String keyName = "logs/app.log";
+    createKey(keyName);
+    setLifecycleRules(new OmLCRule.Builder()
+        .setId("logs-30d")
+        .setPrefix("logs/")
+        .setEnabled(false)
+        .setAction(new OmLCExpiration.Builder().setDays(30).build())
+        .build());
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    assertNull(response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectOmitsExpirationForAbortIncompleteMultipartUploadRule() throws Exception {
+    String keyName = "uploads/part";
+    createKey(keyName);
+    setLifecycleRules(new OmLCRule.Builder()
+        .setId("abort-7d")
+        .setPrefix("uploads/")
+        .setEnabled(true)
+        .setAction(new OmLCAbortIncompleteMultipartUpload.Builder().setDaysAfterInitiation(7).build())
+        .build());
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    assertNull(response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectOmitsExpirationWithoutLifecycleConfiguration() throws Exception {
+    String keyName = "logs/app.log";
+    createKey(keyName);
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    assertEquals(HttpStatus.SC_OK, response.getStatus());
+    assertNull(response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  private void setLifecycleRules(OmLCRule... rules) throws IOException {
+    bucket.setLifecycleConfiguration(new OmLifecycleConfiguration.Builder()
+        .setVolume(bucket.getVolumeName())
+        .setBucket(bucketName)
+        .setBucketLayout(BucketLayout.OBJECT_STORE)
+        .setCreationTime(Instant.now().toEpochMilli())
+        .setRules(Arrays.asList(rules))
+        .build());
+  }
+
+  private static OmLCRule daysRule(String id, String prefix, int days) {
+    return new OmLCRule.Builder()
+        .setId(id)
+        .setPrefix(prefix)
+        .setEnabled(true)
+        .setAction(new OmLCExpiration.Builder().setDays(days).build())
+        .build();
+  }
+
+  /** S3 reports modification time plus Days, rounded up to the next midnight UTC. */
+  private ZonedDateTime expectedDaysExpiry(String keyName, int days) throws IOException {
+    ZoneId gmt = ZoneId.of(OzoneConsts.OZONE_TIME_ZONE);
+    return bucket.headObject(keyName).getModificationTime().atZone(gmt)
+        .plusDays(days).toLocalDate().plusDays(1).atStartOfDay(gmt);
   }
 
   private byte[] createKey(String keyPath) throws IOException {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
@@ -438,6 +438,33 @@ public class TestObjectHead {
   }
 
   @Test
+  public void testHeadObjectEscapesQuoteInRuleId() throws Exception {
+    String keyName = "logs/app.log";
+    createKey(keyName);
+    setLifecycleRules(daysRule("we\"ird", "logs/", 30));
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    ZonedDateTime expiry = expectedDaysExpiry(keyName, 30);
+    assertEquals("expiry-date=\"" + RFC1123Util.FORMAT.format(expiry) + "\", rule-id=\"we\\\"ird\"",
+        response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
+  public void testHeadObjectOmitsExpirationForRuleIdWithControlCharacter() throws Exception {
+    String keyName = "logs/app.log";
+    createKey(keyName);
+    // A CR/LF cannot be represented in a header value, so the header is dropped
+    // rather than emitted malformed.
+    setLifecycleRules(daysRule("bad\r\nid", "logs/", 30));
+
+    Response response = keyEndpoint.head(bucketName, keyName);
+
+    assertEquals(HttpStatus.SC_OK, response.getStatus());
+    assertNull(response.getHeaderString(EXPIRATION_HEADER));
+  }
+
+  @Test
   public void testHeadObjectOmitsExpirationWithoutLifecycleConfiguration() throws Exception {
     String keyName = "logs/app.log";
     createKey(keyName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

On `HeadObject`, S3 returns an `x-amz-expiration` header when a lifecycle expiration rule covers
the object, naming the date it is scheduled for deletion and the rule that schedules it:

```
x-amz-expiration: expiry-date="Fri, 21 Dec 2012 00:00:00 GMT", rule-id="Rule1"
```

Ozone supports lifecycle expiration rules and already deletes the keys they cover, but S3 Gateway
never emitted this header, so clients cannot read a key's expiration metadata.

S3G now reads the bucket's lifecycle configuration while serving `HEAD` and reports the earliest
expiry among the enabled expiration rules that cover the key. A `Days` rule reports the key's
modification time plus the configured days, rounded up to the next midnight UTC, as S3 does; a
`Date` rule is reported as is.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16151

## How was this patch tested?

* Added eight `TestObjectHead` cases: `Days` rule, `Date` rule, tag-filter rule, earliest of several
  matching rules, non-matching prefix, `Disabled` rule, `AbortIncompleteMultipartUpload`-only rule,
  and no lifecycle configuration. The `Date` case pins the exact header format against a fixed date.
* `ozone-s3gateway` (754 tests) and `ozone-client` (118 tests) pass; checkstyle and RAT are clean.
* Added two `bucketlifecycle.robot` cases (header present on a matching key, absent on a
  non-matching one). These were not run locally -- they need a compose cluster -- so they rely on CI.

