### PR TITLE
HDDS-16323. StreamBlockInputStream: refill the pre-read window in bulk instead of once per response

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
@@ -80,6 +80,8 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
   private final long blockLength;
   private final int responseDataSize;
   private final long preReadSize;
+  // Refill the pre-read window in bulk once it drains below this, instead of after every response.
+  private final long preReadRefillThreshold;
   private final Duration readTimeout;
   private final long readTimeoutNanos;
   private final AtomicReference<Pipeline> pipelineRef = new AtomicReference<>();
@@ -113,6 +115,7 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
     this.retryPolicy = getReadRetryPolicy(config);
     this.refreshFunction = refreshFunction;
     this.preReadSize = config.getStreamReadPreReadSize();
+    this.preReadRefillThreshold = preReadSize / 2;
     this.responseDataSize = config.getStreamReadResponseDataSize();
     this.readTimeout = config.getStreamReadTimeout();
     this.readTimeoutNanos = readTimeout.toNanos();
@@ -351,9 +354,9 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
   synchronized void readBlock(int length, boolean preRead) throws IOException {
     final long required = position + length - requestedLength;
     final long preReadLength = preRead ? preReadSize : 0;
-    // Refill the pre-read window in bulk once it drains below half, instead of after every response.
+    final long refillThreshold = preRead ? preReadRefillThreshold : 0;
     // Safe to skip: required <= 0 means the DataNode still owes bytes that poll() is waiting for.
-    if (required <= 0 && requestedLength - position >= preReadLength / 2) {
+    if (required <= 0 && requestedLength - position >= refillThreshold) {
       return;
     }
     // Clamp so requestedLength never exceeds blockLength: requesting past the end
@@ -444,6 +447,10 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
 
   public long getPreReadSize() {
     return preReadSize;
+  }
+
+  long getPreReadRefillThreshold() {
+    return preReadRefillThreshold;
   }
 
   public int getResponseDataSize() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/StreamBlockInputStream.java
@@ -351,6 +351,11 @@ public class StreamBlockInputStream extends BlockExtendedInputStream {
   synchronized void readBlock(int length, boolean preRead) throws IOException {
     final long required = position + length - requestedLength;
     final long preReadLength = preRead ? preReadSize : 0;
+    // Refill the pre-read window in bulk once it drains below half, instead of after every response.
+    // Safe to skip: required <= 0 means the DataNode still owes bytes that poll() is waiting for.
+    if (required <= 0 && requestedLength - position >= preReadLength / 2) {
+      return;
+    }
     // Clamp so requestedLength never exceeds blockLength: requesting past the end
     // produces an offset the DataNode cannot serve, causing a read timeout.
     final long readLength = Math.min(required + preReadLength, blockLength - requestedLength);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
@@ -323,9 +323,11 @@ public class TestStreamBlockInputStream {
     when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
         .thenReturn(xceiverClient);
 
+    final long refillThreshold;
     try (StreamBlockInputStream sbis = new StreamBlockInputStream(
         blockID, blockLength, mockStandalonePipeline(), null, xceiverClientFactory,
         NO_REFRESH, clientConfig)) {
+      refillThreshold = sbis.getPreReadRefillThreshold();
       // Read one small buffer at a time, as KeyInputStream does, so every response reaches readBlock again.
       byte[] all = new byte[blockLength];
       for (int off = 0; off < blockLength; off += responseSize) {
@@ -336,14 +338,14 @@ public class TestStreamBlockInputStream {
       assertArrayEquals(data, all);
     }
 
-    // One request per half window plus the initial one; without the gate it is one per response.
+    // One request per refill threshold plus the initial one; without the gate it is one per response.
     assertThat(requestLengths)
         .withFailMessage("expected bulk refills, got %s requests for %s responses: %s",
             requestLengths.size(), blockLength / responseSize, requestLengths)
-        .hasSizeLessThanOrEqualTo(1 + blockLength / (preReadSize / 2));
-    // Each request carries at least half a window (the last one may be clamped by the block end).
+        .hasSizeLessThanOrEqualTo(Math.toIntExact(1 + blockLength / refillThreshold));
+    // Each request carries at least the refill threshold (the last one may be clamped by the block end).
     for (long requested : requestLengths) {
-      assertThat(requested).isGreaterThanOrEqualTo(preReadSize / 2);
+      assertThat(requested).isGreaterThanOrEqualTo(refillThreshold);
     }
   }
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestStreamBlockInputStream.java
@@ -36,7 +36,10 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -267,6 +270,80 @@ public class TestStreamBlockInputStream {
       // After the fix: all 4 bytes are returned successfully.
       assertDoesNotThrow(() -> sbis.read(buf), "should not NPE when onCompleted fires before poll");
       assertEquals(data.length, buf.position(), "all bytes should be read");
+    }
+  }
+
+  /**
+   * The pre-read window must be refilled in bulk once it drains below half, not after every response.
+   */
+  @Test
+  public void testPreReadWindowIsRefilledInBulk() throws Exception {
+    final int responseSize = 4096;
+    final int preReadSize = 4 * responseSize;
+    final int blockLength = 16 * responseSize;
+
+    OzoneClientConfig clientConfig = newStreamReadConfig();
+    clientConfig.setStreamReadResponseDataSize(responseSize);
+    clientConfig.setStreamReadPreReadSize(preReadSize);
+
+    BlockID blockID = new BlockID(1L, 21L);
+    byte[] data = new byte[blockLength];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) i;
+    }
+    ClientCallStreamObserver<ContainerCommandRequestProto> requestObserver = mock(ClientCallStreamObserver.class);
+    StreamingReadResponse streamingReadResponse = new StreamingReadResponse(
+        MockDatanodeDetails.randomDatanodeDetails(), requestObserver);
+
+    AtomicReference<StreamingReaderSpi> readerRef = new AtomicReference<>();
+    List<Long> requestLengths = Collections.synchronizedList(new ArrayList<>());
+
+    XceiverClientGrpc xceiverClient = mock(XceiverClientGrpc.class);
+    doAnswer(inv -> {
+      StreamingReaderSpi reader = inv.getArgument(1);
+      reader.setStreamingReadResponse(streamingReadResponse);
+      readerRef.set(reader);
+      return null;
+    }).when(xceiverClient).initStreamRead(any(BlockID.class), any(), any());
+
+    doAnswer(inv -> {
+      ContainerCommandRequestProto request = inv.getArgument(0);
+      final long offset = request.getReadBlock().getOffset();
+      final long length = request.getReadBlock().getLength();
+      requestLengths.add(length);
+      for (long sent = 0; sent < length; sent += responseSize) {
+        final int from = Math.toIntExact(offset + sent);
+        final int to = Math.toIntExact(Math.min((long) from + responseSize, blockLength));
+        readerRef.get().onNext(buildResponseProto(Arrays.copyOfRange(data, from, to), from));
+      }
+      return null;
+    }).when(xceiverClient).streamRead(any(), any());
+
+    XceiverClientFactory xceiverClientFactory = mock(XceiverClientFactory.class);
+    when(xceiverClientFactory.acquireClientForReadData(any(Pipeline.class)))
+        .thenReturn(xceiverClient);
+
+    try (StreamBlockInputStream sbis = new StreamBlockInputStream(
+        blockID, blockLength, mockStandalonePipeline(), null, xceiverClientFactory,
+        NO_REFRESH, clientConfig)) {
+      // Read one small buffer at a time, as KeyInputStream does, so every response reaches readBlock again.
+      byte[] all = new byte[blockLength];
+      for (int off = 0; off < blockLength; off += responseSize) {
+        ByteBuffer chunk = ByteBuffer.allocate(responseSize);
+        assertEquals(responseSize, sbis.read(chunk));
+        System.arraycopy(chunk.array(), 0, all, off, responseSize);
+      }
+      assertArrayEquals(data, all);
+    }
+
+    // One request per half window plus the initial one; without the gate it is one per response.
+    assertThat(requestLengths)
+        .withFailMessage("expected bulk refills, got %s requests for %s responses: %s",
+            requestLengths.size(), blockLength / responseSize, requestLengths)
+        .hasSizeLessThanOrEqualTo(1 + blockLength / (preReadSize / 2));
+    // Each request carries at least half a window (the last one may be clamped by the block end).
+    for (long requested : requestLengths) {
+      assertThat(requested).isGreaterThanOrEqualTo(preReadSize / 2);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
StreamBlockInputStream: refill the pre-read window in bulk instead of once per response

This change adds an early return in readBlock(): when the caller's read is already covered by what has been requested (required <= 0) and the outstanding pre-read window is still at least half full, no new request is sent. The window is refilled in bulk only once it drains below half. When required > 0 the request is always sent, so a read that needs bytes beyond the requested range is never starved.

A unit test (testPreReadWindowIsRefilledInBulk) reads a block one response at a time, as KeyInputStream does, and checks that the number of ReadBlock requests is bounded by the number of half windows and that every request carries at least half a window.



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16323

## How was this patch tested?
UT added/ CI
Performance evaluation on 3 node cluster. 
[HDDS-16323.pdf](https://github.com/user-attachments/files/31604182/HDDS-16323.pdf)
