### PR TITLE
HDDS-16336. S3 GET inverted Range with start inside object yields negative Content-Length

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.calculateDigest;
 import static org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils.createFile;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.stripQuotes;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -1627,6 +1628,24 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
       assertThat(malformed.statusCode()).isEqualTo(SC_BAD_REQUEST);
       assertEquals("InvalidArgument", malformed.awsErrorDetails().errorCode());
     }
+  }
+
+  @Test
+  public void testGetObjectInvertedRange() {
+    final String bucketName = getBucketName();
+    final String keyName = getKeyName();
+    final String content = "0123456789";
+    s3Client.createBucket(b -> b.bucket(bucketName));
+    s3Client.putObject(b -> b.bucket(bucketName).key(keyName), RequestBody.fromString(content));
+
+    // An inverted range is ignored and the whole object is returned, matching AWS GetObject.
+    ResponseBytes<GetObjectResponse> response = s3Client.getObjectAsBytes(
+        b -> b.bucket(bucketName).key(keyName).range("bytes=8-3"));
+
+    assertEquals(SC_OK, response.response().sdkHttpResponse().statusCode());
+    assertEquals(content, response.asUtf8String());
+    assertEquals(Long.valueOf(content.length()), response.response().contentLength());
+    assertNull(response.response().contentRange());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/RangeHeaderParserUtil.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/RangeHeaderParserUtil.java
@@ -75,7 +75,11 @@ public final class RangeHeaderParserUtil {
             end = length - 1;
           }
         } else {
-          if (end >= length) {
+          if (start > end) {
+            readFull = true;
+            start = 0;
+            end = length - 1;
+          } else if (end >= length) {
             end = length - 1;
           }
         }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestRangeHeaderParserUtil.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestRangeHeaderParserUtil.java
@@ -61,6 +61,13 @@ public class TestRangeHeaderParserUtil {
     assertTrue(rangeHeader.isReadFull());
     assertFalse(rangeHeader.isInValidRange());
 
+    // inverted range, start is still inside the object
+    rangeHeader = RangeHeaderParserUtil.parseRangeHeader("bytes=8-3", 10);
+    assertEquals(0, rangeHeader.getStartOffset());
+    assertEquals(9, rangeHeader.getEndOffset());
+    assertTrue(rangeHeader.isReadFull());
+    assertFalse(rangeHeader.isInValidRange());
+
     // bytes spec is wrong
     rangeHeader = RangeHeaderParserUtil.parseRangeHeader("mb=11-8", 10);
     assertEquals(0, rangeHeader.getStartOffset());


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3 Gateway GetObject treated an inverted `Range` (`start > end`) with `start` still inside the object as a partial read. For example, a 10-byte object with `Range: bytes=8-3` produced `copyLength = -4`, then `new byte[getIOBufferSize(-4)]` threw `NegativeArraySizeException`.

`RangeHeaderParserUtil` now treats that case as `readFull` (ignore `Range`, HTTP 200), matching observed AWS S3 GetObject. Unsatisfiable ranges (`start >= length`) still return 416. The MPU `x-amz-copy-source-range` path is unchanged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16336

## How was this patch tested?

- Unit tests: `TestRangeHeaderParserUtil` (new `bytes=8-3` case) and existing `TestObjectGet` range cases