### PR TITLE
HDDS-16337. StorageSize.parse uses untrimmed length after trim and fails on whitespace

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/StorageSize.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/StorageSize.java
@@ -86,7 +86,7 @@ public class StorageSize {
         "match. Internal error.");
 
     String valString =
-        sanitizedValue.substring(0, value.length() - suffix.length());
+        sanitizedValue.substring(0, sanitizedValue.length() - suffix.length());
     return new StorageSize(parsedUnit, Double.parseDouble(valString));
 
   }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestStorageSize.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestStorageSize.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.conf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TestStorageSize {
+
+  @Test
+  void parseWithoutWhitespace() {
+    StorageSize s = StorageSize.parse("1000MB");
+    assertEquals(StorageUnit.MB, s.getUnit());
+    assertEquals(1000.0, s.getValue());
+  }
+
+  @Test
+  void parseLeadingWhitespace() {
+    StorageSize s = StorageSize.parse(" 100MB");
+    assertEquals(StorageUnit.MB, s.getUnit());
+    assertEquals(100.0, s.getValue());
+  }
+
+  @Test
+  void parseTrailingWhitespace() {
+    StorageSize s = StorageSize.parse("100m ");
+    assertEquals(StorageUnit.MB, s.getUnit());
+    assertEquals(100.0, s.getValue());
+  }
+
+  @Test
+  void parseWhitespaceLongerThanSuffix() {
+    StorageSize s = StorageSize.parse("  100m");
+    assertEquals(StorageUnit.MB, s.getUnit());
+    assertEquals(100.0, s.getValue());
+  }
+
+  @Test
+  void parseWithDefaultUnitWhenNoSuffix() {
+    StorageSize s = StorageSize.parse("1024", StorageUnit.BYTES);
+    assertEquals(StorageUnit.BYTES, s.getUnit());
+    assertEquals(1024.0, s.getValue());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`StorageSize.parse` trims the input into `sanitizedValue`, then extracts the numeric part with `sanitizedValue.substring(0, value.length() - suffix.length())`. The end index uses the untrimmed length, so values with leading/trailing whitespace fail.

This change uses `sanitizedValue.length()` for the substring.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16337

## How was this patch tested?

CI: https://github.com/shuan1026/ozone/actions/runs/33287169910