### PR TITLE
HDDS-16348. StorageSize.parse fails on values with surrounding whitespace

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/StorageSize.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/StorageSize.java
@@ -86,7 +86,7 @@ public class StorageSize {
         "match. Internal error.");
 
     String valString =
-        sanitizedValue.substring(0, value.length() - suffix.length());
+        sanitizedValue.substring(0, sanitizedValue.length() - suffix.length());
     return new StorageSize(parsedUnit, Double.parseDouble(valString));
 
   }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestStorageSize.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestStorageSize.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.conf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link StorageSize}.
+ */
+class TestStorageSize {
+
+  @Test
+  void parsesValueAndUnit() {
+    StorageSize size = StorageSize.parse("10MB");
+
+    assertEquals(StorageUnit.MB, size.getUnit());
+    assertEquals(10.0, size.getValue());
+  }
+
+  /**
+   * XML config values are commonly indented, so parse() trims its input.
+   * The cases below cover whitespace shorter than, equal to, and longer than
+   * the unit suffix being stripped.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {" 10MB", "10MB ", " 10MB ", "\n    10MB\n  "})
+  void parsesValueWithSurroundingWhitespace(String value) {
+    StorageSize size = StorageSize.parse(value);
+
+    assertEquals(StorageUnit.MB, size.getUnit());
+    assertEquals(10.0, size.getValue());
+  }
+
+  /**
+   * The default-unit overload only falls back on IllegalArgumentException,
+   * so whitespace long enough to push the offset past the end of the value
+   * used to escape it as a StringIndexOutOfBoundsException.
+   */
+  @Test
+  void parsesWhitespaceWithDefaultUnit() {
+    StorageSize size = StorageSize.parse("\n    5GB\n  ", StorageUnit.BYTES);
+
+    assertEquals(StorageUnit.GB, size.getUnit());
+    assertEquals(5.0, size.getValue());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`StorageSize.parse()` trims its input, but then computes the substring end
offset from the *untrimmed* string:

```java
String sanitizedValue = value.trim().toLowerCase(Locale.ENGLISH);
...
sanitizedValue.substring(0, value.length() - suffix.length());
```

The offset is shifted right by however many whitespace characters `trim()`
removed, so any surrounding whitespace breaks parsing:

| Input | Result |
| --- | --- |
| `"10MB"` | 10.0 megabytes |
| `" 10MB"` | `NumberFormatException: For input string: "10m"` |
| `"  128MB  "` | `StringIndexOutOfBoundsException: begin 0, end 7, length 5` |

This is reachable from configuration, since `ConfigurationSource.getStorageSize()`
reads the value with `get()` rather than `getTrimmed()`, and XML values are
commonly indented:

```xml
<property>
  <name>ozone.scm.container.size</name>
  <value>
    5GB
  </value>
</property>
```

The out-of-bounds case is also not caught by the `parse(String, StorageUnit)`
fallback, which only catches `IllegalArgumentException`.

The fix is one line: derive the offset from `sanitizedValue.length()`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16348

## How was this patch tested?

New unit test `TestStorageSize` in `hadoop-hdds/config`, covering whitespace
shorter than, equal to, and longer than the unit suffix being stripped, plus
the `parse(String, StorageUnit)` overload. All three failure modes reproduce
against the unpatched code and pass with the fix.
