### PR TITLE
HDDS-16349. Use HashSet instead of TreeSet for the per-datanode container index

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/DatanodeEntry.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/DatanodeEntry.java
@@ -17,8 +17,8 @@
 
 package org.apache.hadoop.hdds.scm.node.states;
 
+import java.util.HashSet;
 import java.util.Set;
-import java.util.TreeSet;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 
@@ -28,7 +28,7 @@ import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
  */
 public class DatanodeEntry {
   private final DatanodeInfo info;
-  private final Set<ContainerID> containers = new TreeSet<>();
+  private final Set<ContainerID> containers = new HashSet<>();
 
   DatanodeEntry(DatanodeInfo info) {
     this.info = info;
@@ -43,7 +43,7 @@ public class DatanodeEntry {
   }
 
   public Set<ContainerID> copyContainers() {
-    return new TreeSet<>(containers);
+    return new HashSet<>(containers);
   }
 
   public void add(ContainerID containerId) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DatanodeEntry` keeps the set of containers hosted on a datanode. Inside SCM's
`NodeStateMap` there is one such entry per datanode, and every container report
adds/removes/looks up `ContainerID`s in it. The set was a `TreeSet`, so every
insert paid `O(log n)` to keep the containers in sorted order, but nothing reads
that order:

- `DatanodeEntry` only exposes the set through `Set<ContainerID>` (via
  `copyContainers()`), never `NavigableSet`/`SortedSet`, so callers cannot rely
  on ordering.
- The consumers of `NodeManager.getContainers(dn)` iterate for membership,
  counting, or set math; none depends on sorted iteration.
- The set is in-memory only and is not serialized to the wire.

This swaps both the field and the `copyContainers()` copy to `HashSet`, giving
`O(1)` add/remove/contains on the per-datanode container index and dropping the
ordering work that no one uses. The ordered `NavigableSet` in `PipelineStateMap`
is a different set and is untouched.

## What is the link to the Apache Jira

https://issues.apache.org/jira/browse/HDDS-16349

## How was this patch tested?

https://github.com/rich7420/ozone/actions/runs/33312522441