### PR TITLE
HDDS-16351. FeatureProvider.Feature.of throws NoSuchElementException instead of IllegalArgumentException

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/FeatureProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/FeatureProvider.java
@@ -58,14 +58,10 @@ public final class FeatureProvider {
     }
 
     public static Feature of(String featureName) {
-      Feature featureEnum = Arrays.stream(Feature.values())
+      return Arrays.stream(Feature.values())
           .filter(feature -> feature.getFeatureName().equals(featureName))
-          .findFirst().get();
-      if (null == featureEnum) {
-        throw new IllegalArgumentException("Unrecognized value for " +
-            "Features enum: " + featureName);
-      }
-      return featureEnum;
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("Unrecognized value for Features enum: " + featureName));
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/types/TestFeatureProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/types/TestFeatureProvider.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.recon.api.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.hadoop.ozone.recon.api.types.FeatureProvider.Feature;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,12 +29,13 @@ class TestFeatureProvider {
 
   @Test
   void ofReturnsFeatureForKnownName() {
-    assertThat(Feature.of(Feature.HEATMAP.getFeatureName())).isEqualTo(Feature.HEATMAP);
+    assertThat(FeatureProvider.Feature.of(FeatureProvider.Feature.HEATMAP.getFeatureName()))
+        .isEqualTo(FeatureProvider.Feature.HEATMAP);
   }
 
   @Test
   void ofRejectsUnknownName() {
-    assertThatThrownBy(() -> Feature.of("NoSuchFeature"))
+    assertThatThrownBy(() -> FeatureProvider.Feature.of("NoSuchFeature"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("NoSuchFeature");
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/types/TestFeatureProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/types/TestFeatureProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.api.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.hadoop.ozone.recon.api.types.FeatureProvider.Feature;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link FeatureProvider.Feature} name lookup.
+ */
+class TestFeatureProvider {
+
+  @Test
+  void ofReturnsFeatureForKnownName() {
+    assertThat(Feature.of(Feature.HEATMAP.getFeatureName())).isEqualTo(Feature.HEATMAP);
+  }
+
+  @Test
+  void ofRejectsUnknownName() {
+    assertThatThrownBy(() -> Feature.of("NoSuchFeature"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("NoSuchFeature");
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`FeatureProvider.Feature.of(String)` used `Optional.get()` followed by a null check.
`Optional.get()` never returns null, so the check was dead code and an unknown
feature name threw `NoSuchElementException` instead of `IllegalArgumentException`.
Replaced with `orElseThrow`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16351

## How was this patch tested?

New unit test `TestFeatureProvider`.