### PR TITLE
HDDS-16352. OM logs a missing lifecycle configuration as an ERROR with a stack trace

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1816,7 +1816,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     } catch (IOException ex) {
       // An absent configuration is an expected outcome, already logged above at
       // debug level. Only a genuine failure is worth an error and a stack trace.
-      if (!isLifecycleConfigurationNotFound(ex)) {
+      if (!(ex instanceof OMException && ((OMException) ex).getResult() == LIFECYCLE_CONFIGURATION_NOT_FOUND)) {
         LOG.error("Exception while getting lifecycle configuration for " +
             "bucket: /{}/{}, LifecycleConfiguration {}", volumeName, bucketName,
             value != null ? value.getProtobuf() : "", ex);
@@ -1824,15 +1824,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
       throw ex;
     }
-  }
-
-  /**
-   * @return true if the exception reports that the bucket carries no lifecycle
-   *     configuration, rather than a failure to read it.
-   */
-  public static boolean isLifecycleConfigurationNotFound(Exception ex) {
-    return ex instanceof OMException
-        && ((OMException) ex).getResult() == LIFECYCLE_CONFIGURATION_NOT_FOUND;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1814,12 +1814,25 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       value.valid();
       return value;
     } catch (IOException ex) {
-      LOG.error("Exception while getting lifecycle configuration for " +
-          "bucket: /{}/{}, LifecycleConfiguration {}", volumeName, bucketName,
-          value != null ? value.getProtobuf() : "", ex);
+      // An absent configuration is an expected outcome, already logged above at
+      // debug level. Only a genuine failure is worth an error and a stack trace.
+      if (!isLifecycleConfigurationNotFound(ex)) {
+        LOG.error("Exception while getting lifecycle configuration for " +
+            "bucket: /{}/{}, LifecycleConfiguration {}", volumeName, bucketName,
+            value != null ? value.getProtobuf() : "", ex);
+      }
 
       throw ex;
     }
+  }
+
+  /**
+   * @return true if the exception reports that the bucket carries no lifecycle
+   *     configuration, rather than a failure to read it.
+   */
+  public static boolean isLifecycleConfigurationNotFound(Exception ex) {
+    return ex instanceof OMException
+        && ((OMException) ex).getResult() == LIFECYCLE_CONFIGURATION_NOT_FOUND;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3297,9 +3297,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return metadataManager.getLifecycleConfiguration(
           resolvedBucket.realVolume(), resolvedBucket.realBucket());
     } catch (Exception ex) {
-      auditSuccess = false;
-      AUDIT.logReadFailure(buildAuditMessageForFailure(
-          OMAction.GET_LIFECYCLE_CONFIGURATION, auditMap, ex));
+      // A bucket without a lifecycle configuration is an expected outcome, so it
+      // is audited as a completed read rather than a failure.
+      if (!OmMetadataManagerImpl.isLifecycleConfigurationNotFound(ex)) {
+        auditSuccess = false;
+        AUDIT.logReadFailure(buildAuditMessageForFailure(
+            OMAction.GET_LIFECYCLE_CONFIGURATION, auditMap, ex));
+      }
       throw ex;
     } finally {
       if (lockAcquired) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -99,6 +99,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INTE
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_AUTH_METHOD;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_PATH;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_SUPPORTED_OPERATION;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PERMISSION_DENIED;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
@@ -3299,7 +3300,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     } catch (Exception ex) {
       // A bucket without a lifecycle configuration is an expected outcome, so it
       // is audited as a completed read rather than a failure.
-      if (!OmMetadataManagerImpl.isLifecycleConfigurationNotFound(ex)) {
+      if (!(ex instanceof OMException && ((OMException) ex).getResult() == LIFECYCLE_CONFIGURATION_NOT_FOUND)) {
         auditSuccess = false;
         AUDIT.logReadFailure(buildAuditMessageForFailure(
             OMAction.GET_LIFECYCLE_CONFIGURATION, auditMap, ex));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -165,8 +165,7 @@ public class TestOmMetadataManager {
   }
 
   @Test
-  public void testGetMissingLifecycleConfigurationIsNotLoggedAsError()
-      throws Exception {
+  public void testGetMissingLifecycleConfigurationIsNotLoggedAsError() throws Exception {
     LogCapturer logCapturer = LogCapturer.captureLogs(OmMetadataManagerImpl.class);
 
     OMException ex = assertThrows(OMException.class, () ->
@@ -175,18 +174,7 @@ public class TestOmMetadataManager {
     assertEquals(ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND, ex.getResult());
     // A bucket without a lifecycle configuration is an expected outcome, so the
     // catch-all must not report it with an error and a stack trace.
-    assertFalse(logCapturer.getOutput()
-        .contains("Exception while getting lifecycle configuration"));
-  }
-
-  @Test
-  public void testOnlyMissingLifecycleConfigurationIsTreatedAsNotFound() {
-    assertTrue(OmMetadataManagerImpl.isLifecycleConfigurationNotFound(
-        new OMException("not found", ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND)));
-    assertFalse(OmMetadataManagerImpl.isLifecycleConfigurationNotFound(
-        new OMException("internal error", ResultCodes.INTERNAL_ERROR)));
-    assertFalse(OmMetadataManagerImpl.isLifecycleConfigurationNotFound(
-        new IOException("read failure")));
+    assertFalse(logCapturer.getOutput().contains("Exception while getting lifecycle configuration"));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -166,15 +166,15 @@ public class TestOmMetadataManager {
 
   @Test
   public void testGetMissingLifecycleConfigurationIsNotLoggedAsError() throws Exception {
-    LogCapturer logCapturer = LogCapturer.captureLogs(OmMetadataManagerImpl.class);
+    try (LogCapturer logCapturer = LogCapturer.captureLogs(OmMetadataManagerImpl.class)) {
+      OMException ex = assertThrows(OMException.class, () ->
+          omMetadataManager.getLifecycleConfiguration("volume1", "bucket1"));
 
-    OMException ex = assertThrows(OMException.class, () ->
-        omMetadataManager.getLifecycleConfiguration("volume1", "bucket1"));
-
-    assertEquals(ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND, ex.getResult());
-    // A bucket without a lifecycle configuration is an expected outcome, so the
-    // catch-all must not report it with an error and a stack trace.
-    assertFalse(logCapturer.getOutput().contains("Exception while getting lifecycle configuration"));
+      assertEquals(ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND, ex.getResult());
+      // A bucket without a lifecycle configuration is an expected outcome, so the
+      // catch-all must not report it with an error and a stack trace.
+      assertFalse(logCapturer.getOutput().contains("Exception while getting lifecycle configuration"));
+    }
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -173,7 +173,7 @@ public class TestOmMetadataManager {
       assertEquals(ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND, ex.getResult());
       // A bucket without a lifecycle configuration is an expected outcome, so the
       // catch-all must not report it with an error and a stack trace.
-      assertFalse(logCapturer.getOutput().contains("Exception while getting lifecycle configuration"));
+      assertThat(logCapturer.getOutput()).doesNotContain("Exception while getting lifecycle configuration");
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -109,6 +109,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKey
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
 import org.apache.hadoop.util.Time;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -161,6 +162,31 @@ public class TestOmMetadataManager {
     ozoneConfiguration.set(OZONE_OM_DB_DIRS,
         folder.getAbsolutePath());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
+  }
+
+  @Test
+  public void testGetMissingLifecycleConfigurationIsNotLoggedAsError()
+      throws Exception {
+    LogCapturer logCapturer = LogCapturer.captureLogs(OmMetadataManagerImpl.class);
+
+    OMException ex = assertThrows(OMException.class, () ->
+        omMetadataManager.getLifecycleConfiguration("volume1", "bucket1"));
+
+    assertEquals(ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND, ex.getResult());
+    // A bucket without a lifecycle configuration is an expected outcome, so the
+    // catch-all must not report it with an error and a stack trace.
+    assertFalse(logCapturer.getOutput()
+        .contains("Exception while getting lifecycle configuration"));
+  }
+
+  @Test
+  public void testOnlyMissingLifecycleConfigurationIsTreatedAsNotFound() {
+    assertTrue(OmMetadataManagerImpl.isLifecycleConfigurationNotFound(
+        new OMException("not found", ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND)));
+    assertFalse(OmMetadataManagerImpl.isLifecycleConfigurationNotFound(
+        new OMException("internal error", ResultCodes.INTERNAL_ERROR)));
+    assertFalse(OmMetadataManagerImpl.isLifecycleConfigurationNotFound(
+        new IOException("read failure")));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerGetLifecycleConfiguration.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerGetLifecycleConfiguration.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
+import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.ozone.audit.AuditMessage;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for audit reporting of {@link OzoneManager#getLifecycleConfiguration}.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestOzoneManagerGetLifecycleConfiguration {
+
+  private static final String REQUESTED_VOLUME = "requestedVolume";
+  private static final String REQUESTED_BUCKET = "requestedBucket";
+  private static final String REAL_VOLUME = "realVolume";
+  private static final String REAL_BUCKET = "realBucket";
+
+  private OmTestManagers omTestManagers;
+  private OzoneManager om;
+
+  private OzoneManager omSpy;
+
+  @BeforeAll
+  void setup(@TempDir File folder) throws Exception {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    ServerUtils.setOzoneMetaDirPath(conf, folder.toString());
+    omTestManagers = new OmTestManagers(conf);
+    om = omTestManagers.getOzoneManager();
+  }
+
+  @AfterAll
+  void cleanup() {
+    if (omTestManagers != null) {
+      omTestManagers.stop();
+    }
+  }
+
+  @BeforeEach
+  void init() throws Exception {
+    omSpy = spy(om);
+    HddsWhiteboxTestUtils.setInternalState(omSpy, "omMetadataReader", mock(OmMetadataReader.class));
+
+    doReturn(new ResolvedBucket(REQUESTED_VOLUME, REQUESTED_BUCKET, REAL_VOLUME, REAL_BUCKET, "owner", null))
+        .when(omSpy).resolveBucketLink(Pair.of(REQUESTED_VOLUME, REQUESTED_BUCKET));
+
+    final AuditMessage mockAuditMessage = mock(AuditMessage.class);
+    when(mockAuditMessage.getOp()).thenReturn(OMAction.GET_LIFECYCLE_CONFIGURATION.getAction());
+    doReturn(mockAuditMessage).when(omSpy).buildAuditMessageForSuccess(any(), anyMap());
+    doReturn(mockAuditMessage).when(omSpy).buildAuditMessageForFailure(any(), anyMap(), any(Throwable.class));
+  }
+
+  @Test
+  void testMissingConfigurationIsAuditedAsCompletedRead() throws Exception {
+    // Nothing was written to the lifecycle configuration table, so the read reports not-found.
+    OMException ex = assertThrows(OMException.class,
+        () -> omSpy.getLifecycleConfiguration(REQUESTED_VOLUME, REQUESTED_BUCKET));
+
+    assertEquals(OMException.ResultCodes.LIFECYCLE_CONFIGURATION_NOT_FOUND, ex.getResult());
+    verify(omSpy, never()).buildAuditMessageForFailure(any(), anyMap(), any(Throwable.class));
+    verify(omSpy).buildAuditMessageForSuccess(eq(OMAction.GET_LIFECYCLE_CONFIGURATION), anyMap());
+  }
+
+  @Test
+  void testGenuineFailureIsAuditedAsReadFailure() throws Exception {
+    OMException failure = new OMException("read failure", OMException.ResultCodes.INTERNAL_ERROR);
+    OMMetadataManager metadataManagerSpy = spy(om.getMetadataManager());
+    doThrow(failure).when(metadataManagerSpy).getLifecycleConfiguration(REAL_VOLUME, REAL_BUCKET);
+    HddsWhiteboxTestUtils.setInternalState(omSpy, "metadataManager", metadataManagerSpy);
+
+    OMException ex = assertThrows(OMException.class,
+        () -> omSpy.getLifecycleConfiguration(REQUESTED_VOLUME, REQUESTED_BUCKET));
+
+    assertEquals(OMException.ResultCodes.INTERNAL_ERROR, ex.getResult());
+    verify(omSpy).buildAuditMessageForFailure(eq(OMAction.GET_LIFECYCLE_CONFIGURATION), anyMap(), eq(failure));
+    verify(omSpy, never()).buildAuditMessageForSuccess(any(), anyMap());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OmMetadataManagerImpl#getLifecycleConfiguration` logs the not-found case at debug level and then throws
`LIFECYCLE_CONFIGURATION_NOT_FOUND`. Since `OMException` extends `IOException`, the method's own catch-all
immediately reports the same condition again at error level with a full stack trace, overriding the debug
level the not-found path deliberately chose. `OzoneManager#getLifecycleConfiguration` additionally records
it as an audit read failure.

A bucket without a lifecycle configuration is an expected outcome, not an error. This patch lets that
result propagate without the error log, and audits it as a completed read rather than a failure. Genuine
failures keep logging and auditing as before, and the exception returned to the client is unchanged.

This is latent today because the only caller is `GetBucketLifecycleConfiguration`, which is not a hot path.
HDDS-16151 adds a lifecycle lookup to `HeadObject`, where every request against a bucket without a
configuration would hit it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16352

## How was this patch tested?

New unit tests in `ozone-manager`:

* `TestOmMetadataManager#testGetMissingLifecycleConfigurationIsNotLoggedAsError` — a missing configuration
  still throws `LIFECYCLE_CONFIGURATION_NOT_FOUND`, but no longer produces the error log.
* `TestOzoneManagerGetLifecycleConfiguration` — a missing configuration is audited as a completed read,
  while a genuine failure is still audited as a read failure.

Verified locally with `mvn -pl :ozone-manager test -Dtest='TestOmMetadataManager,TestOzoneManagerGetLifecycleConfiguration'`,
plus `checkstyle:check` and `apache-rat:check` on the module.
