### PR TITLE
HDDS-11717. Upgrade Spring Framework to 6.2.19, jOOQ to 3.19.37

### DIFF
--- a/hadoop-ozone/dev-support/checks/license.sh
+++ b/hadoop-ozone/dev-support/checks/license.sh
@@ -56,6 +56,7 @@ grep '(' ${src} \
     -e "Apache ${L}" -e "Apache Software ${L}" -e "Apache v2" -e "Apache.2" \
     -e "Bouncy Castle ${L}" \
     -e "(BSD)" -e "(The BSD ${L})" -e "\<BSD.[23]" -e "\<BSD ${L} [23]" -e "\<[23]\>.Clause.\<BSD\>" \
+    -e "(CC0)" \
     -e "(CDDL\>" -e ' CDDL '\
     -e "(EDL\>" -e "Eclipse Distribution ${L}" \
     -e "(EPL\>" -e "Eclipse Public ${L}" \

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -367,6 +367,7 @@ Apache License 2.0
    io.prometheus:simpleclient
    io.prometheus:simpleclient_common
    io.prometheus:simpleclient_dropwizard
+   io.r2dbc:r2dbc-spi
    joda-time:joda-time
    jakarta.inject:jakarta.inject-api
    jakarta.validation:jakarta.validation-api
@@ -497,6 +498,12 @@ Public Domain
 =====================
 
    aopalliance:aopalliance
+
+
+CC0
+=====================
+
+   org.reactivestreams:reactive-streams
 
 
 BSD 3-Clause

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -267,10 +267,10 @@ share/ozone/lib/picocli-shell-jline3.jar
 share/ozone/lib/picocli.jar
 share/ozone/lib/proto-google-common-protos.jar
 share/ozone/lib/protobuf-java.jar
-share/ozone/lib/protobuf-java.jar
 share/ozone/lib/ranger-audit-core.jar
 share/ozone/lib/ranger-authz-api.jar
 share/ozone/lib/ranger-common-utils.jar
+share/ozone/lib/r2dbc-spi.RELEASE.jar
 share/ozone/lib/ranger-intg.jar
 share/ozone/lib/ranger-plugin-classloader.jar
 share/ozone/lib/ranger-plugins-common.jar
@@ -288,6 +288,7 @@ share/ozone/lib/ratis-shell.jar
 share/ozone/lib/ratis-thirdparty-misc.jar
 share/ozone/lib/ratis-tools.jar
 share/ozone/lib/re2j.jar
+share/ozone/lib/reactive-streams.jar
 share/ozone/lib/reflections.jar
 share/ozone/lib/reload4j.jar
 share/ozone/lib/retrofit.jar

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -63,12 +63,6 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
     </dependency>
-    <dependency>
-      <!-- for javadoc with Java9+; check if can be removed with HDDS-11142 -->
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -78,6 +72,14 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <proc>none</proc>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <!-- https://bugs.openjdk.org/browse/JDK-8305250 -->
+          <failOnWarnings>false</failOnWarnings>
         </configuration>
       </plugin>
     </plugins>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -479,7 +479,7 @@ public class ReconUtils {
     Timestamp now =
         using(sqlConfiguration).fetchValue(select(currentTimestamp()));
     GlobalStats record = globalStatsDao.fetchOneByKey(key);
-    GlobalStats newRecord = new GlobalStats(key, count, now);
+    GlobalStats newRecord = new GlobalStats(key, count, now.toLocalDateTime());
 
     // Insert a new record for key if it does not exist
     if (record == null) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -920,21 +919,20 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
   @Test
   public void testKeyCountsForValidAndInvalidKeyPrefix() throws IOException {
-    Timestamp now = new Timestamp(System.currentTimeMillis());
     ReconGlobalStatsManager statsManager = omdbInsightEndpoint.getReconGlobalStatsManager();
 
     // Insert valid key count with valid key prefix
-    insertGlobalStatsRecords(statsManager, now,
+    insertGlobalStatsRecords(statsManager,
         "openKeyTable" + "Count", 3L);
-    insertGlobalStatsRecords(statsManager, now,
+    insertGlobalStatsRecords(statsManager,
         "openFileTable" + "Count", 3L);
-    insertGlobalStatsRecords(statsManager, now,
+    insertGlobalStatsRecords(statsManager,
         "openKeyTable" + "ReplicatedDataSize", 150L);
-    insertGlobalStatsRecords(statsManager, now,
+    insertGlobalStatsRecords(statsManager,
         "openFileTable" + "ReplicatedDataSize", 150L);
-    insertGlobalStatsRecords(statsManager, now,
+    insertGlobalStatsRecords(statsManager,
         "openKeyTable" + "UnReplicatedDataSize", 50L);
-    insertGlobalStatsRecords(statsManager, now,
+    insertGlobalStatsRecords(statsManager,
         "openFileTable" + "UnReplicatedDataSize", 50L);
 
     Response openKeyInfoResp =
@@ -961,9 +959,9 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     globalStatsTable.delete("openFileTable" + "UnReplicatedDataSize");
 
     // Insert new record for a key with invalid prefix
-    insertGlobalStatsRecords(statsManager, now, "openKeyTable" + "InvalidPrefix",
+    insertGlobalStatsRecords(statsManager, "openKeyTable" + "InvalidPrefix",
         3L);
-    insertGlobalStatsRecords(statsManager, now, "openFileTable" + "InvalidPrefix",
+    insertGlobalStatsRecords(statsManager, "openFileTable" + "InvalidPrefix",
         3L);
 
     openKeyInfoResp =
@@ -983,26 +981,25 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
   @Test
   public void testKeysSummaryAttribute() throws IOException {
-    Timestamp now = new Timestamp(System.currentTimeMillis());
     ReconGlobalStatsManager statsManager = omdbInsightEndpoint.getReconGlobalStatsManager();
     // Insert records for replicated and unreplicated data sizes
-    insertGlobalStatsRecords(statsManager, now, "openFileTableReplicatedDataSize",
+    insertGlobalStatsRecords(statsManager, "openFileTableReplicatedDataSize",
         30L);
-    insertGlobalStatsRecords(statsManager, now, "openKeyTableReplicatedDataSize",
+    insertGlobalStatsRecords(statsManager, "openKeyTableReplicatedDataSize",
         30L);
-    insertGlobalStatsRecords(statsManager, now, "deletedTableReplicatedDataSize",
+    insertGlobalStatsRecords(statsManager, "deletedTableReplicatedDataSize",
         30L);
-    insertGlobalStatsRecords(statsManager, now, "openFileTableUnReplicatedDataSize",
+    insertGlobalStatsRecords(statsManager, "openFileTableUnReplicatedDataSize",
         10L);
-    insertGlobalStatsRecords(statsManager, now, "openKeyTableUnReplicatedDataSize",
+    insertGlobalStatsRecords(statsManager, "openKeyTableUnReplicatedDataSize",
         10L);
-    insertGlobalStatsRecords(statsManager, now, "deletedTableUnReplicatedDataSize",
+    insertGlobalStatsRecords(statsManager, "deletedTableUnReplicatedDataSize",
         10L);
 
     // Insert records for table counts
-    insertGlobalStatsRecords(statsManager, now, "openKeyTableCount", 3L);
-    insertGlobalStatsRecords(statsManager, now, "openFileTableCount", 3L);
-    insertGlobalStatsRecords(statsManager, now, "deletedTableCount", 3L);
+    insertGlobalStatsRecords(statsManager, "openKeyTableCount", 3L);
+    insertGlobalStatsRecords(statsManager, "openFileTableCount", 3L);
+    insertGlobalStatsRecords(statsManager, "deletedTableCount", 3L);
 
     // Call the API of Open keys to get the response
     Response openKeyInfoResp =
@@ -1036,8 +1033,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   }
 
   private void insertGlobalStatsRecords(ReconGlobalStatsManager statsManager,
-                                        Timestamp timestamp, String key,
-                                        long value) throws IOException {
+      String key, long value) throws IOException {
     GlobalStatsValue newRecord = new GlobalStatsValue(value);
     statsManager.getGlobalStatsTable().put(key, newRecord);
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestStatsSchemaDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestStatsSchemaDefinition.java
@@ -24,8 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
-import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -84,16 +85,17 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
 
     GlobalStatsDao dao = getDao(GlobalStatsDao.class);
 
-    long now = System.currentTimeMillis();
+    LocalDateTime now = LocalDateTime.now(Clock.systemUTC().getZone());
     GlobalStats newRecord = new GlobalStats();
-    newRecord.setLastUpdatedTimestamp(new Timestamp(now));
+    newRecord.setLastUpdatedTimestamp(now);
     newRecord.setKey("key1");
     newRecord.setValue(500L);
 
     // Create
     dao.insert(newRecord);
     GlobalStats newRecord2 = new GlobalStats();
-    newRecord2.setLastUpdatedTimestamp(new Timestamp(now + 1000L));
+    LocalDateTime dateTime1 = now.plusSeconds(1);
+    newRecord2.setLastUpdatedTimestamp(dateTime1);
     newRecord2.setKey("key2");
     newRecord2.setValue(10L);
     dao.insert(newRecord2);
@@ -103,25 +105,23 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
 
     assertEquals("key1", dbRecord.getKey());
     assertEquals(Long.valueOf(500), dbRecord.getValue());
-    assertEquals(new Timestamp(now),
-        dbRecord.getLastUpdatedTimestamp());
+    assertEquals(now, dbRecord.getLastUpdatedTimestamp());
 
     dbRecord = dao.findById("key2");
     assertEquals("key2", dbRecord.getKey());
     assertEquals(Long.valueOf(10), dbRecord.getValue());
-    assertEquals(new Timestamp(now + 1000L),
-        dbRecord.getLastUpdatedTimestamp());
+    assertEquals(dateTime1, dbRecord.getLastUpdatedTimestamp());
 
     // Update
+    LocalDateTime dateTime2 = dateTime1.plusSeconds(1);
     dbRecord.setValue(100L);
-    dbRecord.setLastUpdatedTimestamp(new Timestamp(now + 2000L));
+    dbRecord.setLastUpdatedTimestamp(dateTime2);
     dao.update(dbRecord);
 
     // Read updated
     dbRecord = dao.findById("key2");
 
-    assertEquals(new Timestamp(now + 2000L),
-        dbRecord.getLastUpdatedTimestamp());
+    assertEquals(dateTime2, dbRecord.getLastUpdatedTimestamp());
     assertEquals(Long.valueOf(100L), dbRecord.getValue());
 
     // Delete

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUtilizationSchemaDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUtilizationSchemaDefinition.java
@@ -29,8 +29,8 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -147,9 +147,9 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     }
 
     ClusterGrowthDailyDao dao = getDao(ClusterGrowthDailyDao.class);
-    long now = System.currentTimeMillis();
+    LocalDateTime now = LocalDateTime.now();
     ClusterGrowthDaily newRecord = new ClusterGrowthDaily();
-    newRecord.setTimestamp(new Timestamp(now));
+    newRecord.setTimestamp(now);
     newRecord.setDatanodeId(10);
     newRecord.setDatanodeHost("host1");
     newRecord.setRackId("rack1");
@@ -165,7 +165,8 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     ClusterGrowthDaily dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now)).value2(10));
+            .value1(now)
+            .value2(10));
 
     assertEquals("host1", dbRecord.getDatanodeHost());
     assertEquals("rack1", dbRecord.getRackId());
@@ -183,7 +184,8 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now)).value2(10));
+            .value1(now)
+            .value2(10));
 
     assertEquals(Long.valueOf(700), dbRecord.getUsedSize());
     assertEquals(Integer.valueOf(30), dbRecord.getBlockCount());
@@ -191,13 +193,15 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     // Delete
     dao.deleteById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
         CLUSTER_GROWTH_DAILY.DATANODE_ID)
-        .value1(new Timestamp(now)).value2(10));
+        .value1(now)
+        .value2(10));
 
     // Verify
     dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now)).value2(10));
+            .value1(now)
+            .value2(10));
 
     assertNull(dbRecord);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <sonar.projectKey>hadoop-ozone</sonar.projectKey>
     <sortpom-maven-plugin.version>3.0.1</sortpom-maven-plugin.version>
     <spotbugs.version>3.1.12.2</spotbugs.version>
-    <spring.version>5.3.39</spring.version>
+    <spring.version>6.2.19</spring.version>
     <sqlite.version>3.53.2.1</sqlite.version>
     <stax2.version>4.2.2</stax2.version>
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <jnr-constants.version>0.11.0</jnr-constants.version>
     <jnr-posix.version>3.2.2</jnr-posix.version>
     <joda.time.version>2.12.7</joda.time.version>
-    <jooq.version>3.11.10</jooq.version>
+    <jooq.version>3.19.37</jooq.version>
     <jsch.version>0.1.55</jsch.version>
     <jsp-api.version>2.1</jsp-api.version>
     <jsr311-api.version>1.1.1</jsr311-api.version>
@@ -1610,12 +1610,6 @@
         <groupId>org.jooq</groupId>
         <artifactId>jooq</artifactId>
         <version>${jooq.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jooq</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spring 5 is EOL, upgrade to current GA version 6.2.19.  Also bump jOOQ to 3.19.37 (the last version with Java 17 support).

https://issues.apache.org/jira/browse/HDDS-11717

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/33368872072