### PR TITLE
HDDS-16357. Recon fileCount API does not normalize the fileSize query parameter

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/UtilizationEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/UtilizationEndpoint.java
@@ -89,14 +89,15 @@ public class UtilizationEndpoint {
       Table<FileSizeCountKey, Long> fileCountTable = reconFileMetadataManager.getFileCountTable();
       
       if (volume != null && bucket != null && fileSize > 0) {
-        // Query for specific volume, bucket, and file size
-        FileSizeCountKey key = new FileSizeCountKey(volume, bucket, fileSize);
+        // Counts are stored per file size bin, so map the requested size to its bin upper bound.
+        long fileSizeUpperBound = ReconUtils.getFileSizeUpperBound(fileSize);
+        FileSizeCountKey key = new FileSizeCountKey(volume, bucket, fileSizeUpperBound);
         Long count = fileCountTable.get(key);
         if (count != null && count > 0) {
           FileCountBySize record = new FileCountBySize();
           record.setVolume(volume);
           record.setBucket(bucket);
-          record.setFileSize(fileSize);
+          record.setFileSize(fileSizeUpperBound);
           record.setCount(count);
           resultSet.add(record);
         }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -965,8 +965,10 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     resultSet = (List<FileCountBySize>) response.getEntity();
     assertEquals(1, resultSet.size());
     o = resultSet.get(0);
-    assertTrue(o.getVolume().equals("vol1") && o.getBucket().equals("bucket1") &&
-        o.getFileSize() == 131072 && o.getCount() == 2L);
+    assertEquals("vol1", o.getVolume());
+    assertEquals("bucket1", o.getBucket());
+    assertEquals(131072L, o.getFileSize());
+    assertEquals(2L, o.getCount());
 
     // Test for a fileSize that is mapped to an empty bin.
     response = utilizationEndpoint.getFileCounts("vol1", "bucket1", 1310725);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -960,7 +960,15 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     assertTrue(o.getVolume().equals("vol1") && o.getBucket().equals("bucket1") &&
         o.getFileSize() == 131072);
 
-    // Test for non-existent fileSize.
+    // Test for a fileSize that is not a bin boundary. It is mapped to bin 131072.
+    response = utilizationEndpoint.getFileCounts("vol1", "bucket1", 100000);
+    resultSet = (List<FileCountBySize>) response.getEntity();
+    assertEquals(1, resultSet.size());
+    o = resultSet.get(0);
+    assertTrue(o.getVolume().equals("vol1") && o.getBucket().equals("bucket1") &&
+        o.getFileSize() == 131072 && o.getCount() == 2L);
+
+    // Test for a fileSize that is mapped to an empty bin.
     response = utilizationEndpoint.getFileCounts("vol1", "bucket1", 1310725);
     resultSet = (List<FileCountBySize>) response.getEntity();
     assertEquals(0, resultSet.size());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon stores file counts in a histogram keyed by `(volume, bucket, fileSizeUpperBound)`, where the
upper bound is a power of two computed by `ReconUtils.getFileSizeUpperBound()`. The write path applies
this normalization in `FileSizeCountTaskHelper#getFileSizeCountKey()`, but the read path in
`UtilizationEndpoint#getFileCounts()` built the lookup key from the raw `fileSize` query parameter.
As a result, `GET /api/v1/utilization/fileCount` returned an empty list for any size that is not
an exact bin boundary:

```
# bucket contains two 100000-byte keys, stored in bin 131072
GET /api/v1/utilization/fileCount?volume=vol1&bucket=bucket1&fileSize=100000
-> []

GET /api/v1/utilization/fileCount?volume=vol1&bucket=bucket1&fileSize=131072
-> [{"fileSize":131072,"count":2}]
```

The sibling endpoint `/utilization/containerCount` already normalizes its parameter through
`ReconUtils.getContainerSizeUpperBound()`, so the two APIs behaved inconsistently.

This PR normalizes the parameter before the lookup, and sets the normalized value on the response.
The latter matters because the unfiltered branch of the same endpoint returns
`key.getFileSizeUpperBound()`, so without it the meaning of the `fileSize` response field would
depend on whether the query parameter was supplied.

Changed files:

* `hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/UtilizationEndpoint.java` -
  normalize `fileSize` via `ReconUtils.getFileSizeUpperBound()` and return the bin upper bound.
* `hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java` -
  add a non-boundary query assertion. The existing test only queried exact bin boundaries, which is
  why this was not caught.

The write path and the on-disk layout are unchanged, so no existing Recon data is affected.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16357

## How was this patch tested?

Unit tests: `mvn -pl :ozone-recon test -Dtest=TestEndpoints` passes (15/15).