### PR TITLE
HDDS-16359. Make CI survive Maven Central rate limiting

### DIFF
--- a/.github/workflows/build-ratis.yml
+++ b/.github/workflows/build-ratis.yml
@@ -58,7 +58,7 @@ on:
         description: "Arguments for building with Ratis"
         value: ${{ jobs.summary.outputs.build-args }}
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Daether.connector.http.retryHandler.count=10
 permissions: { }
 jobs:
   ratis:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -137,7 +137,7 @@ on:
 env:
   HADOOP_IMAGE: ghcr.io/apache/hadoop
   MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Daether.connector.http.retryHandler.count=10
   OZONE_IMAGE: ghcr.io/apache/ozone
   OZONE_RUNNER_IMAGE: ghcr.io/apache/ozone-runner
   OZONE_VOLUME_OWNER: 1000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ env:
   TEST_JAVA_VERSION: 25 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
   # MAVEN_ARGS and MAVEN_OPTS are duplicated in check.yml and populate-cache.yml, please keep in sync
   MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  # Maven 3.9 downloads dependencies via maven-resolver-transport-http, which reads aether.* and ignores maven.wagon.*
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Daether.connector.http.retryHandler.count=10
   OZONE_WITH_COVERAGE: ${{ github.event_name == 'push' }}
 
 permissions: { }

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -57,7 +57,7 @@ on:
         default: '25'
         required: true
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Daether.connector.http.retryHandler.count=10
   TEST_CLASS: ${{ github.event.inputs.test-class}}
   TEST_METHOD: ${{ github.event.inputs.test-name }}
   ITERATIONS: ${{ github.event.inputs.iterations }}

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -38,7 +38,7 @@ env:
   BUILD_ARGS: "-Pdist -Psrc -Dmaven.javadoc.skip=true -Drocks_tools_native"
   TEST_JAVA_VERSION: 25 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
   MAVEN_ARGS: --batch-mode --settings ${{ github.workspace }}/dev-support/ci/maven-settings.xml
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Daether.connector.http.retryHandler.count=10
 
 jobs:
   build:

--- a/.github/workflows/repeat-acceptance.yml
+++ b/.github/workflows/repeat-acceptance.yml
@@ -43,7 +43,7 @@ on:
         default: false
         required: true
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Daether.connector.http.retryHandler.count=10
   OZONE_ACCEPTANCE_SUITE: ${{ github.event.inputs.test-suite}}
   OZONE_TEST_SELECTOR: ${{ github.event.inputs.test-filter }}
   FAIL_FAST: ${{ github.event.inputs.fail-fast }}


### PR DESCRIPTION
## Summary

A PR based on an older master can restore a Maven cache built from newer POMs, causing a missing dependency to be fetched from Maven Central. If Central returns HTTP 429, the job fails during dependency resolution before compilation or tests.

The existing retry settings use `maven.wagon.http.*`, but Maven 3.9 resolves dependencies through `maven-resolver-transport-http`, which uses `aether.connector.http.retryHandler.*`. The Wagon properties are ignored, leaving only the resolver's default of three retries (~30s), matching the 32s failure seen in the JIRA job.

This changes the settings to the resolver properties, increasing retry time to ~275s. The maximum individual wait remains 50s, below the resolver's 300s `intervalMax`, and existing job timeouts still bound total runtime.

`maven.wagon.http.pool` is removed for the same reason. `http.keepAlive` remains because it is JDK-level.

JIRA: https://issues.apache.org/jira/browse/HDDS-16359

## Tests

Tested with Maven 3.9.16 against a repository returning HTTP 429:

| `MAVEN_OPTS` | Requests | Elapsed |
| --- | ---: | ---: |
| (none) | 4 | 32s |
| `maven.wagon.http.retryHandler.count=0` | 4 | 31s |
| `aether.connector.http.retryHandler.count=0` | 1 | 4s |
| `aether.connector.http.retryHandler.count=10` | 11 | 268s |

The Wagon setting has no effect; the resolver setting works as expected.