### PR TITLE
HDDS-15925. Skip redundant InfoBucket RPC on OFS getFileStatus with a bounded bucket-layout cache

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -284,6 +284,25 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private String fsDefaultBucketLayout = "FILE_SYSTEM_OPTIMIZED";
 
+  @Config(key = "ozone.client.fs.bucket.layout.cache.expiry",
+      defaultValue = "2m",
+      type = ConfigType.TIME,
+      description = "Expiry of entries in the client-side cache of resolved bucket layouts used by "
+          + "OFS getFileStatus. Bucket layout is immutable for a bucket's lifetime, so a cached "
+          + "layout lets getFileStatus skip the per-call InfoBucket RPC; the expiry bounds staleness "
+          + "if a bucket is deleted and recreated with a different layout. OBJECT_STORE layouts are "
+          + "cached as well and re-rejected from the cache, so this expiry applies to them too.",
+      tags = ConfigTag.CLIENT)
+  private Duration fsBucketLayoutCacheExpiry = Duration.ofMinutes(2);
+
+  @Config(key = "ozone.client.fs.bucket.layout.cache.size",
+      defaultValue = "1000",
+      description = "Maximum number of resolved bucket layouts cached client-side for OFS "
+          + "getFileStatus. Bounds the memory used by the layout cache; a value of 0 disables "
+          + "caching, so every getFileStatus re-fetches and re-validates the bucket layout.",
+      tags = ConfigTag.CLIENT)
+  private long fsBucketLayoutCacheSize = 1000;
+
   @Config(key = "ozone.client.hbase.enhancements.allowed",
       defaultValue = "false",
       description = "When set to false, client-side HBase enhancement-related Ozone (experimental) features " +
@@ -628,6 +647,14 @@ public class OzoneClientConfig {
 
   public String getFsDefaultBucketLayout() {
     return fsDefaultBucketLayout;
+  }
+
+  public Duration getFsBucketLayoutCacheExpiry() {
+    return fsBucketLayoutCacheExpiry;
+  }
+
+  public long getFsBucketLayoutCacheSize() {
+    return fsBucketLayoutCacheSize;
   }
 
   public void setEnablePutblockPiggybacking(boolean enablePutblockPiggybacking) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -742,6 +742,68 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
   }
 
   /**
+   * getFileStatus caches the bucket layout so a repeated call on the same
+   * bucket serves the layout from the cache and skips the InfoBucket RPC.
+   */
+  @Test
+  void testGetFileStatusSkipsBucketInfoOnCacheHit() throws IOException {
+    String volName = getRandomNonExistVolumeName();
+    objectStore.createVolume(volName);
+    OzoneVolume ozoneVolume = objectStore.getVolume(volName);
+    String buckName = uniqueObjectName("bucket-");
+    ozoneVolume.createBucket(buckName, BucketArgs.newBuilder()
+        .setBucketLayout(bucketLayout).build());
+    Path file = new Path("/" + volName + "/" + buckName + "/file1");
+    ContractTestUtils.touch(fs, file);
+
+    // First call populates the layout cache (one InfoBucket RPC).
+    fs.getFileStatus(file);
+    long bucketInfosBefore = getOMMetrics().getNumBucketInfos();
+    long getFileStatusBefore = getOMMetrics().getNumGetFileStatus();
+
+    // Second call is served from the cache: no additional InfoBucket RPC,
+    // but the getFileStatus RPC still happens.
+    fs.getFileStatus(file);
+    assertThat(getOMMetrics().getNumBucketInfos() - bucketInfosBefore)
+        .isEqualTo(0);
+    assertThat(getOMMetrics().getNumGetFileStatus() - getFileStatusBefore)
+        .isGreaterThanOrEqualTo(1);
+
+    fs.delete(file, false);
+    ozoneVolume.deleteBucket(buckName);
+    objectStore.deleteVolume(volName);
+  }
+
+  /**
+   * getFileStatus on an OBJECT_STORE bucket is rejected (no file system
+   * semantics), and the rejection is served from the cached layout on repeat
+   * without another InfoBucket RPC.
+   */
+  @Test
+  void testGetFileStatusOnObjectStoreBucketRejected() throws IOException {
+    String volName = getRandomNonExistVolumeName();
+    objectStore.createVolume(volName);
+    OzoneVolume ozoneVolume = objectStore.getVolume(volName);
+    String buckName = uniqueObjectName("obs-");
+    ozoneVolume.createBucket(buckName, BucketArgs.newBuilder()
+        .setBucketLayout(BucketLayout.OBJECT_STORE).build());
+    Path key = new Path("/" + volName + "/" + buckName + "/key");
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> fs.getFileStatus(key));
+    assertThat(ex.getMessage()).contains(BucketLayout.OBJECT_STORE.name());
+
+    long bucketInfosBefore = getOMMetrics().getNumBucketInfos();
+    assertThrows(IllegalArgumentException.class,
+        () -> fs.getFileStatus(key));
+    assertThat(getOMMetrics().getNumBucketInfos() - bucketInfosBefore)
+        .isEqualTo(0);
+
+    ozoneVolume.deleteBucket(buckName);
+    objectStore.deleteVolume(volName);
+  }
+
+  /**
    * OFS: Test non-recursive listStatus on root and volume.
    */
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOfsGetFileStatusCacheBenchmark.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOfsGetFileStatusCacheBenchmark.java
@@ -28,8 +28,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
@@ -55,13 +59,13 @@ import org.slf4j.LoggerFactory;
 /**
  * Benchmark for the OFS getFileStatus bucket-layout cache (HDDS-15925).
  *
- * <p>Runs an 80% cache-hit getFileStatus workload against one
+ * <p>Runs a cache-hit-heavy getFileStatus workload against one
  * {@link MiniOzoneCluster} using the default client configuration, and reports
  * the InfoBucket RPCs, getFileStatus RPCs, per-call latency (mean/p50/p90/p99/
  * max) and throughput measured by OM. The workload touches {@link #NUM_BUCKETS}
  * buckets {@link #ACCESSES_PER_BUCKET} times each, so exactly one access per
- * bucket is a cold miss and the rest would hit a per-bucket layout cache — an
- * 80% cache-hit workload.
+ * bucket is a cold miss and the rest would hit a per-bucket layout cache — a
+ * 90% cache-hit workload.
  *
  * <p>This benchmark makes no assumption about whether the cache exists, so the
  * identical test runs on both the optimized branch and the baseline
@@ -76,6 +80,13 @@ import org.slf4j.LoggerFactory;
  * The getFileStatus RPC count is identical either way, showing the optimization
  * removes only the redundant InfoBucket RPC and changes no behaviour; the
  * latency percentiles show the effect of dropping that RPC per call.
+ *
+ * <p>A second test runs the same workload single-threaded and then across
+ * {@link #CONCURRENT_THREADS} client threads sharing one {@code FileSystem} (and
+ * thus one layout cache), and logs the two side by side. It confirms the atomic
+ * get-or-load holds the InfoBucket RPC count at one per bucket under concurrency
+ * — concurrent cold misses on the same bucket collapse to a single RPC instead
+ * of stampeding — while throughput scales with the added client threads.
  */
 @Tag("benchmark")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -87,12 +98,14 @@ public class TestOfsGetFileStatusCacheBenchmark {
   /** Distinct buckets in the working set (each is one cold miss). */
   private static final int NUM_BUCKETS = 200;
   /** getFileStatus calls per bucket: 1 miss + (N-1) hits. */
-  private static final int ACCESSES_PER_BUCKET = 5;
-  /** (ACCESSES_PER_BUCKET - 1) / ACCESSES_PER_BUCKET = 0.80. */
+  private static final int ACCESSES_PER_BUCKET = 10;
+  /** (ACCESSES_PER_BUCKET - 1) / ACCESSES_PER_BUCKET = 0.90. */
   private static final double TARGET_HIT_RATIO =
       (ACCESSES_PER_BUCKET - 1) / (double) ACCESSES_PER_BUCKET;
   private static final int TOTAL_CALLS = NUM_BUCKETS * ACCESSES_PER_BUCKET;
   private static final long SHUFFLE_SEED = 20250831L;
+  /** Client threads issuing getFileStatus in the concurrent comparison. */
+  private static final int CONCURRENT_THREADS = 10;
 
   private MiniOzoneCluster cluster;
   private OzoneClient client;
@@ -147,27 +160,69 @@ public class TestOfsGetFileStatusCacheBenchmark {
   }
 
   @Test
-  void benchmarkCacheHitWorkflow() throws IOException {
+  void benchmarkCacheHitWorkflow() throws Exception {
     // Prime OM-side state and the JVM so the measured run pays no cold-start.
-    runWorkload();
+    runWorkload(1);
 
-    Result measured = runWorkload();
+    Result measured = runWorkload(1);
 
-    // Invariants that hold on both the baseline and the optimized code, so the
-    // identical benchmark passes in either worktree: every getFileStatus still
-    // issues its getFileStatus RPC, and the InfoBucket RPCs lie between the
-    // fully-cached best case (one per bucket) and the no-cache worst case (one
-    // per call).
-    assertThat(measured.getFileStatusRpcs).isEqualTo(TOTAL_CALLS);
-    assertThat(measured.infoBucketRpcs)
-        .isBetween((long) NUM_BUCKETS, (long) TOTAL_CALLS);
+    assertWorkloadInvariants(measured);
+    logResult("single-threaded", measured);
+  }
 
-    double achievedHitRatio =
-        (TOTAL_CALLS - measured.infoBucketRpcs) / (double) TOTAL_CALLS;
+  @Test
+  void benchmarkConcurrentVsSingleThreaded() throws Exception {
+    // Warm the JVM/OM, then measure the same workload single-threaded and again
+    // across CONCURRENT_THREADS client threads sharing one FileSystem (and thus
+    // one bucket-layout cache). The atomic get-or-load keeps the InfoBucket RPC
+    // count at one per bucket in both cases: concurrent cold misses on the same
+    // bucket collapse to a single InfoBucket RPC rather than stampeding.
+    runWorkload(1);
 
+    Result single = runWorkload(1);
+    Result concurrent = runWorkload(CONCURRENT_THREADS);
+
+    assertWorkloadInvariants(single);
+    assertWorkloadInvariants(concurrent);
+
+    logResult("single-threaded", single);
+    logResult(CONCURRENT_THREADS + " concurrent threads", concurrent);
     LOG.info(String.format("%n"
-            + "OFS getFileStatus bucket-layout cache benchmark (HDDS-15925)%n"
-            + "  buckets=%d, accesses/bucket=%d, total getFileStatus=%d%n"
+            + "single-threaded vs %d concurrent threads (optimized)%n"
+            + "  InfoBucket RPCs     : %d  ->  %d%n"
+            + "  getFileStatus RPCs  : %d  ->  %d%n"
+            + "  latency mean (ms)   : %.3f  ->  %.3f%n"
+            + "  latency p99 (ms)    : %.3f  ->  %.3f%n"
+            + "  throughput (ops/s)  : %.1f  ->  %.1f  (%.2fx)%n",
+        CONCURRENT_THREADS,
+        single.infoBucketRpcs, concurrent.infoBucketRpcs,
+        single.getFileStatusRpcs, concurrent.getFileStatusRpcs,
+        millis(single.mean()), millis(concurrent.mean()),
+        millis(single.percentile(0.99)), millis(concurrent.percentile(0.99)),
+        single.opsPerSecond(), concurrent.opsPerSecond(),
+        concurrent.opsPerSecond() / single.opsPerSecond()));
+  }
+
+  /**
+   * Invariants that hold on both the baseline and the optimized code, so the
+   * identical benchmark passes in either worktree: every getFileStatus still
+   * issues its getFileStatus RPC, and the InfoBucket RPCs lie between the
+   * fully-cached best case (one per bucket) and the no-cache worst case (one
+   * per call).
+   */
+  private void assertWorkloadInvariants(Result r) {
+    assertThat(r.getFileStatusRpcs).isEqualTo(TOTAL_CALLS);
+    assertThat(r.infoBucketRpcs)
+        .isBetween((long) NUM_BUCKETS, (long) TOTAL_CALLS);
+  }
+
+  private void logResult(String label, Result r) {
+    double achievedHitRatio =
+        (TOTAL_CALLS - r.infoBucketRpcs) / (double) TOTAL_CALLS;
+    LOG.info(String.format("%n"
+            + "OFS getFileStatus bucket-layout cache benchmark (HDDS-15925) — %s%n"
+            + "  buckets=%d, accesses/bucket=%d, total getFileStatus=%d, "
+            + "threads=%d%n"
             + "  target cache-hit ratio      : %.0f%%%n"
             + "  ------------------------------------------------------------%n"
             + "  InfoBucket RPCs             : %d%n"
@@ -181,21 +236,22 @@ public class TestOfsGetFileStatusCacheBenchmark {
             + "  latency p99                 : %.3f ms%n"
             + "  latency max                 : %.3f ms%n"
             + "  throughput                  : %.1f getFileStatus/s%n",
-        NUM_BUCKETS, ACCESSES_PER_BUCKET, TOTAL_CALLS,
+        label, NUM_BUCKETS, ACCESSES_PER_BUCKET, TOTAL_CALLS, r.threads,
         TARGET_HIT_RATIO * 100,
-        measured.infoBucketRpcs, measured.getFileStatusRpcs,
-        measured.infoBucketRpcs / (double) TOTAL_CALLS,
+        r.infoBucketRpcs, r.getFileStatusRpcs,
+        r.infoBucketRpcs / (double) TOTAL_CALLS,
         achievedHitRatio * 100,
-        millis(measured.mean()), millis(measured.percentile(0.50)),
-        millis(measured.percentile(0.90)), millis(measured.percentile(0.99)),
-        millis(measured.max()), measured.opsPerSecond()));
+        millis(r.mean()), millis(r.percentile(0.50)),
+        millis(r.percentile(0.90)), millis(r.percentile(0.99)),
+        millis(r.max()), r.opsPerSecond()));
   }
 
   private static double millis(double nanos) {
     return nanos / (double) TimeUnit.MILLISECONDS.toNanos(1);
   }
 
-  private Result runWorkload() throws IOException {
+  private Result runWorkload(int threads)
+      throws IOException, InterruptedException {
     OzoneConfiguration runConf = new OzoneConfiguration(conf);
     runConf.set(FS_DEFAULT_NAME_KEY, rootPath);
 
@@ -204,29 +260,78 @@ public class TestOfsGetFileStatusCacheBenchmark {
     try (FileSystem fs = FileSystem.newInstance(URI.create(rootPath), runConf)) {
       long bucketInfosBefore = metrics.getNumBucketInfos();
       long getFileStatusBefore = metrics.getNumGetFileStatus();
-      long startNanos = System.nanoTime();
-      int i = 0;
-      for (Path path : accessSequence) {
-        long callStart = System.nanoTime();
-        fs.getFileStatus(path);
-        latencyNanos[i++] = System.nanoTime() - callStart;
-      }
-      long elapsedNanos = System.nanoTime() - startNanos;
-      return new Result(
+      long elapsedNanos = threads == 1
+          ? runSequential(fs, latencyNanos)
+          : runConcurrent(fs, threads, latencyNanos);
+      return new Result(threads,
           metrics.getNumBucketInfos() - bucketInfosBefore,
           metrics.getNumGetFileStatus() - getFileStatusBefore,
           elapsedNanos, latencyNanos);
     }
   }
 
+  private long runSequential(FileSystem fs, long[] latencyNanos)
+      throws IOException {
+    long startNanos = System.nanoTime();
+    int i = 0;
+    for (Path path : accessSequence) {
+      long callStart = System.nanoTime();
+      fs.getFileStatus(path);
+      latencyNanos[i++] = System.nanoTime() - callStart;
+    }
+    return System.nanoTime() - startNanos;
+  }
+
+  private long runConcurrent(FileSystem fs, int threads, long[] latencyNanos)
+      throws IOException, InterruptedException {
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch startGate = new CountDownLatch(1);
+    CountDownLatch doneGate = new CountDownLatch(threads);
+    AtomicReference<IOException> failure = new AtomicReference<>();
+    // Disjoint, contiguous slices of the shuffled sequence; each thread writes
+    // only its own latency indices, so no synchronization is needed per call.
+    int chunk = (TOTAL_CALLS + threads - 1) / threads;
+    for (int t = 0; t < threads; t++) {
+      final int from = t * chunk;
+      final int to = Math.min(TOTAL_CALLS, from + chunk);
+      pool.submit(() -> {
+        try {
+          startGate.await();
+          for (int i = from; i < to; i++) {
+            long callStart = System.nanoTime();
+            fs.getFileStatus(accessSequence.get(i));
+            latencyNanos[i] = System.nanoTime() - callStart;
+          }
+        } catch (IOException e) {
+          failure.compareAndSet(null, e);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          doneGate.countDown();
+        }
+      });
+    }
+    long startNanos = System.nanoTime();
+    startGate.countDown();
+    doneGate.await();
+    long elapsedNanos = System.nanoTime() - startNanos;
+    pool.shutdownNow();
+    if (failure.get() != null) {
+      throw failure.get();
+    }
+    return elapsedNanos;
+  }
+
   private static final class Result {
+    private final int threads;
     private final long infoBucketRpcs;
     private final long getFileStatusRpcs;
     private final long elapsedNanos;
     private final long[] sortedLatencyNanos;
 
-    Result(long infoBucketRpcs, long getFileStatusRpcs, long elapsedNanos,
-        long[] latencyNanos) {
+    Result(int threads, long infoBucketRpcs, long getFileStatusRpcs,
+        long elapsedNanos, long[] latencyNanos) {
+      this.threads = threads;
       this.infoBucketRpcs = infoBucketRpcs;
       this.getFileStatusRpcs = getFileStatusRpcs;
       this.elapsedNanos = elapsedNanos;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOfsGetFileStatusCacheBenchmark.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOfsGetFileStatusCacheBenchmark.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmark for the OFS getFileStatus bucket-layout cache (HDDS-15925).
+ *
+ * <p>Runs an 80% cache-hit getFileStatus workload against one
+ * {@link MiniOzoneCluster} using the default client configuration, and reports
+ * the InfoBucket RPCs, getFileStatus RPCs, per-call latency (mean/p50/p90/p99/
+ * max) and throughput measured by OM. The workload touches {@link #NUM_BUCKETS}
+ * buckets {@link #ACCESSES_PER_BUCKET} times each, so exactly one access per
+ * bucket is a cold miss and the rest would hit a per-bucket layout cache — an
+ * 80% cache-hit workload.
+ *
+ * <p>This benchmark makes no assumption about whether the cache exists, so the
+ * identical test runs on both the optimized branch and the baseline
+ * ({@code master}) code. The before/after comparison is what OM reports for the
+ * same workload:
+ * <ul>
+ *   <li>baseline (no cache): two RPCs per getFileStatus (InfoBucket +
+ *       getFileStatus), one InfoBucket RPC per call ({@link #TOTAL_CALLS});</li>
+ *   <li>optimized (cache on by default): one RPC per cache hit, so one
+ *       InfoBucket RPC per distinct bucket ({@link #NUM_BUCKETS}).</li>
+ * </ul>
+ * The getFileStatus RPC count is identical either way, showing the optimization
+ * removes only the redundant InfoBucket RPC and changes no behaviour; the
+ * latency percentiles show the effect of dropping that RPC per call.
+ */
+@Tag("benchmark")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestOfsGetFileStatusCacheBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestOfsGetFileStatusCacheBenchmark.class);
+
+  /** Distinct buckets in the working set (each is one cold miss). */
+  private static final int NUM_BUCKETS = 200;
+  /** getFileStatus calls per bucket: 1 miss + (N-1) hits. */
+  private static final int ACCESSES_PER_BUCKET = 5;
+  /** (ACCESSES_PER_BUCKET - 1) / ACCESSES_PER_BUCKET = 0.80. */
+  private static final double TARGET_HIT_RATIO =
+      (ACCESSES_PER_BUCKET - 1) / (double) ACCESSES_PER_BUCKET;
+  private static final int TOTAL_CALLS = NUM_BUCKETS * ACCESSES_PER_BUCKET;
+  private static final long SHUFFLE_SEED = 20250831L;
+
+  private MiniOzoneCluster cluster;
+  private OzoneClient client;
+  private OzoneConfiguration conf;
+  private String rootPath;
+
+  private final List<Path> accessSequence = new ArrayList<>(TOTAL_CALLS);
+
+  @BeforeAll
+  void init() throws IOException, InterruptedException, TimeoutException {
+    conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
+    rootPath = String.format("%s://%s/",
+        OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
+
+    // One volume, NUM_BUCKETS FSO buckets, one file per bucket. The access
+    // sequence lists each file ACCESSES_PER_BUCKET times, then is shuffled with
+    // a fixed seed so hits and misses interleave the way a real workload would.
+    ObjectStore objectStore = client.getObjectStore();
+    String volName = "benchvol";
+    objectStore.createVolume(volName);
+    OzoneVolume volume = objectStore.getVolume(volName);
+    BucketArgs fsoArgs = BucketArgs.newBuilder()
+        .setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED).build();
+    try (FileSystem setupFs =
+        FileSystem.newInstance(URI.create(rootPath), conf)) {
+      for (int i = 0; i < NUM_BUCKETS; i++) {
+        String buckName = "benchbucket-" + i;
+        volume.createBucket(buckName, fsoArgs);
+        Path file = new Path("/" + volName + "/" + buckName + "/file");
+        ContractTestUtils.touch(setupFs, file);
+        for (int a = 0; a < ACCESSES_PER_BUCKET; a++) {
+          accessSequence.add(file);
+        }
+      }
+    }
+    Collections.shuffle(accessSequence, new Random(SHUFFLE_SEED));
+  }
+
+  @AfterAll
+  void shutdown() {
+    IOUtils.closeQuietly(client);
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  void benchmarkCacheHitWorkflow() throws IOException {
+    // Prime OM-side state and the JVM so the measured run pays no cold-start.
+    runWorkload();
+
+    Result measured = runWorkload();
+
+    // Invariants that hold on both the baseline and the optimized code, so the
+    // identical benchmark passes in either worktree: every getFileStatus still
+    // issues its getFileStatus RPC, and the InfoBucket RPCs lie between the
+    // fully-cached best case (one per bucket) and the no-cache worst case (one
+    // per call).
+    assertThat(measured.getFileStatusRpcs).isEqualTo(TOTAL_CALLS);
+    assertThat(measured.infoBucketRpcs)
+        .isBetween((long) NUM_BUCKETS, (long) TOTAL_CALLS);
+
+    double achievedHitRatio =
+        (TOTAL_CALLS - measured.infoBucketRpcs) / (double) TOTAL_CALLS;
+
+    LOG.info(String.format("%n"
+            + "OFS getFileStatus bucket-layout cache benchmark (HDDS-15925)%n"
+            + "  buckets=%d, accesses/bucket=%d, total getFileStatus=%d%n"
+            + "  target cache-hit ratio      : %.0f%%%n"
+            + "  ------------------------------------------------------------%n"
+            + "  InfoBucket RPCs             : %d%n"
+            + "  getFileStatus RPCs          : %d%n"
+            + "  InfoBucket RPCs per call    : %.2f%n"
+            + "  cache-hit ratio achieved    : %.0f%%%n"
+            + "  ------------------------------------------------------------%n"
+            + "  latency mean                : %.3f ms%n"
+            + "  latency p50                 : %.3f ms%n"
+            + "  latency p90                 : %.3f ms%n"
+            + "  latency p99                 : %.3f ms%n"
+            + "  latency max                 : %.3f ms%n"
+            + "  throughput                  : %.1f getFileStatus/s%n",
+        NUM_BUCKETS, ACCESSES_PER_BUCKET, TOTAL_CALLS,
+        TARGET_HIT_RATIO * 100,
+        measured.infoBucketRpcs, measured.getFileStatusRpcs,
+        measured.infoBucketRpcs / (double) TOTAL_CALLS,
+        achievedHitRatio * 100,
+        millis(measured.mean()), millis(measured.percentile(0.50)),
+        millis(measured.percentile(0.90)), millis(measured.percentile(0.99)),
+        millis(measured.max()), measured.opsPerSecond()));
+  }
+
+  private static double millis(double nanos) {
+    return nanos / (double) TimeUnit.MILLISECONDS.toNanos(1);
+  }
+
+  private Result runWorkload() throws IOException {
+    OzoneConfiguration runConf = new OzoneConfiguration(conf);
+    runConf.set(FS_DEFAULT_NAME_KEY, rootPath);
+
+    OMMetrics metrics = cluster.getOzoneManager().getMetrics();
+    long[] latencyNanos = new long[TOTAL_CALLS];
+    try (FileSystem fs = FileSystem.newInstance(URI.create(rootPath), runConf)) {
+      long bucketInfosBefore = metrics.getNumBucketInfos();
+      long getFileStatusBefore = metrics.getNumGetFileStatus();
+      long startNanos = System.nanoTime();
+      int i = 0;
+      for (Path path : accessSequence) {
+        long callStart = System.nanoTime();
+        fs.getFileStatus(path);
+        latencyNanos[i++] = System.nanoTime() - callStart;
+      }
+      long elapsedNanos = System.nanoTime() - startNanos;
+      return new Result(
+          metrics.getNumBucketInfos() - bucketInfosBefore,
+          metrics.getNumGetFileStatus() - getFileStatusBefore,
+          elapsedNanos, latencyNanos);
+    }
+  }
+
+  private static final class Result {
+    private final long infoBucketRpcs;
+    private final long getFileStatusRpcs;
+    private final long elapsedNanos;
+    private final long[] sortedLatencyNanos;
+
+    Result(long infoBucketRpcs, long getFileStatusRpcs, long elapsedNanos,
+        long[] latencyNanos) {
+      this.infoBucketRpcs = infoBucketRpcs;
+      this.getFileStatusRpcs = getFileStatusRpcs;
+      this.elapsedNanos = elapsedNanos;
+      this.sortedLatencyNanos = latencyNanos.clone();
+      Arrays.sort(this.sortedLatencyNanos);
+    }
+
+    double opsPerSecond() {
+      return TOTAL_CALLS
+          / (elapsedNanos / (double) TimeUnit.SECONDS.toNanos(1));
+    }
+
+    double mean() {
+      long sum = 0;
+      for (long l : sortedLatencyNanos) {
+        sum += l;
+      }
+      return sum / (double) sortedLatencyNanos.length;
+    }
+
+    double percentile(double q) {
+      int idx = (int) Math.ceil(q * sortedLatencyNanos.length) - 1;
+      idx = Math.max(0, Math.min(sortedLatencyNanos.length - 1, idx));
+      return sortedLatencyNanos[idx];
+    }
+
+    double max() {
+      return sortedLatencyNanos[sortedLatencyNanos.length - 1];
+    }
+  }
+}

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -29,6 +29,8 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLU
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -132,6 +135,10 @@ public class BasicRootedOzoneClientAdapterImpl
   private BucketLayout defaultOFSBucketLayout;
   private final OzoneConfiguration config;
   private final OzoneClientConfig clientConfig;
+  // Caches resolved bucket layouts by "volume/bucket" so getFileStatus can skip
+  // the InfoBucket RPC. Bucket layout is immutable for a bucket's lifetime;
+  // OBJECT_STORE layouts are cached too and re-rejected from the cache.
+  private final Cache<String, BucketLayout> bucketLayoutCache;
 
   /**
    * Create new OzoneClientAdapter implementation.
@@ -220,6 +227,12 @@ public class BasicRootedOzoneClientAdapterImpl
           OzoneConfigKeys.HDDS_CONTAINER_IPC_PORT_DEFAULT);
 
       clientConfig = conf.getObject(OzoneClientConfig.class);
+      bucketLayoutCache = CacheBuilder.newBuilder()
+          .expireAfterWrite(
+              clientConfig.getFsBucketLayoutCacheExpiry().toMillis(),
+              TimeUnit.MILLISECONDS)
+          .maximumSize(clientConfig.getFsBucketLayoutCacheSize())
+          .build();
       // Fetches the bucket layout to be used by OFS.
       try {
         initDefaultFsBucketLayout(conf);
@@ -351,6 +364,29 @@ public class BasicRootedOzoneClientAdapterImpl
     }
 
     return bucket;
+  }
+
+  /**
+   * Returns the resolved bucket layout for the given path, caching it so that
+   * repeated getFileStatus calls on the same bucket avoid the InfoBucket RPC.
+   * On a cache miss the layout is fetched via {@link ClientProtocol
+   * #getBucketDetails} and, for link buckets, resolved to the source bucket's
+   * layout. OBJECT_STORE layouts are cached like any other; the caller is
+   * responsible for validating the returned layout.
+   */
+  private BucketLayout getResolvedBucketLayout(OFSPath ofsPath)
+      throws IOException {
+    String volumeStr = ofsPath.getVolumeName();
+    String bucketStr = ofsPath.getBucketName();
+    String cacheKey = volumeStr + OZONE_URI_DELIMITER + bucketStr;
+    BucketLayout resolvedBucketLayout = bucketLayoutCache.getIfPresent(cacheKey);
+    if (resolvedBucketLayout == null) {
+      OzoneBucket bucket = proxy.getBucketDetails(volumeStr, bucketStr);
+      resolvedBucketLayout = OzoneClientUtils.resolveLinkBucketLayout(
+          bucket, objectStore, new HashSet<>());
+      bucketLayoutCache.put(cacheKey, resolvedBucketLayout);
+    }
+    return resolvedBucketLayout;
   }
 
   /**
@@ -696,13 +732,19 @@ public class BasicRootedOzoneClientAdapterImpl
       boolean headOp) throws IOException {
     String key = ofsPath.getKeyName();
     try {
-      OzoneBucket bucket = getBucket(ofsPath, false);
       if (ofsPath.isSnapshotPath()) {
+        OzoneBucket bucket = getBucket(ofsPath, false);
         OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
         return getFileStatusAdapterWithSnapshotIndicator(
             volume, bucket, uri);
       } else {
-        OzoneFileStatus status = bucket.getFileStatus(key, headOp);
+        // Validate the bucket layout (rejecting OBJECT_STORE) from the cached
+        // resolved layout, so the InfoBucket RPC is skipped on a cache hit
+        // while preserving the same rejection behavior as getBucket.
+        OzoneFSUtils.validateBucketLayout(ofsPath.getBucketName(),
+            getResolvedBucketLayout(ofsPath));
+        OzoneFileStatus status = proxy.getOzoneFileStatus(
+            ofsPath.getVolumeName(), ofsPath.getBucketName(), key, headOp);
         return toFileStatusAdapter(status, userName, uri, qualifiedPath,
             ofsPath.getNonKeyPath());
       }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
@@ -379,14 +380,24 @@ public class BasicRootedOzoneClientAdapterImpl
     String volumeStr = ofsPath.getVolumeName();
     String bucketStr = ofsPath.getBucketName();
     String cacheKey = volumeStr + OZONE_URI_DELIMITER + bucketStr;
-    BucketLayout resolvedBucketLayout = bucketLayoutCache.getIfPresent(cacheKey);
-    if (resolvedBucketLayout == null) {
-      OzoneBucket bucket = proxy.getBucketDetails(volumeStr, bucketStr);
-      resolvedBucketLayout = OzoneClientUtils.resolveLinkBucketLayout(
-          bucket, objectStore, new HashSet<>());
-      bucketLayoutCache.put(cacheKey, resolvedBucketLayout);
+    try {
+      // Atomic get-or-load: a single thread resolves the layout for a given
+      // bucket on a miss while others wait, so concurrent getFileStatus calls
+      // do not each issue a redundant InfoBucket RPC.
+      return bucketLayoutCache.get(cacheKey, () -> {
+        OzoneBucket bucket = proxy.getBucketDetails(volumeStr, bucketStr);
+        return OzoneClientUtils.resolveLinkBucketLayout(
+            bucket, objectStore, new HashSet<>());
+      });
+    } catch (ExecutionException e) {
+      // Preserve the original IOException (e.g. OMException with BUCKET_NOT_FOUND)
+      // so the caller's result-code handling is unchanged.
+      if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      }
+      throw new IOException("Failed to resolve bucket layout for " + cacheKey,
+          e.getCause());
     }
-    return resolvedBucketLayout;
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
@@ -27,9 +27,13 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -43,7 +47,9 @@ import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,8 +58,10 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * Unit tests for headOp propagation through
- * {@link BasicRootedOzoneClientAdapterImpl#getFileStatus} (HDDS-15678). Uses a
- * partial mock so no OM connection is required.
+ * {@link BasicRootedOzoneClientAdapterImpl#getFileStatus} (HDDS-15678) and the
+ * bucket-layout cache that lets non-snapshot getFileStatus skip the InfoBucket
+ * RPC while still rejecting OBJECT_STORE buckets (HDDS-15925). Uses a partial
+ * mock so no OM connection is required.
  */
 public class TestBasicRootedOzoneClientAdapterHeadOp {
 
@@ -62,6 +70,7 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   private BasicRootedOzoneClientAdapterImpl adapter;
   private OzoneBucket bucket;
+  private ClientProtocol proxy;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -77,10 +86,28 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
     when(volume.getCreationTime()).thenReturn(Instant.EPOCH);
     ObjectStore objectStore = mock(ObjectStore.class);
     when(objectStore.getVolume(anyString())).thenReturn(volume);
+    setField("objectStore", objectStore);
+
+    // The partial mock bypasses the constructor, so inject the client proxy and
+    // a real (unbounded) layout cache that the non-snapshot path relies on.
+    proxy = mock(ClientProtocol.class);
+    setField("proxy", proxy);
+    Cache<String, BucketLayout> bucketLayoutCache =
+        CacheBuilder.newBuilder().build();
+    setField("bucketLayoutCache", bucketLayoutCache);
+  }
+
+  private void setField(String name, Object value) throws Exception {
     Field field =
-        BasicRootedOzoneClientAdapterImpl.class.getDeclaredField("objectStore");
+        BasicRootedOzoneClientAdapterImpl.class.getDeclaredField(name);
     field.setAccessible(true);
-    field.set(adapter, objectStore);
+    field.set(adapter, value);
+  }
+
+  private void stubBucketDetails(BucketLayout layout) throws IOException {
+    OzoneBucket b = mock(OzoneBucket.class);
+    when(b.getBucketLayout()).thenReturn(layout);
+    when(proxy.getBucketDetails(anyString(), anyString())).thenReturn(b);
   }
 
   private static OzoneFileStatus fileStatus(boolean isDir) {
@@ -101,25 +128,29 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void keyPathThreadsHeadOp() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenReturn(fileStatus(false));
+    stubBucketDetails(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(),
+        anyBoolean())).thenReturn(fileStatus(false));
 
     assertFalse(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user", true).isDir());
 
     ArgumentCaptor<Boolean> headOp = ArgumentCaptor.forClass(Boolean.class);
-    verify(bucket).getFileStatus(anyString(), headOp.capture());
+    verify(proxy).getOzoneFileStatus(anyString(), anyString(), anyString(),
+        headOp.capture());
     assertTrue(headOp.getValue());
   }
 
   @Test
   public void fourArgOverloadDoesNotUseHeadOp() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenReturn(fileStatus(true));
+    stubBucketDetails(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(),
+        anyBoolean())).thenReturn(fileStatus(true));
 
     assertTrue(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user").isDir());
-    verify(bucket).getFileStatus(anyString(), eq(false));
+    verify(proxy).getOzoneFileStatus(anyString(), anyString(), anyString(),
+        eq(false));
   }
 
   @Test
@@ -130,8 +161,9 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void fileNotFoundMappedToFileNotFoundException() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenThrow(new OMException("missing",
+    stubBucketDetails(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(),
+        anyBoolean())).thenThrow(new OMException("missing",
             OMException.ResultCodes.FILE_NOT_FOUND));
     assertThrows(FileNotFoundException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
@@ -140,8 +172,9 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void otherOMExceptionPropagates() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
-        .thenThrow(new OMException("boom",
+    stubBucketDetails(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(),
+        anyBoolean())).thenThrow(new OMException("boom",
             OMException.ResultCodes.INTERNAL_ERROR));
     assertThrows(OMException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
@@ -150,12 +183,44 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void bucketNotFoundMappedToFileNotFoundException() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
+    when(proxy.getBucketDetails(anyString(), anyString()))
         .thenThrow(new OMException("no bucket",
             OMException.ResultCodes.BUCKET_NOT_FOUND));
     assertThrows(FileNotFoundException.class,
         () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
             "user", true));
+  }
+
+  @Test
+  public void cacheHitSkipsGetBucketDetails() throws IOException {
+    stubBucketDetails(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(),
+        anyBoolean())).thenReturn(fileStatus(false));
+
+    adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR, "user", true);
+    adapter.getFileStatus("/vol/bucket/key2", URI_OFS, WORKING_DIR, "user", true);
+
+    // Second call to the same bucket is served from the layout cache.
+    verify(proxy, times(1)).getBucketDetails(anyString(), anyString());
+    verify(proxy, times(2)).getOzoneFileStatus(anyString(), anyString(),
+        anyString(), anyBoolean());
+  }
+
+  @Test
+  public void objectStoreLayoutRejectedFromCache() throws IOException {
+    stubBucketDetails(BucketLayout.OBJECT_STORE);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
+            "user", true));
+    // Layout is cached, so the second rejection needs no further InfoBucket RPC.
+    assertThrows(IllegalArgumentException.class,
+        () -> adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
+            "user", true));
+
+    verify(proxy, times(1)).getBucketDetails(anyString(), anyString());
+    verify(proxy, never()).getOzoneFileStatus(anyString(), anyString(),
+        anyString(), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem

On rooted OFS (ofs://), a getFileStatus on a key issues two OM RPCs: getBucket (InfoBucket, to fetch and validate the bucket layout) followed by the actual getFileStatus. This doubles client→OM traffic on getFileStatus-heavy workloads (e.g. Hive/Impala stats collection, listing-then-stat patterns), and the InfoBucket calls are the single largest caller class on the OM read path under load.

The layout fetch exists for one reason on the read path: to reject OBJECT_STORE (OBS) buckets client-side, because OM itself does not reject getFileStatus on an OBS bucket. So the RPC can't simply be dropped without changing behavior.

### Approach

Add a bounded, configurable client-side cache of resolved (volume, bucket) → BucketLayout. Bucket layout is immutable for a bucket's lifetime, so caching it is safe; a TTL bounds the only edge case (delete + recreate with a different layout).

On a non-snapshot key getFileStatus:

Atomic get-or-load the resolved layout via Guava Cache.get(key, Callable) — a single thread resolves a given bucket on a miss while others wait, so concurrent cold misses don't each fire an InfoBucket RPC.
Re-validate the cached layout on every call with OzoneFSUtils.validateBucketLayout, which throws IllegalArgumentException for OBS exactly as getBucket does today — whether the layout came from the cache or a fresh fetch.
The cache holds every resolved layout, OBS included, so repeated access to an OBS bucket is rejected from the cache with zero further RPCs. OMException mapping (FILE_NOT_FOUND / BUCKET_NOT_FOUND → FileNotFoundException) is preserved by rethrowing the original IOException out of the loader. Snapshot paths and all write paths keep calling getBucket unchanged.

Net effect (per bucket, within TTL): first call = 2 RPCs; subsequent FS-bucket calls = 1; subsequent OBS calls = 0 (rejected from cache). getFileStatus behavior is identical to master, only cheaper.

### Configuration

ozone.client.fs.bucket.layout.cache.expiry — ConfigType.TIME, default 2m. Bounds staleness of a cached layout.
ozone.client.fs.bucket.layout.cache.size — default 1000. Bounds cache memory; 0 disables caching (every call re-fetches and re-validates, still correct).
Testing

Generated-by: Claude Code (claude-opus-4-8)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15925

## How was this patch tested?

1. CI: https://github.com/yandrey321/ozone/actions/runs/33423535153/job/99591663437
2. unit test, intgration tests
3. Benchmark (TestOfsGetFileStatusCacheBenchmark, tagged @Tag("benchmark") One MiniOzoneCluster, 200 FSO buckets, 2000 getFileStatus calls (90% cache-hit workload), measured single-threaded and across 10 concurrent client threads sharing one FileSystem. Numbers below are baseline (master) vs this PR, on the same host.

Single-threaded

Metric | Baseline | This PR | Change
-- | -- | -- | --
InfoBucket RPCs | 2000 (1.00/call) | 200 (0.10/call) | −90%
getFileStatus RPCs | 2000 | 2000 | unchanged
latency mean | 0.266 ms | 0.172 ms | −35%
latency p99 | 0.512 ms | 0.377 ms | −26%
throughput | 3,748.7 ops/s | 5,786.8 ops/s | +54%

10 concurrent threads

Metric | Baseline | This PR | Change
-- | -- | -- | --
InfoBucket RPCs | 2000 (1.00/call) | 200 (0.10/call) | −90%
getFileStatus RPCs | 2000 | 2000 | unchanged
latency mean | 0.615 ms | 0.403 ms | −34%
throughput | 16,086.3 ops/s | 24,439.7 ops/s | +52%

The −90% InfoBucket RPC reduction holds identically at 1 and 10 threads: the atomic get-or-load keeps the count at one per bucket even under concurrency, rather than stampeding to one per call. getFileStatus RPC count is unchanged, confirming behavior is preserved