### PR TITLE
HDDS-16353. Pipeline violates the equals and hashCode contract

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -36,8 +36,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicatedReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -519,20 +517,14 @@ public final class Pipeline {
 
     Pipeline that = (Pipeline) o;
 
-    return new EqualsBuilder()
-        .append(id, that.id)
-        .append(replicationConfig, that.replicationConfig)
-        .append(nodeStatus.keySet(), that.nodeStatus.keySet())
-        .isEquals();
+    return id.equals(that.id)
+        && replicationConfig.equals(that.replicationConfig)
+        && nodeStatus.keySet().equals(that.nodeStatus.keySet());
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder()
-        .append(id)
-        .append(replicationConfig.getReplicationType())
-        .append(nodeStatus)
-        .toHashCode();
+    return id.hashCode();
   }
 
   @Override

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -147,4 +147,16 @@ public class TestPipeline {
     Pipeline subject = MockPipeline.createRatisPipeline();
     assertThrows(IllegalStateException.class, () -> subject.copyForReadFromNode(randomDatanodeDetails()));
   }
+
+  @Test
+  void testEqualsAndHashCodeIgnoreNodeStatusValues() throws IOException {
+    Pipeline pipeline = MockPipeline.createRatisPipeline();
+    Pipeline copy = pipeline.toBuilder().setNodes(pipeline.getNodes()).build();
+
+    pipeline.reportDatanode(pipeline.getNodes().get(0));
+
+    assertEquals(pipeline, copy);
+    assertEquals(pipeline.hashCode(), copy.hashCode());
+    assertEquals(pipeline.getId().hashCode(), pipeline.hashCode());
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`Pipeline.equals()` compares the pipeline ID, replication configuration, and the set of datanodes. However, `Pipeline.hashCode()` previously included the complete `nodeStatus` map, whose values contain mutable datanode report timestamps.

As a result, two pipelines with the same ID, replication configuration, and datanodes could be equal while producing different hash codes if their report timestamps differed. This violated the `equals()` and `hashCode()` contract.

This PR:
* Preserves the existing `Pipeline.equals()` semantics while replacing `EqualsBuilder` with direct comparisons.
* Changes `Pipeline.hashCode()` to use only the pipeline ID.
* Removes the unused `EqualsBuilder` and `HashCodeBuilder` imports.
* Adds a regression test covering equal pipelines with different `nodeStatus` values.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16353

## How was this patch tested?

Local Test
```
mvn -pl :hdds-common -am test \
  -Dtest=TestPipeline \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/33425156442

Generated-by: Codex (GPT-5)