### PR TITLE
HDDS-15916. Native memory leak in ECKeyOutputStream: encoder.release() not called in close(), causing ISA-L native memory accumulation

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -727,6 +727,11 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   public synchronized void close() {
     super.close();
     freeBuffers();
+    if (decoder != null) {
+      // Release the decoder's native resources (e.g. ISA-L coder context)
+      // that were allocated lazily in init().
+      decoder.release();
+    }
   }
 
   @Override

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
@@ -26,6 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -52,11 +56,15 @@ import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.ozone.client.io.ECStreamTestUtil.TestBlockInputStream;
 import org.apache.hadoop.ozone.client.io.ECStreamTestUtil.TestBlockInputStreamFactory;
+import org.apache.ozone.erasurecode.rawcoder.RSRawErasureCoderFactory;
+import org.apache.ozone.erasurecode.rawcoder.RawErasureDecoder;
+import org.apache.ozone.erasurecode.rawcoder.util.CodecUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
 
 /**
  * Test for the ECBlockReconstructedStripeInputStream.
@@ -805,6 +813,40 @@ public class TestECBlockReconstructedStripeInputStream {
         assertThat(stream.getEcReplicaIndex()).isGreaterThan(2);
       }
     }
+  }
+
+  @Test
+  public void testDecoderReleasedOnClose() throws IOException {
+    // The stream must release its RawErasureDecoder on close so the decoder's
+    // native resources (e.g. ISA-L coder context) are not leaked. The decoder
+    // is created lazily in init() on the first read.
+    int chunkSize = repConfig.getEcChunkSize();
+    int blockLength = chunkSize * repConfig.getData();
+    ByteBuffer[] dataBufs = allocateBuffers(repConfig.getData(), chunkSize);
+    ECStreamTestUtil.randomFill(dataBufs, chunkSize, dataGen, blockLength);
+    ByteBuffer[] parity = generateParity(dataBufs, repConfig);
+    addDataStreamsToFactory(dataBufs, parity);
+
+    // Data index 1 is missing, so a read must build the decoder to reconstruct.
+    Map<DatanodeDetails, Integer> dnMap =
+        ECStreamTestUtil.createIndexMap(2, 3, 4, 5);
+    BlockLocationInfo keyInfo =
+        ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
+    streamFactory.setCurrentPipeline(keyInfo.getPipeline());
+
+    RawErasureDecoder spyDecoder =
+        spy(new RSRawErasureCoderFactory().createDecoder(repConfig));
+    ByteBuffer[] bufs = allocateByteBuffers(repConfig);
+    try (MockedStatic<CodecUtil> mocked = mockStatic(CodecUtil.class)) {
+      mocked.when(() -> CodecUtil.createRawDecoderWithFallback(any()))
+          .thenReturn(spyDecoder);
+      try (ECBlockReconstructedStripeInputStream ecBlockReconstructedStripeInputStream =
+          createInputStream(keyInfo)) {
+        // The read triggers init(), which creates the (spied) decoder.
+        ecBlockReconstructedStripeInputStream.read(bufs);
+      }
+    }
+    verify(spyDecoder).release();
   }
 
   private ECBlockReconstructedStripeInputStream createInputStream(

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -499,6 +499,9 @@ public final class ECKeyOutputStream extends KeyOutputStream
     } finally {
       closeCurrentStreamEntry();
       blockOutputStreamEntryPool.cleanup();
+      // Release the encoder's native resources (e.g. ISA-L coder context)
+      // that were allocated in the constructor.
+      encoder.release();
     }
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -22,6 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -64,11 +68,13 @@ import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ozone.erasurecode.rawcoder.RSRawErasureCoderFactory;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
+import org.apache.ozone.erasurecode.rawcoder.util.CodecUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 /**
  * Real unit test for OzoneECClient.
@@ -602,6 +608,21 @@ public class TestOzoneECClient {
       assertEquals(inSize, is.read(fileContent));
       assertArrayEquals(partialChunk, Arrays.copyOf(fileContent, inSize));
     }
+  }
+
+  @Test
+  public void testEncoderReleasedOnClose() throws IOException {
+    // The ECKeyOutputStream must release its RawErasureEncoder on close so the
+    // encoder's native resources (e.g. ISA-L coder context) are not leaked.
+    RawErasureEncoder spyEncoder = spy(new RSRawErasureCoderFactory()
+        .createEncoder(new ECReplicationConfig(dataBlocks, parityBlocks)));
+    try (MockedStatic<CodecUtil> mocked = mockStatic(CodecUtil.class)) {
+      mocked.when(() -> CodecUtil.createRawEncoderWithFallback(any()))
+          .thenReturn(spyEncoder);
+      // Creates the ECKeyOutputStream (picks up the spy encoder) and closes it.
+      writeIntoECKey(inputChunks, keyName, null);
+    }
+    verify(spyEncoder).release();
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Any long lived client JVM which is writing EC Keys using `ECKeyOutputStream` leaks native memory. This occurs because `ECKeyOutputStream.close()` never calls `encoder.release()`. When `NativeRSRawEncoder` is in use by `ECKeyOutputStream`, each key creation results in acquiring native memory to store lookup tables used in calculation of Parity Data. This native memory is only freed by calling `release()`. This PR adds `encoder.release()` in `ECKeyOutputStream.close()` to free the native memory.

A similar native memory leak is present through the decoder in `ECBlockReconstructedStripeInputStream`. This PR adds a conditional `decoder.release()` in `ECBlockReconstructedStripeInputStream.close()` to free the native memory.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-15916

## How was this patch tested?
1. Unit Test - Ensures `encoder.release()` is called.
2. Local Docker compose cluster:

### **Env Setup:**
1. Build with `-Phadoop-native-lib`:
`mvn clean package -Pdist -Phadoop-native-lib -DskipTests -DskipShade -DskipRecon -DskipDocs`

2. Update `docker-compose.yaml `to include `isa-l` libraries pre starting `S3Gateway`:
```yaml
s3g:
    <<: *common-config
    environment:
      OZONE_OPTS:
      <<: *replication
    ports:
      - 9878:9878
      - 19878:19878
    command: [ "bash","-c","sudo dnf install -y epel-release && sudo dnf install -y isa-l && exec
      ozone s3g" ]
```

3. Use `linux/amd64` as the default platform:
`export DOCKER_DEFAULT_PLATFORM=linux/amd64`

4. Start the cluster:
`docker compose up -d --scale datanode=5`


### **Running the test:**
1. Create an S3 bucket.
2. Create many objects for key put's through the s3 gateway:
```shell
mkdir -p /tmp/many && cd /tmp/many          # 20,000 tiny objects = 20,000 EC keys
for i in $(seq 1 20000); do echo x > f$i; done
```
3. Put the keys through s3g:
`aws s3 $EP cp --recursive --storage-class STANDARD_IA /tmp/many  s3://leaktest/r1/`

### **Results:**
The RSS (Resident Set Size) for the s3 gateway process was captured after the runs with the fix and without the fix.
Commands used:
1. Trigger manual GC: `jcmd $PID GC.run`
2. Grep the Process RSS: `grep VmRSS /proc/$PID/status`


#### Post-GC RSS floor of the S3 Gateway JVM

| Round | Without fix | Δ/round | With fix | Δ/round |
|------:|------------:|--------:|---------:|--------:|
| baseline | 564 MB | — | 568 MB | — |
| 1 | 789 MB | +225  | 807 MB | +239  |
| 2 | 913 MB | **+124** | 830 MB | **+23** |
| 3 | 993 MB | **+80** | 845 MB | **+16** |
| 4 | 1105 MB | **+112** | 831 MB | **−14** |
| **net (r1→r4)** | | **+316 MB** | | **+25 MB, flat** |%

Without the fix, post each run, there is a clear upward trend in RSS of the `S3Gateway` process.