### PR TITLE
HDDS-16338. Fix no-op table size assertions in TestHSync

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -501,7 +501,7 @@ public class TestHSync {
           // Verify hsync openKey gets committed eventually
           // Key without hsync is deleted
           GenericTestUtils.waitFor(() ->
-              getOpenKeyInfo(BUCKET_LAYOUT).isEmpty(), 1000, 12000);
+              filterByKeyName(getOpenKeyInfo(BUCKET_LAYOUT), key1.getName(), key2.getName()).isEmpty(), 1000, 12000);
           // Verify only one key is still present in fileTable
           assertEquals(1, filterByKeyName(getKeyInfo(BUCKET_LAYOUT), key1.getName(), key2.getName()).size());
 
@@ -578,14 +578,14 @@ public class TestHSync {
         os.write(1);
         os.hsync();
         // There should be 1 key in openFileTable
-        assertEquals(1, getOpenKeyInfo(BUCKET_LAYOUT).size());
+        assertEquals(1, filterByKeyName(getOpenKeyInfo(BUCKET_LAYOUT), key1.getName()).size());
         // Delete directory recursively
         fs.delete(new Path(OZONE_ROOT + bucket.getVolumeName() + OZONE_URI_DELIMITER +
             bucket.getName() + OZONE_URI_DELIMITER + "dir1/"), true);
 
         // Verify if DELETED_HSYNC_KEY metadata is added to openKey
         GenericTestUtils.waitFor(() -> {
-          List<OmKeyInfo> omKeyInfo = getOpenKeyInfo(BUCKET_LAYOUT);
+          List<OmKeyInfo> omKeyInfo = filterByKeyName(getOpenKeyInfo(BUCKET_LAYOUT), key1.getName());
           return !omKeyInfo.isEmpty() && omKeyInfo.get(0).getMetadata().containsKey(OzoneConsts.DELETED_HSYNC_KEY);
         }, 1000, 12000);
 
@@ -594,7 +594,7 @@ public class TestHSync {
 
         // Verify entry from openKey gets deleted eventually
         GenericTestUtils.waitFor(() ->
-            getOpenKeyInfo(BUCKET_LAYOUT).isEmpty(), 1000, 12000);
+            filterByKeyName(getOpenKeyInfo(BUCKET_LAYOUT), key1.getName()).isEmpty(), 1000, 12000);
       } catch (OMException ex) {
         assertEquals(OMException.ResultCodes.DIRECTORY_NOT_FOUND, ex.getResult());
       } finally {
@@ -621,10 +621,10 @@ public class TestHSync {
   private List<OmKeyInfo> getKeyInfo(BucketLayout bucketLayout) {
     List<OmKeyInfo> omKeyInfo = new ArrayList<>();
 
-    Table<String, OmKeyInfo> openFileTable =
+    Table<String, OmKeyInfo> fileTable =
         cluster.getOzoneManager().getMetadataManager().getKeyTable(bucketLayout);
     try (Table.KeyValueIterator<String, OmKeyInfo>
-             iterator = openFileTable.iterator()) {
+             iterator = fileTable.iterator()) {
       while (iterator.hasNext()) {
         omKeyInfo.add(iterator.next().getValue());
       }
@@ -641,7 +641,7 @@ public class TestHSync {
     List<OmKeyInfo> filtered = new ArrayList<>();
     for (OmKeyInfo omKeyInfo : omKeyInfos) {
       for (String keyName : keyNames) {
-        if (keyName.equals(omKeyInfo.getKeyName())) {
+        if (keyName.equals(omKeyInfo.getFileName())) {
           filtered.add(omKeyInfo);
           break;
         }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -35,7 +35,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_LEASE_HARD_LIMIT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD;
 import static org.apache.ozone.test.OzoneTestBase.uniqueObjectName;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -493,9 +492,9 @@ public class TestHSync {
         try (FSDataOutputStream os1 = fs.create(key2, true)) {
           os1.write(1);
           // There should be 2 key in openFileTable
-          assertThat(2 == getOpenKeyInfo(BUCKET_LAYOUT).size());
+          assertEquals(2, getOpenKeyInfo(BUCKET_LAYOUT).size());
           // One key will be in fileTable as hsynced
-          assertThat(1 == getKeyInfo(BUCKET_LAYOUT).size());
+          assertEquals(1, getKeyInfo(BUCKET_LAYOUT).size());
 
           // Resume openKeyCleanupService
           openKeyCleanupService.resume();
@@ -504,7 +503,7 @@ public class TestHSync {
           GenericTestUtils.waitFor(() ->
               getOpenKeyInfo(BUCKET_LAYOUT).isEmpty(), 1000, 12000);
           // Verify only one key is still present in fileTable
-          assertThat(1 == getKeyInfo(BUCKET_LAYOUT).size());
+          assertEquals(1, getKeyInfo(BUCKET_LAYOUT).size());
 
           // Clean up
           assertTrue(fs.delete(key1, false));
@@ -579,7 +578,7 @@ public class TestHSync {
         os.write(1);
         os.hsync();
         // There should be 1 key in openFileTable
-        assertThat(1 == getOpenKeyInfo(BUCKET_LAYOUT).size());
+        assertEquals(1, getOpenKeyInfo(BUCKET_LAYOUT).size());
         // Delete directory recursively
         fs.delete(new Path(OZONE_ROOT + bucket.getVolumeName() + OZONE_URI_DELIMITER +
             bucket.getName() + OZONE_URI_DELIMITER + "dir1/"), true);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -492,9 +492,9 @@ public class TestHSync {
         try (FSDataOutputStream os1 = fs.create(key2, true)) {
           os1.write(1);
           // There should be 2 key in openFileTable
-          assertEquals(2, getOpenKeyInfo(BUCKET_LAYOUT).size());
+          assertEquals(2, filterByKeyName(getOpenKeyInfo(BUCKET_LAYOUT), key1.getName(), key2.getName()).size());
           // One key will be in fileTable as hsynced
-          assertEquals(1, getKeyInfo(BUCKET_LAYOUT).size());
+          assertEquals(1, filterByKeyName(getKeyInfo(BUCKET_LAYOUT), key1.getName(), key2.getName()).size());
 
           // Resume openKeyCleanupService
           openKeyCleanupService.resume();
@@ -503,7 +503,7 @@ public class TestHSync {
           GenericTestUtils.waitFor(() ->
               getOpenKeyInfo(BUCKET_LAYOUT).isEmpty(), 1000, 12000);
           // Verify only one key is still present in fileTable
-          assertEquals(1, getKeyInfo(BUCKET_LAYOUT).size());
+          assertEquals(1, filterByKeyName(getKeyInfo(BUCKET_LAYOUT), key1.getName(), key2.getName()).size());
 
           // Clean up
           assertTrue(fs.delete(key1, false));
@@ -631,6 +631,23 @@ public class TestHSync {
     } catch (Exception e) {
     }
     return omKeyInfo;
+  }
+
+  /**
+   * Tests in this class share one bucket, so other tests' keys can still be in the tables.
+   * Narrow a table listing down to the keys the calling test created.
+   */
+  private List<OmKeyInfo> filterByKeyName(List<OmKeyInfo> omKeyInfos, String... keyNames) {
+    List<OmKeyInfo> filtered = new ArrayList<>();
+    for (OmKeyInfo omKeyInfo : omKeyInfos) {
+      for (String keyName : keyNames) {
+        if (keyName.equals(omKeyInfo.getKeyName())) {
+          filtered.add(omKeyInfo);
+          break;
+        }
+      }
+    }
+    return filtered;
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestHSync` had four no-op AssertJ calls of the form `assertThat(n == collection.size())`. `assertThat(boolean)` only builds an `AbstractBooleanAssert`, so those size checks never failed.

They live in two tests:

* `testHSyncOpenKeyCommitAfterExpiry`: after expire, `OpenKeyCleanupService` should commit the hsynced open key and delete the non-hsync one. The size checks are about this test's `key1`/`key2`, not the whole tables.
* `testHSyncOpenKeyDeletionWhileDeleteDirectory`: after hsync, openFileTable should have that one open key before the directory is deleted.

This class shares one static bucket and `getOpenKeyInfo` / `getKeyInfo` scan the entire layout. Turning the first test's checks into global `assertEquals` failed CI (`expected: <1> but was: <4>` on fileTable; [round 1](https://github.com/shuan1026/ozone/actions/runs/33292933066/job/99208880146)) because other tests leave committed keys behind. That is shared test state, not an hsync/cleanup product bug.

This PR:

* replaces all four no-ops with `assertEquals`, matching the rest of the file
* scopes the three expiry-test counts with `filterByKeyName(..., key1, key2)`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16338

## How was this patch tested?

- Round 1 (global table `assertEquals` only): failed `TestHSync.testHSyncOpenKeyCommitAfterExpiry`: https://github.com/shuan1026/ozone/actions/runs/33292933066/job/99208880146
- Round 2 (with `filterByKeyName`): full fork CI: https://github.com/shuan1026/ozone/actions/runs/33299986156