### PR TITLE
HDDS-16145. Fix race between DeletedBlockLogStateManager transaction removal and SCM HA buffer flush

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -157,14 +157,23 @@ public class DeletedBlockLogStateManagerImpl
   @Override
   public void removeTransactionsFromDB(ArrayList<Long> txIDs, DeletedBlocksTransactionSummary summary)
       throws IOException {
-    if (deletingTxIDs != null) {
-      deletingTxIDs.addAll(txIDs);
-    }
-    for (Long txID : txIDs) {
-      transactionBuffer.removeFromBuffer(deletedTable, txID);
-    }
-    if (summary != null) {
-      transactionBuffer.addToBuffer(statefulConfigTable, SERVICE_NAME, summary.toByteString());
+    // Hold the buffer lock across the whole mark-remove-summary sequence so that a concurrent flush()
+    // (checkpoint download or leader transfer) cannot land between marking these txIDs as hidden and their
+    // removal being durably flushed. Otherwise onFlush() would reset deletingTxIDs while the row is still
+    // present, re-exposing it to the deletion scanner and causing the summary to be double-decremented.
+    transactionBuffer.lock();
+    try {
+      if (deletingTxIDs != null) {
+        deletingTxIDs.addAll(txIDs);
+      }
+      for (Long txID : txIDs) {
+        transactionBuffer.removeFromBuffer(deletedTable, txID);
+      }
+      if (summary != null) {
+        transactionBuffer.addToBuffer(statefulConfigTable, SERVICE_NAME, summary.toByteString());
+      }
+    } finally {
+      transactionBuffer.unlock();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -72,8 +72,8 @@ public class DeletedBlockLogStateManagerImpl
       throws IOException {
     return new Table.KeyValueIterator<Long, DeletedBlocksTransaction>() {
 
-      private final Table.KeyValueIterator<Long, DeletedBlocksTransaction> iter = deletedTable.iterator();
       private final Set<Long> snapshotDeletingTxIDs = deletingTxIDs;
+      private final Table.KeyValueIterator<Long, DeletedBlocksTransaction> iter = deletedTable.iterator();
       private TypedTable.KeyValue<Long, DeletedBlocksTransaction> nextTx;
 
       {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBuffer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBuffer.java
@@ -54,4 +54,8 @@ public interface SCMHADBTransactionBuffer
   void beginApplyingTransaction();
 
   void endApplyingTransaction();
+
+  void lock();
+
+  void unlock();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
@@ -185,6 +185,16 @@ public class SCMHADBTransactionBufferImpl implements SCMHADBTransactionBuffer {
   }
 
   @Override
+  public void lock() {
+    rwLock.readLock().lock();
+  }
+
+  @Override
+  public void unlock() {
+    rwLock.readLock().unlock();
+  }
+
+  @Override
   public void init() throws RocksDatabaseException, CodecException {
     metadataStore = scm.getScmMetadataStore();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferStub.java
@@ -115,6 +115,16 @@ public class SCMHADBTransactionBufferStub implements SCMHADBTransactionBuffer {
   }
 
   @Override
+  public void lock() {
+    rwLock.readLock().lock();
+  }
+
+  @Override
+  public void unlock() {
+    rwLock.readLock().unlock();
+  }
+
+  @Override
   public void flush() throws RocksDatabaseException {
     rwLock.writeLock().lock();
     try {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHATransactionBufferMonitorTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHATransactionBufferMonitorTask.java
@@ -18,21 +18,36 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
+import static org.apache.ozone.test.GenericTestUtils.waitFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
 import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.block.BlockManager;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
+import org.apache.hadoop.hdds.scm.block.DeletedBlockLogStateManagerImpl;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStoreImpl;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -64,6 +79,7 @@ public class TestSCMHATransactionBufferMonitorTask {
   private SCMHADBTransactionBufferImpl transactionBuffer;
   private Table<String, ByteString> statefulServiceConfigTable;
   private Table<String, TransactionInfo> transactionInfoTable;
+  private DeletedBlockLogImpl deletedBlockLog;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -74,7 +90,7 @@ public class TestSCMHATransactionBufferMonitorTask {
 
     StorageContainerManager scm = mock(StorageContainerManager.class);
     BlockManager blockManager = mock(BlockManager.class);
-    DeletedBlockLogImpl deletedBlockLog = mock(DeletedBlockLogImpl.class);
+    deletedBlockLog = mock(DeletedBlockLogImpl.class);
     Clock clock = mock(Clock.class);
     when(clock.millis()).thenAnswer(invocation -> clockMillis.get());
     when(scm.getScmMetadataStore()).thenReturn(metadataStore);
@@ -271,5 +287,123 @@ public class TestSCMHATransactionBufferMonitorTask {
     assertEquals(TRX_INFO_T5, transactionInfoTable.get(TRANSACTION_INFO_KEY));
     assertEquals(ByteString.copyFromUtf8("value"),
         statefulServiceConfigTable.get("key"));
+  }
+
+  /**
+   * Verifies that {@link SCMHADBTransactionBuffer#lock()} establishes mutual exclusion with
+   * {@link SCMHADBTransactionBufferImpl#flush()}'s write lock (HDDS-16145).
+   */
+  @Test
+  public void testLockBlocksConcurrentFlush() throws Exception {
+    transactionBuffer.updateLatestTrxInfo(TRX_INFO_T4);
+    transactionBuffer.flush();
+
+    transactionBuffer.lock();
+    Thread flusher = new Thread(() -> {
+      transactionBuffer.updateLatestTrxInfo(TRX_INFO_T5);
+      try {
+        transactionBuffer.flush();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    flusher.start();
+    waitFor(() -> flusher.getState() == Thread.State.WAITING, 10, 5_000);
+
+    // flush() must not have committed while the buffer lock is held.
+    assertEquals(TRX_INFO_T4, transactionInfoTable.get(TRANSACTION_INFO_KEY));
+
+    transactionBuffer.unlock();
+    flusher.join(10_000);
+    assertEquals(TRX_INFO_T5, transactionInfoTable.get(TRANSACTION_INFO_KEY));
+  }
+
+  /**
+   * Verifies that {@link DeletedBlockLogStateManagerImpl#removeTransactionsFromDB} holds the buffer
+   * lock across its whole mark-remove-summary sequence, so a concurrent flush() cannot land right
+   * after txId is marked hidden but before it is actually removed from the buffer (HDDS-16145).
+   * Without the fix, that gap has no lock protecting it: flush() lands there, resets
+   * {@code deletingTxIDs}, and re-exposes the still-present row to the deletion scanner.
+   */
+  @Test
+  public void testRemoveTransactionsFromDBBlocksConcurrentFlushUntilDurable() throws Exception {
+    long txId = 42L;
+    DeletedBlocksTransaction tx = DeletedBlocksTransaction.newBuilder()
+        .setTxID(txId)
+        .setContainerID(1L)
+        .setCount(0)
+        .addLocalID(1L)
+        .build();
+
+    Table<Long, DeletedBlocksTransaction> deletedTable = metadataStore.getDeletedBlocksTXTable();
+    DeletedBlockLogStateManagerImpl stateManager = new DeletedBlockLogStateManagerImpl(
+        deletedTable, statefulServiceConfigTable, mock(ContainerManager.class), transactionBuffer);
+    doAnswer(invocation -> {
+      stateManager.onFlush();
+      return null;
+    }).when(deletedBlockLog).onFlush();
+
+    // Baseline: the transaction is durably present and deletingTxIDs is empty.
+    stateManager.addTransactionsToDB(new ArrayList<>(Collections.singletonList(tx)), null);
+    transactionBuffer.updateLatestTrxInfo(TRX_INFO_T4);
+    transactionBuffer.flush();
+    assertNotNull(deletedTable.get(txId));
+
+    // Replace deletingTxIDs with a spy so the remover can be paused right after it marks txId as
+    // hidden but before it removes the row from the buffer - the exact gap the fix's buffer lock
+    // must cover.
+    Field deletingTxIDsField = DeletedBlockLogStateManagerImpl.class.getDeclaredField("deletingTxIDs");
+    deletingTxIDsField.setAccessible(true);
+    Set<Long> spyDeletingTxIDs = spy((Set<Long>) deletingTxIDsField.get(stateManager));
+    deletingTxIDsField.set(stateManager, spyDeletingTxIDs);
+
+    CountDownLatch marked = new CountDownLatch(1);
+    CountDownLatch releaseRemoval = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      boolean result = (Boolean) invocation.callRealMethod();
+      marked.countDown();
+      releaseRemoval.await(10, TimeUnit.SECONDS);
+      return result;
+    }).when(spyDeletingTxIDs).addAll(any());
+
+    ArrayList<Long> txIDs = new ArrayList<>(Collections.singletonList(txId));
+    Thread remover = new Thread(() -> {
+      try {
+        stateManager.removeTransactionsFromDB(txIDs, null);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+    remover.start();
+    assertTrue(marked.await(10, TimeUnit.SECONDS),
+        "Timed out waiting for remover to mark txId as hidden");
+
+    Thread flusher = new Thread(() -> {
+      transactionBuffer.updateLatestTrxInfo(TRX_INFO_T5);
+      try {
+        transactionBuffer.flush();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    flusher.start();
+    waitFor(() -> flusher.getState() == Thread.State.WAITING, 10, 5_000);
+
+    // The remover has marked txId as hidden but not yet removed it from the buffer: flush must
+    // still be blocked by the buffer lock, so the row remains durably present and hidden.
+    assertEquals(TRX_INFO_T4, transactionInfoTable.get(TRANSACTION_INFO_KEY));
+    assertNotNull(deletedTable.get(txId));
+
+    releaseRemoval.countDown();
+    remover.join(10_000);
+    flusher.join(10_000);
+
+    // Only once removeTransactionsFromDB releases the lock can flush proceed: it durably removes
+    // the row and resets deletingTxIDs together, so the row is never re-exposed to the scanner.
+    assertNull(deletedTable.get(txId));
+    assertEquals(TRX_INFO_T5, transactionInfoTable.get(TRANSACTION_INFO_KEY));
+    try (Table.KeyValueIterator<Long, DeletedBlocksTransaction> iterator = stateManager.getReadOnlyIterator()) {
+      assertFalse(iterator.hasNext());
+    }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHATransactionBufferMonitorTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHATransactionBufferMonitorTask.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.block.BlockManager;
@@ -298,7 +299,6 @@ public class TestSCMHATransactionBufferMonitorTask {
     transactionBuffer.updateLatestTrxInfo(TRX_INFO_T4);
     transactionBuffer.flush();
 
-    transactionBuffer.lock();
     Thread flusher = new Thread(() -> {
       transactionBuffer.updateLatestTrxInfo(TRX_INFO_T5);
       try {
@@ -307,13 +307,16 @@ public class TestSCMHATransactionBufferMonitorTask {
         throw new RuntimeException(e);
       }
     });
-    flusher.start();
-    waitFor(() -> flusher.getState() == Thread.State.WAITING, 10, 5_000);
+    transactionBuffer.lock();
+    try {
+      flusher.start();
+      waitFor(() -> flusher.getState() == Thread.State.WAITING, 10, 5_000);
 
-    // flush() must not have committed while the buffer lock is held.
-    assertEquals(TRX_INFO_T4, transactionInfoTable.get(TRANSACTION_INFO_KEY));
-
-    transactionBuffer.unlock();
+      // flush() must not have committed while the buffer lock is held.
+      assertEquals(TRX_INFO_T4, transactionInfoTable.get(TRANSACTION_INFO_KEY));
+    } finally {
+      transactionBuffer.unlock();
+    }
     flusher.join(10_000);
     assertEquals(TRX_INFO_T5, transactionInfoTable.get(TRANSACTION_INFO_KEY));
   }
@@ -404,6 +407,75 @@ public class TestSCMHATransactionBufferMonitorTask {
     assertEquals(TRX_INFO_T5, transactionInfoTable.get(TRANSACTION_INFO_KEY));
     try (Table.KeyValueIterator<Long, DeletedBlocksTransaction> iterator = stateManager.getReadOnlyIterator()) {
       assertFalse(iterator.hasNext());
+    }
+  }
+
+  /**
+   * Verifies that getReadOnlyIterator does not return a row that a concurrent
+   * flush() has already removed. deletingTxIDs must be captured before creating
+   * the RocksDB iterator to avoid a race where flush() removes the row and resets
+   * deletingTxIDs before it is read.
+   */
+  @Test
+  public void testGetReadOnlyIteratorDoesNotReExposeRowRemovedDuringConcurrentFlush() throws Exception {
+    long txId = 42L;
+    DeletedBlocksTransaction tx = DeletedBlocksTransaction.newBuilder()
+        .setTxID(txId)
+        .setContainerID(1L)
+        .setCount(0)
+        .addLocalID(1L)
+        .build();
+
+    Table<Long, DeletedBlocksTransaction> deletedTable = spy(metadataStore.getDeletedBlocksTXTable());
+    DeletedBlockLogStateManagerImpl stateManager = new DeletedBlockLogStateManagerImpl(
+        deletedTable, statefulServiceConfigTable, mock(ContainerManager.class), transactionBuffer);
+    doAnswer(invocation -> {
+      stateManager.onFlush();
+      return null;
+    }).when(deletedBlockLog).onFlush();
+
+    stateManager.addTransactionsToDB(new ArrayList<>(Collections.singletonList(tx)), null);
+    transactionBuffer.updateLatestTrxInfo(TRX_INFO_T4);
+    transactionBuffer.flush();
+
+    // Mark txId as hidden and buffer its removal without flushing yet - mirrors the state right
+    // after removeTransactionsFromDB() runs but before the next flush() makes it durable.
+    stateManager.removeTransactionsFromDB(new ArrayList<>(Collections.singletonList(txId)), null);
+
+    // Let the RocksDB iterator take its snapshot (still showing txId, since the removal above is
+    // only buffered, not yet committed), then pause before returning it so a concurrent flush() can
+    // commit the removal and reset deletingTxIDs underneath the already-created iterator.
+    CountDownLatch iteratorSnapshotTaken = new CountDownLatch(1);
+    CountDownLatch releaseIterator = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      Table.KeyValueIterator<Long, DeletedBlocksTransaction> result =
+          (Table.KeyValueIterator<Long, DeletedBlocksTransaction>) invocation.callRealMethod();
+      iteratorSnapshotTaken.countDown();
+      releaseIterator.await(10, TimeUnit.SECONDS);
+      return result;
+    }).when(deletedTable).iterator(any(), any());
+
+    AtomicReference<Table.KeyValueIterator<Long, DeletedBlocksTransaction>> iteratorRef = new AtomicReference<>();
+    Thread reader = new Thread(() -> {
+      try {
+        iteratorRef.set(stateManager.getReadOnlyIterator());
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+    reader.start();
+    assertTrue(iteratorSnapshotTaken.await(10, TimeUnit.SECONDS),
+        "Timed out waiting for getReadOnlyIterator to take its RocksDB snapshot");
+
+    transactionBuffer.updateLatestTrxInfo(TRX_INFO_T5);
+    transactionBuffer.flush();
+
+    releaseIterator.countDown();
+    reader.join(10_000);
+
+    try (Table.KeyValueIterator<Long, DeletedBlocksTransaction> iterator = iteratorRef.get()) {
+      assertFalse(iterator.hasNext(),
+          "getReadOnlyIterator must not re-expose a row that flush() already committed and hid");
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`DeletedBlockLogStateManagerImpl#removeTransactionsFromDB` marks a batch of transaction IDs as hidden (`deletingTxIDs`), removes each one from the SCM HA transaction buffer, and writes an updated summary — as three
separate calls, each independently protected only for its own duration by `SCMHADBTransactionBuffer`'s internal read lock.

A concurrent `flush()` (holding the buffer's write lock, e.g. triggered by the periodic flush monitor, a Ratis checkpoint download, or a leader transfer) can land in the gap between these calls. If it lands after a
txID has been marked hidden but before it has actually been removed from the buffer, `flush()` calls `onFlush()`, which resets `deletingTxIDs` — while the transaction's row is still durably present in the deleted-blocks table. The row is then re-exposed to `getReadOnlyIterator()` (the deletion scanner) even though its removal is still in progress, which can cause the transaction to be processed again and its summary count to be double-decremented.

This PR adds `lock()`/`unlock()` to `SCMHADBTransactionBuffer` (backed by the buffer's existing `ReentrantReadWriteLock` read lock) and has `removeTransactionsFromDB` acquire it across the entire mark-remove-
summary sequence. Since `flush()` takes the write lock, it cannot proceed until the whole sequence has released the read lock, so it can only observe the sequence fully completed or not yet started — never midway through.

## What is the link to the Apache JIRA

HDDS-16145

## How was this patch tested?

Added testcases
