### PR TITLE
HDDS-16372. Surface OM's detailed message for rejected lifecycle configuration

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -2190,6 +2190,27 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     assertEquals(ErrorType.Client, ase2.getErrorType());
     assertEquals(HttpURLConnection.HTTP_NOT_FOUND, ase2.getStatusCode());
     assertEquals("NoSuchBucket", ase2.getErrorCode());
+
+    BucketLifecycleConfiguration pastDateConfig = new BucketLifecycleConfiguration();
+    List<BucketLifecycleConfiguration.Rule> pastDateRules = new ArrayList<>();
+    BucketLifecycleConfiguration.Rule pastDateRule = new BucketLifecycleConfiguration.Rule()
+        .withId("past-date")
+        .withPrefix("logs/")
+        .withStatus(BucketLifecycleConfiguration.ENABLED)
+        .withExpirationDate(Date.from(Instant.parse("2020-01-01T00:00:00Z")));
+    pastDateRules.add(pastDateRule);
+    pastDateConfig.setRules(pastDateRules);
+    SetBucketLifecycleConfigurationRequest pastDateRequest =
+        new SetBucketLifecycleConfigurationRequest(bucketName, pastDateConfig);
+
+    AmazonServiceException ase3 = assertThrows(AmazonServiceException.class,
+        () -> s3Client.setBucketLifecycleConfiguration(pastDateRequest));
+    assertEquals(ErrorType.Client, ase3.getErrorType());
+    assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, ase3.getStatusCode());
+    assertEquals(S3ErrorTable.INVALID_REQUEST.getCode(), ase3.getErrorCode());
+    assertTrue(ase3.getErrorMessage().contains("must be in the future"),
+        "The client should receive OM's detailed message explaining the date is in the past, got: "
+            + ase3.getErrorMessage());
   }
 
   @Test

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -2589,6 +2589,26 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
             .lifecycleConfiguration(validConfig)));
     assertEquals(HttpURLConnection.HTTP_NOT_FOUND, exception2.statusCode());
     assertEquals(S3ErrorTable.NO_SUCH_BUCKET.getCode(), exception2.awsErrorDetails().errorCode());
+
+    LifecycleRule pastDateRule = LifecycleRule.builder()
+        .id("past-date")
+        .prefix("logs/")
+        .status(ExpirationStatus.ENABLED)
+        .expiration(LifecycleExpiration.builder().date(Instant.parse("2020-01-01T00:00:00Z")).build())
+        .build();
+    BucketLifecycleConfiguration pastDateConfig = BucketLifecycleConfiguration.builder()
+        .rules(pastDateRule)
+        .build();
+
+    S3Exception exception3 = assertThrows(S3Exception.class,
+        () -> s3Client.putBucketLifecycleConfiguration(b -> b
+            .bucket(bucketName)
+            .lifecycleConfiguration(pastDateConfig)));
+    assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, exception3.statusCode());
+    assertEquals(S3ErrorTable.INVALID_REQUEST.getCode(), exception3.awsErrorDetails().errorCode());
+    assertTrue(exception3.awsErrorDetails().errorMessage().contains("must be in the future"),
+        "The client should receive OM's detailed message explaining the date is in the past, got: "
+            + exception3.awsErrorDetails().errorMessage());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
@@ -142,9 +142,9 @@ public class BucketLifecycleHandler extends BucketOperationHandler {
       // translation maps to InvalidRequest. AWS S3 uses InvalidArgument for a rejected lifecycle
       // configuration, so only this validation step is remapped.
       if (ex.getResult() == OMException.ResultCodes.INVALID_REQUEST) {
-        throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, bucketName, ex);
+        throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, bucketName, ex).withMessage(ex.getMessage());
       }
-      throw S3ErrorTable.newError(bucketName, ex);
+      throw S3ErrorTable.newError(bucketName, ex).withMessage(ex.getMessage());
     }
 
     try {
@@ -152,7 +152,7 @@ public class BucketLifecycleHandler extends BucketOperationHandler {
     } catch (OMException ex) {
       // OM raises INVALID_REQUEST for server-side conditions as well, such as a bucket layout
       // mismatch, so its result codes keep the shared translation instead of being remapped.
-      throw S3ErrorTable.newError(bucketName, ex);
+      throw S3ErrorTable.newError(bucketName, ex).withMessage(ex.getMessage());
     }
     return Response.ok().build();
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketLifecycleHandler.java
@@ -152,7 +152,11 @@ public class BucketLifecycleHandler extends BucketOperationHandler {
     } catch (OMException ex) {
       // OM raises INVALID_REQUEST for server-side conditions as well, such as a bucket layout
       // mismatch, so its result codes keep the shared translation instead of being remapped.
-      throw S3ErrorTable.newError(bucketName, ex).withMessage(ex.getMessage());
+      OS3Exception os3Exception = S3ErrorTable.newError(bucketName, ex);
+      if (ex.getResult() == OMException.ResultCodes.INVALID_REQUEST) {
+        os3Exception.withMessage(ex.getMessage());
+      }
+      throw os3Exception;
     }
     return Response.ok().build();
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
@@ -32,6 +32,7 @@ import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.QUOTA_EXCEEDED;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.EXPECTED_BUCKET_OWNER_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -53,6 +54,7 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmLCExpiration;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.junit.jupiter.api.BeforeEach;
@@ -246,6 +248,12 @@ public class TestS3LifecycleConfigurationPut {
 
   private void assertUnhandledOMExceptionPropagated(OMException omException,
       int expectedHttpCode, String expectedErrorCode) throws Exception {
+    OS3Exception ex = putLifecycleConfigurationThrowingOm(omException);
+    assertEquals(expectedHttpCode, ex.getHttpCode());
+    assertEquals(expectedErrorCode, ex.getCode());
+  }
+
+  private OS3Exception putLifecycleConfigurationThrowingOm(OMException omException) throws Exception {
     OzoneClient mockClient = mock(OzoneClient.class);
     ObjectStore mockObjectStore = mock(ObjectStore.class);
     OzoneVolume mockVolume = mock(OzoneVolume.class);
@@ -266,10 +274,23 @@ public class TestS3LifecycleConfigurationPut {
         .build();
     endpoint.queryParamsForTest().set(S3Consts.QueryParams.LIFECYCLE, "");
 
-    OS3Exception ex = assertThrows(OS3Exception.class,
-        () -> endpoint.put("bucket1", onePrefix()));
-    assertEquals(expectedHttpCode, ex.getHttpCode());
-    assertEquals(expectedErrorCode, ex.getCode());
+    return assertThrows(OS3Exception.class, () -> endpoint.put("bucket1", onePrefix()));
+  }
+
+  @Test
+  public void testPutLifecycleConfigurationWithPastExpirationDateReturnsDetailedMessage() throws Exception {
+    OMException omException = assertThrows(OMException.class,
+        () -> new OmLCExpiration.Builder().setDate("2020-01-01T00:00:00Z").build()
+            .valid(System.currentTimeMillis()));
+    assertTrue(omException.getMessage().contains("must be in the future"),
+        "Precondition: OM's real validation message should explain the date is in the past, got: "
+            + omException.getMessage());
+
+    OS3Exception ex = putLifecycleConfigurationThrowingOm(omException);
+    assertEquals(HTTP_BAD_REQUEST, ex.getHttpCode());
+    assertEquals(INVALID_REQUEST.getCode(), ex.getCode());
+    assertEquals(omException.getMessage(), ex.getErrorMessage(),
+        "The client should receive OM's detailed message explaining the date is in the past");
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestS3LifecycleConfigurationPut.java
@@ -241,9 +241,11 @@ public class TestS3LifecycleConfigurationPut {
       throws Exception {
     // An unexpected internal OM failure must be reported as InternalError (HTTP 500),
     // not swallowed into a false HTTP 200 success.
-    assertUnhandledOMExceptionPropagated(
-        new OMException("boom", OMException.ResultCodes.INTERNAL_ERROR),
-        HTTP_INTERNAL_ERROR, INTERNAL_ERROR.getCode());
+    OMException omException = new OMException("boom", OMException.ResultCodes.INTERNAL_ERROR);
+    OS3Exception ex = putLifecycleConfigurationThrowingOm(omException);
+    assertEquals(HTTP_INTERNAL_ERROR, ex.getHttpCode());
+    assertEquals(INTERNAL_ERROR.getCode(), ex.getCode());
+    assertEquals(INTERNAL_ERROR.getErrorMessage(), ex.getErrorMessage());
   }
 
   private void assertUnhandledOMExceptionPropagated(OMException omException,


### PR DESCRIPTION
## What changes were proposed in this pull request?
`PutBucketLifecycleConfiguration` was returning only the generic "Invalid Request" message for any lifecycle configuration rejected by OM — for example, a lifecycle rule with an `Expiration.Date` in the past — with no indication of *why* the request was rejected.

`BucketLifecycleHandler.putBucketLifecycleConfiguration()` catches `OMException` from both the client-side rule validation and the `ozoneBucket.setLifecycleConfiguration(...)` RPC call, and rethrows it as an `OS3Exception` via `S3ErrorTable.newError(...)`. However, `OS3Exception`'s constructor always sets `errorMessage` to the static generic `S3ErrorTable` text and never copies the underlying cause's message, so OM's specific validation detail (e.g. "Invalid lifecycle configuration: 'Date' must be in the future ...") never reached the client.

This chains `.withMessage(ex.getMessage())` onto the `OS3Exception` at all three `S3ErrorTable.newError(...)` call sites in `putBucketLifecycleConfiguration()`, matching the existing pattern already used in `MessageUnmarshaller` and `CompleteMultipartUploadRequestUnmarshaller` for the same purpose.

## What is the link to the Apache JIRA

HDDS-16372

## How was this patch tested?

Tested using added test cases that created by AI
