### PR TITLE
HDDS-16373. Fix InterSCMGrpcClient checkpoint download deadline unit

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
@@ -81,7 +81,7 @@ public class InterSCMGrpcClient implements SCMSnapshotDownloader {
 
     channel = channelBuilder.build();
     client = InterSCMProtocolServiceGrpc.newStub(channel).
-        withDeadlineAfter(timeout, TimeUnit.SECONDS);
+        withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcClient.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcClient.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.scm.proto.InterSCMProtocolProtos.CopyDBCheckpointRequestProto;
+import org.apache.hadoop.hdds.protocol.scm.proto.InterSCMProtocolProtos.CopyDBCheckpointResponseProto;
+import org.apache.hadoop.hdds.protocol.scm.proto.InterSCMProtocolServiceGrpc;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.ozone.test.GenericTestUtils.PortAllocator;
+import org.apache.ratis.thirdparty.io.grpc.Server;
+import org.apache.ratis.thirdparty.io.grpc.ServerBuilder;
+import org.apache.ratis.thirdparty.io.grpc.Status;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link InterSCMGrpcClient}.
+ */
+class TestInterSCMGrpcClient {
+
+  @TempDir
+  private Path temp;
+
+  /**
+   * {@link ScmConfigKeys#OZONE_SCM_HA_GRPC_DEADLINE_INTERVAL} is read in
+   * milliseconds, so the gRPC deadline has to be declared in milliseconds as
+   * well. A seconds declaration inflates the configured deadline 1000 times,
+   * and a stuck download is not aborted at the configured interval.
+   */
+  @Test
+  void testDownloadIsAbortedAtConfiguredDeadline() throws Exception {
+    int port = PortAllocator.getFreePort();
+    Server server = ServerBuilder.forPort(port)
+        .addService(new NeverRespondingService())
+        .build();
+    server.start();
+
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(ScmConfigKeys.OZONE_SCM_HA_GRPC_DEADLINE_INTERVAL, "200ms");
+
+    try (InterSCMGrpcClient client =
+        new InterSCMGrpcClient("localhost", port, conf, null)) {
+      CompletableFuture<Path> res = client.download(temp.resolve("cpFile"));
+      ExecutionException e = assertThrows(ExecutionException.class,
+          () -> res.get(10, TimeUnit.SECONDS));
+      assertEquals(Status.Code.DEADLINE_EXCEEDED,
+          Status.fromThrowable(e.getCause()).getCode());
+    } finally {
+      server.shutdownNow();
+      server.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  /**
+   * Keeps the download stream pending, so that the client side deadline is
+   * the only way the call can end.
+   */
+  private static final class NeverRespondingService
+      extends InterSCMProtocolServiceGrpc.InterSCMProtocolServiceImplBase {
+
+    @Override
+    public void download(CopyDBCheckpointRequestProto request,
+        StreamObserver<CopyDBCheckpointResponseProto> responseObserver) {
+      // intentionally left pending
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`InterSCMGrpcClient` reads `ozone.scm.ha.grpc.deadline.interval` in milliseconds, then applies the same numeric value to gRPC with `TimeUnit.SECONDS`. The default 30-minute deadline therefore becomes ~20 days (1000x). This affects SCM HA install-snapshot catch-up and Recon SCM DB sync.

Added a test that sets `ozone.scm.ha.grpc.deadline.interval` to `200ms`, uses a hanging Inter-SCM download RPC, and asserts the client fails with `DEADLINE_EXCEEDED` within a bounded timeout.

This patch keeps the fetch unit and the gRPC unit consistent:

```java
client = InterSCMProtocolServiceGrpc.newStub(channel)
    .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16373

## How was this patch tested?

- TestInterSCMGrpcClient pass.
- ci: https://github.com/shuan1026/ozone/actions/runs/33625361380