### PR TITLE
HDDS-16374. Use the datanode-specific block deletion interval during reconfiguration

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -24,7 +24,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NODES_KEY;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getRemoteUser;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClientWithMaxRetry;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_WORKERS;
 import static org.apache.hadoop.ozone.common.Storage.StorageState.INITIALIZED;
@@ -315,8 +314,6 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
                   this::reconfigBlockDeleteThreadMax)
               .register(OZONE_BLOCK_DELETING_SERVICE_WORKERS,
                   this::reconfigDeletingServiceWorkers)
-              .register(OZONE_BLOCK_DELETING_SERVICE_INTERVAL,
-                  this::reconfigBlockDeletingServiceInterval)
               .register(OZONE_BLOCK_DELETING_SERVICE_TIMEOUT,
                   this::reconfigBlockDeletingServiceTimeout)
               .register(REPLICATION_STREAMS_LIMIT_KEY,
@@ -742,10 +739,6 @@ public class HddsDatanodeService extends GenericCli implements Callable<Void>, S
           + "{}: {}", value, e.getMessage(), e);
       throw e;
     }
-    return value;
-  }
-
-  private String reconfigBlockDeletingServiceInterval(String value) {
     return value;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
@@ -17,12 +17,11 @@
 
 package org.apache.hadoop.ozone.container.common.impl;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_WORKERS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_WORKERS_DEFAULT;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETING_SERVICE_INTERVAL_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
@@ -115,7 +114,7 @@ public class BlockDeletingService extends BackgroundService {
 
   public void registerReconfigCallbacks(ReconfigurationHandler handler) {
     handler.registerCompleteCallback((changedKeys, newConf) -> {
-      if (changedKeys.containsKey(OZONE_BLOCK_DELETING_SERVICE_INTERVAL) ||
+      if (changedKeys.containsKey(BLOCK_DELETING_SERVICE_INTERVAL_KEY) ||
           changedKeys.containsKey(OZONE_BLOCK_DELETING_SERVICE_TIMEOUT) ||
           changedKeys.containsKey(OZONE_BLOCK_DELETING_SERVICE_WORKERS)) {
         updateAndRestart((OzoneConfiguration) newConf);
@@ -124,21 +123,21 @@ public class BlockDeletingService extends BackgroundService {
   }
 
   public void updateAndRestart(OzoneConfiguration ozoneConf) {
-    long newInterval = ozoneConf.getTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL,
-        OZONE_BLOCK_DELETING_SERVICE_INTERVAL_DEFAULT, TimeUnit.SECONDS);
+    long newInterval = ozoneConf.getObject(DatanodeConfiguration.class)
+        .getBlockDeletionInterval().toMillis();
     int newCorePoolSize = ozoneConf.getInt(OZONE_BLOCK_DELETING_SERVICE_WORKERS,
         OZONE_BLOCK_DELETING_SERVICE_WORKERS_DEFAULT);
     long newTimeout = ozoneConf.getTimeDuration(OZONE_BLOCK_DELETING_SERVICE_TIMEOUT,
         OZONE_BLOCK_DELETING_SERVICE_TIMEOUT_DEFAULT, TimeUnit.NANOSECONDS);
     LOG.info("Updating and restarting BlockDeletingService with interval {} {}" +
             ", core pool size {} and timeout {} {}",
-        newInterval, TimeUnit.SECONDS.name().toLowerCase(), newCorePoolSize, newTimeout,
+        newInterval, TimeUnit.MILLISECONDS.name().toLowerCase(), newCorePoolSize, newTimeout,
         TimeUnit.NANOSECONDS.name().toLowerCase());
     // shutdown() awaits the executor; do not hold this monitor (same object as
     // BackgroundService.PeriodicalTask) or the pool thread can deadlock.
     shutdown();
     synchronized (this) {
-      setInterval(newInterval, TimeUnit.SECONDS);
+      setInterval(newInterval, TimeUnit.MILLISECONDS);
       setPoolSize(newCorePoolSize);
       setServiceTimeoutInNanos(newTimeout);
       start();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -52,6 +52,7 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(DatanodeConfiguration.class);
 
+  public static final String BLOCK_DELETING_SERVICE_INTERVAL_KEY = "hdds.datanode.block.deleting.service.interval";
   static final String CONTAINER_DELETE_THREADS_MAX_KEY = "hdds.datanode.container.delete.threads.max";
   static final String CONTAINER_CLOSE_THREADS_MAX_KEY = "hdds.datanode.container.close.threads.max";
   static final String PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY = "hdds.datanode.periodic.disk.check.interval.minutes";
@@ -257,6 +258,7 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
 
   @Config(key = "hdds.datanode.block.deleting.service.interval",
           defaultValue = "60s",
+          reconfigurable = true,
           type = ConfigType.TIME,
           tags = { ConfigTag.SCM, ConfigTag.DELETION },
           description =

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container.common;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_WORKERS;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V1;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V2;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V3;
@@ -113,6 +114,7 @@ import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -876,6 +878,39 @@ public class TestBlockDeletingService {
     // Shutdown service and verify all threads are stopped
     service.shutdown();
     GenericTestUtils.waitFor(() -> service.getThreadCount() == 0, 100, 1000);
+  }
+
+  @Test
+  public void testUpdateAndRestartUsesDatanodeInterval() throws Exception {
+    Duration startupInterval = Duration.ofMinutes(5);
+    DatanodeConfiguration dnConf = conf.getObject(DatanodeConfiguration.class);
+    dnConf.setBlockDeletionInterval(startupInterval);
+    conf.setFromObject(dnConf);
+
+    OzoneContainer ozoneContainer = mockDependencies(newContainerSet(), null);
+    BlockDeletingService svc = new BlockDeletingService(ozoneContainer,
+        startupInterval.toMillis(), 1000, TimeUnit.MILLISECONDS, 10, conf,
+        new ContainerChecksumTreeManager(conf));
+    try {
+      // Reconfiguring only the workers must keep the interval configured for
+      // the datanode, not fall back to the OM's block deleting interval.
+      OzoneConfiguration updatedConf = new OzoneConfiguration(conf);
+      updatedConf.setInt(OZONE_BLOCK_DELETING_SERVICE_WORKERS, 20);
+      svc.updateAndRestart(updatedConf);
+      assertEquals(startupInterval.toMillis(), svc.getIntervalMillis());
+      assertEquals(20, svc.getExecutorService().getCorePoolSize());
+
+      // Changing the datanode interval is what updates the running service.
+      Duration newInterval = Duration.ofSeconds(30);
+      DatanodeConfiguration updatedDnConf =
+          updatedConf.getObject(DatanodeConfiguration.class);
+      updatedDnConf.setBlockDeletionInterval(newInterval);
+      updatedConf.setFromObject(updatedDnConf);
+      svc.updateAndRestart(updatedConf);
+      assertEquals(newInterval.toMillis(), svc.getIntervalMillis());
+    } finally {
+      svc.shutdown();
+    }
   }
 
   @ContainerTestVersionInfo.ContainerTest

--- a/hadoop-hdds/docs/content/feature/Reconfigurability.md
+++ b/hadoop-hdds/docs/content/feature/Reconfigurability.md
@@ -102,7 +102,7 @@ ozone admin reconfig --service=[OM|SCM|DATANODE] --address=<ip:port|hostname:por
 | `hdds.datanode.block.deleting.limit.per.interval` | `20000` | Maximum blocks deleted per interval on a datanode |
 | `hdds.datanode.block.delete.threads.max` | `5` | Maximum threads for block deletion |
 | `ozone.block.deleting.service.workers` | `10` | Number of block deletion service workers |
-| `ozone.block.deleting.service.interval` | `60s` | Block deletion service run interval |
+| `hdds.datanode.block.deleting.service.interval` | `60s` | Block deletion service run interval |
 | `ozone.block.deleting.service.timeout` | `300s` | Block deletion service timeout |
 | `hdds.datanode.replication.streams.limit` | `10` | Base size of the global replication handler executor and inbound replication server executor |
 | `hdds.datanode.replication.per.volume.streams.limit` | `2` | Maximum push replication streams per data volume when per-volume replication thread pools are enabled (separate from streams.limit) |

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestDatanodeReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestDatanodeReconfiguration.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.reconfig;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_WORKERS;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_BLOCK_DELETE_THREAD_MAX;
@@ -52,7 +51,6 @@ public abstract class TestDatanodeReconfiguration extends ReconfigurationTestBas
     Set<String> expected = ImmutableSet.<String>builder()
         .add(HDDS_DATANODE_BLOCK_DELETE_THREAD_MAX)
         .add(OZONE_BLOCK_DELETING_SERVICE_WORKERS)
-        .add(OZONE_BLOCK_DELETING_SERVICE_INTERVAL)
         .add(OZONE_BLOCK_DELETING_SERVICE_TIMEOUT)
         .add(PER_VOLUME_STREAMS_LIMIT_KEY)
         .add(REPLICATION_STREAMS_LIMIT_KEY)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Datanode `BlockDeletingService` starts from `hdds.datanode.block.deleting.service.interval`, but `updateAndRestart` reread `ozone.block.deleting.service.interval` (OM's key). HDDS-11513 wired the reconfig path to the shared key after HDDS-4367 had split them. Details are on the Jira.

This patch uses the datanode-specific key on every path:

- Mark `hdds.datanode.block.deleting.service.interval` as `reconfigurable = true` and register it via `register(dnConf)`.
- `updateAndRestart` reads `DatanodeConfiguration.getBlockDeletionInterval()` in milliseconds, same as startup.
- Remove the DataNode registration of `ozone.block.deleting.service.interval`. Timeout / workers and OM's shared key are unchanged.
- `Reconfigurability.md` is updated to match the change.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16374

## How was this patch tested?

- `TestBlockDeletingService` (including new `testUpdateAndRestartUsesDatanodeInterval`): pass. Restoring the old key read fails with `expected: <300000> but was: <60000>`.
- ci: https://github.com/shuan1026/ozone/actions/runs/33639637827