### PR TITLE
HDDS-16365. Pipeline.getReplicaIndexes() unnecessarily create a new map.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.BlockData;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.DatanodeBlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.GetBlockRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.GetBlockResponseProto;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
@@ -268,24 +269,15 @@ public class BlockInputStream extends BlockExtendedInputStream {
           blockID.getContainerID());
     }
 
-    DatanodeBlockID.Builder blkIDBuilder =
-        DatanodeBlockID.newBuilder().setContainerID(blockID.getContainerID())
-            .setLocalID(blockID.getLocalID())
-            .setBlockCommitSequenceId(blockID.getBlockCommitSequenceId());
-
     int replicaIndex = pipeline.getReplicaIndex(xceiverClientShortCircuit.getDn());
-    if (replicaIndex > 0) {
-      blkIDBuilder.setReplicaIndex(replicaIndex);
-    }
-    DatanodeBlockID datanodeBlockID = blkIDBuilder.build();
-    ContainerProtos.GetBlockRequestProto.Builder readBlockRequest =
-        ContainerProtos.GetBlockRequestProto.newBuilder().setBlockID(datanodeBlockID)
-            .setRequestShortCircuitAccess(true);
+    final GetBlockRequestProto.Builder getBlockRequest = GetBlockRequestProto.newBuilder()
+        .setBlockID(blockID.getDatanodeBlockIDProtobufBuilder(replicaIndex))
+        .setRequestShortCircuitAccess(true);
     ContainerProtos.ContainerCommandRequestProto.Builder builder =
         ContainerProtos.ContainerCommandRequestProto.newBuilder()
             .setCmdType(ContainerProtos.Type.GetBlock)
-            .setContainerID(datanodeBlockID.getContainerID())
-            .setGetBlock(readBlockRequest)
+            .setContainerID(blockID.getContainerID())
+            .setGetBlock(getBlockRequest)
             .setClientId(xceiverClientShortCircuit.getClientId())
             .setCallId(xceiverClientShortCircuit.getCallId());
     if (tokenRef.get() != null) {
@@ -294,13 +286,12 @@ public class BlockInputStream extends BlockExtendedInputStream {
     GetBlockResponseProto response = ContainerProtocolCalls.getBlock(xceiverClientShortCircuit,
         VALIDATORS, builder, xceiverClientShortCircuit.getDn());
 
-    blockFileInputStream = xceiverClientShortCircuit.getFileInputStream(
-        builder.getCallId(), datanodeBlockID.getLocalID());
+    blockFileInputStream = xceiverClientShortCircuit.getFileInputStream(builder.getCallId(), blockID.getLocalID());
     if (blockFileInputStream == null) {
-      throw new IOException("Failed to get file InputStream for block " + datanodeBlockID);
+      throw new IOException("Failed to get file InputStream for block " + blockID);
     } else {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Get the FileInputStream of block {}", datanodeBlockID);
+        LOG.debug("Get the FileInputStream of block {}", blockID);
       }
     }
     return response.getBlockData();
@@ -316,7 +307,7 @@ public class BlockInputStream extends BlockExtendedInputStream {
     }
 
     GetBlockResponseProto response = ContainerProtocolCalls.getBlock(
-        xceiverClientGrpc, VALIDATORS, blockID, tokenRef.get(), pipeline.getReplicaIndexes());
+        xceiverClientGrpc, VALIDATORS, blockID, tokenRef.get(), pipeline);
     return response.getBlockData();
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -187,16 +187,9 @@ public class BlockOutputStream extends OutputStream {
     KeyValue keyValue =
         KeyValue.newBuilder().setKey("TYPE").setValue("KEY").build();
 
-    ContainerProtos.DatanodeBlockID.Builder blkIDBuilder =
-        ContainerProtos.DatanodeBlockID.newBuilder()
-            .setContainerID(blockID.getContainerID())
-            .setLocalID(blockID.getLocalID())
-            .setBlockCommitSequenceId(blockID.getBlockCommitSequenceId());
-    if (replicationIndex > 0) {
-      blkIDBuilder.setReplicaIndex(replicationIndex);
-    }
-    this.containerBlockData = BlockData.newBuilder().setBlockID(
-        blkIDBuilder.build()).addMetadata(keyValue);
+    this.containerBlockData = BlockData.newBuilder()
+        .setBlockID(blockID.getDatanodeBlockIDProtobufBuilder(replicationIndex))
+        .addMetadata(keyValue);
     this.pipeline = pipeline;
     // tell DataNode I will send incremental chunk list
     this.supportIncrementalChunkList = canEnableIncrementalChunkList();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -297,11 +297,7 @@ public class ChunkInputStream extends InputStream
   private void updateDatanodeBlockId(Pipeline pipeline) throws IOException {
     DatanodeDetails closestNode = pipeline.getClosestNode();
     int replicaIdx = pipeline.getReplicaIndex(closestNode);
-    ContainerProtos.DatanodeBlockID.Builder builder = blockID.getDatanodeBlockIDProtobufBuilder();
-    if (replicaIdx > 0) {
-      builder.setReplicaIndex(replicaIdx);
-    }
-    datanodeBlockID = builder.build();
+    datanodeBlockID = blockID.getDatanodeBlockIDProtobufBuilder(replicaIdx).build();
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/BlockID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/BlockID.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdds.client;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Objects;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.DatanodeBlockID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
 /**
@@ -98,24 +98,24 @@ public class BlockID {
   }
 
   @JsonIgnore
-  public ContainerProtos.DatanodeBlockID getDatanodeBlockIDProtobuf() {
-    ContainerProtos.DatanodeBlockID.Builder blockID = getDatanodeBlockIDProtobufBuilder();
-    if (replicaIndex != null) {
-      blockID.setReplicaIndex(replicaIndex);
-    }
-    return blockID.build();
+  public DatanodeBlockID getDatanodeBlockIDProtobuf() {
+    return getDatanodeBlockIDProtobufBuilder(replicaIndex).build();
   }
 
   @JsonIgnore
-  public ContainerProtos.DatanodeBlockID.Builder getDatanodeBlockIDProtobufBuilder() {
-    return ContainerProtos.DatanodeBlockID.newBuilder().
-        setContainerID(containerBlockID.getContainerID())
+  public DatanodeBlockID.Builder getDatanodeBlockIDProtobufBuilder(Integer replicaIdx) {
+    final DatanodeBlockID.Builder b = DatanodeBlockID.newBuilder()
+        .setContainerID(containerBlockID.getContainerID())
         .setLocalID(containerBlockID.getLocalID())
         .setBlockCommitSequenceId(blockCommitSequenceId);
+    if (replicaIdx != null && replicaIdx > 0) {
+      b.setReplicaIndex(replicaIdx);
+    }
+    return b;
   }
 
   @JsonIgnore
-  public static BlockID getFromProtobuf(ContainerProtos.DatanodeBlockID blockID) {
+  public static BlockID getFromProtobuf(DatanodeBlockID blockID) {
     return new BlockID(blockID.getContainerID(),
         blockID.getLocalID(),
         blockID.getBlockCommitSequenceId(),

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/BlockID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/BlockID.java
@@ -108,7 +108,7 @@ public class BlockID {
         .setContainerID(containerBlockID.getContainerID())
         .setLocalID(containerBlockID.getLocalID())
         .setBlockCommitSequenceId(blockCommitSequenceId);
-    if (replicaIdx != null && replicaIdx > 0) {
+    if (replicaIdx != null) {
       b.setReplicaIndex(replicaIdx);
     }
     return b;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -33,8 +33,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicatedReplicationConfig;
@@ -240,10 +238,27 @@ public final class Pipeline {
   }
 
   /**
-   * Get the replicaIndex Map.
+   * @param fromIndex the replica index starting from (inclusive)
+   * @param toIndex the replica index starting to (exclusive)
+   * @return true iff this pipeline contain all replica indexes within the given range.
    */
-  public Map<DatanodeDetails, Integer> getReplicaIndexes() {
-    return this.getNodes().stream().collect(Collectors.toMap(Function.identity(), this::getReplicaIndex));
+  public boolean containsAllReplicaIndexes(int fromIndex, int toIndex) {
+    final boolean[] contains = new boolean[toIndex - fromIndex];
+    for (int r : replicaIndexes.values()) {
+      if (r >= fromIndex && r < toIndex) {
+        contains[r - fromIndex] = true;
+      }
+    }
+    for (boolean contain : contains) {
+      if (!contain) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public Map<DatanodeDetails, Integer> getReplicaIndexesForTesting() {
+    return Collections.unmodifiableMap(replicaIndexes);
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -240,7 +240,7 @@ public final class Pipeline {
   /**
    * @param fromIndex the replica index starting from (inclusive)
    * @param toIndex the replica index starting to (exclusive)
-   * @return true iff this pipeline contain all replica indexes within the given range.
+   * @return true if this pipeline contains all replica indexes within the given range.
    */
   public boolean containsAllReplicaIndexes(int fromIndex, int toIndex) {
     final boolean[] contains = new boolean[toIndex - fromIndex];

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -257,7 +257,7 @@ public final class Pipeline {
     return true;
   }
 
-  public Map<DatanodeDetails, Integer> getReplicaIndexesForTesting() {
+  public Map<DatanodeDetails, Integer> getReplicaIndexes() {
     return Collections.unmodifiableMap(replicaIndexes);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -188,7 +188,7 @@ public final class ContainerProtocolCalls  {
    */
   public static GetBlockResponseProto getBlock(XceiverClientSpi xceiverClient,
       List<Validator> validators, BlockID blockID, Token<? extends TokenIdentifier> token,
-      Map<DatanodeDetails, Integer> replicaIndexes) throws IOException {
+      Pipeline pipeline) throws IOException {
     ContainerCommandRequestProto.Builder builder = ContainerCommandRequestProto
         .newBuilder()
         .setCmdType(Type.GetBlock)
@@ -198,7 +198,7 @@ public final class ContainerProtocolCalls  {
     }
 
     return tryEachDatanode(xceiverClient.getPipeline(),
-        d -> getBlock(xceiverClient, validators, builder, blockID, d, replicaIndexes),
+        d -> getBlock(xceiverClient, validators, builder, blockID, d, pipeline),
         d -> toErrorMessage(blockID, d));
   }
 
@@ -209,8 +209,8 @@ public final class ContainerProtocolCalls  {
 
   public static GetBlockResponseProto getBlock(XceiverClientSpi xceiverClient,
       BlockID datanodeBlockID,
-      Token<? extends TokenIdentifier> token, Map<DatanodeDetails, Integer> replicaIndexes) throws IOException {
-    return getBlock(xceiverClient, getValidatorList(), datanodeBlockID, token, replicaIndexes);
+      Token<? extends TokenIdentifier> token, Pipeline pipeline) throws IOException {
+    return getBlock(xceiverClient, getValidatorList(), datanodeBlockID, token, pipeline);
   }
 
   /**
@@ -221,7 +221,6 @@ public final class ContainerProtocolCalls  {
    * @param blockID blockID to identify container
    * @param token a token for this block (may be null)
    * @param datanode datanode to query
-   * @param replicaIndexes replica indexes for EC pipelines
    * @return container protocol get block response
    * @throws IOException if there is an I/O error while performing the call
    */
@@ -230,7 +229,7 @@ public final class ContainerProtocolCalls  {
       BlockID blockID,
       Token<? extends TokenIdentifier> token,
       DatanodeDetails datanode,
-      Map<DatanodeDetails, Integer> replicaIndexes) throws IOException {
+      Pipeline pipeline) throws IOException {
     ContainerCommandRequestProto.Builder builder = ContainerCommandRequestProto
         .newBuilder()
         .setCmdType(Type.GetBlock)
@@ -238,23 +237,19 @@ public final class ContainerProtocolCalls  {
     if (token != null) {
       builder.setEncodedToken(token.encodeToUrlString());
     }
-    return getBlock(xceiverClient, getValidatorList(), builder, blockID, datanode,
-        replicaIndexes);
+    return getBlock(xceiverClient, getValidatorList(), builder, blockID, datanode, pipeline);
   }
 
   private static GetBlockResponseProto getBlock(XceiverClientSpi xceiverClient,
       List<Validator> validators,
       ContainerCommandRequestProto.Builder builder, BlockID blockID,
-      DatanodeDetails datanode, Map<DatanodeDetails, Integer> replicaIndexes) throws IOException {
+      DatanodeDetails datanode, Pipeline pipeline) throws IOException {
     String traceId = TracingUtil.exportCurrentSpan();
     if (traceId != null) {
       builder.setTraceID(traceId);
     }
-    final DatanodeBlockID.Builder datanodeBlockID = blockID.getDatanodeBlockIDProtobufBuilder();
-    int replicaIndex = replicaIndexes.getOrDefault(datanode, 0);
-    if (replicaIndex > 0) {
-      datanodeBlockID.setReplicaIndex(replicaIndex);
-    }
+    final int replicaIndex = pipeline.getReplicaIndex(datanode);
+    final DatanodeBlockID.Builder datanodeBlockID = blockID.getDatanodeBlockIDProtobufBuilder(replicaIndex);
     final GetBlockRequestProto.Builder readBlockRequest = GetBlockRequestProto.newBuilder()
         .setBlockID(datanodeBlockID.build());
     final ContainerCommandRequestProto request = builder
@@ -510,16 +505,10 @@ public final class ContainerProtocolCalls  {
       boolean containerAutoCreate)
       throws IOException, ExecutionException, InterruptedException {
 
-    WriteChunkRequestProto.Builder writeChunkRequest =
-        WriteChunkRequestProto.newBuilder()
-            .setBlockID(DatanodeBlockID.newBuilder()
-                .setContainerID(blockID.getContainerID())
-                .setLocalID(blockID.getLocalID())
-                .setBlockCommitSequenceId(blockID.getBlockCommitSequenceId())
-                .setReplicaIndex(replicationIndex)
-                .build())
-            .setChunkData(chunk)
-            .setData(data);
+    final WriteChunkRequestProto.Builder writeChunkRequest = WriteChunkRequestProto.newBuilder()
+        .setBlockID(blockID.getDatanodeBlockIDProtobufBuilder(replicationIndex))
+        .setChunkData(chunk)
+        .setData(data);
     if (blockData != null) {
       PutBlockRequestProto.Builder createBlockRequest =
           PutBlockRequestProto.newBuilder()
@@ -931,41 +920,6 @@ public final class ContainerProtocolCalls  {
     return Collections.unmodifiableList(validators);
   }
 
-  public static HashMap<DatanodeDetails, GetBlockResponseProto>
-      getBlockFromAllNodes(
-      XceiverClientSpi xceiverClient,
-      DatanodeBlockID datanodeBlockID,
-      Token<OzoneBlockTokenIdentifier> token)
-      throws IOException, InterruptedException {
-    GetBlockRequestProto.Builder readBlockRequest = GetBlockRequestProto
-            .newBuilder()
-            .setBlockID(datanodeBlockID);
-    HashMap<DatanodeDetails, GetBlockResponseProto> datanodeToResponseMap
-            = new HashMap<>();
-    String id = xceiverClient.getPipeline().getFirstNode().getUuidString();
-    ContainerCommandRequestProto.Builder builder = ContainerCommandRequestProto
-        .newBuilder()
-        .setCmdType(Type.GetBlock)
-        .setContainerID(datanodeBlockID.getContainerID())
-        .setDatanodeUuid(id)
-        .setGetBlock(readBlockRequest);
-    if (token != null) {
-      builder.setEncodedToken(token.encodeToUrlString());
-    }
-    String traceId = TracingUtil.exportCurrentSpan();
-    if (traceId != null) {
-      builder.setTraceID(traceId);
-    }
-    ContainerCommandRequestProto request = builder.build();
-    Map<DatanodeDetails, ContainerCommandResponseProto> responses =
-            xceiverClient.sendCommandOnAllNodes(request);
-    for (Map.Entry<DatanodeDetails, ContainerCommandResponseProto> entry:
-           responses.entrySet()) {
-      datanodeToResponseMap.put(entry.getKey(), entry.getValue().getGetBlock());
-    }
-    return datanodeToResponseMap;
-  }
-
   public static HashMap<DatanodeDetails, ReadContainerResponseProto>
       readContainerFromAllNodes(XceiverClientSpi client, long containerID,
       String encodedToken) throws IOException, InterruptedException {
@@ -1000,12 +954,12 @@ public final class ContainerProtocolCalls  {
       Token<? extends TokenIdentifier> token, Pipeline pipeline)
       throws IOException {
     final DatanodeDetails datanode = pipeline.getClosestNode();
-    final DatanodeBlockID datanodeBlockID = getDatanodeBlockID(blockID, datanode, pipeline.getReplicaIndexes());
+    final int replicaIndex = pipeline.getReplicaIndex(datanode);
     final ReadBlockRequestProto.Builder readBlockRequest = ReadBlockRequestProto.newBuilder()
         .setOffset(offset)
         .setLength(length)
         .setResponseDataSize(responseDataSize)
-        .setBlockID(datanodeBlockID);
+        .setBlockID(blockID.getDatanodeBlockIDProtobufBuilder(replicaIndex));
     final ContainerCommandRequestProto.Builder builder =
         ContainerCommandRequestProto.newBuilder().setCmdType(Type.ReadBlock)
             .setContainerID(blockID.getContainerID());
@@ -1016,15 +970,5 @@ public final class ContainerProtocolCalls  {
     return builder.setDatanodeUuid(datanode.getUuidString())
         .setReadBlock(readBlockRequest)
         .build();
-  }
-
-  static DatanodeBlockID getDatanodeBlockID(BlockID blockID, DatanodeDetails datanode,
-      Map<DatanodeDetails, Integer> replicaIndexes) {
-    final DatanodeBlockID.Builder b = blockID.getDatanodeBlockIDProtobufBuilder();
-    final int replicaIndex = replicaIndexes.getOrDefault(datanode, 0);
-    if (replicaIndex > 0) {
-      b.setReplicaIndex(replicaIndex);
-    }
-    return b.build();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestContainerReconciliationWithMockDatanodes.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doThrow;
 import  static org.mockito.Mockito.spy;
 
@@ -390,7 +389,7 @@ public class TestContainerReconciliationWithMockDatanodes {
         });
 
     // Mock getBlock
-    containerProtocolMock.when(() -> ContainerProtocolCalls.getBlock(any(), any(), any(), any(), anyMap()))
+    containerProtocolMock.when(() -> ContainerProtocolCalls.getBlock(any(), any(), any(), any(), any()))
         .thenAnswer(inv -> {
           XceiverClientSpi xceiverClientSpi = inv.getArgument(0);
           BlockID blockID = inv.getArgument(2);

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/BlockExistenceVerifier.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/BlockExistenceVerifier.java
@@ -58,7 +58,7 @@ public class BlockExistenceVerifier implements ReplicaVerifier {
           client,
           keyLocation.getBlockID(),
           keyLocation.getToken(),
-          pipeline.getReplicaIndexes()
+          pipeline
       );
 
       boolean hasBlock = response != null && response.hasBlockData();

--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/replicas/chunk/ChunkKeyHandler.java
@@ -131,7 +131,7 @@ public class ChunkKeyHandler extends KeyHandler {
                         keyLocation.getBlockID(),
                         keyLocation.getToken(),
                         datanodeDetails,
-                        pipeline.getReplicaIndexes());
+                        pipeline);
 
                 if (blockResponse == null || !blockResponse.hasBlockData()) {
                   System.err.printf("GetBlock call failed on %s datanode and %s block.%n",

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -123,7 +123,7 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
       xceiverClientSpi = getXceiverClientFactory().acquireClientForReadData(pipeline);
 
       ContainerProtos.GetBlockResponseProto response = ContainerProtocolCalls
-          .getBlock(xceiverClientSpi, blockID, token, pipeline.getReplicaIndexes());
+          .getBlock(xceiverClientSpi, blockID, token, pipeline);
 
       chunks = response.getBlockData().getChunksList();
     } finally {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -75,7 +75,7 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
       }
       xceiverClientSpi = getXceiverClientFactory().acquireClientForReadData(pipeline);
       ContainerProtos.GetBlockResponseProto response = ContainerProtocolCalls
-          .getBlock(xceiverClientSpi, blockID, token, pipeline.getReplicaIndexes());
+          .getBlock(xceiverClientSpi, blockID, token, pipeline);
 
       chunks = response.getBlockData().getChunksList();
     } finally {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -269,7 +269,7 @@ public class TestXceiverClientGrpc {
             .setContainerID(1)
             .setLocalID(1)
             .setBlockCommitSequenceId(1)
-            .build()), null, client.getPipeline().getReplicaIndexes());
+            .build()), null, client.getPipeline());
   }
 
   private void invokeXceiverClientReadChunk(XceiverClientSpi client)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -516,7 +516,7 @@ public class TestContainerCommandsEC {
         ContainerProtos.ReadChunkResponseProto readChunkResponseProto =
             ContainerProtocolCalls.readChunk(dnClient,
                 writeChunkRequest.getWriteChunk().getChunkData(),
-                blockID.getDatanodeBlockIDProtobufBuilder().setReplicaIndex(replicaIndex).build(), null,
+                blockID.getDatanodeBlockIDProtobufBuilder(replicaIndex).build(), null,
                 blockToken);
         ByteBuffer[] readOnlyByteBuffersArray = BufferUtils
             .getReadOnlyByteBuffersArray(
@@ -834,7 +834,7 @@ public class TestContainerCommandsEC {
       BlockID entryBlockID = blockOutputStreamEntry.getBlockID();
       long entryContainerID = entryBlockID.getContainerID();
       Pipeline entryPipeline = blockOutputStreamEntry.getPipeline();
-      Map<DatanodeDetails, Integer> replicaIndexes = entryPipeline.getReplicaIndexes();
+      Map<DatanodeDetails, Integer> replicaIndexes = entryPipeline.getReplicaIndexesForTesting();
       try {
         for (Map.Entry<DatanodeDetails, Integer> entry : replicaIndexes.entrySet()) {
           DatanodeDetails key = entry.getKey();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -834,7 +834,7 @@ public class TestContainerCommandsEC {
       BlockID entryBlockID = blockOutputStreamEntry.getBlockID();
       long entryContainerID = entryBlockID.getContainerID();
       Pipeline entryPipeline = blockOutputStreamEntry.getPipeline();
-      Map<DatanodeDetails, Integer> replicaIndexes = entryPipeline.getReplicaIndexesForTesting();
+      Map<DatanodeDetails, Integer> replicaIndexes = entryPipeline.getReplicaIndexes();
       try {
         for (Map.Entry<DatanodeDetails, Integer> entry : replicaIndexes.entrySet()) {
           DatanodeDetails key = entry.getKey();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -225,9 +225,11 @@ public class TestECKeyOutputStream {
       OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
       long containerId = omKeyLocationInfo.getContainerID();
       Pipeline pipeline = omKeyLocationInfo.getPipeline();
-      DatanodeDetails dnWithReplicaIndex1 =
-          pipeline.getReplicaIndexes().entrySet().stream().filter(e -> e.getValue() == 1).map(Map.Entry::getKey)
-              .findFirst().get();
+      DatanodeDetails dnWithReplicaIndex1 = pipeline.getReplicaIndexesForTesting().entrySet().stream()
+          .filter(e -> e.getValue() == 1)
+          .map(Map.Entry::getKey)
+          .findFirst()
+          .get();
       Mockito.when(handlers.get(dnWithReplicaIndex1.getUuidString()).getDatanodeId())
           .thenAnswer(i -> {
             if (!failed.get()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -225,7 +225,7 @@ public class TestECKeyOutputStream {
       OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
       long containerId = omKeyLocationInfo.getContainerID();
       Pipeline pipeline = omKeyLocationInfo.getPipeline();
-      DatanodeDetails dnWithReplicaIndex1 = pipeline.getReplicaIndexesForTesting().entrySet().stream()
+      DatanodeDetails dnWithReplicaIndex1 = pipeline.getReplicaIndexes().entrySet().stream()
           .filter(e -> e.getValue() == 1)
           .map(Map.Entry::getKey)
           .findFirst()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -152,6 +152,20 @@ public class ScmClient {
     return this.containerClient;
   }
 
+  /** Don't keep empty pipelines or insufficient EC pipelines in the cache. */
+  static boolean shouldInvalidate(Pipeline pipeline) {
+    if (pipeline.isEmpty()) {
+      return true;
+    }
+
+    final ReplicationConfig repConfig = pipeline.getReplicationConfig();
+    if (!(repConfig instanceof ECReplicationConfig)) {
+      return false;
+    }
+    final int d = ((ECReplicationConfig) repConfig).getData();
+    return !pipeline.containsAllReplicaIndexes(1, d + 1); // 1 <= i <= d are the data strips
+  }
+
   public Map<Long, Pipeline> getContainerLocations(Iterable<Long> containerIds,
                                                   boolean forceRefresh)
       throws IOException {
@@ -160,29 +174,13 @@ public class ScmClient {
     }
     try {
       Map<Long, Pipeline> result = containerLocationCache.getAll(containerIds);
-      // Don't keep empty pipelines or insufficient EC pipelines in the cache.
-      List<Long> uncachePipelines = result.entrySet().stream()
-          .filter(e -> {
-            Pipeline pipeline = e.getValue();
-            // filter empty pipelines
-            if (pipeline.isEmpty()) {
-              return true;
-            }
-            // filter insufficient EC pipelines which missing any data index
-            ReplicationConfig repConfig = pipeline.getReplicationConfig();
-            if (repConfig instanceof ECReplicationConfig) {
-              int d = ((ECReplicationConfig) repConfig).getData();
-              for (int i = 1; i <= d; i++) {
-                if (!pipeline.getReplicaIndexes().containsValue(i)) {
-                  return true;
-                }
-              }
-            }
-            return false;
-          })
-          .map(Map.Entry::getKey)
-          .collect(Collectors.toList());
-      containerLocationCache.invalidateAll(uncachePipelines);
+
+      for (Map.Entry<Long, Pipeline> entry : result.entrySet()) {
+        if (shouldInvalidate(entry.getValue())) {
+          containerLocationCache.invalidate(entry.getKey());
+        }
+      }
+
       return result;
     } catch (ExecutionException e) {
       return handleCacheExecutionException(e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Pipeline, the getReplicaIndexes() method, which copies the replicaIndexes map, is not really needed:
1. In many cases, the copied map is used for calling get(dn) -- just directly call the existing getReplicaIndex(dn) method.
2. One special case is in the ScmClient in OM for checking if a pipeline containing all replica indexes -- create a new containsAllReplicaIndexes method.
3. The remaining cases are used in tests for iterating the nodes -- rename it to getReplicaIndexesForTesting() and use unmodifiableMap instead of copying.

For #1 above, getReplicaIndexes() is mainly used for building DatanodeBlockID protos.  We will also refactor the code:
- Add a new replicaIdx parameter to BlockID.getDatanodeBlockIDProtobufBuilder().
- For the code using DatanodeBlockID.Builder, change them to use getDatanodeBlockIDProtobufBuilder(..) instead.


## What is the link to the Apache JIRA

HDDS-16365

## How was this patch tested?

By updating existing tests.

