### PR TITLE
HDDS-16324. XceiverClientGrpc.streamRead should wait for flow-control readiness via onReadyHandler instead of a 10 ms poll

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.LockSupport;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -72,6 +71,7 @@ import org.apache.ratis.thirdparty.io.grpc.Status;
 import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
 import org.apache.ratis.thirdparty.io.grpc.stub.ClientCallStreamObserver;
+import org.apache.ratis.thirdparty.io.grpc.stub.ClientResponseObserver;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
 import org.slf4j.Logger;
@@ -573,16 +573,13 @@ public class XceiverClientGrpc extends XceiverClientSpi {
           request.getReadBlock().getBlockID().getLocalID(),
           request.getReadBlock().getOffset(),
           request.getReadBlock().getLength());
-      final long deadlineNs = System.nanoTime() + streamReadTimeoutNanos;
-      while (!obs.isReady() && System.nanoTime() - deadlineNs < 0) {
-        LockSupport.parkNanos(10_000_000L);
-        if (Thread.currentThread().isInterrupted()) {
-          Thread.currentThread().interrupt();
-          throw new InterruptedIOException("Interrupted while waiting for stream to become ready: " + streamObserver);
+      try {
+        if (!streamObserver.awaitReady(streamReadTimeoutNanos)) {
+          throw new TimeoutIOException("Timed out waiting for stream to become ready: " + streamObserver);
         }
-      }
-      if (!obs.isReady()) {
-        throw new TimeoutIOException("Timed out waiting for stream to become ready: " + streamObserver);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new InterruptedIOException("Interrupted while waiting for stream to become ready: " + streamObserver);
       }
     }
 
@@ -619,11 +616,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
           throw new IOException("Failed to get gRPC stub for DataNode: " + dn);
         }
         LOG.debug("initStreamRead {} on datanode {}", blockID.getContainerBlockID(), dn);
-        StreamObserver<ContainerCommandRequestProto> requestObserver = stub
-            .withDeadlineAfter(timeout, TimeUnit.SECONDS)
-            .send(streamObserver);
-        streamObserver.setStreamingReadResponse(new StreamingReadResponse(dn,
-            (ClientCallStreamObserver<ContainerCommandRequestProto>) requestObserver));
+        stub.withDeadlineAfter(timeout, TimeUnit.SECONDS)
+            .send(new ReadyAwareResponseObserver(dn, streamObserver));
         return;
       } catch (IOException e) {
         LOG.error("Failed to start streaming read to DataNode {}", dn, e);
@@ -638,6 +632,47 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       throw lastException;
     } else {
       throw new IOException("Failed to start streaming read to any available DataNodes");
+    }
+  }
+
+  /**
+   * Registers the request stream's {@code onReadyHandler} in {@code beforeStart}, the only point gRPC allows it,
+   * hands the {@link StreamingReadResponse} to the reader from there, and tells it when the call terminates so a
+   * sender blocked in {@link StreamingReadResponse#awaitReady(long)} fails right away.
+   */
+  private static final class ReadyAwareResponseObserver
+      implements ClientResponseObserver<ContainerCommandRequestProto, ContainerCommandResponseProto> {
+    private final DatanodeDetails dn;
+    private final StreamingReaderSpi reader;
+    private StreamingReadResponse response;
+
+    ReadyAwareResponseObserver(DatanodeDetails dn, StreamingReaderSpi reader) {
+      this.dn = dn;
+      this.reader = reader;
+    }
+
+    @Override
+    public void beforeStart(ClientCallStreamObserver<ContainerCommandRequestProto> requestStream) {
+      response = new StreamingReadResponse(dn, requestStream);
+      requestStream.setOnReadyHandler(response::signalReady);
+      reader.setStreamingReadResponse(response);
+    }
+
+    @Override
+    public void onNext(ContainerCommandResponseProto value) {
+      reader.onNext(value);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      response.signalTerminated(t);
+      reader.onError(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      response.signalTerminated(null);
+      reader.onCompleted();
     }
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -579,7 +579,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new InterruptedIOException("Interrupted while waiting for stream to become ready: " + streamObserver);
+        throw (IOException) new InterruptedIOException(
+            "Interrupted while waiting for stream to become ready: " + streamObserver)
+            .initCause(e);
       }
     }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/StreamingReadResponse.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/StreamingReadResponse.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.hdds.scm;
 
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.ratis.thirdparty.io.grpc.stub.ClientCallStreamObserver;
@@ -27,6 +29,11 @@ import org.apache.ratis.thirdparty.io.grpc.stub.ClientCallStreamObserver;
  */
 public class StreamingReadResponse {
 
+  private final Object readyLock = new Object();
+  /** Set once the call has terminated; guarded by {@link #readyLock}. */
+  private boolean terminated;
+  /** The failure that terminated the call, or null if it completed normally; guarded by {@link #readyLock}. */
+  private Throwable terminationCause;
   private final DatanodeDetails dn;
   private final ClientCallStreamObserver<ContainerProtos.ContainerCommandRequestProto> requestObserver;
   private final String name;
@@ -46,6 +53,51 @@ public class StreamingReadResponse {
 
   public ClientCallStreamObserver<ContainerProtos.ContainerCommandRequestProto> getRequestObserver() {
     return requestObserver;
+  }
+
+  /** Registered as the request stream's {@code onReadyHandler}. */
+  public void signalReady() {
+    synchronized (readyLock) {
+      readyLock.notifyAll();
+    }
+  }
+
+  /**
+   * Called when the call has terminated, so that {@link #awaitReady(long)} fails immediately instead of waiting
+   * for the timeout: a terminated stream never becomes ready and gRPC no longer invokes the {@code onReadyHandler}.
+   *
+   * @param cause the error that terminated the call, or null if it completed normally.
+   */
+  public void signalTerminated(Throwable cause) {
+    synchronized (readyLock) {
+      terminated = true;
+      terminationCause = cause;
+      readyLock.notifyAll();
+    }
+  }
+
+  /**
+   * Wait until the request stream can accept another message.
+   *
+   * @return true if the stream is ready, false if the timeout expired first.
+   * @throws IOException if the call terminated before the stream became ready.
+   */
+  public boolean awaitReady(long timeoutNanos) throws InterruptedException, IOException {
+    final long deadlineNanos = System.nanoTime() + timeoutNanos;
+    synchronized (readyLock) {
+      while (!requestObserver.isReady()) {
+        if (terminated) {
+          throw new IOException("Stream " + name + " terminated while waiting for it to become ready",
+              terminationCause);
+        }
+        final long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+          return false;
+        }
+        TimeUnit.NANOSECONDS.timedWait(readyLock, remainingNanos);
+      }
+    }
+    return true;
   }
 
   @Override

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/TestStreamingReadResponse.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/TestStreamingReadResponse.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.ratis.thirdparty.io.grpc.stub.ClientCallStreamObserver;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link StreamingReadResponse#awaitReady(long)}.
+ */
+class TestStreamingReadResponse {
+
+  private static final class FakeRequestObserver extends ClientCallStreamObserver<ContainerCommandRequestProto> {
+    private final AtomicBoolean ready = new AtomicBoolean();
+
+    @Override
+    public boolean isReady() {
+      return ready.get();
+    }
+
+    @Override
+    public void setOnReadyHandler(Runnable onReadyHandler) {
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+    }
+
+    @Override
+    public void request(int count) {
+    }
+
+    @Override
+    public void setMessageCompression(boolean enable) {
+    }
+
+    @Override
+    public void cancel(String message, Throwable cause) {
+    }
+
+    @Override
+    public void onNext(ContainerCommandRequestProto value) {
+    }
+
+    @Override
+    public void onError(Throwable t) {
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+  }
+
+  private static StreamingReadResponse newResponse(FakeRequestObserver observer) {
+    return new StreamingReadResponse(MockDatanodeDetails.randomDatanodeDetails(), observer);
+  }
+
+  @Test
+  void returnsImmediatelyWhenAlreadyReady() throws Exception {
+    final FakeRequestObserver observer = new FakeRequestObserver();
+    observer.ready.set(true);
+    assertTrue(newResponse(observer).awaitReady(TimeUnit.SECONDS.toNanos(10)));
+  }
+
+  @Test
+  void timesOutWithoutASignal() throws Exception {
+    final FakeRequestObserver observer = new FakeRequestObserver();
+    final long start = System.nanoTime();
+    assertFalse(newResponse(observer).awaitReady(TimeUnit.MILLISECONDS.toNanos(50)));
+    assertTrue(System.nanoTime() - start >= TimeUnit.MILLISECONDS.toNanos(50), "must wait out the timeout");
+  }
+
+  @Test
+  void wakesOnSignalReady() throws Exception {
+    final FakeRequestObserver observer = new FakeRequestObserver();
+    final StreamingReadResponse response = newResponse(observer);
+    final CountDownLatch waiting = new CountDownLatch(1);
+    final AtomicBoolean result = new AtomicBoolean();
+    final Thread waiter = new Thread(() -> {
+      try {
+        waiting.countDown();
+        result.set(response.awaitReady(TimeUnit.SECONDS.toNanos(30)));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+    waiter.start();
+    assertTrue(waiting.await(10, TimeUnit.SECONDS));
+
+    observer.ready.set(true);
+    response.signalReady();
+    waiter.join(TimeUnit.SECONDS.toMillis(10));
+    assertFalse(waiter.isAlive(), "waiter did not return");
+    assertTrue(result.get());
+  }
+
+  @Test
+  void failsImmediatelyWhenAlreadyTerminated() {
+    final FakeRequestObserver observer = new FakeRequestObserver();
+    final StreamingReadResponse response = newResponse(observer);
+    final Throwable cause = new RuntimeException("boom");
+    response.signalTerminated(cause);
+    final long start = System.nanoTime();
+    final IOException e = assertThrows(IOException.class, () -> response.awaitReady(TimeUnit.SECONDS.toNanos(30)));
+    assertSame(cause, e.getCause());
+    assertTrue(System.nanoTime() - start < TimeUnit.SECONDS.toNanos(5), "must not wait out the timeout");
+  }
+
+  @Test
+  void wakesOnSignalTerminated() throws Exception {
+    final FakeRequestObserver observer = new FakeRequestObserver();
+    final StreamingReadResponse response = newResponse(observer);
+    final CountDownLatch waiting = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread waiter = new Thread(() -> {
+      try {
+        waiting.countDown();
+        response.awaitReady(TimeUnit.SECONDS.toNanos(30));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (IOException e) {
+        failure.set(e);
+      }
+    });
+    waiter.start();
+    assertTrue(waiting.await(10, TimeUnit.SECONDS));
+
+    response.signalTerminated(null);
+    waiter.join(TimeUnit.SECONDS.toMillis(10));
+    assertFalse(waiter.isAlive(), "waiter did not return");
+    assertTrue(failure.get() instanceof IOException, "waiter was not failed by signalTerminated");
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/TestStreamingReadResponse.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/TestStreamingReadResponse.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.io.grpc.stub.ClientCallStreamObserver;
 import org.junit.jupiter.api.Test;
 
@@ -102,11 +103,9 @@ class TestStreamingReadResponse {
   void wakesOnSignalReady() throws Exception {
     final FakeRequestObserver observer = new FakeRequestObserver();
     final StreamingReadResponse response = newResponse(observer);
-    final CountDownLatch waiting = new CountDownLatch(1);
     final AtomicBoolean result = new AtomicBoolean();
     final Thread waiter = new Thread(() -> {
       try {
-        waiting.countDown();
         result.set(response.awaitReady(TimeUnit.SECONDS.toNanos(30)));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -115,13 +114,23 @@ class TestStreamingReadResponse {
       }
     });
     waiter.start();
-    assertTrue(waiting.await(10, TimeUnit.SECONDS));
+    awaitBlocked(waiter);
+
+    // a spurious signalReady() while isReady() is still false must not wake the waiter with a wrong result
+    response.signalReady();
+    awaitBlocked(waiter);
+    assertTrue(waiter.isAlive(), "waiter must still be waiting after a spurious signalReady()");
 
     observer.ready.set(true);
     response.signalReady();
     waiter.join(TimeUnit.SECONDS.toMillis(10));
     assertFalse(waiter.isAlive(), "waiter did not return");
     assertTrue(result.get());
+  }
+
+  /** Waits until {@code thread} is actually parked in {@link StreamingReadResponse#awaitReady(long)}. */
+  private static void awaitBlocked(Thread thread) throws Exception {
+    GenericTestUtils.waitFor(() -> thread.getState() == Thread.State.TIMED_WAITING, 10, 10_000);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -300,7 +300,7 @@ public class TestXceiverClientGrpc {
   /** streamRead() calls onNext() immediately when isReady() is true from the start. */
   @Test
   public void testStreamReadSendsImmediatelyWhenReady() throws Exception {
-    TrackingStreamObserver obs = new TrackingStreamObserver(0);
+    TrackingStreamObserver obs = new TrackingStreamObserver(true);
     StreamingReadResponse response = new StreamingReadResponse(
         MockDatanodeDetails.randomDatanodeDetails(), obs);
     ContainerProtos.ContainerCommandRequestProto request = buildReadBlockRequest();
@@ -315,21 +315,37 @@ public class TestXceiverClientGrpc {
         "isReady() must be checked exactly once when stream is immediately ready");
   }
 
-  /** streamRead() spin-waits until isReady() becomes true, then calls onNext(). */
+  /** streamRead() blocks until the onReadyHandler fires and isReady() becomes true, then calls onNext(). */
   @Test
   public void testStreamReadWaitsUntilReadyThenSends() throws Exception {
-    TrackingStreamObserver obs = new TrackingStreamObserver(3);
+    TrackingStreamObserver obs = new TrackingStreamObserver(false);
     StreamingReadResponse response = new StreamingReadResponse(
         MockDatanodeDetails.randomDatanodeDetails(), obs);
+    // mirrors what ReadyAwareResponseObserver.beforeStart() registers on a real call
+    obs.setOnReadyHandler(response::signalReady);
     ContainerProtos.ContainerCommandRequestProto request = buildReadBlockRequest();
 
+    Thread readySignaller = new Thread(() -> {
+      try {
+        Thread.sleep(200);
+      } catch (InterruptedException ignored) {
+        return;
+      }
+      obs.markReady();
+    });
+    long start;
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf)) {
+      start = System.currentTimeMillis();
+      readySignaller.start();
       client.streamRead(request, response);
     }
+    long elapsed = System.currentTimeMillis() - start;
+    readySignaller.join();
 
     assertEquals(1, obs.getSent().size(), "onNext must be called exactly once");
     assertEquals(request, obs.getSent().get(0));
-    assertThat(obs.getReadyCalls().get()).isGreaterThanOrEqualTo(4);
+    assertThat(elapsed).isGreaterThanOrEqualTo(200L);
+    assertThat(obs.getReadyCalls().get()).isGreaterThanOrEqualTo(2);
   }
 
   /**
@@ -340,7 +356,7 @@ public class TestXceiverClientGrpc {
     OzoneConfiguration timeoutConf = new OzoneConfiguration();
     timeoutConf.set("ozone.client.stream.read.timeout", "1s");
 
-    TrackingStreamObserver obs = new TrackingStreamObserver(Integer.MAX_VALUE);
+    TrackingStreamObserver obs = new TrackingStreamObserver(false);
     StreamingReadResponse response = new StreamingReadResponse(
         MockDatanodeDetails.randomDatanodeDetails(), obs);
     ContainerProtos.ContainerCommandRequestProto request = buildReadBlockRequest();
@@ -357,10 +373,10 @@ public class TestXceiverClientGrpc {
     assertThat(elapsed).isLessThan(10_000L);
   }
 
-  /** streamRead() exits the spin-wait immediately on interrupt and restores the interrupt flag. */
+  /** streamRead() exits the ready wait immediately on interrupt and restores the interrupt flag. */
   @Test
   public void testStreamReadRestoresInterruptFlagOnInterruption() throws Exception {
-    TrackingStreamObserver obs = new TrackingStreamObserver(Integer.MAX_VALUE);
+    TrackingStreamObserver obs = new TrackingStreamObserver(false);
     StreamingReadResponse response = new StreamingReadResponse(
         MockDatanodeDetails.randomDatanodeDetails(), obs);
     ContainerProtos.ContainerCommandRequestProto request = buildReadBlockRequest();
@@ -390,16 +406,28 @@ public class TestXceiverClientGrpc {
     }
   }
 
-  /** Records onNext() calls and controls when isReady() starts returning true. */
+  /**
+   * Records onNext() calls and models gRPC flow control: isReady() reflects a flag that {@link #markReady()} flips,
+   * after which the registered onReadyHandler is invoked, as gRPC does when the transport becomes writable.
+   */
   private static final class TrackingStreamObserver
       extends ClientCallStreamObserver<ContainerProtos.ContainerCommandRequestProto> {
 
     private final List<ContainerProtos.ContainerCommandRequestProto> sent = new ArrayList<>();
     private final AtomicInteger readyCalls = new AtomicInteger();
-    private final int readyAfter;
+    private volatile boolean ready;
+    private volatile Runnable onReadyHandler;
 
-    TrackingStreamObserver(int readyAfter) {
-      this.readyAfter = readyAfter;
+    TrackingStreamObserver(boolean ready) {
+      this.ready = ready;
+    }
+
+    void markReady() {
+      ready = true;
+      final Runnable handler = onReadyHandler;
+      if (handler != null) {
+        handler.run();
+      }
     }
 
     List<ContainerProtos.ContainerCommandRequestProto> getSent() {
@@ -412,7 +440,8 @@ public class TestXceiverClientGrpc {
 
     @Override
     public boolean isReady() {
-      return readyCalls.incrementAndGet() > readyAfter;
+      readyCalls.incrementAndGet();
+      return ready;
     }
 
     @Override
@@ -426,6 +455,7 @@ public class TestXceiverClientGrpc {
 
     @Override
     public void setOnReadyHandler(Runnable r) {
+      onReadyHandler = r;
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
XceiverClientGrpc.streamRead should wait for flow-control readiness via onReadyHandler instead of a 10 ms poll
XceiverClientGrpc.streamRead() waits for the gRPC request stream to become ready (flow control) by polling isReady() in a loop with a 10 ms sleep between checks. This adds up to 10 ms of latency to every send that hits back-pressure, burns CPU on a busy client, and keeps the caller waiting for the full timeout if the call fails in the meantime, since a terminated stream never becomes ready.
PR uses the readiness callback that gRPC already provides instead of polling. initStreamRead() now wraps the reader in a ClientResponseObserver so the onReadyHandler can be registered in beforeStart(), the only place gRPC allows it. The handler wakes the sender via StreamingReadResponse.signalReady().streamRead() calls the new StreamingReadResponse.awaitReady(timeout), which blocks on a monitor until the stream is ready, the timeout expires, or the call terminates. onError/onCompleted call signalTerminated(), so a sender blocked in awaitReady() fails immediately with the termination cause instead of waiting out the timeout.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16324

## How was this patch tested?
UTs has been added. 