### PR TITLE
HDDS-16379. Recon returns 500 NPE instead of proxying error when metrics endpoint responds with a non-enum status code

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/MetricsProxyEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/MetricsProxyEndpoint.java
@@ -71,13 +71,16 @@ public class MetricsProxyEndpoint {
       HttpURLConnection connection = metricsServiceProvider.getMetricsResponse(
           api, uriInfo.getRequestUri().getQuery());
       InputStream inputStream;
-      if (Response.Status.fromStatusCode(connection.getResponseCode())
-          .getFamily() == Response.Status.Family.SUCCESSFUL) {
+      if (Response.Status.Family.familyOf(connection.getResponseCode()) == Response.Status.Family.SUCCESSFUL) {
         inputStream = connection.getInputStream();
       } else {
         // Throw a bad gateway error if HttpResponseCode is not 2xx
         httpServletResponse.setStatus(HttpServletResponse.SC_BAD_GATEWAY);
         inputStream = connection.getErrorStream();
+        if (inputStream == null) {
+          // The metrics endpoint sent no error body
+          return;
+        }
       }
       try (
           OutputStream outputStream =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/JmxServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/JmxServiceProviderImpl.java
@@ -110,8 +110,7 @@ public class JmxServiceProviderImpl implements MetricsServiceProvider {
     return SecurityUtil.doAsLoginUser(() -> {
       HttpURLConnection urlConnection =
           getMetricsResponse(api, queryString);
-      if (Response.Status.fromStatusCode(urlConnection.getResponseCode())
-          .getFamily() == Response.Status.Family.SUCCESSFUL) {
+      if (Response.Status.Family.familyOf(urlConnection.getResponseCode()) == Response.Status.Family.SUCCESSFUL) {
         try (InputStream inputStream = urlConnection.getInputStream()) {
           Map<String, Object> jsonMap = JsonUtils.getDefaultMapper().readValue(inputStream, Map.class);
           Object beansObj = jsonMap.get("beans");

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/PrometheusServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/PrometheusServiceProviderImpl.java
@@ -126,8 +126,7 @@ public class PrometheusServiceProviderImpl
     HttpURLConnection urlConnection =
         getMetricsResponse(api, queryString);
     List<Metric> metrics = null;
-    if (Response.Status.fromStatusCode(urlConnection.getResponseCode())
-        .getFamily() == Response.Status.Family.SUCCESSFUL) {
+    if (Response.Status.Family.familyOf(urlConnection.getResponseCode()) == Response.Status.Family.SUCCESSFUL) {
       InputStream inputStream = urlConnection.getInputStream();
       ObjectMapper mapper = new ObjectMapper();
       Map<String, Object> jsonMap = mapper.readValue(inputStream, Map.class);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.recon.api;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -788,6 +790,52 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
             .getFile())
     );
     verify(outputStreamMock).write(fileBytes, 0, fileBytes.length);
+  }
+
+  @Test
+  public void testGetMetricsResponseWithNonEnumStatusCode() throws Exception {
+    HttpServletResponse responseMock = mock(HttpServletResponse.class);
+    ServletOutputStream outputStreamMock = mock(ServletOutputStream.class);
+    when(responseMock.getOutputStream()).thenReturn(outputStreamMock);
+    UriInfo uriInfoMock = mock(UriInfo.class);
+    URI uriMock = mock(URI.class);
+    when(uriMock.getQuery()).thenReturn("");
+    when(uriInfoMock.getRequestUri()).thenReturn(uriMock);
+
+    // 422 has no Response.Status enum constant; the error body must still be proxied back.
+    byte[] errorBody = "{\"status\":\"error\",\"errorType\":\"bad_data\"}".getBytes(UTF_8);
+    HttpURLConnection urlConnectionMock = mock(HttpURLConnection.class);
+    when(urlConnectionMock.getResponseCode()).thenReturn(422);
+    when(urlConnectionMock.getErrorStream())
+        .thenReturn(new ByteArrayInputStream(errorBody));
+    when(reconUtilsMock.makeHttpCall(any(URLConnectionFactory.class),
+        anyString(), anyBoolean())).thenReturn(urlConnectionMock);
+
+    metricsProxyEndpoint.getMetricsResponse(PROMETHEUS_INSTANT_QUERY_API,
+        uriInfoMock, responseMock);
+
+    verify(responseMock).setStatus(HttpServletResponse.SC_BAD_GATEWAY);
+    verify(outputStreamMock).write(errorBody, 0, errorBody.length);
+  }
+
+  @Test
+  public void testGetMetricsResponseWithNullErrorStream() throws Exception {
+    HttpServletResponse responseMock = mock(HttpServletResponse.class);
+    UriInfo uriInfoMock = mock(UriInfo.class);
+    URI uriMock = mock(URI.class);
+    when(uriMock.getQuery()).thenReturn("");
+    when(uriInfoMock.getRequestUri()).thenReturn(uriMock);
+
+    HttpURLConnection urlConnectionMock = mock(HttpURLConnection.class);
+    when(urlConnectionMock.getResponseCode()).thenReturn(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    when(urlConnectionMock.getErrorStream()).thenReturn(null);
+    when(reconUtilsMock.makeHttpCall(any(URLConnectionFactory.class),
+        anyString(), anyBoolean())).thenReturn(urlConnectionMock);
+
+    assertDoesNotThrow(() -> metricsProxyEndpoint.getMetricsResponse(PROMETHEUS_INSTANT_QUERY_API,
+        uriInfoMock, responseMock));
+
+    verify(responseMock).setStatus(HttpServletResponse.SC_BAD_GATEWAY);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon's metrics proxy and metrics service providers checked the upstream HTTP status with
`Response.Status.fromStatusCode(code).getFamily()`. `Response.Status` is a JAX-RS enum that
only lists common status codes, and `fromStatusCode()` returns `null` for any code not in the
enum (e.g. 422, which the Prometheus HTTP API returns when a query expression cannot be
executed). Calling `.getFamily()` on that `null` throws a NullPointerException, so Recon
responds 500 with a stack trace instead of setting 502 and proxying the Prometheus error body
back as intended.

This PR:
- Replaces the check with `Response.Status.Family.familyOf(code)`, which classifies any status
  code by its first digit and never returns null, in `MetricsProxyEndpoint`,
  `PrometheusServiceProviderImpl`, and `JmxServiceProviderImpl`.
- Guards against `HttpURLConnection#getErrorStream()` returning `null` (per its javadoc) in the
  error path of `MetricsProxyEndpoint`, which previously caused a second NPE in
  `Channels.newChannel(null)` and in the `finally` close.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16379

## How was this patch tested?

Added two unit tests to the existing `TestEndpoints` suite, following the mock pattern of
`testGetMetricsResponse`:
- `testGetMetricsResponseWithNonEnumStatusCode`: upstream returns 422 with an error body;
  verifies Recon sets 502 and proxies the body back (the path that previously threw NPE).
- `testGetMetricsResponseWithNullErrorStream`: upstream returns an error status with no error
  body; verifies no exception and a 502 response.