### PR TITLE
HDDS-16378. Do not write upgrade.complete during upgrade-container-schema --dry-run

### DIFF
--- a/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/datanode/schemaupgrade/UpgradeContainerSchema.java
+++ b/hadoop-ozone/cli-repair/src/main/java/org/apache/hadoop/ozone/repair/datanode/schemaupgrade/UpgradeContainerSchema.java
@@ -311,7 +311,7 @@ public class UpgradeContainerSchema extends RepairTool {
         final File file =
             UpgradeUtils.getVolumeUpgradeCompleteFile(r.getHddsVolume());
         // create a flag file
-        if (e == null && r.isSuccess()) {
+        if (e == null && r.isSuccess() && !isDryRun()) {
           try {
             UpgradeUtils.createFile(file);
           } catch (IOException ioe) {
@@ -321,7 +321,7 @@ public class UpgradeContainerSchema extends RepairTool {
         if (lockFile.exists()) {
           boolean deleted = lockFile.delete();
           if (!deleted) {
-            error("Failed to delete upgrade lock file %s.", file);
+            error("Failed to delete upgrade lock file %s.", lockFile);
           }
         }
       });

--- a/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/datanode/schemaupgrade/TestUpgradeContainerSchema.java
+++ b/hadoop-ozone/cli-repair/src/test/java/org/apache/hadoop/ozone/repair/datanode/schemaupgrade/TestUpgradeContainerSchema.java
@@ -219,6 +219,15 @@ class TestUpgradeContainerSchema {
       }
     }
 
+    for (HddsVolume volume : volumes) {
+      File completeFile = UpgradeUtils.getVolumeUpgradeCompleteFile(volume);
+      if (dryRun) {
+        assertThat(completeFile).doesNotExist();
+      } else {
+        assertThat(completeFile).exists();
+      }
+    }
+
     if (!dryRun) {
       checkV3MetaData(keyValueContainerBlockDataMap, results);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`--dry-run` of `ozone repair datanode upgrade-container-schema` still wrote the permanent `upgrade.complete` marker. The real run then skipped every marked volume. Details are on the Jira.

This patch:

- Creates `upgrade.complete` only when `e == null && r.isSuccess() && !isDryRun()`. Dry-run still deletes `upgrade.lock`.
- Passes `lockFile` (not `file`) to the lock-delete error log in the same `whenComplete`.
- Asserts in `TestUpgradeContainerSchema.testUpgrade` that the marker is absent after dry-run and present after a real run.

This does not delete markers already left by an older dry-run. Operators who already ran `--dry-run` should remove each volume's `hddsRootDir/upgrade.complete` before the real upgrade.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16378

## How was this patch tested?

- `TestUpgradeContainerSchema` (including the new `upgrade.complete` existence checks on both `dryRun` parameter values).
- ci: https://github.com/shuan1026/ozone/actions/runs/33729155957