### PR TITLE
HDDS-16135. Fix remaining intermittent failures in TestKeyLifecycleService

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java
@@ -375,9 +375,14 @@ class TestKeyLifecycleService extends OzoneTestBase {
 
       // Verify that scan state was updated through the DeleteKeysRequest
       String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
-      OmLifecycleScanState scanState = metadataManager.getLifecycleScanStateTable().get(bucketKey);
-      assertNotNull(scanState);
-      assertNotNull(scanState.getScanEndTime());
+      GenericTestUtils.waitFor(() -> {
+        try {
+          OmLifecycleScanState scanState = metadataManager.getLifecycleScanStateTable().get(bucketKey);
+          return scanState != null && scanState.getScanEndTime() != null;
+        } catch (IOException e) {
+          return false;
+        }
+      }, WAIT_CHECK_INTERVAL, 10000);
 
       deleteLifecyclePolicy(volumeName, bucketName);
     }
@@ -2594,6 +2599,7 @@ class TestKeyLifecycleService extends OzoneTestBase {
         LOG.info("Dir {} refreshes its modification time", dirName);
         KeyInfoWithVolumeContext keyInfo2 = getDirectory(volumeName, bucketName, dirName);
         assertNotEquals(keyInfo.getKeyInfo().getModificationTime(), keyInfo2.getKeyInfo().getModificationTime());
+        awaitDirCacheDrained(volumeName, bucketName);
       }
 
       // resume KeyLifecycleService bucket scan


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-16135](https://issues.apache.org/jira/browse/HDDS-16135) reported intermittent failures in `TestKeyLifecycleService$Normal#testNestedFSODirectoryScanResume`. After [HDDS-16033](https://issues.apache.org/jira/browse/HDDS-16033) / [#11145](https://github.com/apache/ozone/pull/11145) resolve the most of the issues, that method is stable. The full `$Normal` class still flakes in two other methods.

### `testScanStatePiggybackedOnDelete`

The test reads `OmLifecycleScanState` once and asserts `scanEndTime != null`. After the first scan finishes, the lifecycle policy is still present, the next tick recreates the row with `scanEndTime = null` (a ~40ms window). The one-shot read can land in that window.

This change waits with `GenericTestUtils.waitFor` until a completed scan state is visible.

### `testMultipleDirectoriesMatched`

The test renames a directory to refresh mtime and immediately unparks the scan. `getSubDirectory()` merges the dirTable cache with the RocksDB iterator and does not dedupe live entries, so the same directory can be evaluated twice: the cache copy and the DB copy. The stale copy still looks expired, so a just-renewed directory is deleted and `waitFor(deletedDirectory == expected)` never settles.

This change calls `awaitDirCacheDrained` after the rename.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16135

## How was this patch tested?

Before:
`TestKeyLifecycleService$Normal#ALL` (20x10 ALL) Fail
https://github.com/shuan1026/ozone/actions/runs/33775402686

After:
`TestKeyLifecycleService$Normal#ALL` (20x10 ALL) Pass
https://github.com/shuan1026/ozone/actions/runs/33849488601

Full CI:
https://github.com/shuan1026/ozone/actions/runs/33849024847