### PR TITLE
HDDS-16375. Apply fileSize filter independently in Recon fileCount endpoint

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/UtilizationEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/UtilizationEndpoint.java
@@ -116,7 +116,7 @@ public class UtilizationEndpoint {
             if (bucket != null && !bucket.equals(key.getBucket())) {
               matches = false;
             }
-            if (fileSize > 0 && !Long.valueOf(fileSize).equals(key.getFileSizeUpperBound())) {
+            if (fileSize > 0 && fileSize != key.getFileSizeUpperBound()) {
               matches = false;
             }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/UtilizationEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/UtilizationEndpoint.java
@@ -116,7 +116,10 @@ public class UtilizationEndpoint {
             if (bucket != null && !bucket.equals(key.getBucket())) {
               matches = false;
             }
-            
+            if (fileSize > 0 && !Long.valueOf(fileSize).equals(key.getFileSizeUpperBound())) {
+              matches = false;
+            }
+
             if (matches && count != null && count > 0) {
               FileCountBySize record = new FileCountBySize();
               record.setVolume(key.getVolume());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -915,6 +915,15 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     assertEquals(2L, rocksCount3.longValue(), "Expected RocksDB bin 1024 to have count 2 for vol2/bucket1");
 
     // --- Now test the query endpoints of the utilization service ---
+    verifyFileCountQueries();
+  }
+
+  /**
+   * Verify the filtering behaviour of the fileCount endpoint against the
+   * bins written by {@link #testGetFileCounts()}: vol1/bucket1:1024,
+   * vol1/bucket1:131072 and vol2/bucket1:1024, each with count 2.
+   */
+  private void verifyFileCountQueries() {
     Response response = utilizationEndpoint.getFileCounts(null, null, 0);
     List<FileCountBySize> resultSet =
         (List<FileCountBySize>) response.getEntity();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -952,6 +952,32 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     resultSet = (List<FileCountBySize>) response.getEntity();
     assertEquals(0, resultSet.size());
 
+    // Test for "fileSize" query param on its own.
+    response = utilizationEndpoint.getFileCounts(null, null, 131072);
+    resultSet = (List<FileCountBySize>) response.getEntity();
+    assertEquals(1, resultSet.size());
+    assertTrue(resultSet.stream().allMatch(o -> o.getVolume().equals("vol1") &&
+        o.getBucket().equals("bucket1") && o.getFileSize() == 131072L));
+
+    // Test for "volume" + "fileSize" query params, without bucket.
+    response = utilizationEndpoint.getFileCounts("vol1", null, 131072);
+    resultSet = (List<FileCountBySize>) response.getEntity();
+    assertEquals(1, resultSet.size());
+    assertTrue(resultSet.stream().allMatch(o -> o.getVolume().equals("vol1") &&
+        o.getFileSize() == 131072L));
+
+    // Test for "bucket" + "fileSize" query params, without volume.
+    response = utilizationEndpoint.getFileCounts(null, "bucket1", 1024);
+    resultSet = (List<FileCountBySize>) response.getEntity();
+    assertEquals(2, resultSet.size());
+    assertTrue(resultSet.stream().allMatch(o -> o.getBucket().equals("bucket1") &&
+        o.getFileSize() == 1024L));
+
+    // Test for a fileSize that is not a bin upper bound, without volume and bucket.
+    response = utilizationEndpoint.getFileCounts(null, null, 1310725);
+    resultSet = (List<FileCountBySize>) response.getEntity();
+    assertEquals(0, resultSet.size());
+
     // Test for "volume" + "bucket" + "fileSize" query params.
     response = utilizationEndpoint.getFileCounts("vol1", "bucket1", 131072);
     resultSet = (List<FileCountBySize>) response.getEntity();


### PR DESCRIPTION

`ReconApi.md` lists `fileSize` as optional and describes it as "Filters the
results based on the given fileSize", with no stated dependency on the other
two parameters. This patch makes the code match the documented behaviour by
applying the `fileSize` filter independently in the scan branch. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16375

## How was this patch tested?

Extended `TestEndpoints#testGetFileCounts` with the four parameter combinations
that were previously uncovered: `fileSize` alone, `volume` + `fileSize`,
`bucket` + `fileSize`, and a `fileSize` that is not a bin upper bound with no
volume or bucket. The first two reproduce the measurements above and fail
without the fix. The existing assertions for the other combinations are
unchanged.

Verified by a full `build-branch` workflow run on the fork.

