### PR TITLE
HDDS-16385. Minor cleanups in NodeDecommissionManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -106,7 +105,7 @@ public class NodeDecommissionManager {
 
         if (this.hostname == null) {
           throw new InvalidHostStringException("The string " + rawHostname +
-              " does not contain a value hostname or hostname:port definition");
+              " does not contain a valid hostname or hostname:port definition");
         }
       } catch (URISyntaxException e) {
         throw new InvalidHostStringException(
@@ -537,8 +536,7 @@ public class NodeDecommissionManager {
 
   private synchronized boolean checkIfMaintenancePossible(List<DatanodeDetails> dns, List<DatanodeAdminError> errors) {
     int numMaintenance = dns.size();
-    List<DatanodeDetails> validDns = dns.stream().collect(Collectors.toList());
-    Collections.copy(validDns, dns);
+    List<DatanodeDetails> validDns = new ArrayList<>(dns);
     int inServiceTotal = nodeManager.getNodeCount(NodeStatus.inServiceHealthy());
     for (DatanodeDetails dn : dns) {
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix typo and remove redundant list copy in NodeDecommissionManager.

1. In NodeDecommissionManager.parseHostname(), the InvalidHostStringException message has a typo — "does not contain a value hostname or hostname:port definition" should read "a valid hostname".
2. In NodeDecommissionManager.checkIfMaintenancePossible(), the list copy is redundant 
` List<DatanodeDetails> validDns = dns.stream().collect(Collectors.toList()); `
Followed by `Collections.copy(validDns, dns); `
Which copies dns twice, and should be simplified to `List<DatanodeDetails> validDns = new ArrayList<>(dns); `
Which is matching with other implementations like checkIfDecommissionPossible() definition.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16385

## How was this patch tested?
No behaviour changes, Ran existing unit tests in TestNodeDecommissionManager
Successful CI Build : https://github.com/navinko/ozone/actions/runs/33965658546