### PR TITLE
HDDS-16273. OM bootstrap never completes when a single SST file is larger than ozone.om.ratis.snapshot.max.total.sst.size

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2413,7 +2413,8 @@
     <value>10737418240</value>
     <tag>OZONE, OM, RATIS</tag>
     <description>
-      Max size of SST files in OM Ratis Snapshot tarball.
+      Max size of SST files in OM Ratis Snapshot tarball. A single file larger than this limit is
+      still sent, so that the transfer always makes progress.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -53,6 +53,9 @@ public abstract class RDBSnapshotProvider implements Closeable {
   private static final Logger LOG =
       LoggerFactory.getLogger(RDBSnapshotProvider.class);
 
+  // Tolerate one no-progress part, e.g. a truncated exclude list made the leader resend files already present.
+  private static final int MAX_NO_PROGRESS_PARTS = 2;
+
   private final File snapshotDir;
   private final File candidateDir;
   private final String dbName;
@@ -109,14 +112,16 @@ public abstract class RDBSnapshotProvider implements Closeable {
         "reloading state from the snapshot.", leaderNodeID);
     checkLeaderConsistency(leaderNodeID);
     int numParts = 0;
+    int numNoProgressParts = 0;
+    int numFiles = HAUtils.getExistingFiles(candidateDir).size();
 
     while (true) {
       String snapshotFileName = getSnapshotFileName(leaderNodeID);
       File targetFile = new File(snapshotDir, snapshotFileName);
       downloadSnapshot(leaderNodeID, targetFile);
+      numParts++;
       LOG.info("Successfully download the latest snapshot {} from leader OM: {}, part : {}",
           targetFile, leaderNodeID, numParts);
-      numParts++;
 
       numDownloaded.incrementAndGet();
       injectPause();
@@ -129,6 +134,22 @@ public abstract class RDBSnapshotProvider implements Closeable {
         LOG.info("DB snapshot transfer is complete.");
         return getCheckpointFromUntarredDb(unTarredDb);
       }
+
+      // The next request is built from the files already in the candidate dir, so a part which brings
+      // no new file leaves the leader with the same request to answer and the transfer cannot progress.
+      int numFilesAfterPart = HAUtils.getExistingFiles(candidateDir).size();
+      if (numFilesAfterPart > numFiles) {
+        numNoProgressParts = 0;
+      } else if (++numNoProgressParts >= MAX_NO_PROGRESS_PARTS) {
+        throw new IOException(String.format("DB snapshot transfer from leader %s aborted after %d parts: the last"
+            + " %d parts brought no new file into %s and the transfer is still incomplete. A single file on the"
+            + " leader is likely larger than its per-request SST size limit"
+            + " (OM: ozone.om.ratis.snapshot.max.total.sst.size).",
+            leaderNodeID, numParts, numNoProgressParts, candidateDir));
+      } else {
+        LOG.warn("Part {} from leader {} brought no new file into {}.", numParts, leaderNodeID, candidateDir);
+      }
+      numFiles = numFilesAfterPart;
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -35,6 +36,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -51,6 +53,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
@@ -253,5 +256,34 @@ public class TestRDBSnapshotProvider {
     // Confirm setting different leader does reinitialize.
     rdbSnapshotProvider.checkLeaderConsistency("node2");
     assertEquals(3, rdbSnapshotProvider.getInitCount());
+  }
+
+  /**
+   * A leader which keeps sending parts that bring no new file cannot complete the transfer,
+   * so the download has to fail instead of looping forever.
+   */
+  @Test
+  @Timeout(60)
+  public void testDownloadAbortsWhenPartsBringNoNewFile() throws Exception {
+    AtomicInteger numParts = new AtomicInteger();
+    RDBSnapshotProvider provider = new RDBSnapshotProvider(testDir, "noprogress.db") {
+      @Override
+      public void close() {
+      }
+
+      @Override
+      public void downloadSnapshot(String leaderNodeID, File targetFile) throws IOException {
+        // A tarball with neither a new file nor the completion flag.
+        numParts.incrementAndGet();
+        try (OutputStream outputStream = Files.newOutputStream(targetFile.toPath())) {
+          Archiver.tar(outputStream).close();
+        }
+      }
+    };
+
+    IOException ioe = assertThrows(IOException.class, () -> provider.downloadDBSnapshotFromLeader(LEADER_ID));
+    assertThat(ioe.getMessage()).contains("brought no new file");
+    // The first part is tolerated, the second one aborts the download.
+    assertEquals(2, numParts.get());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServletInodeBasedXfer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServletInodeBasedXfer.java
@@ -317,7 +317,7 @@ public class TestOMDbCheckpointServletInodeBasedXfer {
     try (Stream<Path> list = Files.list(newDbDir.toPath())) {
       totalSize = list.mapToLong(path -> path.toFile().length()).sum();
     }
-    boolean obtainedFilesUnderMaxLimit = totalSize < maxFileSizeLimit;
+    boolean obtainedFilesUnderMaxLimit = totalSize <= maxFileSizeLimit;
     if (!includeSnapshots) {
       // If includeSnapshotData flag is set to false , it always sends all data
       // in one batch and doesn't respect the max size config. This is how Recon
@@ -946,6 +946,62 @@ public class TestOMDbCheckpointServletInodeBasedXfer {
       servlet.collectFilesFromDir(sstFilesToExclude, filesUnderDir.stream(),
           maxTotalSstSize, true, archiverSpy, false);
     });
+  }
+
+  /**
+   * A request must always transfer at least one file, even when a single file is larger than the
+   * max total SST size. Otherwise the leader keeps replying with an empty tarball and the follower
+   * asks for the same files forever without making any progress.
+   */
+  @Test
+  public void testCollectFilesFromDirTransfersFileLargerThanMaxSize() throws Exception {
+    OMDBCheckpointServletInodeBasedXfer servlet = new OMDBCheckpointServletInodeBasedXfer();
+    Path dbDir = Files.createTempDirectory(folder, "oversized-sst-");
+    Path sstFile1 = dbDir.resolve("file1.sst");
+    Path sstFile2 = dbDir.resolve("file2.sst");
+    Files.write(sstFile1, new byte[1024]);
+    Files.write(sstFile2, new byte[1024]);
+    // Both files are larger than the whole budget of a single request.
+    long maxTotalSstSize = 512;
+    Set<String> sstFilesToExclude = new HashSet<>();
+
+    for (int part = 1; part <= 2; part++) {
+      // Every request starts with a fresh archiver and the full budget, the same way the servlet does.
+      OMDBArchiver archiver = newArchiver("tmp-oversized-part" + part);
+      assertFalse(servlet.collectFilesFromDir(sstFilesToExclude, Stream.of(sstFile1, sstFile2),
+          new AtomicLong(maxTotalSstSize), true, archiver, false), "A part carrying an oversized file ends there");
+      assertEquals(1, archiver.getFilesToWriteIntoTarball().size(),
+          "Part " + part + " should transfer exactly one file");
+      assertEquals(part, sstFilesToExclude.size(), "Every part should make progress");
+    }
+    // Once every file has been sent, the scan completes without recording anything.
+    OMDBArchiver finalArchiver = newArchiver("tmp-oversized-final");
+    assertTrue(servlet.collectFilesFromDir(sstFilesToExclude, Stream.of(sstFile1, sstFile2),
+        new AtomicLong(maxTotalSstSize), true, finalArchiver, false));
+    assertTrue(finalArchiver.getFilesToWriteIntoTarball().isEmpty());
+
+    // The relaxation is per request: one budget spans all the directories of a request, and once the
+    // tarball holds a file the limit is enforced again.
+    OMDBArchiver archiver = newArchiver("tmp-oversized-multi-dir");
+    Set<String> excludeNothing = new HashSet<>();
+    AtomicLong budget = new AtomicLong(maxTotalSstSize);
+    assertFalse(servlet.collectFilesFromDir(excludeNothing, Stream.of(sstFile1), budget, true, archiver, false));
+    assertFalse(servlet.collectFilesFromDir(excludeNothing, Stream.of(sstFile2), budget, true, archiver, false));
+    assertEquals(1, archiver.getFilesToWriteIntoTarball().size());
+
+    // A file which exactly fills the budget is not over it.
+    OMDBArchiver exactFitArchiver = newArchiver("tmp-oversized-exact-fit");
+    assertTrue(servlet.collectFilesFromDir(new HashSet<>(), Stream.of(sstFile1), new AtomicLong(1024), true,
+        exactFitArchiver, false));
+    assertEquals(1, exactFitArchiver.getFilesToWriteIntoTarball().size());
+  }
+
+  private OMDBArchiver newArchiver(String tmpDirName) throws IOException {
+    OMDBArchiver archiver = new OMDBArchiver();
+    Path tmpDir = folder.resolve(tmpDirName);
+    Files.createDirectories(tmpDir);
+    archiver.setTmpDir(tmpDir);
+    return archiver;
   }
 
   private void writeDummyKeyToDeleteTableOfSnapshotDB(OzoneSnapshot snapshotToModify, String bucketName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServletInodeBasedXfer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServletInodeBasedXfer.java
@@ -563,13 +563,24 @@ public class OMDBCheckpointServletInodeBasedXfer extends DBCheckpointServlet {
         if (!sstFilesToExclude.contains(fileId)) {
           try {
             long fileSize = Files.size(dbFile);
-            if (maxTotalSstSize.get() - fileSize <= 0) {
-              return false;
+            boolean overBudget = maxTotalSstSize.get() - fileSize < 0;
+            if (overBudget) {
+              if (!omdbArchiver.getFilesToWriteIntoTarball().isEmpty()) {
+                return false;
+              }
+              // Nothing has been collected for this request yet. Returning here would send an empty tarball,
+              // and the follower would come back asking for the same files, so send this one on its own.
+              LOG.warn("File {} of size {} bytes exceeds {} ({} bytes). Transferring it in a tarball of its own.",
+                  dbFile, fileSize, OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_KEY, maxTotalSstSize.get());
             }
             bytesRecorded += omdbArchiver.recordFileEntry(dbFile.toFile(), fileId);
             filesWritten++;
             maxTotalSstSize.addAndGet(-fileSize);
             sstFilesToExclude.add(fileId);
+            if (overBudget) {
+              // End the part here so the oversized file really is the tarball's only entry.
+              return false;
+            }
           } catch (NoSuchFileException e) {
             if (ignoreNoSuchFileException) {
               logFileNoLongerExists(dbFile);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OMDBCheckpointServletInodeBasedXfer.collectFilesFromDir()` checks the per-request budget
(`ozone.om.ratis.snapshot.max.total.sst.size`) before recording a file. When a single SST file is larger than
the whole budget it is the first non-excluded file of every request, so the leader answers with an empty
tarball each time. The follower's exclude list never changes, and `RDBSnapshotProvider.downloadDBSnapshotFromLeader()`
loops forever while holding the `OzoneManager` monitor: no error, no bound, no progress. The comparison was also
`<= 0`, so a file exactly equal to the remaining budget was treated as over budget.

Leader side: when a file does not fit and nothing has been collected for the request yet, record it anyway and
end the part, so every request transfers at least one file. The budget check is now `< 0`, so an exact fit is
not over budget. The v1 `OMDBCheckpointServlet` records before checking and was never affected.

Follower side: `RDBSnapshotProvider` counts consecutive parts that bring no new file into the candidate dir and
aborts with a diagnosable `IOException` after two instead of looping forever. One no-progress part is tolerated
for transient causes such as a truncated exclude list. The `part : N` log is now 1-based.

The `ozone-default.xml` description now states that an oversized file is still sent.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16273

## How was this patch tested?

- New `TestOMDbCheckpointServletInodeBasedXfer#testCollectFilesFromDirTransfersFileLargerThanMaxSize`: two
  files larger than the budget are sent one per request, the limit is enforced again once the tarball holds a
  file, and a file exactly filling the budget is accepted.
- `testTarballBatching` assertion changed to `<=` to match the exact-fit semantics; both parameterizations pass.
- New `TestRDBSnapshotProvider#testDownloadAbortsWhenPartsBringNoNewFile`: the first empty part is tolerated,
  the second aborts with the new message.
- `checkstyle.sh` — 0 violations.

Generated-by: Claude Code (Claude Fable 5.1)

