### PR TITLE
HDDS-16389. Add command to display snapshot counts per bucket.

### DIFF
--- a/.m2-tmp/com/gradle/develocity-maven-extension/2.5.0/develocity-maven-extension-2.5.0.pom.lastUpdated
+++ b/.m2-tmp/com/gradle/develocity-maven-extension/2.5.0/develocity-maven-extension-2.5.0.pom.lastUpdated
@@ -1,4 +1,0 @@
-#NOTE: This is a Maven Resolver internal implementation file, its format can be changed without prior notice.
-#Tue Sep 08 13:54:07 IST 2026
-@default-central-https\://repo.maven.apache.org/maven2/.lastUpdated=1788855847295
-https\://repo.maven.apache.org/maven2/.error=Could not transfer artifact com.gradle\:develocity-maven-extension\:pom\:2.5.0 from/to central (https\://repo.maven.apache.org/maven2)\: repo.maven.apache.org\: nodename nor servname provided, or not known

--- a/.m2-tmp/com/gradle/develocity-maven-extension/2.5.0/develocity-maven-extension-2.5.0.pom.lastUpdated
+++ b/.m2-tmp/com/gradle/develocity-maven-extension/2.5.0/develocity-maven-extension-2.5.0.pom.lastUpdated
@@ -1,0 +1,4 @@
+#NOTE: This is a Maven Resolver internal implementation file, its format can be changed without prior notice.
+#Tue Sep 08 13:54:07 IST 2026
+@default-central-https\://repo.maven.apache.org/maven2/.lastUpdated=1788855847295
+https\://repo.maven.apache.org/maven2/.error=Could not transfer artifact com.gradle\:develocity-maven-extension\:pom\:2.5.0 from/to central (https\://repo.maven.apache.org/maven2)\: repo.maven.apache.org\: nodename nor servname provided, or not known

--- a/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/CountSnapshotHandler.java
+++ b/hadoop-ozone/cli-shell/src/main/java/org/apache/hadoop/ozone/shell/snapshot/CountSnapshotHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.shell.snapshot;
+
+import java.io.IOException;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.shell.Handler;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.snapshot.SnapshotBucketCount;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
+import picocli.CommandLine;
+
+/**
+ * ozone sh snapshot count.
+ * Displays bucket-wise snapshot distribution in the cluster.
+ */
+@CommandLine.Command(name = "count",
+    description = "Display bucket-wise snapshot distribution for the cluster.")
+public class CountSnapshotHandler extends Handler {
+
+  @CommandLine.Option(names = {"-b", "--bucket"},
+      description = "Optional bucket filter. Accepts either <bucket> or <volume>/<bucket>.")
+  private String bucketFilter;
+
+  @Override
+  protected void execute(OzoneClient client, OzoneAddress address)
+      throws IOException {
+    SnapshotCountResponse response = client.getObjectStore().snapshotCount(bucketFilter);
+    printObjectAsJson(new ShellSnapshotCountResponse(response));
+  }
+
+  private static final class ShellSnapshotCountResponse {
+    private final Count total;
+    private final java.util.Map<String, Count> buckets = new java.util.TreeMap<>();
+
+    private ShellSnapshotCountResponse(SnapshotCountResponse response) {
+      this.total = new Count(response.getActive(), response.getDeleted(), response.getTotal());
+      for (SnapshotBucketCount bucketCount : response.getBuckets()) {
+        buckets.put(bucketCount.getVolumeName() + "/" + bucketCount.getBucketName(),
+            new Count(bucketCount.getActive(), bucketCount.getDeleted(), bucketCount.getTotal()));
+      }
+    }
+
+    public Count getTotal() {
+      return total;
+    }
+
+    public java.util.Map<String, Count> getBuckets() {
+      return buckets;
+    }
+  }
+
+  private static final class Count {
+    private final long active;
+    private final long deleted;
+    private final long total;
+
+    private Count(long active, long deleted, long total) {
+      this.active = active;
+      this.deleted = deleted;
+      this.total = total;
+    }
+
+    public long getActive() {
+      return active;
+    }
+
+    public long getDeleted() {
+      return deleted;
+    }
+
+    public long getTotal() {
+      return total;
+    }
+  }
+}

--- a/hadoop-ozone/cli-shell/src/test/java/org/apache/hadoop/ozone/shell/snapshot/TestCountSnapshotHandler.java
+++ b/hadoop-ozone/cli-shell/src/test/java/org/apache/hadoop/ozone/shell/snapshot/TestCountSnapshotHandler.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.shell.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.snapshot.SnapshotBucketCount;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CountSnapshotHandler}.
+ */
+public class TestCountSnapshotHandler {
+
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+
+  @BeforeEach
+  public void setup() throws UnsupportedEncodingException {
+    outContent.reset();
+    System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
+  }
+
+  @AfterEach
+  public void teardown() {
+    System.setOut(originalOut);
+  }
+
+  @Test
+  public void testCountBucketWiseSnapshotDistribution() throws IOException {
+    CountSnapshotHandler handler = new CountSnapshotHandler();
+    OzoneClient client = mock(OzoneClient.class);
+    ObjectStore store = mock(ObjectStore.class);
+    when(client.getObjectStore()).thenReturn(store);
+
+    SnapshotCountResponse countResponse = new SnapshotCountResponse(3, 1, 4, Arrays.asList(
+        new SnapshotBucketCount("vol1", "bucket1", 1, 1, 2),
+        new SnapshotBucketCount("vol2", "bucket3", 2, 0, 2)));
+    when(store.snapshotCount(null)).thenReturn(countResponse);
+
+    handler.execute(client, new OzoneAddress());
+
+    JsonNode output = new ObjectMapper().readTree(outContent.toString(DEFAULT_ENCODING));
+    assertEquals(3, output.get("total").get("active").asInt());
+    assertEquals(1, output.get("total").get("deleted").asInt());
+    assertEquals(4, output.get("total").get("total").asInt());
+
+    assertEquals(2, output.get("buckets").size());
+    JsonNode bucket1Count = output.get("buckets").get("vol1/bucket1");
+    assertEquals(1, bucket1Count.get("active").asInt());
+    assertEquals(1, bucket1Count.get("deleted").asInt());
+    assertEquals(2, bucket1Count.get("total").asInt());
+
+    JsonNode bucket3Count = output.get("buckets").get("vol2/bucket3");
+    assertEquals(2, bucket3Count.get("active").asInt());
+    assertEquals(0, bucket3Count.get("deleted").asInt());
+    assertEquals(2, bucket3Count.get("total").asInt());
+  }
+
+  @Test
+  public void testCountBucketFilterIncludesMatchingEmptyBucket() throws Exception {
+    CountSnapshotHandler handler = new CountSnapshotHandler();
+    setBucketFilter(handler, "vol1/bucket2");
+
+    OzoneClient client = mock(OzoneClient.class);
+    ObjectStore store = mock(ObjectStore.class);
+    when(client.getObjectStore()).thenReturn(store);
+    SnapshotCountResponse emptyBucketResponse = new SnapshotCountResponse(0, 0, 0,
+        Arrays.asList(new SnapshotBucketCount("vol1", "bucket2", 0, 0, 0)));
+    when(store.snapshotCount("vol1/bucket2")).thenReturn(emptyBucketResponse);
+
+    handler.execute(client, new OzoneAddress());
+    verify(store).snapshotCount("vol1/bucket2");
+
+    JsonNode output = new ObjectMapper().readTree(outContent.toString(DEFAULT_ENCODING));
+    assertEquals(0, output.get("total").get("active").asInt());
+    assertEquals(0, output.get("total").get("deleted").asInt());
+    assertEquals(0, output.get("total").get("total").asInt());
+    assertEquals(1, output.get("buckets").size());
+    assertEquals(0, output.get("buckets").get("vol1/bucket2").get("total").asInt());
+  }
+
+  private static void setBucketFilter(CountSnapshotHandler handler, String value) throws Exception {
+    Field field = CountSnapshotHandler.class.getDeclaredField("bucketFilter");
+    field.setAccessible(true);
+    field.set(handler, value);
+  }
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -618,6 +619,16 @@ public class ObjectStore {
                                               String snapshotPrefix,
                                               String prevSnapshot) throws IOException {
     return new SnapshotIterator(volumeName, bucketName, snapshotPrefix, prevSnapshot);
+  }
+
+  /**
+   * Get bucket-wise snapshot count distribution from snapshotInfo table.
+   * @param bucketFilter optional filter, accepts either bucket or volume/bucket
+   * @return snapshot counts aggregated by bucket
+   * @throws IOException
+   */
+  public SnapshotCountResponse snapshotCount(String bucketFilter) throws IOException {
+    return proxy.snapshotCount(bucketFilter);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.security.KerberosInfo;
@@ -1460,6 +1461,14 @@ public interface ClientProtocol {
   ListSnapshotResponse listSnapshot(
       String volumeName, String bucketName, String snapshotPrefix,
       String prevSnapshot, int maxListResult) throws IOException;
+
+  /**
+   * Bucket-wise snapshot count distribution from snapshotInfo table.
+   * @param bucketFilter optional filter, accepts either bucket or volume/bucket
+   * @return snapshot counts aggregated by bucket
+   * @throws IOException
+   */
+  SnapshotCountResponse snapshotCount(String bucketFilter) throws IOException;
 
   /**
    * Get the differences between two snapshots.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -177,6 +177,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -1141,6 +1142,12 @@ public class RpcClient implements ClientProtocol {
     Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
         "bucket can't be null or empty.");
     return ozoneManagerClient.listSnapshot(volumeName, bucketName, snapshotPrefix, prevSnapshot, maxListResult);
+  }
+
+  @Override
+  public SnapshotCountResponse snapshotCount(String bucketFilter)
+      throws IOException {
+    return ozoneManagerClient.snapshotCount(bucketFilter);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -242,6 +242,7 @@ public final class OmUtils {
     case TenantGetUserInfo:
     case TenantListUser:
     case ListSnapshot:
+    case SnapshotCount:
     case RefetchSecretKey:
     case RangerBGSync:
       // RangerBGSync is a read operation in the sense that it doesn't directly
@@ -384,6 +385,7 @@ public final class OmUtils {
     case TenantGetUserInfo:
     case TenantListUser:
     case ListSnapshot:
+    case SnapshotCount:
     case RefetchSecretKey:
     case GetKeyInfo:
     case GetSnapshotInfo:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization;
@@ -782,6 +783,17 @@ public interface OzoneManagerProtocol
   default ListSnapshotResponse listSnapshot(
       String volumeName, String bucketName, String snapshotPrefix,
       String prevSnapshot, int maxListResult) throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
+   * Bucket-wise snapshot count distribution from snapshotInfo table.
+   * @param bucketFilter optional filter, accepts either bucket or volume/bucket
+   * @return snapshot counts aggregated by bucket
+   * @throws IOException
+   */
+  default SnapshotCountResponse snapshotCount(String bucketFilter) throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
         "this to be implemented");
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -256,6 +256,8 @@ import org.apache.hadoop.ozone.security.proto.SecurityProtos.RenewDelegationToke
 import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotBucketCount;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
@@ -1400,6 +1402,29 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     }
 
     return new ListSnapshotResponse(snapshotInfos, lastSnapshot);
+  }
+
+  @Override
+  public SnapshotCountResponse snapshotCount(String bucketFilter)
+      throws IOException {
+    final OzoneManagerProtocolProtos.SnapshotCountRequest.Builder requestBuilder =
+        OzoneManagerProtocolProtos.SnapshotCountRequest.newBuilder();
+    if (bucketFilter != null) {
+      requestBuilder.setBucketFilter(bucketFilter);
+    }
+    final OMRequest omRequest = createOMRequest(Type.SnapshotCount)
+        .setSnapshotCountRequest(requestBuilder)
+        .build();
+    final OMResponse omResponse = submitRequest(omRequest);
+    handleError(omResponse);
+
+    OzoneManagerProtocolProtos.SnapshotCountResponse response = omResponse.getSnapshotCountResponse();
+    List<SnapshotBucketCount> bucketCounts = response.getBucketsList().stream()
+        .map(count -> new SnapshotBucketCount(count.getVolumeName(), count.getBucketName(),
+            count.getActive(), count.getDeleted(), count.getTotal()))
+        .collect(Collectors.toList());
+
+    return new SnapshotCountResponse(response.getActive(), response.getDeleted(), response.getTotal(), bucketCounts);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotBucketCount.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotBucketCount.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.snapshot;
+
+/**
+ * Bucket-wise snapshot count distribution.
+ */
+public final class SnapshotBucketCount {
+  private final String volumeName;
+  private final String bucketName;
+  private final long active;
+  private final long deleted;
+  private final long total;
+
+  public SnapshotBucketCount(String volumeName, String bucketName, long active, long deleted, long total) {
+    this.volumeName = volumeName;
+    this.bucketName = bucketName;
+    this.active = active;
+    this.deleted = deleted;
+    this.total = total;
+  }
+
+  public String getVolumeName() {
+    return volumeName;
+  }
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  public long getActive() {
+    return active;
+  }
+
+  public long getDeleted() {
+    return deleted;
+  }
+
+  public long getTotal() {
+    return total;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotCountResponse.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotCountResponse.java
@@ -15,28 +15,39 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.shell.snapshot;
+package org.apache.hadoop.ozone.snapshot;
 
-import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import picocli.CommandLine.Command;
+import java.util.List;
 
 /**
- * Subcommands for the snapshot related operations.
+ * POJO for snapshot count API.
  */
-@Command(name = "snapshot",
-    description = "Snapshot specific operations",
-    subcommands = {
-        CreateSnapshotHandler.class,
-        DeleteSnapshotHandler.class,
-        CountSnapshotHandler.class,
-        ListSnapshotHandler.class,
-        SnapshotDiffHandler.class,
-        ListSnapshotDiffHandler.class,
-        InfoSnapshotHandler.class,
-        RenameSnapshotHandler.class
-    },
-    mixinStandardHelpOptions = true,
-    versionProvider = HddsVersionProvider.class)
-public class SnapshotCommands {
+public final class SnapshotCountResponse {
+  private final long active;
+  private final long deleted;
+  private final long total;
+  private final List<SnapshotBucketCount> buckets;
 
+  public SnapshotCountResponse(long active, long deleted, long total, List<SnapshotBucketCount> buckets) {
+    this.active = active;
+    this.deleted = deleted;
+    this.total = total;
+    this.buckets = buckets;
+  }
+
+  public long getActive() {
+    return active;
+  }
+
+  public long getDeleted() {
+    return deleted;
+  }
+
+  public long getTotal() {
+    return total;
+  }
+
+  public List<SnapshotBucketCount> getBuckets() {
+    return buckets;
+  }
 }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -166,6 +166,7 @@ enum Type {
   GetLifecycleServiceStatus    = 150;
   SetLifecycleServiceStatus    = 151;
   SaveLifecycleScanState       = 152;
+  SnapshotCount                = 153;
 }
 
 enum SafeMode {
@@ -326,6 +327,7 @@ message OMRequest {
   optional GetLifecycleServiceStatusRequest getLifecycleServiceStatusRequest = 151;
   optional SetLifecycleServiceStatusRequest setLifecycleServiceStatusRequest = 152;
   optional SaveLifecycleScanStateRequest saveLifecycleScanStateRequest = 153;
+  optional SnapshotCountRequest snapshotCountRequest = 154;
 }
 
 message OMResponse {
@@ -471,6 +473,7 @@ message OMResponse {
   optional GetLifecycleServiceStatusResponse getLifecycleServiceStatusResponse = 150;
   optional SetLifecycleServiceStatusResponse setLifecycleServiceStatusResponse = 151;
   optional SaveLifecycleScanStateResponse saveLifecycleScanStateResponse = 152;
+  optional SnapshotCountResponse snapshotCountResponse = 154;
 }
 
 enum Status {
@@ -2085,6 +2088,10 @@ message ListSnapshotRequest {
   optional uint32 maxListResult = 5;
 }
 
+message SnapshotCountRequest {
+  optional string bucketFilter = 1;
+}
+
 message SnapshotDiffRequest {
   optional string volumeName = 1;
   optional string bucketName = 2;
@@ -2230,6 +2237,21 @@ message CreateSnapshotResponse {
 message ListSnapshotResponse {
   repeated SnapshotInfo snapshotInfo = 1;
   optional string lastSnapshot = 2;
+}
+
+message SnapshotBucketCount {
+  optional string volumeName = 1;
+  optional string bucketName = 2;
+  optional uint64 active = 3;
+  optional uint64 deleted = 4;
+  optional uint64 total = 5;
+}
+
+message SnapshotCountResponse {
+  optional uint64 active = 1;
+  optional uint64 deleted = 2;
+  optional uint64 total = 3;
+  repeated SnapshotBucketCount buckets = 4;
 }
 
 message SnapshotDiffResponse {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -341,6 +341,8 @@ import org.apache.hadoop.ozone.security.acl.RequestContext;
 import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotBucketCount;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
@@ -3265,6 +3267,144 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       AUDIT.logReadFailure(buildAuditMessageForFailure(OMAction.LIST_SNAPSHOT,
           auditMap, ex));
       throw ex;
+    }
+  }
+
+  @Override
+  public SnapshotCountResponse snapshotCount(String bucketFilter)
+      throws IOException {
+    Map<String, String> auditMap = new LinkedHashMap<>();
+    auditMap.put("bucketFilter", StringUtils.defaultString(bucketFilter));
+
+    try {
+      BucketFilter parsedFilter = BucketFilter.parse(bucketFilter);
+      Map<String, BucketSnapshotCount> bucketCounts = new LinkedHashMap<>();
+      Map<String, Boolean> bucketAclCache = new LinkedHashMap<>();
+
+      try (TableIterator<String, ? extends Table.KeyValue<String, SnapshotInfo>> keyIter =
+               metadataManager.getSnapshotInfoTable().iterator()) {
+        while (keyIter.hasNext()) {
+          SnapshotInfo snapshotInfo = keyIter.next().getValue();
+          String volumeName = snapshotInfo.getVolumeName();
+          String bucketName = snapshotInfo.getBucketName();
+          if (!parsedFilter.matches(volumeName, bucketName)) {
+            continue;
+          }
+
+          if (getAclsEnabled() && !hasListAccess(volumeName, bucketName, bucketAclCache)) {
+            continue;
+          }
+
+          String bucketKey = volumeName + "/" + bucketName;
+          BucketSnapshotCount bucketCount =
+              bucketCounts.computeIfAbsent(bucketKey, unused -> new BucketSnapshotCount(volumeName, bucketName));
+          bucketCount.increment(snapshotInfo.getSnapshotStatus());
+        }
+      }
+
+      long totalActive = 0;
+      long totalDeleted = 0;
+      long total = 0;
+      List<SnapshotBucketCount> bucketCountList = new ArrayList<>(bucketCounts.size());
+      for (BucketSnapshotCount bucketCount : bucketCounts.values()) {
+        bucketCountList.add(bucketCount.toResponse());
+        totalActive += bucketCount.active;
+        totalDeleted += bucketCount.deleted;
+        total += bucketCount.total;
+      }
+
+      AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction.LIST_SNAPSHOT, auditMap));
+      return new SnapshotCountResponse(totalActive, totalDeleted, total, bucketCountList);
+    } catch (Exception ex) {
+      AUDIT.logReadFailure(buildAuditMessageForFailure(OMAction.LIST_SNAPSHOT, auditMap, ex));
+      throw ex;
+    }
+  }
+
+  private boolean hasListAccess(String volumeName, String bucketName, Map<String, Boolean> bucketAclCache)
+      throws IOException {
+    String bucketKey = volumeName + "/" + bucketName;
+    Boolean hasAccess = bucketAclCache.get(bucketKey);
+    if (hasAccess != null) {
+      return hasAccess;
+    }
+
+    try {
+      omMetadataReader.checkAcls(ResourceType.BUCKET, StoreType.OZONE, ACLType.LIST, volumeName, bucketName, null);
+      bucketAclCache.put(bucketKey, true);
+      return true;
+    } catch (OMException ex) {
+      if (ex.getResult() == OMException.ResultCodes.ACCESS_DENIED) {
+        bucketAclCache.put(bucketKey, false);
+        return false;
+      }
+      throw ex;
+    }
+  }
+
+  private static final class BucketFilter {
+    private final String volumeName;
+    private final String bucketName;
+
+    private BucketFilter(String volumeName, String bucketName) {
+      this.volumeName = volumeName;
+      this.bucketName = bucketName;
+    }
+
+    static BucketFilter parse(String filter) throws OMException {
+      if (StringUtils.isBlank(filter)) {
+        return new BucketFilter(null, null);
+      }
+
+      String normalized = StringUtils.strip(filter, "/");
+      int slashIndex = normalized.indexOf('/');
+      if (slashIndex < 0) {
+        return new BucketFilter(null, normalized);
+      }
+
+      String volume = normalized.substring(0, slashIndex);
+      String bucket = normalized.substring(slashIndex + 1);
+      if (StringUtils.isBlank(volume) || StringUtils.isBlank(bucket)) {
+        throw new OMException("Invalid --bucket filter. Use either <bucket> or <volume>/<bucket>.",
+            OMException.ResultCodes.INVALID_REQUEST);
+      }
+      return new BucketFilter(volume, bucket);
+    }
+
+    boolean matches(String volume, String bucket) {
+      if (bucketName == null) {
+        return true;
+      }
+      if (volumeName == null) {
+        return bucketName.equals(bucket);
+      }
+      return volumeName.equals(volume) && bucketName.equals(bucket);
+    }
+  }
+
+  private static final class BucketSnapshotCount {
+    private final String volumeName;
+    private final String bucketName;
+    private long active;
+    private long deleted;
+    private long total;
+
+    private BucketSnapshotCount(String volumeName, String bucketName) {
+      this.volumeName = volumeName;
+      this.bucketName = bucketName;
+    }
+
+    private void increment(SnapshotInfo.SnapshotStatus status) {
+      if (status == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED) {
+        deleted++;
+      } else if (status == SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE) {
+        active++;
+      }
+      total++;
+    }
+
+    private SnapshotBucketCount toResponse() {
+      return new SnapshotBucketCount(volumeName, bucketName, active, deleted, total);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -173,6 +173,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.request.validation.RequestProcessingPhase;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalization.StatusAndMessages;
 import org.apache.hadoop.ozone.util.PayloadUtils;
 import org.apache.hadoop.ozone.util.ProtobufUtils;
@@ -342,6 +343,11 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         OzoneManagerProtocolProtos.ListSnapshotResponse listSnapshotResponse =
             getSnapshots(request.getListSnapshotRequest());
         responseBuilder.setListSnapshotResponse(listSnapshotResponse);
+        break;
+      case SnapshotCount:
+        OzoneManagerProtocolProtos.SnapshotCountResponse snapshotCountResponse =
+            getSnapshotCount(request.getSnapshotCountRequest());
+        responseBuilder.setSnapshotCountResponse(snapshotCountResponse);
         break;
       case SnapshotDiff:
         SnapshotDiffResponse snapshotDiffReport = snapshotDiff(
@@ -1615,6 +1621,29 @@ public class OzoneManagerRequestHandler implements RequestHandler {
       builder.setLastSnapshot(implResponse.getLastSnapshot());
     }
     return builder.build();
+  }
+
+  @DisallowedUntilLayoutVersion(FILESYSTEM_SNAPSHOT)
+  private OzoneManagerProtocolProtos.SnapshotCountResponse getSnapshotCount(
+      OzoneManagerProtocolProtos.SnapshotCountRequest request) throws IOException {
+    SnapshotCountResponse implResponse = impl.snapshotCount(
+        request.hasBucketFilter() ? request.getBucketFilter() : null);
+    List<OzoneManagerProtocolProtos.SnapshotBucketCount> bucketCountList = implResponse.getBuckets().stream()
+        .map(bucketCount -> OzoneManagerProtocolProtos.SnapshotBucketCount.newBuilder()
+            .setVolumeName(bucketCount.getVolumeName())
+            .setBucketName(bucketCount.getBucketName())
+            .setActive(bucketCount.getActive())
+            .setDeleted(bucketCount.getDeleted())
+            .setTotal(bucketCount.getTotal())
+            .build())
+        .collect(Collectors.toList());
+
+    return OzoneManagerProtocolProtos.SnapshotCountResponse.newBuilder()
+        .setActive(implResponse.getActive())
+        .setDeleted(implResponse.getDeleted())
+        .setTotal(implResponse.getTotal())
+        .addAllBuckets(bucketCountList)
+        .build();
   }
 
   private TransferLeadershipResponseProto transferLeadership(

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotDiffJobResponse;
 import org.apache.hadoop.ozone.snapshot.ListSnapshotResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotCountResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SubmitSnapshotDiffResponse;
 import org.apache.hadoop.security.token.Token;
@@ -781,6 +782,12 @@ public class ClientProtocolStub implements ClientProtocol {
   public ListSnapshotResponse listSnapshot(
       String volumeName, String bucketName, String snapshotPrefix,
       String prevSnapshot, int maxListResult) throws IOException {
+    return null;
+  }
+
+  @Override
+  public SnapshotCountResponse snapshotCount(String bucketFilter)
+      throws IOException {
     return null;
   }
   


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to add a command to understand snapshot counts per bucket as currently there is no direct way to fetch this info

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16389

## How was this patch tested?
Unit tests
