### PR TITLE
HDDS-16354. Make the dfsrw read/write ratio configurable

### DIFF
--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsReadWriteValidator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsReadWriteValidator.java
@@ -49,6 +49,10 @@ import picocli.CommandLine.Option;
  * concurrent load, including in time-based (--duration) runs where paths are
  * reused.
  * <p>
+ * --read-write-ratio tunes the mix: a task still writes a single file, but
+ * reads back as many as the ratio asks for, so a run can be made read-heavy or
+ * write-heavy without changing what any one read validates.
+ * <p>
  * CRC32 keeps the validation off the critical path of the measured throughput.
  * Successive writes of a path differ in the marker only, and markers less than
  * 2^32 apart never share a CRC32, so a stale read is always detected.
@@ -89,6 +93,14 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
       defaultValue = "10000")
   private int maxFilesPerThread;
 
+  @Option(names = {"--read-write-ratio"},
+      description = "Number of reads issued per write. 1 pairs one read with every write, 4 makes the run "
+          + "read-heavy with four read-backs of each write, and 0.25 makes it write-heavy with one read-back "
+          + "every fourth write. A ratio that is not a whole number is spread over the writes of a thread "
+          + "rather than rounded on every one of them.",
+      defaultValue = "1.0")
+  private double readWriteRatio;
+
   private ContentGenerator contentGenerator;
 
   private Timer writeTimer;
@@ -112,6 +124,12 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
     if (maxFilesPerThread <= 0) {
       throw new IllegalArgumentException(
           "--max-files-per-thread must be positive");
+    }
+    // NaN fails the first test, and an infinite ratio would make a single task
+    // read forever
+    if (!(readWriteRatio > 0) || Double.isInfinite(readWriteRatio)) {
+      throw new IllegalArgumentException(
+          "--read-write-ratio must be a positive finite number");
     }
 
     super.init();
@@ -155,6 +173,17 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
     }
     history.record(fileId, checksum);
 
+    for (int reads = history.readsDue(readWriteRatio); reads > 0; reads--) {
+      validateRandomFile(history);
+    }
+  }
+
+  /**
+   * Read back one of the files this thread wrote, picked at random, and verify
+   * that its content still matches the checksum of the latest write of that
+   * path.
+   */
+  private void validateRandomFile(ThreadHistory history) throws Exception {
     long readId = history.randomFileId();
     Path target = objectPath(readId);
     long expected = history.checksumOf(readId);
@@ -215,13 +244,15 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
    * is keyed by file id (an overwrite updates the checksum), so it holds one
    * entry per file the thread wrote and never more than
    * --max-files-per-thread. The id is kept rather than the {@link Path} it maps
-   * to, which {@link #objectPath} rebuilds on demand.
+   * to, which {@link #objectPath} rebuilds on demand. It also carries the
+   * thread's share of the read/write ratio, see {@link #readsDue(double)}.
    */
   private static final class ThreadHistory {
     private final long markerBase;
     private int markerSeq;
     private final Map<Long, Long> checksums = new HashMap<>();
     private final List<Long> fileIds = new ArrayList<>();
+    private double readCredit;
 
     private ThreadHistory(long threadSequenceId) {
       this.markerBase = threadSequenceId << Integer.SIZE;
@@ -258,6 +289,20 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
 
     private long checksumOf(long fileId) {
       return checksums.get(fileId);
+    }
+
+    /**
+     * How many files to read back after the write that just completed. The
+     * fraction a ratio like 2.5 leaves over is carried to the next write
+     * instead of being rounded away, so the thread issues the requested number
+     * of reads per write on average, and a ratio below 1 reads back every
+     * n-th write rather than never reading at all.
+     */
+    private int readsDue(double readsPerWrite) {
+      readCredit += readsPerWrite;
+      int reads = (int) readCredit;
+      readCredit -= reads;
+      return reads;
     }
   }
 }

--- a/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsReadWriteValidator.java
+++ b/hadoop-ozone/freon/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsReadWriteValidator.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.freon;
 
 import com.codahale.metrics.Timer;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -49,8 +51,8 @@ import picocli.CommandLine.Option;
  * concurrent load, including in time-based (--duration) runs where paths are
  * reused.
  * <p>
- * --read-write-ratio tunes the mix: a task still writes a single file, but
- * reads back as many as the ratio asks for, so a run can be made read-heavy or
+ * --reads-per-write tunes the mix: a task still writes a single file, but reads
+ * back as many as the ratio asks for, so a run can be made read-heavy or
  * write-heavy without changing what any one read validates.
  * <p>
  * CRC32 keeps the validation off the critical path of the measured throughput.
@@ -67,6 +69,21 @@ import picocli.CommandLine.Option;
 @MetaInfServices(FreonSubcommand.class)
 public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
     implements Callable<Void> {
+
+  /**
+   * One read, in the fixed-point units the read credit of a thread is counted
+   * in. The ratio is converted to whole units once, so the fraction it leaves
+   * over on every write is carried exactly. Accumulating the ratio itself as a
+   * double drifts: adding 0.1 ten times gives 0.9999999999999999, which delays
+   * the read the tenth write is due to an eleventh write.
+   */
+  private static final long CREDIT_UNIT = 1_000_000L;
+
+  /**
+   * Beyond this a run reads back more files per write than it could complete,
+   * and the bound is what keeps the credit of a thread well inside a long.
+   */
+  private static final BigDecimal MAX_READS_PER_WRITE = new BigDecimal("1000000");
 
   @Option(names = {"-s", "--size"},
       description = "Size of the generated files. " +
@@ -93,13 +110,17 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
       defaultValue = "10000")
   private int maxFilesPerThread;
 
-  @Option(names = {"--read-write-ratio"},
-      description = "Number of reads issued per write. 1 pairs one read with every write, 4 makes the run "
-          + "read-heavy with four read-backs of each write, and 0.25 makes it write-heavy with one read-back "
-          + "every fourth write. A ratio that is not a whole number is spread over the writes of a thread "
-          + "rather than rounded on every one of them.",
+  @Option(names = {"--reads-per-write"},
+      description = "Number of validation reads issued per write. 1 pairs one read with every write, 4 makes the "
+          + "run read-heavy with four validation reads per write, and 0.25 makes it write-heavy with one read "
+          + "every fourth write. Every read picks a file the thread wrote at random, so this changes how many "
+          + "files a task validates, not which write it validates. A value that is not a whole number is spread "
+          + "over the writes of a thread rather than rounded on every one of them.",
       defaultValue = "1.0")
-  private double readWriteRatio;
+  private BigDecimal readsPerWrite;
+
+  /** {@link #readsPerWrite} in the units of {@link ThreadHistory#readCredit}. */
+  private long creditPerWrite;
 
   private ContentGenerator contentGenerator;
 
@@ -125,12 +146,16 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
       throw new IllegalArgumentException(
           "--max-files-per-thread must be positive");
     }
-    // NaN fails the first test, and an infinite ratio would make a single task
-    // read forever
-    if (!(readWriteRatio > 0) || Double.isInfinite(readWriteRatio)) {
-      throw new IllegalArgumentException(
-          "--read-write-ratio must be a positive finite number");
+    if (readsPerWrite.signum() <= 0
+        || readsPerWrite.compareTo(MAX_READS_PER_WRITE) > 0) {
+      throw new IllegalArgumentException("--reads-per-write must be positive "
+          + "and at most " + MAX_READS_PER_WRITE.toPlainString());
     }
+    // Rounded away from zero, so a ratio finer than a credit unit still reads
+    // back now and then instead of silently never reading at all.
+    creditPerWrite = readsPerWrite.multiply(BigDecimal.valueOf(CREDIT_UNIT))
+        .setScale(0, RoundingMode.UP)
+        .longValueExact();
 
     super.init();
 
@@ -173,7 +198,7 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
     }
     history.record(fileId, checksum);
 
-    for (int reads = history.readsDue(readWriteRatio); reads > 0; reads--) {
+    for (int reads = history.readsDue(creditPerWrite); reads > 0; reads--) {
       validateRandomFile(history);
     }
   }
@@ -245,14 +270,15 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
    * entry per file the thread wrote and never more than
    * --max-files-per-thread. The id is kept rather than the {@link Path} it maps
    * to, which {@link #objectPath} rebuilds on demand. It also carries the
-   * thread's share of the read/write ratio, see {@link #readsDue(double)}.
+   * thread's share of the read/write ratio, see {@link #readsDue(long)}.
    */
   private static final class ThreadHistory {
     private final long markerBase;
     private int markerSeq;
     private final Map<Long, Long> checksums = new HashMap<>();
     private final List<Long> fileIds = new ArrayList<>();
-    private double readCredit;
+    /** Owed reads, in {@link #CREDIT_UNIT}s, left over by earlier writes. */
+    private long readCredit;
 
     private ThreadHistory(long threadSequenceId) {
       this.markerBase = threadSequenceId << Integer.SIZE;
@@ -296,12 +322,13 @@ public class HadoopFsReadWriteValidator extends HadoopBaseFreonGenerator
      * fraction a ratio like 2.5 leaves over is carried to the next write
      * instead of being rounded away, so the thread issues the requested number
      * of reads per write on average, and a ratio below 1 reads back every
-     * n-th write rather than never reading at all.
+     * n-th write rather than never reading at all. The carry is exact: it is
+     * counted in whole {@link #CREDIT_UNIT}s, not accumulated as a double.
      */
-    private int readsDue(double readsPerWrite) {
-      readCredit += readsPerWrite;
-      int reads = (int) readCredit;
-      readCredit -= reads;
+    private int readsDue(long creditPerWrite) {
+      readCredit += creditPerWrite;
+      int reads = (int) (readCredit / CREDIT_UNIT);
+      readCredit %= CREDIT_UNIT;
       return reads;
     }
   }

--- a/hadoop-ozone/freon/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopFsReadWriteRatio.java
+++ b/hadoop-ozone/freon/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopFsReadWriteRatio.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.freon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PositionedReadable;
+import org.apache.hadoop.fs.Seekable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import picocli.CommandLine;
+
+/**
+ * Verifies that {@code --read-write-ratio} of {@link HadoopFsReadWriteValidator}
+ * (dfsrw) controls how many reads the run issues per write. The workload only
+ * needs a Hadoop {@code FileSystem}, so these run against the local one instead
+ * of a cluster.
+ */
+public class TestHadoopFsReadWriteRatio {
+
+  private static final int WRITES = 8;
+
+  @TempDir
+  private java.nio.file.Path tempDir;
+
+  private String rootPath;
+
+  @BeforeEach
+  void setUp() {
+    // toUri() rather than the path itself: on Windows the latter is not a valid
+    // URI, it has backslashes and a drive letter where the authority goes
+    String uri = tempDir.toUri().toString();
+    rootPath = uri.endsWith("/") ? uri.substring(0, uri.length() - 1) : uri;
+    CorruptingLocalFileSystem.corruptFromRead(Integer.MAX_VALUE);
+  }
+
+  /**
+   * One read per write is the default, and it stays that way when the ratio is
+   * given explicitly.
+   */
+  @Test
+  void pairsOneReadWithEveryWriteByDefault() {
+    CommandLine cmd = runValidator(2);
+
+    assertEquals(WRITES, writeCount(cmd));
+    assertEquals(WRITES, readCount(cmd));
+  }
+
+  /**
+   * A whole number of reads per write holds however the writes are spread over
+   * the threads, so this can afford more than one of them.
+   */
+  @ParameterizedTest
+  @ValueSource(ints = {2, 3, 5})
+  void issuesRequestedReadsPerWrite(int ratio) {
+    CommandLine cmd =
+        runValidator(2, "--read-write-ratio", String.valueOf(ratio));
+
+    assertEquals(WRITES, writeCount(cmd));
+    assertEquals((long) WRITES * ratio, readCount(cmd));
+  }
+
+  /**
+   * A ratio below 1 reads back only every n-th write, and the fraction it
+   * leaves over is carried between writes rather than rounded away on each of
+   * them, which would read back nothing at all. The leftover is per thread, so
+   * only a single thread gives an exact count.
+   */
+  @Test
+  void spreadsFractionalRatioOverWrites() {
+    CommandLine cmd = runValidator(1, "--read-write-ratio", "0.25");
+
+    assertEquals(WRITES, writeCount(cmd));
+    assertEquals(WRITES / 4, readCount(cmd));
+  }
+
+  /** A ratio with a whole and a fractional part mixes the two behaviours. */
+  @Test
+  void spreadsMixedRatioOverWrites() {
+    CommandLine cmd = runValidator(1, "--read-write-ratio", "1.5");
+
+    assertEquals(WRITES, writeCount(cmd));
+    assertEquals(WRITES * 3 / 2, readCount(cmd));
+  }
+
+  /**
+   * Every read of a task validates, not only the first one: a single write read
+   * back three times fails the run when the content is corrupted before the
+   * last of the three reads.
+   */
+  @Test
+  void everyReadOfATaskValidatesContent() {
+    CorruptingLocalFileSystem.corruptFromRead(3);
+
+    int exitCode = new Freon().getCmd().execute(
+        "-D", "fs.file.impl=" + CorruptingLocalFileSystem.class.getName(),
+        "dfsrw",
+        "-r", rootPath,
+        "-p", "dfsrw-corrupt",
+        "-n", "1",
+        "-t", "1",
+        "-s", "1KB",
+        "--buffer", "1024",
+        "--copy-buffer", "1024",
+        "--read-write-ratio", "3");
+
+    assertNotEquals(0, exitCode, "Corrupted content was not detected");
+  }
+
+  @Test
+  void rejectsNonPositiveRatio() {
+    assertThat(execute(new Freon().getCmd(), 1, "--read-write-ratio", "0"))
+        .isNotZero();
+    assertThat(execute(new Freon().getCmd(), 1, "--read-write-ratio", "-1"))
+        .isNotZero();
+  }
+
+  private CommandLine runValidator(int threads, String... args) {
+    CommandLine cmd = new Freon().getCmd();
+    assertEquals(0, execute(cmd, threads, args), "Freon dfsrw command failed");
+    return cmd;
+  }
+
+  private int execute(CommandLine cmd, int threads, String... args) {
+    String[] fixed = {
+        "dfsrw",
+        "-r", rootPath,
+        "-p", "dfsrw",
+        "-n", String.valueOf(WRITES),
+        "-t", String.valueOf(threads),
+        "-s", "1KB",
+        "--buffer", "1024",
+        "--copy-buffer", "1024"};
+    String[] argv = new String[fixed.length + args.length];
+    System.arraycopy(fixed, 0, argv, 0, fixed.length);
+    System.arraycopy(args, 0, argv, fixed.length, args.length);
+    return cmd.execute(argv);
+  }
+
+  private static long writeCount(CommandLine cmd) {
+    return timerCount(cmd, "file-write");
+  }
+
+  private static long readCount(CommandLine cmd) {
+    return timerCount(cmd, "file-read-validate");
+  }
+
+  private static long timerCount(CommandLine cmd, String name) {
+    BaseFreonGenerator subject = (BaseFreonGenerator)
+        cmd.getParseResult().subcommand().commandSpec().userObject();
+    return subject.getMetrics().timer(name).getCount();
+  }
+
+  /**
+   * A {@link LocalFileSystem} that alters the content it hands out from the
+   * n-th {@code open()} on. The bytes are changed above the checksum
+   * verification of {@link org.apache.hadoop.fs.ChecksumFileSystem}, so it is
+   * the workload, not the file system, that has to notice.
+   */
+  public static final class CorruptingLocalFileSystem extends LocalFileSystem {
+
+    private static final AtomicInteger READS = new AtomicInteger();
+    private static int corruptFrom = Integer.MAX_VALUE;
+
+    static void corruptFromRead(int read) {
+      READS.set(0);
+      corruptFrom = read;
+    }
+
+    @Override
+    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+      FSDataInputStream input = super.open(f, bufferSize);
+      // the hidden .crc companions are the checksum bookkeeping of the file
+      // system itself, only the reads of the workload are to be counted
+      if (f.getName().startsWith(".") || READS.incrementAndGet() < corruptFrom) {
+        return input;
+      }
+      return new FSDataInputStream(new FlippingInputStream(input));
+    }
+  }
+
+  /**
+   * Passes the wrapped stream through, with the first byte of the file flipped.
+   */
+  private static final class FlippingInputStream extends InputStream
+      implements Seekable, PositionedReadable {
+
+    private final FSDataInputStream input;
+
+    private FlippingInputStream(FSDataInputStream input) {
+      this.input = input;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      long pos = input.getPos();
+      int read = input.read(b, off, len);
+      if (read > 0 && pos == 0) {
+        b[off] ^= 0xff;
+      }
+      return read;
+    }
+
+    @Override
+    public int read() throws IOException {
+      long pos = input.getPos();
+      int b = input.read();
+      return b >= 0 && pos == 0 ? b ^ 0xff : b;
+    }
+
+    @Override
+    public void close() throws IOException {
+      input.close();
+    }
+
+    @Override
+    public void seek(long pos) throws IOException {
+      input.seek(pos);
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return input.getPos();
+    }
+
+    @Override
+    public boolean seekToNewSource(long targetPos) throws IOException {
+      return input.seekToNewSource(targetPos);
+    }
+
+    @Override
+    public int read(long position, byte[] buffer, int offset, int length)
+        throws IOException {
+      return input.read(position, buffer, offset, length);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int offset, int length)
+        throws IOException {
+      input.readFully(position, buffer, offset, length);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer) throws IOException {
+      input.readFully(position, buffer);
+    }
+  }
+}

--- a/hadoop-ozone/freon/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopFsReadWriteRatio.java
+++ b/hadoop-ozone/freon/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopFsReadWriteRatio.java
@@ -22,13 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PositionedReadable;
-import org.apache.hadoop.fs.Seekable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,7 +35,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 /**
- * Verifies that {@code --read-write-ratio} of {@link HadoopFsReadWriteValidator}
+ * Verifies that {@code --reads-per-write} of {@link HadoopFsReadWriteValidator}
  * (dfsrw) controls how many reads the run issues per write. The workload only
  * needs a Hadoop {@code FileSystem}, so these run against the local one instead
  * of a cluster.
@@ -80,7 +78,7 @@ public class TestHadoopFsReadWriteRatio {
   @ValueSource(ints = {2, 3, 5})
   void issuesRequestedReadsPerWrite(int ratio) {
     CommandLine cmd =
-        runValidator(2, "--read-write-ratio", String.valueOf(ratio));
+        runValidator(2, "--reads-per-write", String.valueOf(ratio));
 
     assertEquals(WRITES, writeCount(cmd));
     assertEquals((long) WRITES * ratio, readCount(cmd));
@@ -94,7 +92,7 @@ public class TestHadoopFsReadWriteRatio {
    */
   @Test
   void spreadsFractionalRatioOverWrites() {
-    CommandLine cmd = runValidator(1, "--read-write-ratio", "0.25");
+    CommandLine cmd = runValidator(1, "--reads-per-write", "0.25");
 
     assertEquals(WRITES, writeCount(cmd));
     assertEquals(WRITES / 4, readCount(cmd));
@@ -103,20 +101,35 @@ public class TestHadoopFsReadWriteRatio {
   /** A ratio with a whole and a fractional part mixes the two behaviours. */
   @Test
   void spreadsMixedRatioOverWrites() {
-    CommandLine cmd = runValidator(1, "--read-write-ratio", "1.5");
+    CommandLine cmd = runValidator(1, "--reads-per-write", "1.5");
 
     assertEquals(WRITES, writeCount(cmd));
     assertEquals(WRITES * 3 / 2, readCount(cmd));
   }
 
   /**
-   * Every read of a task validates, not only the first one: a single write read
-   * back three times fails the run when the content is corrupted before the
-   * last of the three reads.
+   * The leftover of a fractional ratio is carried exactly, so the tenth write
+   * of a run at 0.1 is read back. A ratio accumulated as a double drifts —
+   * adding 0.1 ten times gives 0.9999999999999999 — which would put that read
+   * off to an eleventh write a ten-write run never makes.
    */
   @Test
-  void everyReadOfATaskValidatesContent() {
-    CorruptingLocalFileSystem.corruptFromRead(3);
+  void carriesFractionalRatioWithoutDrift() {
+    CommandLine cmd = runValidator(1, 10, "--reads-per-write", "0.1");
+
+    assertEquals(10, writeCount(cmd));
+    assertEquals(1, readCount(cmd));
+  }
+
+  /**
+   * Every read of a task validates, not only the first or the last one: a
+   * single write read back three times fails the run wherever among the three
+   * the content is corrupted.
+   */
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3})
+  void everyReadOfATaskValidatesContent(int corruptedRead) {
+    CorruptingLocalFileSystem.corruptFromRead(corruptedRead);
 
     int exitCode = new Freon().getCmd().execute(
         "-D", "fs.file.impl=" + CorruptingLocalFileSystem.class.getName(),
@@ -128,31 +141,38 @@ public class TestHadoopFsReadWriteRatio {
         "-s", "1KB",
         "--buffer", "1024",
         "--copy-buffer", "1024",
-        "--read-write-ratio", "3");
+        "--reads-per-write", "3");
 
-    assertNotEquals(0, exitCode, "Corrupted content was not detected");
+    assertNotEquals(0, exitCode,
+        "Corrupted content of read " + corruptedRead + " was not detected");
   }
 
   @Test
   void rejectsNonPositiveRatio() {
-    assertThat(execute(new Freon().getCmd(), 1, "--read-write-ratio", "0"))
+    assertThat(execute(new Freon().getCmd(), 1, WRITES, "--reads-per-write", "0"))
         .isNotZero();
-    assertThat(execute(new Freon().getCmd(), 1, "--read-write-ratio", "-1"))
+    assertThat(execute(new Freon().getCmd(), 1, WRITES, "--reads-per-write", "-1"))
         .isNotZero();
   }
 
   private CommandLine runValidator(int threads, String... args) {
+    return runValidator(threads, WRITES, args);
+  }
+
+  private CommandLine runValidator(int threads, int writes, String... args) {
     CommandLine cmd = new Freon().getCmd();
-    assertEquals(0, execute(cmd, threads, args), "Freon dfsrw command failed");
+    assertEquals(0, execute(cmd, threads, writes, args),
+        "Freon dfsrw command failed");
     return cmd;
   }
 
-  private int execute(CommandLine cmd, int threads, String... args) {
+  private int execute(CommandLine cmd, int threads, int writes,
+      String... args) {
     String[] fixed = {
         "dfsrw",
         "-r", rootPath,
         "-p", "dfsrw",
-        "-n", String.valueOf(WRITES),
+        "-n", String.valueOf(writes),
         "-t", String.valueOf(threads),
         "-s", "1KB",
         "--buffer", "1024",
@@ -207,9 +227,10 @@ public class TestHadoopFsReadWriteRatio {
 
   /**
    * Passes the wrapped stream through, with the first byte of the file flipped.
+   * {@link FSInputStream} supplies the positioned reads on top of seek and
+   * read, so only those two and the plain reads are forwarded here.
    */
-  private static final class FlippingInputStream extends InputStream
-      implements Seekable, PositionedReadable {
+  private static final class FlippingInputStream extends FSInputStream {
 
     private final FSDataInputStream input;
 
@@ -252,23 +273,6 @@ public class TestHadoopFsReadWriteRatio {
     @Override
     public boolean seekToNewSource(long targetPos) throws IOException {
       return input.seekToNewSource(targetPos);
-    }
-
-    @Override
-    public int read(long position, byte[] buffer, int offset, int length)
-        throws IOException {
-      return input.read(position, buffer, offset, length);
-    }
-
-    @Override
-    public void readFully(long position, byte[] buffer, int offset, int length)
-        throws IOException {
-      input.readFully(position, buffer, offset, length);
-    }
-
-    @Override
-    public void readFully(long position, byte[] buffer) throws IOException {
-      input.readFully(position, buffer);
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up from HDDS-14524.

The `dfsrw` (`dfs-read-write-validator`) freon workload issues exactly one read
after every write, so its read/write mix is pinned at 1:1. Real workloads are
rarely balanced, and the benchmark is more useful when the mix can be tuned
toward read-heavy or write-heavy.

This PR adds a `--read-write-ratio` option that sets how many reads each write is
followed by:

| `--read-write-ratio` | effect |
| --- | --- |
| `1.0` (default) | one read per write, the workload as it is today |
| `4` | read-heavy: each write is read back four times |
| `0.25` | write-heavy: one read back every fourth write |

The existing per-path CRC32 validation and stale-read detection are unaffected. A
read still picks a random file from the history of the thread that wrote it and
compares against the checksum of the most recent write of that path, so both
corruption and an overwritten path returning older bytes are still detected.

### Why a ratio rather than a `--read-threads` / `--write-threads` split

A read-only thread would have no write history of its own, so it would have to
read paths owned by other threads. Those paths are overwritten concurrently,
which is precisely the situation the stale-read check treats as a failure.
Splitting threads would therefore have meant weakening the validation, so every
read is kept inside the thread that wrote the file.

### Fractional ratios

A ratio that is not a whole number is accumulated per thread rather than rounded
on each write:

```java
private int readsDue(double readsPerWrite) {
  readCredit += readsPerWrite;
  int reads = (int) readCredit;
  readCredit -= reads;
  return reads;
}
```

Rounding per write would collapse every ratio below 0.5 to zero reads, leaving a
"validator" that never validates. Carrying the remainder makes `0.25` read back
every fourth write and `1.5` alternate between one and two reads. At the default
of `1.0` the credit lands on exactly 1.0 every time, so the default path is
unchanged.

### Notes

* `-n` keeps its meaning: one task is one write, and the number of files written
  for a given `-n` does not change with the ratio.
* The `file-write` and `file-read-validate` timers are unchanged, so the two
  sides of the mix stay separately measurable.
* A ratio that is not a positive finite number is rejected at startup, alongside
  the existing `--size`, `--buffer` and `--max-files-per-thread` checks.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16354

## How was this patch tested?

New unit test `TestHadoopFsReadWriteRatio` in `hadoop-ozone/freon`. 

The existing integration test `TestHadoopFsReadWriteValidator` is unchanged and
continues to cover the default behaviour against a real cluster.
