### PR TITLE
HDDS-16388. Datanode putBlock Support StorageType

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -41,7 +41,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.BlockData;
@@ -186,7 +188,6 @@ public class BlockOutputStream extends OutputStream {
     replicationIndex = pipeline.getReplicaIndex(pipeline.getClosestNode());
     KeyValue keyValue =
         KeyValue.newBuilder().setKey("TYPE").setValue("KEY").build();
-
     ContainerProtos.DatanodeBlockID.Builder blkIDBuilder =
         ContainerProtos.DatanodeBlockID.newBuilder()
             .setContainerID(blockID.getContainerID())
@@ -195,6 +196,8 @@ public class BlockOutputStream extends OutputStream {
     if (replicationIndex > 0) {
       blkIDBuilder.setReplicaIndex(replicationIndex);
     }
+    // TODO: Replica to the method parameter
+    blkIDBuilder.setStorageTypeID(StorageTypeUtils.getID(StorageType.DISK));
     this.containerBlockData = BlockData.newBuilder().setBlockID(
         blkIDBuilder.build()).addMetadata(keyValue);
     this.pipeline = pipeline;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/BlockID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/BlockID.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.client;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Objects;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
@@ -34,29 +35,42 @@ public class BlockID {
   // BlockID object.
   private final Integer replicaIndex;
 
+  // Represents storage type of Block on a particular Datanode.
+  // Note this variable in the OM side will be null,
+  // because the OmKeyLocationInfo#getProtobuf Use BlockID#getProtobuf to get Protobuf object,
+  // BlockID#getProtobuf does not set storageType value in Protobuf.
+
+  // Currently for java class BlockID, OM and Datanode share the same java class object,
+  // but the protobuf objects HddsProtos.BlockID and ContainerProtos.DatanodeBlockID are
+  // used for OM and Datanode respectively.
+  private StorageType storageType;
+
   public BlockID(long containerID, long localID) {
-    this(containerID, localID, 0, null);
+    this(containerID, localID, 0, null, null);
   }
 
-  private BlockID(long containerID, long localID, long bcsID, Integer repIndex) {
+  private BlockID(long containerID, long localID, long bcsID, Integer repIndex,
+      StorageType storageType) {
     containerBlockID = new ContainerBlockID(containerID, localID);
     blockCommitSequenceId = bcsID;
     this.replicaIndex = repIndex;
+    this.storageType = storageType;
   }
 
   public BlockID(BlockID blockID) {
     this(blockID.getContainerID(), blockID.getLocalID(), blockID.getBlockCommitSequenceId(),
-        blockID.getReplicaIndex());
+        blockID.getReplicaIndex(), blockID.getStorageType());
   }
 
   public BlockID(ContainerBlockID containerBlockID) {
-    this(containerBlockID, 0, null);
+    this(containerBlockID, 0, null, null);
   }
 
-  private BlockID(ContainerBlockID containerBlockID, long bcsId, Integer repIndex) {
+  private BlockID(ContainerBlockID containerBlockID, long bcsId, Integer repIndex, StorageType storageType) {
     this.containerBlockID = containerBlockID;
     blockCommitSequenceId = bcsId;
     this.replicaIndex = repIndex;
+    this.storageType = storageType;
   }
 
   public long getContainerID() {
@@ -84,6 +98,10 @@ public class BlockID {
     return containerBlockID;
   }
 
+  public StorageType getStorageType() {
+    return storageType;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder(64);
@@ -94,7 +112,8 @@ public class BlockID {
   public void appendTo(StringBuilder sb) {
     containerBlockID.appendTo(sb);
     sb.append(" bcsId: ").append(blockCommitSequenceId)
-        .append(" replicaIndex: ").append(replicaIndex);
+        .append(" replicaIndex: ").append(replicaIndex)
+        .append(" storageType: ").append(storageType);
   }
 
   @JsonIgnore
@@ -102,6 +121,9 @@ public class BlockID {
     ContainerProtos.DatanodeBlockID.Builder blockID = getDatanodeBlockIDProtobufBuilder();
     if (replicaIndex != null) {
       blockID.setReplicaIndex(replicaIndex);
+    }
+    if (storageType != null) {
+      blockID.setStorageTypeID(StorageTypeUtils.getID(storageType));
     }
     return blockID.build();
   }
@@ -116,10 +138,15 @@ public class BlockID {
 
   @JsonIgnore
   public static BlockID getFromProtobuf(ContainerProtos.DatanodeBlockID blockID) {
+    StorageType storageType = null;
+    if (blockID.hasStorageTypeID() && blockID.getStorageTypeID() > 0) {
+      storageType = StorageTypeUtils.getStorageTypeFromID(blockID.getStorageTypeID());
+    }
     return new BlockID(blockID.getContainerID(),
         blockID.getLocalID(),
         blockID.getBlockCommitSequenceId(),
-        blockID.hasReplicaIndex() ? blockID.getReplicaIndex() : null);
+        blockID.hasReplicaIndex() ? blockID.getReplicaIndex() : null,
+        storageType);
   }
 
   @JsonIgnore
@@ -133,7 +160,7 @@ public class BlockID {
   public static BlockID getFromProtobuf(HddsProtos.BlockID blockID) {
     return new BlockID(
         ContainerBlockID.getFromProtobuf(blockID.getContainerBlockID()),
-        blockID.getBlockCommitSequenceId(), null);
+        blockID.getBlockCommitSequenceId(), null, null);
   }
 
   @Override
@@ -147,12 +174,13 @@ public class BlockID {
     BlockID blockID = (BlockID) o;
     return this.getContainerBlockID().equals(blockID.getContainerBlockID())
         && this.getBlockCommitSequenceId() == blockID.getBlockCommitSequenceId()
-        && Objects.equals(this.getReplicaIndex(), blockID.getReplicaIndex());
+        && Objects.equals(this.getReplicaIndex(), blockID.getReplicaIndex())
+        && Objects.equals(this.getStorageType(), blockID.getStorageType());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(containerBlockID.getContainerID(), containerBlockID.getLocalID(),
-        blockCommitSequenceId, replicaIndex);
+        blockCommitSequenceId, replicaIndex, storageType);
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StorageTypeUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StorageTypeUtils.java
@@ -103,5 +103,13 @@ public final class StorageTypeUtils {
       throw new IllegalArgumentException("Illegal Storage Type specified");
     }
   }
+
+  /**
+   * Returns integer representation of FileSystem StorageType.
+   * @return storageType int ID value
+   */
+  public static int getID(StorageType storageType) throws IllegalArgumentException {
+    return getStorageTypeProto(storageType).getNumber();
+  }
 }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -636,6 +636,7 @@ public final class ContainerProtocolCalls  {
   public static void createRecoveringContainer(XceiverClientSpi client,
       long containerID, String encodedToken, int replicaIndex)
       throws IOException {
+    // TODO StoragePolicy Support EC
     createContainer(client, containerID, encodedToken,
         ContainerProtos.ContainerDataProto.State.RECOVERING, replicaIndex);
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
@@ -39,7 +39,9 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
@@ -572,14 +574,17 @@ public final class ContainerTestHelper {
   }
 
   public static BlockID getTestBlockID(long containerID) {
-    return getTestBlockID(containerID, null);
+    return getTestBlockID(containerID, null, null);
   }
 
-  public static BlockID getTestBlockID(long containerID, Integer replicaIndex) {
+  public static BlockID getTestBlockID(long containerID, Integer replicaIndex, StorageType storageType) {
     DatanodeBlockID.Builder datanodeBlockID = DatanodeBlockID.newBuilder().setContainerID(containerID)
         .setLocalID(UniqueId.next());
     if (replicaIndex != null) {
       datanodeBlockID.setReplicaIndex(replicaIndex);
+    }
+    if (storageType != null) {
+      datanodeBlockID.setStorageTypeID(StorageTypeUtils.getID(storageType));
     }
     return BlockID.getFromProtobuf(datanodeBlockID.build());
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -177,6 +177,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     case DELETE_ON_OPEN_CONTAINER:
     case UNSUPPORTED_REQUEST:// Blame client for sending unsupported request.
     case MALFORMED_REQUEST:// Blame client for sending malformed request.
+    case INVALID_ARGUMENT:
     case CONTAINER_MISSING:
     case CONTAINER_ALREADY_EXISTS:
       return true;
@@ -194,6 +195,12 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   @Override
   public ContainerCommandResponseProto dispatch(
       ContainerCommandRequestProto msg, DispatcherContext dispatcherContext) {
+    try {
+      HddsUtils.getBlockID(msg);
+    } catch (IllegalArgumentException e) {
+      return ContainerUtils.logAndReturnError(LOG,
+          new StorageContainerException(e.getMessage(), e, Result.INVALID_ARGUMENT), msg);
+    }
     try {
       return dispatcher.processRequest(msg,
           req -> dispatchRequest(msg, dispatcherContext),
@@ -568,6 +575,11 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   @Override
   public void validateContainerCommand(
       ContainerCommandRequestProto msg) throws StorageContainerException {
+    try {
+      HddsUtils.getBlockID(msg);
+    } catch (IllegalArgumentException e) {
+      throw new StorageContainerException(e.getMessage(), e, Result.INVALID_ARGUMENT);
+    }
     try {
       validateToken(msg);
     } catch (IOException ioe) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -1188,7 +1188,8 @@ public class ContainerStateMachine extends BaseStateMachine {
         if (r.getResult() != ContainerProtos.Result.SUCCESS
             && r.getResult() != ContainerProtos.Result.CONTAINER_NOT_OPEN
             && r.getResult() != ContainerProtos.Result.CLOSED_CONTAINER_IO
-            && r.getResult() != ContainerProtos.Result.CHUNK_FILE_INCONSISTENCY) {
+            && r.getResult() != ContainerProtos.Result.CHUNK_FILE_INCONSISTENCY
+            && r.getResult() != ContainerProtos.Result.INVALID_ARGUMENT) {
           StorageContainerException sce =
               new StorageContainerException(r.getMessage(), r.getResult());
           LOG.error(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -695,8 +695,13 @@ public class KeyValueHandler extends Handler {
       Objects.requireNonNull(blockData.getBlockID());
       if (blockData.getBlockID().getStorageType() != null
           && kvContainer.getContainerData().getStorageType() != null) {
-        Preconditions.checkArgument(blockData.getBlockID().getStorageType() ==
-            kvContainer.getContainerData().getStorageType());
+        if (blockData.getBlockID().getStorageType() !=
+            kvContainer.getContainerData().getStorageType()) {
+          throw new StorageContainerException(
+              String.format("Block storage type %s does not match container storage type %s",
+                  blockData.getBlockID().getStorageType(),
+                  kvContainer.getContainerData().getStorageType()), INVALID_ARGUMENT);
+        }
       }
 
       boolean endOfBlock = false;
@@ -1122,8 +1127,11 @@ public class KeyValueHandler extends Handler {
       BlockID blockID = BlockID.getFromProtobuf(writeChunk.getBlockID());
       if (blockID.getStorageType() != null
           && kvContainer.getContainerData().getStorageType() != null) {
-        Preconditions.checkArgument(blockID.getStorageType() ==
-            kvContainer.getContainerData().getStorageType());
+        if (blockID.getStorageType() != kvContainer.getContainerData().getStorageType()) {
+          throw new StorageContainerException(
+              String.format("Block storage type %s does not match container storage type %s",
+                  blockID.getStorageType(), kvContainer.getContainerData().getStorageType()), INVALID_ARGUMENT);
+        }
       }
       ContainerProtos.ChunkInfo chunkInfoProto = writeChunk.getChunkData();
 
@@ -1283,6 +1291,14 @@ public class KeyValueHandler extends Handler {
       BlockData blockData = BlockData.getFromProtoBuf(
           putSmallFileReq.getBlock().getBlockData());
       Objects.requireNonNull(blockData, "blockData == null");
+      if (blockData.getBlockID().getStorageType() != null
+          && kvContainer.getContainerData().getStorageType() != null
+          && blockData.getBlockID().getStorageType() != kvContainer.getContainerData().getStorageType()) {
+        throw new StorageContainerException(
+            String.format("Block storage type %s does not match container storage type %s",
+                blockData.getBlockID().getStorageType(), kvContainer.getContainerData().getStorageType()),
+            INVALID_ARGUMENT);
+      }
 
       ContainerProtos.ChunkInfo chunkInfoProto = putSmallFileReq.getChunkInfo();
       ChunkInfo chunkInfo = ChunkInfo.getFromProtoBuf(chunkInfoProto);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -692,6 +692,12 @@ public class KeyValueHandler extends Handler {
       ContainerProtos.BlockData data = request.getPutBlock().getBlockData();
       BlockData blockData = BlockData.getFromProtoBuf(data);
       Objects.requireNonNull(blockData, "blockData == null");
+      Objects.requireNonNull(blockData.getBlockID());
+      if (blockData.getBlockID().getStorageType() != null
+          && kvContainer.getContainerData().getStorageType() != null) {
+        Preconditions.checkArgument(blockData.getBlockID().getStorageType() ==
+            kvContainer.getContainerData().getStorageType());
+      }
 
       boolean endOfBlock = false;
       if (!request.getPutBlock().hasEof() || request.getPutBlock().getEof()) {
@@ -1114,6 +1120,11 @@ public class KeyValueHandler extends Handler {
 
       WriteChunkRequestProto writeChunk = request.getWriteChunk();
       BlockID blockID = BlockID.getFromProtobuf(writeChunk.getBlockID());
+      if (blockID.getStorageType() != null
+          && kvContainer.getContainerData().getStorageType() != null) {
+        Preconditions.checkArgument(blockID.getStorageType() ==
+            kvContainer.getContainerData().getStorageType());
+      }
       ContainerProtos.ChunkInfo chunkInfoProto = writeChunk.getChunkData();
 
       ChunkInfo chunkInfo = ChunkInfo.getFromProtoBuf(chunkInfoProto);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container.keyvalue.impl;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.BCSID_MISMATCH;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.INVALID_ARGUMENT;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 import static org.apache.hadoop.ozone.OzoneConsts.INCREMENTAL_CHUNK_LIST;
 
@@ -189,8 +190,12 @@ public class BlockManagerImpl implements BlockManager {
         "cannot be negative");
     if (data.getBlockID().getStorageType() != null
         && container.getContainerData().getStorageType() != null) {
-      Preconditions.checkArgument(data.getBlockID().getStorageType() ==
-          container.getContainerData().getStorageType());
+      if (data.getBlockID().getStorageType() != container.getContainerData().getStorageType()) {
+        throw new StorageContainerException(String.format(
+            "Block storage type %s does not match container storage type %s",
+            data.getBlockID().getStorageType(), container.getContainerData().getStorageType()),
+            INVALID_ARGUMENT);
+      }
     }
 
     KeyValueContainerData containerData = container.getContainerData();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -187,6 +187,11 @@ public class BlockManagerImpl implements BlockManager {
     Objects.requireNonNull(data, "data == null");
     Preconditions.checkState(data.getContainerID() >= 0, "Container Id " +
         "cannot be negative");
+    if (data.getBlockID().getStorageType() != null
+        && container.getContainerData().getStorageType() != null) {
+      Preconditions.checkArgument(data.getBlockID().getStorageType() ==
+          container.getContainerData().getStorageType());
+    }
 
     KeyValueContainerData containerData = container.getContainerData();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestBlockData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestBlockData.java
@@ -131,7 +131,7 @@ public class TestBlockData {
     final BlockID blockID = new BlockID(5, 123);
     blockID.setBlockCommitSequenceId(42);
     final BlockData subject = new BlockData(blockID);
-    assertEquals("[blockId=conID: 5 locID: 123 bcsId: 42 replicaIndex: null, size=0]",
+    assertEquals("[blockId=conID: 5 locID: 123 bcsId: 42 replicaIndex: null storageType: null, size=0]",
         subject.toString());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -137,10 +137,17 @@ public class TestContainerPersistence {
   }
 
   @BeforeAll
-  public static void init() {
+  public static void init() throws IOException {
     conf = new OzoneConfiguration();
     hddsPath = hddsFile.getPath();
-    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, hddsPath);
+    StringBuilder hddsDirs = new StringBuilder();
+    for (StorageType storageType : StorageType.values()) {
+      hddsDirs.append('[').append(storageType.name()).append(']');
+      String volume = Files.createTempDirectory(
+          TestContainerPersistence.class.getSimpleName() + storageType.name()).toFile().getAbsolutePath();
+      hddsDirs.append(volume).append(',');
+    }
+    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, hddsDirs.toString());
     conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, hddsPath);
     volumeChoosingPolicy = new RoundRobinVolumeChoosingPolicy();
   }
@@ -194,9 +201,12 @@ public class TestContainerPersistence {
 
   private KeyValueContainer addContainer(ContainerSet cSet, long cID)
       throws IOException {
-    long commitBytesBefore = 0;
-    long commitBytesAfter = 0;
-    long commitIncrement = 0;
+    return addContainer(cSet, cID, StorageType.DISK);
+  }
+
+  private KeyValueContainer addContainer(ContainerSet cSet, long cID,
+      StorageType storageType)
+      throws IOException {
     KeyValueContainerData data = new KeyValueContainerData(cID,
         layout,
         ContainerTestHelper.CONTAINER_MAX_SIZE, UUID.randomUUID().toString(),
@@ -204,17 +214,19 @@ public class TestContainerPersistence {
     data.addMetadata("VOLUME", "shire");
     data.addMetadata("owner)", "bilbo");
     KeyValueContainer container = new KeyValueContainer(data, conf);
-    commitBytesBefore = StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()).get(0).getCommittedBytes();
+    Map<HddsVolume, Long> committedBytes = new HashMap<>();
+    for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(
+        volumeSet.getVolumesList())) {
+      committedBytes.put(volume, volume.getCommittedBytes());
+    }
 
-    container.create(volumeSet, volumeChoosingPolicy, SCM_ID, StorageType.DISK);
+    container.create(volumeSet, volumeChoosingPolicy, SCM_ID, storageType);
     cSet.addContainer(container);
 
-    commitBytesAfter = container.getContainerData()
-        .getVolume().getCommittedBytes();
-    commitIncrement = commitBytesAfter - commitBytesBefore;
     // did we commit space for the new container?
-    assertEquals(commitIncrement,
-        ContainerTestHelper.CONTAINER_MAX_SIZE);
+    HddsVolume volume = container.getContainerData().getVolume();
+    assertEquals(ContainerTestHelper.CONTAINER_MAX_SIZE,
+        volume.getCommittedBytes() - committedBytes.get(volume));
     return container;
   }
 
@@ -423,7 +435,7 @@ public class TestContainerPersistence {
     // Set up container 1.
     long testContainerID1 = getTestContainerID();
     Container<KeyValueContainerData> container1 =
-        addContainer(containerSet, testContainerID1);
+        addContainer(containerSet, testContainerID1, StorageType.DISK);
     BlockID container1Block = addBlockToContainer(container1);
     container1.close();
     KeyValueContainerData container1Data = container1.getContainerData();
@@ -432,7 +444,7 @@ public class TestContainerPersistence {
     // Set up container 2.
     long testContainerID2 = getTestContainerID();
     Container<KeyValueContainerData> container2 =
-        addContainer(containerSet, testContainerID2);
+        addContainer(containerSet, testContainerID2, StorageType.DISK);
     BlockID container2Block = addBlockToContainer(container2);
     container2.close();
     KeyValueContainerData container2Data = container2.getContainerData();
@@ -907,6 +919,64 @@ public class TestContainerPersistence {
     ChunkInfo readChunk =
         ChunkInfo.getFromProtoBuf(readBlockData.getChunks().get(0));
     assertEquals(info.getChecksumData(), readChunk.getChecksumData());
+  }
+
+  /**
+   * Tests a put block and read block with StorageType.
+   * @throws IOException
+   */
+  @ContainerTestVersionInfo.ContainerTest
+  public void testPutBlockWithStorageType(ContainerTestVersionInfo versionInfo)
+      throws IOException {
+    initSchemaAndVersionInfo(versionInfo);
+    for (StorageType storageType : StorageType.values()) {
+      long testContainerID = getTestContainerID();
+      Container container = addContainer(containerSet, testContainerID, storageType);
+
+      BlockID blockID = ContainerTestHelper.getTestBlockID(testContainerID, 0, storageType);
+      ChunkInfo info = writeChunkHelper(blockID);
+      BlockData blockData = new BlockData(blockID);
+      List<ContainerProtos.ChunkInfo> chunkList = new LinkedList<>();
+      chunkList.add(info.getProtoBufMessage());
+      blockData.setChunks(chunkList);
+      blockManager.putBlock(container, blockData);
+      BlockData readBlockData = blockManager.getBlock(container, blockData.getBlockID());
+      ChunkInfo readChunk = ChunkInfo.getFromProtoBuf(readBlockData.getChunks().get(0));
+      assertEquals(info.getChecksumData(), readChunk.getChecksumData());
+      assertEquals(storageType, readBlockData.getBlockID().getStorageType());
+    }
+  }
+
+  /**
+   * Tests a put block and read block with StorageType.
+   * @throws IOException
+   */
+  @ContainerTestVersionInfo.ContainerTest
+  public void testInvalidPutBlockWithStorageType(
+      ContainerTestVersionInfo versionInfo) throws IOException {
+    initSchemaAndVersionInfo(versionInfo);
+    // If StorageType in the request is not null,
+    // the PutBlock must put to a Container of the same StorageType.
+    long testContainerID1 = getTestContainerID();
+    Container container1 = addContainer(containerSet, testContainerID1,
+        StorageType.DISK);
+    BlockData blockData1 = getBlockData(testContainerID1, StorageType.DISK);
+    blockManager.putBlock(container1, blockData1);
+
+    long testContainerID2 = getTestContainerID();
+    Container container2 = addContainer(containerSet, testContainerID2, StorageType.DISK);
+    BlockData blockData2 = getBlockData(testContainerID2, StorageType.SSD);
+    assertThrows(IllegalArgumentException.class, () -> blockManager.putBlock(container2, blockData2));
+  }
+
+  private BlockData getBlockData(long containerID, StorageType storageType) throws IOException {
+    BlockID blockID = ContainerTestHelper.getTestBlockID(containerID, 0, storageType);
+    ChunkInfo info = writeChunkHelper(blockID);
+    BlockData blockData = new BlockData(blockID);
+    List<ContainerProtos.ChunkInfo> chunkList = new LinkedList<>();
+    chunkList.add(info.getProtoBufMessage());
+    blockData.setChunks(chunkList);
+    return blockData;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -58,6 +58,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.StorageTypeUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageSource;
@@ -532,15 +533,20 @@ public class TestHddsDispatcher {
   }
 
   @Test
-  public void testCreateContainerRejectsInvalidStorageType() throws IOException {
+  public void testInvalidStorageTypeDoesNotMarkContainerUnhealthy() throws IOException {
     File diskVolume = Files.createTempDirectory(tempDir, "disk").toFile();
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, diskVolume.getAbsolutePath());
     DatanodeDetails dd = randomDatanodeDetails();
     HddsDispatcher dispatcher = createDispatcher(dd, UUID.randomUUID(), conf);
 
-    ContainerCommandRequestProto writeChunkRequest =
+    ContainerCommandRequestProto validWriteChunkRequest =
         getWriteChunkRequest(dd.getUuidString(), 1L, 1L, null);
+    assertEquals(ContainerProtos.Result.SUCCESS,
+        dispatcher.dispatch(validWriteChunkRequest, null).getResult());
+
+    ContainerCommandRequestProto writeChunkRequest =
+        getWriteChunkRequest(dd.getUuidString(), 1L, 2L, null);
     WriteChunkRequestProto writeChunk = writeChunkRequest.getWriteChunk();
     ContainerCommandRequestProto requestWithInvalidStorageType =
         writeChunkRequest.toBuilder()
@@ -552,6 +558,8 @@ public class TestHddsDispatcher {
     ContainerCommandResponseProto response =
         dispatcher.dispatch(requestWithInvalidStorageType, null);
     assertEquals(ContainerProtos.Result.INVALID_ARGUMENT, response.getResult());
+    assertEquals(ContainerProtos.ContainerDataProto.State.OPEN,
+        dispatcher.getContainer(1L).getContainerData().getState());
   }
 
   private void assertContainerDoNotExist(HddsDispatcher hddsDispatcher,
@@ -870,7 +878,7 @@ public class TestHddsDispatcher {
         new BlockID(containerId, localId).getDatanodeBlockIDProtobufBuilder();
     // TODO: Pass the real storage type from the write path once that BlockID support StorageType
     if (storageType != null) {
-      blockID.setStorageTypeID(storageType.getNumber());
+      blockID.setStorageTypeID(StorageTypeUtils.getIDFromProtobuf(storageType));
     }
 
     WriteChunkRequestProto.Builder writeChunkRequest = WriteChunkRequestProto

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -562,6 +562,38 @@ public class TestHddsDispatcher {
         dispatcher.getContainer(1L).getContainerData().getState());
   }
 
+  @Test
+  public void testStorageTypeMismatchDoesNotMarkContainerUnhealthy() throws IOException {
+    File diskVolume = Files.createTempDirectory(tempDir, "disk").toFile();
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, diskVolume.getAbsolutePath());
+    DatanodeDetails dd = randomDatanodeDetails();
+    HddsDispatcher dispatcher = createDispatcher(dd, UUID.randomUUID(), conf);
+
+    ContainerCommandRequestProto validWriteChunkRequest =
+        getWriteChunkRequest(dd.getUuidString(), 1L, 1L, null);
+    assertEquals(ContainerProtos.Result.SUCCESS,
+        dispatcher.dispatch(validWriteChunkRequest, null).getResult());
+
+    ContainerCommandResponseProto putBlockResponse = dispatcher.dispatch(
+        newPutBlock(1L, 2L, HddsProtos.StorageTypeProto.SSD), null);
+    assertEquals(ContainerProtos.Result.INVALID_ARGUMENT, putBlockResponse.getResult());
+    assertEquals(ContainerProtos.ContainerDataProto.State.OPEN,
+        dispatcher.getContainer(1L).getContainerData().getState());
+
+    ContainerCommandResponseProto putSmallFileResponse = dispatcher.dispatch(
+        newPutSmallFile(1L, 3L, HddsProtos.StorageTypeProto.SSD), null);
+    assertEquals(ContainerProtos.Result.INVALID_ARGUMENT, putSmallFileResponse.getResult());
+    assertEquals(ContainerProtos.ContainerDataProto.State.OPEN,
+        dispatcher.getContainer(1L).getContainerData().getState());
+
+    ContainerCommandResponseProto writeChunkResponse = dispatcher.dispatch(
+        getWriteChunkRequest(dd.getUuidString(), 1L, 4L, HddsProtos.StorageTypeProto.SSD), null);
+    assertEquals(ContainerProtos.Result.INVALID_ARGUMENT, writeChunkResponse.getResult());
+    assertEquals(ContainerProtos.ContainerDataProto.State.OPEN,
+        dispatcher.getContainer(1L).getContainerData().getState());
+  }
+
   private void assertContainerDoNotExist(HddsDispatcher hddsDispatcher,
       ContainerCommandRequestProto request) {
     ContainerCommandResponseProto response =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Datanode putBlock Support StroageType


- BlockID add field storageType to record the specific Block replica's storageType on the Datanode.
- putBlock OP will persist the BlockID, so the Block replica's storageType will be persisted.
- writeChunk and putBlock are unified by passing StorageType information in protobuf DatanodeBlockID.
Datanode putBlock Support StroageType

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-16388

## How was this patch tested?
new test