### PR TITLE
HDDS-16335. Change XceiverClientShortCircuit to support concurrent access

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientShortCircuit.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientShortCircuit.java
@@ -95,7 +95,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
   private final DomainSocketFactory domainSocketFactory;
   private DomainSocket domainSocket;
   private final AtomicBoolean isDomainSocketOpen = new AtomicBoolean(false);
-  // Protects connection state, counters, and RequestEntry.sentTimeNs.
+  // Protects connection state and counters.
   private final Lock lock = new ReentrantLock();
   private final int bufferSize;
   private final ByteString clientId = ByteString.copyFrom(UUID.randomUUID().toString().getBytes(UTF_8));
@@ -427,13 +427,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
   }
 
   void requestTimeout(RequestKey requestKey) {
-    final RequestEntry entry;
-    lock.lock();
-    try {
-      entry = sentRequests.remove(requestKey);
-    } finally {
-      lock.unlock();
-    }
+    final RequestEntry entry = sentRequests.remove(requestKey);
     if (entry != null) {
       LOG.warn("Timeout to receive response for command {}", entry.getRequest());
       ContainerProtos.Type type = entry.getRequest().getCmdType();
@@ -523,15 +517,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
         lock.unlock();
       }
       long timerTaskCancelledCount = 0;
-      while (true) {
-        lock.lock();
-        try {
-          if (!isDomainSocketOpen.get()) {
-            return;
-          }
-        } finally {
-          lock.unlock();
-        }
+      while (isDomainSocketOpen.get()) {
         RequestEntry entry = null;
         try {
           DataInputStream dataIn = new DataInputStream(socket.getInputStream());
@@ -548,14 +534,8 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
           if (LOG.isDebugEnabled()) {
             LOG.debug("received response {} callId {}", type, responseProto.getCallId());
           }
-          final long sentTimeNs;
-          lock.lock();
-          try {
-            entry = sentRequests.remove(new RequestKey(responseProto.getClientId(), responseProto.getCallId()));
-            sentTimeNs = entry == null ? 0 : entry.getSentTimeNs();
-          } finally {
-            lock.unlock();
-          }
+          entry = sentRequests.remove(new RequestKey(responseProto.getClientId(), responseProto.getCallId()));
+          final long sentTimeNs = entry == null ? 0 : entry.getSentTimeNs();
           if (entry == null) {
             // This could be two cases
             // 1. there is bug in the code
@@ -700,8 +680,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
     private final ContainerCommandRequestProto request;
     private final CompletableFuture<ContainerCommandResponseProto> future;
     private final long createTimeNs;
-    // Accessed under the enclosing client's lock.
-    private long sentTimeNs;
+    private final AtomicLong sentTimeNs;
     private final TimerTask timerTask;
 
     RequestEntry(ContainerCommandRequestProto requestProto,
@@ -710,6 +689,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
       this.future = future;
       this.timerTask = timerTask;
       this.createTimeNs = System.nanoTime();
+      this.sentTimeNs = new AtomicLong(createTimeNs);
     }
 
     public ContainerCommandRequestProto getRequest() {
@@ -725,11 +705,11 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
     }
 
     public long getSentTimeNs() {
-      return sentTimeNs;
+      return sentTimeNs.get();
     }
 
     public void setSentTimeNs() {
-      sentTimeNs = System.nanoTime();
+      sentTimeNs.set(System.nanoTime());
     }
 
     public TimerTask getTimerTask() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientShortCircuit.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientShortCircuit.java
@@ -34,6 +34,7 @@ import java.io.InterruptedIOException;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -94,6 +95,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
   private final DomainSocketFactory domainSocketFactory;
   private DomainSocket domainSocket;
   private final AtomicBoolean isDomainSocketOpen = new AtomicBoolean(false);
+  // Protects connection state, counters, and RequestEntry.sentTimeNs.
   private final Lock lock = new ReentrantLock();
   private final int bufferSize;
   private final ByteString clientId = ByteString.copyFrom(UUID.randomUUID().toString().getBytes(UTF_8));
@@ -132,46 +134,95 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
    */
   @Override
   public void connect() throws IOException {
-    // Even the in & out stream has returned EOFException, domainSocket.isOpen() is still true.
-    if (domainSocket != null && domainSocket.isOpen() && isDomainSocketOpen.get()) {
-      return;
+    lock.lock();
+    try {
+      if (closed) {
+        throw new IOException("DomainSocket is closed.");
+      }
+      if (domainSocket != null) {
+        checkOpen();
+        return;
+      }
+      boolean connected = false;
+      try {
+        domainSocket = domainSocketFactory.createSocket(readTimeoutMs, writeTimeoutMs, dnAddr);
+        if (domainSocket == null) {
+          throw new IOException("DomainSocket is not available for " + dn);
+        }
+        prefix = XceiverClientShortCircuit.class.getSimpleName() + "-" + domainSocket;
+        timer = new Timer(prefix + "-Timer");
+        isDomainSocketOpen.set(true);
+        readDaemon.start();
+        connected = true;
+        LOG.info("{} is started", prefix);
+      } finally {
+        if (!connected) {
+          closed = true;
+          isDomainSocketOpen.set(false);
+          if (timer != null) {
+            timer.cancel();
+          }
+          if (domainSocket != null) {
+            try {
+              domainSocket.close();
+            } catch (IOException e) {
+              LOG.warn("Failed to close domain socket for datanode {}", dn, e);
+            }
+          }
+        }
+      }
+    } finally {
+      lock.unlock();
     }
-    domainSocket = domainSocketFactory.createSocket(readTimeoutMs, writeTimeoutMs, dnAddr);
-    isDomainSocketOpen.set(true);
-    prefix = XceiverClientShortCircuit.class.getSimpleName() + "-" + domainSocket.toString();
-    timer = new Timer(prefix + "-Timer");
-    readDaemon.start();
-    LOG.info("{} is started", prefix);
   }
 
   /**
    * Close the DomainSocket.
    */
   @Override
-  public synchronized void close() {
-    closed = true;
-    timer.cancel();
-    if (domainSocket != null) {
-      try {
-        isDomainSocketOpen.set(false);
-        domainSocket.close();
-        LOG.info("{} is closed for {} with {} requests sent and {} responses received",
-            domainSocket.toString(), dn, requestSent, responseReceived);
-      } catch (IOException e) {
-        LOG.warn("Failed to close domain socket for datanode {}", dn, e);
-      }
-    }
-    readDaemon.interrupt();
+  public void close() {
+    final List<RequestEntry> pending;
+    lock.lock();
     try {
-      readDaemon.join();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
+      if (!closed) {
+        closed = true;
+        isDomainSocketOpen.set(false);
+        if (timer != null) {
+          timer.cancel();
+        }
+        if (domainSocket != null) {
+          try {
+            domainSocket.close();
+            LOG.info("{} is closed for {} with {} requests sent and {} responses received",
+                domainSocket, dn, requestSent, responseReceived);
+          } catch (IOException e) {
+            LOG.warn("Failed to close domain socket for datanode {}", dn, e);
+          }
+        }
+        readDaemon.interrupt();
+      }
+      pending = new ArrayList<>(sentRequests.values());
+    } finally {
+      lock.unlock();
+    }
+    pending.forEach(entry -> entry.fail(new ClosedChannelException()));
+    if (Thread.currentThread() != readDaemon) {
+      try {
+        readDaemon.join();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 
   @Override
   public boolean isClosed() {
-    return closed;
+    lock.lock();
+    try {
+      return closed;
+    } finally {
+      lock.unlock();
+    }
   }
 
   @Override
@@ -295,7 +346,12 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
             Objects.requireNonNull(ioException);
             String message = "Failed to execute command {}";
             if (LOG.isDebugEnabled()) {
-              LOG.debug(message + " on the datanode {} {}.", request, dn, domainSocket, ioException);
+              lock.lock();
+              try {
+                LOG.debug(message + " on the datanode {} {}.", request, dn, domainSocket, ioException);
+              } finally {
+                lock.unlock();
+              }
             }
             throw ioException;
           }
@@ -305,10 +361,16 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
   @VisibleForTesting
   public XceiverClientReply sendCommandInternal(ContainerCommandRequestProto request)
       throws IOException, InterruptedException {
-    checkOpen();
     final CompletableFuture<ContainerCommandResponseProto> replyFuture =
         new CompletableFuture<>();
-    RequestEntry entry = new RequestEntry(request, replyFuture);
+    final RequestKey key = new RequestKey(request.getClientId(), request.getCallId());
+    TimerTask task = new TimerTask() {
+      @Override
+      public void run() {
+        requestTimeout(key);
+      }
+    };
+    RequestEntry entry = new RequestEntry(request, replyFuture, task);
     sendRequest(entry);
     return new XceiverClientReply(replyFuture);
   }
@@ -320,13 +382,18 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
     throw new UnsupportedOperationException("Operation Not supported for " + DomainSocketFactory.FEATURE + " client");
   }
 
-  public synchronized void checkOpen() throws IOException {
-    if (closed) {
-      throw new IOException("DomainSocket is not connected.");
-    }
-
-    if (!isDomainSocketOpen.get()) {
-      throw new IOException(domainSocket.toString() + " is not open.");
+  public void checkOpen() throws IOException {
+    lock.lock();
+    try {
+      if (closed || domainSocket == null) {
+        throw new IOException("DomainSocket is not connected.");
+      }
+      // isOpen() may remain true after EOF, so also check the receiver's state.
+      if (!domainSocket.isOpen() || !isDomainSocketOpen.get()) {
+        throw new IOException(domainSocket + " is not open.");
+      }
+    } finally {
+      lock.unlock();
     }
   }
 
@@ -360,7 +427,13 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
   }
 
   void requestTimeout(RequestKey requestKey) {
-    final RequestEntry entry = sentRequests.remove(requestKey);
+    final RequestEntry entry;
+    lock.lock();
+    try {
+      entry = sentRequests.remove(requestKey);
+    } finally {
+      lock.unlock();
+    }
     if (entry != null) {
       LOG.warn("Timeout to receive response for command {}", entry.getRequest());
       ContainerProtos.Type type = entry.getRequest().getCmdType();
@@ -369,30 +442,25 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
     }
   }
 
-  void sendRequest(RequestEntry entry) {
+  void sendRequest(RequestEntry entry) throws IOException {
     ContainerCommandRequestProto request = entry.getRequest();
+    IOException failure = null;
+    List<RequestEntry> pending = null;
+    lock.lock();
     try {
+      checkOpen();
       final RequestKey key = new RequestKey(request.getClientId(), request.getCallId());
-      TimerTask task = new TimerTask() {
-        @Override
-        public void run() {
-          requestTimeout(key);
-        }
-      };
-      entry.setTimerTask(task);
-      timer.schedule(task, readTimeoutMs);
       sentRequests.put(key, entry);
       ContainerProtos.Type type = request.getCmdType();
       metrics.incrPendingContainerOpsMetrics(type);
-      byte[] bytes = request.toByteArray();
-      if (bytes.length != request.getSerializedSize()) {
-        throw new IOException("Serialized request " + request.getCmdType()
-            + " size mismatch, byte array size " + bytes.length +
-            ", serialized size " + request.getSerializedSize());
-      }
-
-      lock.lock();
+      timer.schedule(entry.getTimerTask(), readTimeoutMs);
       try {
+        byte[] bytes = request.toByteArray();
+        if (bytes.length != request.getSerializedSize()) {
+          throw new IOException("Serialized request " + request.getCmdType()
+              + " size mismatch, byte array size " + bytes.length +
+              ", serialized size " + request.getSerializedSize());
+        }
         DataOutputStream dataOut =
             new DataOutputStream(new BufferedOutputStream(domainSocket.getOutputStream(), bufferSize));
         // send version number
@@ -402,14 +470,22 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
         // send request body
         request.writeDelimitedTo(dataOut);
         dataOut.flush();
+      } catch (IOException e) {
+        isDomainSocketOpen.set(false);
+        failure = e;
+        pending = new ArrayList<>(sentRequests.values());
       } finally {
-        lock.unlock();
         entry.setSentTimeNs();
         requestSent++;
       }
-    } catch (IOException e) {
-      LOG.error("Failed to send command {}", request, e);
-      entry.getFuture().completeExceptionally(e);
+    } finally {
+      lock.unlock();
+    }
+    if (failure != null) {
+      LOG.error("Failed to send command {}", request, failure);
+      for (RequestEntry requestEntry : pending) {
+        requestEntry.fail(failure);
+      }
       metrics.decrPendingContainerOpsMetrics(request.getCmdType());
       metrics.addContainerOpsLatency(request.getCmdType(), System.nanoTime() - entry.getCreateTimeNs());
     }
@@ -417,12 +493,17 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
 
   @Override
   public String toString() {
-    final StringBuilder b =
-        new StringBuilder(getClass().getSimpleName())
-            .append('[').append(" DomainSocket: ").append(domainSocket.toString())
-            .append(" Pipeline: ").append(pipeline.toString())
-            .append(" ]");
-    return b.toString();
+    lock.lock();
+    try {
+      final StringBuilder b =
+          new StringBuilder(getClass().getSimpleName())
+              .append('[').append(" DomainSocket: ").append(domainSocket)
+              .append(" Pipeline: ").append(pipeline.toString())
+              .append(" ]");
+      return b.toString();
+    } finally {
+      lock.unlock();
+    }
   }
 
   /**
@@ -431,12 +512,29 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
   public class ReceiveResponseTask implements Runnable {
     @Override
     public void run() {
-      long timerTaskCancelledCount = 0;
-      do {
+      final DomainSocket socket;
+      final Timer responseTimer;
+      lock.lock();
+      try {
+        socket = domainSocket;
+        responseTimer = timer;
         Thread.currentThread().setName(prefix + "-ReceiveResponse");
+      } finally {
+        lock.unlock();
+      }
+      long timerTaskCancelledCount = 0;
+      while (true) {
+        lock.lock();
+        try {
+          if (!isDomainSocketOpen.get()) {
+            return;
+          }
+        } finally {
+          lock.unlock();
+        }
         RequestEntry entry = null;
         try {
-          DataInputStream dataIn = new DataInputStream(domainSocket.getInputStream());
+          DataInputStream dataIn = new DataInputStream(socket.getInputStream());
           final short version = dataIn.readShort();
           if (version != DATA_TRANSFER_VERSION) {
             throw new IOException("Version Mismatch (Expected: " +
@@ -450,7 +548,14 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
           if (LOG.isDebugEnabled()) {
             LOG.debug("received response {} callId {}", type, responseProto.getCallId());
           }
-          entry = sentRequests.remove(new RequestKey(responseProto.getClientId(), responseProto.getCallId()));
+          final long sentTimeNs;
+          lock.lock();
+          try {
+            entry = sentRequests.remove(new RequestKey(responseProto.getClientId(), responseProto.getCallId()));
+            sentTimeNs = entry == null ? 0 : entry.getSentTimeNs();
+          } finally {
+            lock.unlock();
+          }
           if (entry == null) {
             // This could be two cases
             // 1. there is bug in the code
@@ -464,7 +569,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
             timerTaskCancelledCount++;
             // purge timer every 1000 cancels
             if (timerTaskCancelledCount == 1000) {
-              timer.purge();
+              responseTimer.purge();
               timerTaskCancelledCount = 0;
             }
           }
@@ -481,7 +586,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
                 // read FS from domainSocket
                 FileInputStream[] fis = new FileInputStream[1];
                 byte[] buf = new byte[1];
-                int ret = domainSocket.recvFileInputStreams(fis, buf, 0, buf.length);
+                int ret = socket.recvFileInputStreams(fis, buf, 0, buf.length);
                 if (ret == -1) {
                   throw new IOException("failed to get a file descriptor from datanode " + dn +
                       " for peer is shutdown.");
@@ -511,7 +616,7 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
           }
           long currentTime = System.nanoTime();
           long endToEndCost = currentTime - entry.getCreateTimeNs();
-          long sentCost = entry.getSentTimeNs() - entry.getCreateTimeNs();
+          long sentCost = sentTimeNs - entry.getCreateTimeNs();
           long receiveCost = processStartTime - receiveStartTime;
           long processCost = currentTime - processStartTime;
           if (LOG.isDebugEnabled()) {
@@ -519,26 +624,38 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
                     "process {} ns", type, entry.getRequest().getClientId().toStringUtf8(),
                 entry.getRequest().getCallId(), dn, endToEndCost, sentCost, receiveCost, processCost);
           }
-          responseReceived++;
+          lock.lock();
+          try {
+            responseReceived++;
+          } finally {
+            lock.unlock();
+          }
           metrics.decrPendingContainerOpsMetrics(type);
           metrics.addContainerOpsLatency(type, endToEndCost);
-        } catch (SocketTimeoutException | EOFException | ClosedChannelException e) {
-          isDomainSocketOpen.set(false);
-          LOG.info("{} receiveResponseTask is closed after send {} requests and received {} responses, due to {}",
-              domainSocket.toString(), requestSent, responseReceived, e.getClass().getName(), e);
-          // fail all requests pending responses
-          sentRequests.values().forEach(i -> i.fail(e));
         } catch (Throwable e) {
-          isDomainSocketOpen.set(false);
-          LOG.error("{} failed after send {} requests and received {} responses",
-              domainSocket.toString(), requestSent, responseReceived, e);
+          final List<RequestEntry> pending;
+          lock.lock();
+          try {
+            isDomainSocketOpen.set(false);
+            if (e instanceof SocketTimeoutException || e instanceof EOFException
+                || e instanceof ClosedChannelException) {
+              LOG.info("{} receiveResponseTask is closed after send {} requests and received {} responses, due to {}",
+                  socket, requestSent, responseReceived, e.getClass().getName(), e);
+            } else {
+              LOG.error("{} failed after send {} requests and received {} responses",
+                  socket, requestSent, responseReceived, e);
+            }
+            pending = new ArrayList<>(sentRequests.values());
+          } finally {
+            lock.unlock();
+          }
           if (entry != null) {
             entry.getFuture().completeExceptionally(e);
           }
-          sentRequests.values().forEach(i -> i.fail(e));
+          pending.forEach(i -> i.fail(e));
           break;
         }
-      } while (isDomainSocketOpen.get());
+      }
     }
   }
 
@@ -583,13 +700,15 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
     private final ContainerCommandRequestProto request;
     private final CompletableFuture<ContainerCommandResponseProto> future;
     private final long createTimeNs;
+    // Accessed under the enclosing client's lock.
     private long sentTimeNs;
-    private TimerTask timerTask;
+    private final TimerTask timerTask;
 
     RequestEntry(ContainerCommandRequestProto requestProto,
-                 CompletableFuture<ContainerCommandResponseProto> future) {
+                 CompletableFuture<ContainerCommandResponseProto> future, TimerTask timerTask) {
       this.request = requestProto;
       this.future = future;
+      this.timerTask = timerTask;
       this.createTimeNs = System.nanoTime();
     }
 
@@ -611,10 +730,6 @@ public class XceiverClientShortCircuit extends XceiverClientSpi {
 
     public void setSentTimeNs() {
       sentTimeNs = System.nanoTime();
-    }
-
-    public void setTimerTask(TimerTask task) {
-      timerTask = task;
     }
 
     public TimerTask getTimerTask() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientManagerSC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientManagerSC.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,6 +61,7 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -78,6 +81,20 @@ import org.mockito.MockedStatic;
  */
 @Timeout(300)
 public class TestXceiverClientManagerSC {
+
+  private static final int CONCURRENT_OPERATION_COUNT = 8;
+  private static final int REQUEST_COUNT = CONCURRENT_OPERATION_COUNT * 4;
+  private static final int RACE_ITERATION_COUNT = 10;
+  private static final int TEST_TIMEOUT_SECONDS = 30;
+  private static final int TEST_TIMEOUT_MILLIS =
+      Math.toIntExact(TimeUnit.SECONDS.toMillis(TEST_TIMEOUT_SECONDS));
+  private static final int NON_BLOCKING_TIMEOUT_SECONDS = 5;
+  private static final int WAIT_INTERVAL_MILLIS = 100;
+  private static final int DELAYED_ECHO_MILLIS =
+      Math.toIntExact(TimeUnit.SECONDS.toMillis(1));
+  private static final int RECEIVER_READ_TIMEOUT_MILLIS = 200;
+  private static final int BLOCKED_WRITE_PAYLOAD_SIZE =
+      Math.toIntExact(8 * OzoneConsts.MB);
 
   private static OzoneConfiguration config;
   private static MiniOzoneCluster cluster;
@@ -114,7 +131,7 @@ public class TestXceiverClientManagerSC {
     }
     GenericTestUtils.waitFor(() -> cluster.getHddsDatanodes().stream().allMatch(dn -> dn.getDatanodeStateMachine()
         .getContainer().getContainerSet().getContainer(echoContainer.getContainerInfo().getContainerID()) != null),
-        100, 30000);
+        WAIT_INTERVAL_MILLIS, TEST_TIMEOUT_MILLIS);
   }
 
   @AfterAll
@@ -155,21 +172,21 @@ public class TestXceiverClientManagerSC {
   @Test
   public void testConcurrentConnectAndRequests() throws Exception {
     Pipeline pipeline = echoContainer.getPipeline();
-    ExecutorService executor = Executors.newFixedThreadPool(8);
+    ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_OPERATION_COUNT);
     try (XceiverClientShortCircuit client =
         new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
       CountDownLatch start = new CountDownLatch(1);
       List<Future<?>> connections = new ArrayList<>();
-      for (int i = 0; i < 8; i++) {
+      for (int i = 0; i < CONCURRENT_OPERATION_COUNT; i++) {
         connections.add(executor.submit(() -> {
-          assertTrue(start.await(30, TimeUnit.SECONDS));
+          assertTrue(start.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
           client.connect();
           return null;
         }));
       }
       start.countDown();
       for (Future<?> connection : connections) {
-        connection.get(30, TimeUnit.SECONDS);
+        connection.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       }
       client.connect();
       assertFalse(client.isClosed());
@@ -178,21 +195,87 @@ public class TestXceiverClientManagerSC {
 
       CountDownLatch send = new CountDownLatch(1);
       List<Future<?>> requests = new ArrayList<>();
-      for (int i = 0; i < 32; i++) {
+      for (int i = 0; i < REQUEST_COUNT; i++) {
         ContainerCommandRequestProto request = echoRequest(client, 0);
         requests.add(executor.submit(() -> {
-          assertTrue(send.await(30, TimeUnit.SECONDS));
+          assertTrue(send.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
           assertEchoResponse(request, client.sendCommand(request));
           return null;
         }));
       }
       send.countDown();
       for (Future<?> request : requests) {
-        request.get(30, TimeUnit.SECONDS);
+        request.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       }
     } finally {
       executor.shutdownNow();
-      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+      assertTrue(executor.awaitTermination(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  public void testResponseAndTimeoutWhileWriteIsBlocked() throws Exception {
+    Pipeline pipeline = echoContainer.getPipeline();
+    DomainSocketFactory factory = mock(DomainSocketFactory.class);
+    DomainSocket[] sockets = DomainSocket.socketpair();
+    DomainSocket clientSocket = sockets[0];
+    DomainSocket peerSocket = sockets[1];
+    clientSocket.setAttribute(DomainSocket.SEND_BUFFER_SIZE,
+        config.getObject(OzoneClientConfig.class).getShortCircuitBufferSize());
+    when(factory.createSocket(anyInt(), anyInt(), any())).thenReturn(clientSocket);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try (MockedStatic<DomainSocketFactory> mocked = mockStatic(DomainSocketFactory.class)) {
+      mocked.when(() -> DomainSocketFactory.getInstance(config)).thenReturn(factory);
+      try (XceiverClientShortCircuit client =
+          new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
+        client.connect();
+        DataInputStream peerIn = new DataInputStream(peerSocket.getInputStream());
+        DataOutputStream peerOut = new DataOutputStream(peerSocket.getOutputStream());
+
+        ContainerCommandRequestProto responseRequest = echoRequest(client, 0);
+        CompletableFuture<ContainerCommandResponseProto> responseFuture =
+            client.sendCommandInternal(responseRequest).getResponse();
+        assertEquals(responseRequest, readRequest(peerIn));
+
+        ContainerCommandRequestProto timeoutRequest = echoRequest(client, 0);
+        CompletableFuture<ContainerCommandResponseProto> timeoutFuture =
+            client.sendCommandInternal(timeoutRequest).getResponse();
+        assertEquals(timeoutRequest, readRequest(peerIn));
+
+        ContainerCommandRequestProto blockedRequest = echoRequest(client, 0).toBuilder()
+            .setEcho(ContainerProtos.EchoRequestProto.newBuilder()
+                .setReadOnly(true)
+                .setPayload(ByteString.copyFrom(new byte[BLOCKED_WRITE_PAYLOAD_SIZE])))
+            .build();
+        Future<XceiverClientReply> blockedSend =
+            executor.submit(() -> client.sendCommandInternal(blockedRequest));
+        assertEquals(OzoneClientConfig.DATA_TRANSFER_VERSION, peerIn.readShort());
+        assertEquals(ContainerProtos.Type.Echo.getNumber(), peerIn.readShort());
+        assertFalse(blockedSend.isDone());
+
+        sendEchoResponse(responseRequest, peerOut);
+        assertEchoResponse(responseRequest,
+            responseFuture.get(NON_BLOCKING_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+        Future<?> timeout = executor.submit(() ->
+            client.requestTimeout(new XceiverClientShortCircuit.RequestKey(
+                timeoutRequest.getClientId(), timeoutRequest.getCallId())));
+        timeout.get(NON_BLOCKING_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThrows(ExecutionException.class,
+            () -> timeoutFuture.get(NON_BLOCKING_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        assertFalse(blockedSend.isDone());
+
+        peerSocket.close();
+        assertThrows(ExecutionException.class,
+            () -> blockedSend.get(NON_BLOCKING_TIMEOUT_SECONDS, TimeUnit.SECONDS).getResponse()
+                .get(NON_BLOCKING_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+      } finally {
+        IOUtils.cleanupWithLogger(null, peerSocket, clientSocket);
+      }
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
     }
   }
 
@@ -204,17 +287,17 @@ public class TestXceiverClientManagerSC {
       client.connect();
       List<ContainerCommandRequestProto> requests = new ArrayList<>();
       List<CompletableFuture<ContainerCommandResponseProto>> responses = new ArrayList<>();
-      for (int i = 0; i < 8; i++) {
-        ContainerCommandRequestProto request = echoRequest(client, i == 0 ? 1000 : 0);
+      for (int i = 0; i < CONCURRENT_OPERATION_COUNT; i++) {
+        ContainerCommandRequestProto request = echoRequest(client, i == 0 ? DELAYED_ECHO_MILLIS : 0);
         requests.add(request);
         responses.add(client.sendCommandInternal(request).getResponse());
       }
       assertFalse(responses.get(0).isDone());
       for (int i = 0; i < requests.size(); i++) {
-        assertEchoResponse(requests.get(i), responses.get(i).get(30, TimeUnit.SECONDS));
+        assertEchoResponse(requests.get(i), responses.get(i).get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
       }
-      client.sendCommandInternal(echoRequest(client, 1000)).getResponse()
-          .thenRun(client::close).get(30, TimeUnit.SECONDS);
+      client.sendCommandInternal(echoRequest(client, DELAYED_ECHO_MILLIS)).getResponse()
+          .thenRun(client::close).get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       assertTrue(client.isClosed());
     }
   }
@@ -222,26 +305,27 @@ public class TestXceiverClientManagerSC {
   @Test
   public void testConcurrentCloseWithPendingRequests() throws Exception {
     Pipeline pipeline = echoContainer.getPipeline();
-    ExecutorService executor = Executors.newFixedThreadPool(8);
+    ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_OPERATION_COUNT);
     try (XceiverClientShortCircuit client =
         new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
       client.connect();
       CompletableFuture<ContainerCommandResponseProto> pending =
-          client.sendCommandInternal(echoRequest(client, 1000)).getResponse();
+          client.sendCommandInternal(echoRequest(client, DELAYED_ECHO_MILLIS)).getResponse();
       CountDownLatch start = new CountDownLatch(1);
       List<Future<?>> closes = new ArrayList<>();
-      for (int i = 0; i < 8; i++) {
+      for (int i = 0; i < CONCURRENT_OPERATION_COUNT; i++) {
         closes.add(executor.submit(() -> {
-          assertTrue(start.await(30, TimeUnit.SECONDS));
+          assertTrue(start.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
           client.close();
           return null;
         }));
       }
       start.countDown();
       for (Future<?> close : closes) {
-        close.get(30, TimeUnit.SECONDS);
+        close.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
       }
-      assertThrows(ExecutionException.class, () -> pending.get(30, TimeUnit.SECONDS));
+      assertThrows(ExecutionException.class,
+          () -> pending.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
       assertTrue(client.isClosed());
       assertThrows(IOException.class, client::connect);
       assertThrows(IOException.class, client::checkOpen);
@@ -249,7 +333,7 @@ public class TestXceiverClientManagerSC {
       assertNotNull(client.toString());
     } finally {
       executor.shutdownNow();
-      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+      assertTrue(executor.awaitTermination(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
     }
   }
 
@@ -258,7 +342,7 @@ public class TestXceiverClientManagerSC {
     Pipeline pipeline = echoContainer.getPipeline();
     ExecutorService executor = Executors.newFixedThreadPool(3);
     try {
-      for (int i = 0; i < 10; i++) {
+      for (int i = 0; i < RACE_ITERATION_COUNT; i++) {
         try (XceiverClientShortCircuit client =
             new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
           if (i % 2 == 0) {
@@ -266,7 +350,7 @@ public class TestXceiverClientManagerSC {
           }
           CountDownLatch start = new CountDownLatch(1);
           Future<?> connect = executor.submit(() -> {
-            assertTrue(start.await(30, TimeUnit.SECONDS));
+            assertTrue(start.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
             try {
               client.connect();
             } catch (IOException expected) {
@@ -275,10 +359,11 @@ public class TestXceiverClientManagerSC {
             return null;
           });
           Future<?> send = executor.submit(() -> {
-            assertTrue(start.await(30, TimeUnit.SECONDS));
+            assertTrue(start.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
             ContainerCommandRequestProto request = echoRequest(client, 0);
             try {
-              assertEchoResponse(request, client.sendCommandInternal(request).getResponse().get(30, TimeUnit.SECONDS));
+              assertEchoResponse(request,
+                  client.sendCommandInternal(request).getResponse().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
             } catch (IOException expected) {
               // The connection may not have opened yet, or close may have won the lock.
             } catch (ExecutionException expected) {
@@ -287,21 +372,21 @@ public class TestXceiverClientManagerSC {
             return null;
           });
           Future<?> close = executor.submit(() -> {
-            assertTrue(start.await(30, TimeUnit.SECONDS));
+            assertTrue(start.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
             client.close();
             return null;
           });
           start.countDown();
-          connect.get(30, TimeUnit.SECONDS);
-          send.get(30, TimeUnit.SECONDS);
-          close.get(30, TimeUnit.SECONDS);
+          connect.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+          send.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+          close.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
           assertTrue(client.isClosed());
           assertThrows(IOException.class, client::connect);
         }
       }
     } finally {
       executor.shutdownNow();
-      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+      assertTrue(executor.awaitTermination(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
     }
   }
 
@@ -347,7 +432,8 @@ public class TestXceiverClientManagerSC {
   public void testReceiverFailureCannotReconnect() throws Exception {
     Pipeline pipeline = echoContainer.getPipeline();
     OzoneConfiguration timeoutConfig = new OzoneConfiguration(config);
-    timeoutConfig.setTimeDuration(OzoneConfigKeys.OZONE_CLIENT_READ_TIMEOUT, 200, TimeUnit.MILLISECONDS);
+    timeoutConfig.setTimeDuration(OzoneConfigKeys.OZONE_CLIENT_READ_TIMEOUT,
+        RECEIVER_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     try (XceiverClientShortCircuit client =
         new XceiverClientShortCircuit(pipeline, timeoutConfig, pipeline.getClosestNode())) {
       client.connect();
@@ -358,7 +444,7 @@ public class TestXceiverClientManagerSC {
         } catch (IOException expected) {
           return true;
         }
-      }, 50, 30000);
+      }, WAIT_INTERVAL_MILLIS, TEST_TIMEOUT_MILLIS);
       assertFalse(client.isClosed());
       assertNotNull(client.toString());
       assertThrows(IOException.class, client::connect);
@@ -374,15 +460,37 @@ public class TestXceiverClientManagerSC {
         .setClientId(client.getClientId())
         .setCallId(client.getCallId())
         .setEcho(ContainerProtos.EchoRequestProto.newBuilder().setReadOnly(true).setSleepTimeMs(sleepTimeMs)
-            .setPayloadSizeResp(1024))
+            .setPayloadSizeResp(Math.toIntExact(OzoneConsts.KB)))
         .build();
+  }
+
+  private static ContainerCommandRequestProto readRequest(DataInputStream input) throws IOException {
+    assertEquals(OzoneClientConfig.DATA_TRANSFER_VERSION, input.readShort());
+    assertEquals(ContainerProtos.Type.Echo.getNumber(), input.readShort());
+    return ContainerCommandRequestProto.parseDelimitedFrom(input);
+  }
+
+  private static void sendEchoResponse(ContainerCommandRequestProto request, DataOutputStream output)
+      throws IOException {
+    ContainerCommandResponseProto response = ContainerCommandResponseProto.newBuilder()
+        .setCmdType(ContainerProtos.Type.Echo)
+        .setResult(ContainerProtos.Result.SUCCESS)
+        .setClientId(request.getClientId())
+        .setCallId(request.getCallId())
+        .setEcho(ContainerProtos.EchoResponseProto.newBuilder()
+            .setPayload(ByteString.copyFrom(new byte[request.getEcho().getPayloadSizeResp()])))
+        .build();
+    output.writeShort(OzoneClientConfig.DATA_TRANSFER_VERSION);
+    output.writeShort(ContainerProtos.Type.Echo.getNumber());
+    response.writeDelimitedTo(output);
+    output.flush();
   }
 
   private static void assertEchoResponse(ContainerCommandRequestProto request, ContainerCommandResponseProto response) {
     assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
     assertEquals(request.getClientId(), response.getClientId());
     assertEquals(request.getCallId(), response.getCallId());
-    assertEquals(1024, response.getEcho().getPayload().size());
+    assertEquals(request.getEcho().getPayloadSizeResp(), response.getEcho().getPayload().size());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientManagerSC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientManagerSC.java
@@ -18,25 +18,55 @@
 package org.apache.hadoop.hdds.scm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.XceiverClientManager.ScmClientConfig;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
+import org.apache.hadoop.hdds.scm.storage.DomainSocketFactory;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.net.unix.DomainSocket;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
 
 /**
  * Test for short-circuit enabled XceiverClientManager.
@@ -51,6 +81,7 @@ public class TestXceiverClientManagerSC {
 
   private static OzoneConfiguration config;
   private static MiniOzoneCluster cluster;
+  private static ContainerWithPipeline echoContainer;
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
   @TempDir
@@ -70,6 +101,20 @@ public class TestXceiverClientManagerSC {
     cluster.waitForClusterToBeReady();
     storageContainerLocationClient = cluster
         .getStorageContainerLocationClient();
+    echoContainer = storageContainerLocationClient.allocateContainer(HddsProtos.ReplicationType.RATIS,
+        HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
+    try (XceiverClientManager clientManager = new XceiverClientManager(config,
+        config.getObject(ScmClientConfig.class), null)) {
+      XceiverClientSpi client = clientManager.acquireClient(echoContainer.getPipeline());
+      try {
+        ContainerProtocolCalls.createContainer(client, echoContainer.getContainerInfo().getContainerID(), null);
+      } finally {
+        clientManager.releaseClient(client, false);
+      }
+    }
+    GenericTestUtils.waitFor(() -> cluster.getHddsDatanodes().stream().allMatch(dn -> dn.getDatanodeStateMachine()
+        .getContainer().getContainerSet().getContainer(echoContainer.getContainerInfo().getContainerID()) != null),
+        100, 30000);
   }
 
   @AfterAll
@@ -106,4 +151,238 @@ public class TestXceiverClientManagerSC {
       assertTrue(client3 instanceof XceiverClientGrpc);
     }
   }
+
+  @Test
+  public void testConcurrentConnectAndRequests() throws Exception {
+    Pipeline pipeline = echoContainer.getPipeline();
+    ExecutorService executor = Executors.newFixedThreadPool(8);
+    try (XceiverClientShortCircuit client =
+        new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
+      CountDownLatch start = new CountDownLatch(1);
+      List<Future<?>> connections = new ArrayList<>();
+      for (int i = 0; i < 8; i++) {
+        connections.add(executor.submit(() -> {
+          assertTrue(start.await(30, TimeUnit.SECONDS));
+          client.connect();
+          return null;
+        }));
+      }
+      start.countDown();
+      for (Future<?> connection : connections) {
+        connection.get(30, TimeUnit.SECONDS);
+      }
+      client.connect();
+      assertFalse(client.isClosed());
+      client.checkOpen();
+      assertNotNull(client.toString());
+
+      CountDownLatch send = new CountDownLatch(1);
+      List<Future<?>> requests = new ArrayList<>();
+      for (int i = 0; i < 32; i++) {
+        ContainerCommandRequestProto request = echoRequest(client, 0);
+        requests.add(executor.submit(() -> {
+          assertTrue(send.await(30, TimeUnit.SECONDS));
+          assertEchoResponse(request, client.sendCommand(request));
+          return null;
+        }));
+      }
+      send.countDown();
+      for (Future<?> request : requests) {
+        request.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  public void testMultiplePendingRequestsAndCloseFromResponse() throws Exception {
+    Pipeline pipeline = echoContainer.getPipeline();
+    try (XceiverClientShortCircuit client =
+        new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
+      client.connect();
+      List<ContainerCommandRequestProto> requests = new ArrayList<>();
+      List<CompletableFuture<ContainerCommandResponseProto>> responses = new ArrayList<>();
+      for (int i = 0; i < 8; i++) {
+        ContainerCommandRequestProto request = echoRequest(client, i == 0 ? 1000 : 0);
+        requests.add(request);
+        responses.add(client.sendCommandInternal(request).getResponse());
+      }
+      assertFalse(responses.get(0).isDone());
+      for (int i = 0; i < requests.size(); i++) {
+        assertEchoResponse(requests.get(i), responses.get(i).get(30, TimeUnit.SECONDS));
+      }
+      client.sendCommandInternal(echoRequest(client, 1000)).getResponse()
+          .thenRun(client::close).get(30, TimeUnit.SECONDS);
+      assertTrue(client.isClosed());
+    }
+  }
+
+  @Test
+  public void testConcurrentCloseWithPendingRequests() throws Exception {
+    Pipeline pipeline = echoContainer.getPipeline();
+    ExecutorService executor = Executors.newFixedThreadPool(8);
+    try (XceiverClientShortCircuit client =
+        new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
+      client.connect();
+      CompletableFuture<ContainerCommandResponseProto> pending =
+          client.sendCommandInternal(echoRequest(client, 1000)).getResponse();
+      CountDownLatch start = new CountDownLatch(1);
+      List<Future<?>> closes = new ArrayList<>();
+      for (int i = 0; i < 8; i++) {
+        closes.add(executor.submit(() -> {
+          assertTrue(start.await(30, TimeUnit.SECONDS));
+          client.close();
+          return null;
+        }));
+      }
+      start.countDown();
+      for (Future<?> close : closes) {
+        close.get(30, TimeUnit.SECONDS);
+      }
+      assertThrows(ExecutionException.class, () -> pending.get(30, TimeUnit.SECONDS));
+      assertTrue(client.isClosed());
+      assertThrows(IOException.class, client::connect);
+      assertThrows(IOException.class, client::checkOpen);
+      assertThrows(IOException.class, () -> client.sendCommandInternal(echoRequest(client, 0)));
+      assertNotNull(client.toString());
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  public void testConnectAndSendRacingWithClose() throws Exception {
+    Pipeline pipeline = echoContainer.getPipeline();
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    try {
+      for (int i = 0; i < 10; i++) {
+        try (XceiverClientShortCircuit client =
+            new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
+          if (i % 2 == 0) {
+            client.connect();
+          }
+          CountDownLatch start = new CountDownLatch(1);
+          Future<?> connect = executor.submit(() -> {
+            assertTrue(start.await(30, TimeUnit.SECONDS));
+            try {
+              client.connect();
+            } catch (IOException expected) {
+              assertTrue(client.isClosed());
+            }
+            return null;
+          });
+          Future<?> send = executor.submit(() -> {
+            assertTrue(start.await(30, TimeUnit.SECONDS));
+            ContainerCommandRequestProto request = echoRequest(client, 0);
+            try {
+              assertEchoResponse(request, client.sendCommandInternal(request).getResponse().get(30, TimeUnit.SECONDS));
+            } catch (IOException expected) {
+              // The connection may not have opened yet, or close may have won the lock.
+            } catch (ExecutionException expected) {
+              assertTrue(expected.getCause() instanceof IOException);
+            }
+            return null;
+          });
+          Future<?> close = executor.submit(() -> {
+            assertTrue(start.await(30, TimeUnit.SECONDS));
+            client.close();
+            return null;
+          });
+          start.countDown();
+          connect.get(30, TimeUnit.SECONDS);
+          send.get(30, TimeUnit.SECONDS);
+          close.get(30, TimeUnit.SECONDS);
+          assertTrue(client.isClosed());
+          assertThrows(IOException.class, client::connect);
+        }
+      }
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  public void testCloseBeforeConnect() throws Exception {
+    Pipeline pipeline = echoContainer.getPipeline();
+    try (XceiverClientShortCircuit client =
+        new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
+      assertFalse(client.isClosed());
+      assertNotNull(client.toString());
+      assertThrows(IOException.class, client::checkOpen);
+      assertThrows(IOException.class, () -> client.sendCommandInternal(echoRequest(client, 0)));
+      client.close();
+      client.close();
+      assertTrue(client.isClosed());
+      assertThrows(IOException.class, client::connect);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testConnectFailureCannotReconnect(boolean throwException) throws Exception {
+    Pipeline pipeline = echoContainer.getPipeline();
+    DomainSocketFactory factory = mock(DomainSocketFactory.class);
+    if (throwException) {
+      when(factory.createSocket(anyInt(), anyInt(), any())).thenThrow(new IOException("Connection failed"));
+    }
+    try (MockedStatic<DomainSocketFactory> mocked = mockStatic(DomainSocketFactory.class)) {
+      mocked.when(() -> DomainSocketFactory.getInstance(config)).thenReturn(factory);
+      try (XceiverClientShortCircuit client =
+          new XceiverClientShortCircuit(pipeline, config, pipeline.getClosestNode())) {
+        assertThrows(IOException.class, client::connect);
+        assertTrue(client.isClosed());
+        assertNotNull(client.toString());
+        assertThrows(IOException.class, client::connect);
+        assertThrows(IOException.class, client::checkOpen);
+        verify(factory, times(1)).createSocket(anyInt(), anyInt(), any());
+      }
+    }
+  }
+
+  @Test
+  public void testReceiverFailureCannotReconnect() throws Exception {
+    Pipeline pipeline = echoContainer.getPipeline();
+    OzoneConfiguration timeoutConfig = new OzoneConfiguration(config);
+    timeoutConfig.setTimeDuration(OzoneConfigKeys.OZONE_CLIENT_READ_TIMEOUT, 200, TimeUnit.MILLISECONDS);
+    try (XceiverClientShortCircuit client =
+        new XceiverClientShortCircuit(pipeline, timeoutConfig, pipeline.getClosestNode())) {
+      client.connect();
+      GenericTestUtils.waitFor(() -> {
+        try {
+          client.checkOpen();
+          return false;
+        } catch (IOException expected) {
+          return true;
+        }
+      }, 50, 30000);
+      assertFalse(client.isClosed());
+      assertNotNull(client.toString());
+      assertThrows(IOException.class, client::connect);
+      assertThrows(IOException.class, () -> client.sendCommandInternal(echoRequest(client, 0)));
+    }
+  }
+
+  private static ContainerCommandRequestProto echoRequest(XceiverClientShortCircuit client, int sleepTimeMs) {
+    return ContainerCommandRequestProto.newBuilder()
+        .setCmdType(ContainerProtos.Type.Echo)
+        .setContainerID(echoContainer.getContainerInfo().getContainerID())
+        .setDatanodeUuid(client.getDn().getUuidString())
+        .setClientId(client.getClientId())
+        .setCallId(client.getCallId())
+        .setEcho(ContainerProtos.EchoRequestProto.newBuilder().setReadOnly(true).setSleepTimeMs(sleepTimeMs)
+            .setPayloadSizeResp(1024))
+        .build();
+  }
+
+  private static void assertEchoResponse(ContainerCommandRequestProto request, ContainerCommandResponseProto response) {
+    assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+    assertEquals(request.getClientId(), response.getClientId());
+    assertEquals(request.getCallId(), response.getCallId());
+    assertEquals(1024, response.getEcho().getPayload().size());
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`XceiverClientShortCircuit` did not consistently synchronize access to its connection state and other non-final fields.

This pull request uses the existing lock to protect all non-final fields and serialize connection setup, request registration and writes, and close transitions. Blocking reads, response waits, and receiver joins remain outside the lock.

Thread-safe final fields are used for response and timeout processing so they can proceed while a socket write is blocked. The client also remains one-shot: repeated `connect()` calls are allowed while open, but reconnecting after failure or close is rejected.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16335

## How was this patch tested?

Local Test
```
mvn -pl :ozone-integration-test -am test \
  -Dtest=TestXceiverClientManagerSC \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipShade -DskipRecon -DskipDocs
```

GitHub Actions CI: https://github.com/echonesis/ozone/actions/runs/34804142710

Generated-by: Codex (GPT-5)