### PR TITLE
HDDS-15925. Remove redundant InfoBucket RPC from OFS getFileStatus by validating bucket layout server-side

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -61,7 +61,12 @@ public enum OzoneManagerVersion implements ComponentVersion {
   S3_BUCKET_TAGGING_API(13,
       "OzoneManager version that supports S3 bucket tagging APIs, such as "
           + "PutBucketTagging, GetBucketTagging, and DeleteBucketTagging"),
-    
+
+  GET_FILE_STATUS_REJECTS_OBS(14,
+      "OzoneManager version that rejects getFileStatus on OBJECT_STORE "
+          + "buckets server-side, so file system clients no longer need the "
+          + "client-side InfoBucket layout check"),
+
   FUTURE_VERSION(-1, "Used internally in the client when the server side is "
       + " newer and an unknown server version has arrived to the client.");
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneFsServerDefaults;
+import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKey;
@@ -1062,6 +1063,14 @@ public interface ClientProtocol {
    * @throws IOException
    */
   OzoneFsServerDefaults getServerDefaults() throws IOException;
+
+  /**
+   * Returns the negotiated Ozone Manager version for the connected cluster.
+   * In an HA cluster this is the minimum version across all OMs, so callers
+   * can safely gate client behavior on new server-side features.
+   * @return the effective Ozone Manager version.
+   */
+  OzoneManagerVersion getOmVersion();
 
   /**
    * Get KMS client provider.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2846,6 +2846,11 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public OzoneManagerVersion getOmVersion() {
+    return omVersion;
+  }
+
+  @Override
   public OzoneFsServerDefaults getServerDefaults() throws IOException {
     long now = Time.monotonicNow();
     if ((serverDefaults == null) ||

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1836,15 +1836,73 @@ abstract class AbstractRootedOzoneFileSystemTest extends OzoneFileSystemTestBase
   }
 
   @Test
+  void testGetFileStatusUsesSingleOmRpc() throws Exception {
+    String keyName = "single-rpc-" + RandomStringUtils.secure().nextAlphabetic(5);
+    Path filePath = new Path(bucketPath, keyName);
+    ContractTestUtils.touch(fs, filePath);
+
+    OMMetrics metrics = getOMMetrics();
+    long bucketInfosBefore = metrics.getNumBucketInfos();
+    long getFileStatusBefore = metrics.getNumGetFileStatus();
+
+    FileStatus status = fs.getFileStatus(filePath);
+    assertTrue(status.isFile());
+
+    assertEquals(bucketInfosBefore, metrics.getNumBucketInfos(),
+        "getFileStatus must not trigger InfoBucket");
+    assertEquals(getFileStatusBefore + 1, metrics.getNumGetFileStatus());
+
+    long getFileStatusAfterFirst = metrics.getNumGetFileStatus();
+    fs.getFileStatus(filePath);
+    assertEquals(bucketInfosBefore, metrics.getNumBucketInfos());
+    assertEquals(getFileStatusAfterFirst + 1, metrics.getNumGetFileStatus());
+  }
+
+  @Test
+  void testGetFileStatusRejectsObsBucket() throws Exception {
+    OzoneBucket obsBucket =
+        DataTestUtil.createVolumeAndBucket(client, BucketLayout.OBJECT_STORE);
+    Path obsBucketPath = new Path(
+        new Path(OZONE_URI_DELIMITER, obsBucket.getVolumeName()),
+        obsBucket.getName());
+    String keyName = "obs-key-" + RandomStringUtils.secure().nextAlphabetic(5);
+    DataTestUtil.createKey(obsBucket, keyName,
+        "data".getBytes(StandardCharsets.UTF_8));
+    Path keyPath = new Path(obsBucketPath, keyName);
+
+    OMMetrics metrics = getOMMetrics();
+    long bucketInfosBefore = metrics.getNumBucketInfos();
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> fs.getFileStatus(keyPath));
+    assertThat(exception.getMessage()).contains(obsBucket.getName());
+    assertThat(exception.getMessage()).contains("OBJECT_STORE");
+    assertEquals(bucketInfosBefore, metrics.getNumBucketInfos(),
+        "getFileStatus must not trigger InfoBucket");
+  }
+
+  @Test
   void testGetFileStatus() throws Exception {
     String volumeNameLocal = getRandomNonExistVolumeName();
     String bucketNameLocal = RandomStringUtils.secure().nextNumeric(5);
     Path volume = new Path("/" + volumeNameLocal);
     fs.mkdirs(volume);
-    assertThrows(OMException.class,
-        () -> fs.getFileStatus(new Path(volume, bucketNameLocal)));
-    // Cleanup
-    fs.delete(volume, false);
+    try {
+      FileNotFoundException exception = assertThrows(FileNotFoundException.class,
+          () -> fs.getFileStatus(new Path(volume, bucketNameLocal)));
+      assertThat(exception.getMessage()).contains("Bucket doesn't exist");
+    } finally {
+      fs.delete(volume, false);
+    }
+  }
+
+  @Test
+  void testGetFileStatusMissingFile() throws Exception {
+    Path missingFile = new Path(bucketPath, "missing-file-" +
+        RandomStringUtils.secure().nextAlphanumeric(5));
+    FileNotFoundException exception = assertThrows(FileNotFoundException.class,
+        () -> fs.getFileStatus(missingFile));
+    assertThat(exception.getMessage()).contains("No such file or directory");
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOfsGetFileStatusCacheBenchmark.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOfsGetFileStatusCacheBenchmark.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmark for the OFS getFileStatus bucket-layout cache (HDDS-15925).
+ *
+ * <p>Runs a cache-hit-heavy getFileStatus workload against one
+ * {@link MiniOzoneCluster} using the default client configuration, and reports
+ * the InfoBucket RPCs, getFileStatus RPCs, per-call latency (mean/p50/p90/p99/
+ * max) and throughput measured by OM. The workload touches {@link #NUM_BUCKETS}
+ * buckets {@link #ACCESSES_PER_BUCKET} times each, so exactly one access per
+ * bucket is a cold miss and the rest would hit a per-bucket layout cache — a
+ * 90% cache-hit workload.
+ *
+ * <p>This benchmark makes no assumption about whether the cache exists, so the
+ * identical test runs on both the optimized branch and the baseline
+ * ({@code master}) code. The before/after comparison is what OM reports for the
+ * same workload:
+ * <ul>
+ *   <li>baseline (no cache): two RPCs per getFileStatus (InfoBucket +
+ *       getFileStatus), one InfoBucket RPC per call ({@link #TOTAL_CALLS});</li>
+ *   <li>optimized (cache on by default): one RPC per cache hit, so one
+ *       InfoBucket RPC per distinct bucket ({@link #NUM_BUCKETS});</li>
+ *   <li>server-side (HDDS-15925 -alt): getFileStatus talks to OM directly, so
+ *       the InfoBucket RPC is removed entirely (zero for the workload).</li>
+ * </ul>
+ * The getFileStatus RPC count is identical either way, showing the optimization
+ * removes only the redundant InfoBucket RPC and changes no behaviour; the
+ * latency percentiles show the effect of dropping that RPC per call.
+ *
+ * <p>A second test runs the same workload single-threaded and then across
+ * {@link #CONCURRENT_THREADS} client threads sharing one {@code FileSystem} (and
+ * thus one layout cache), and logs the two side by side. It confirms the atomic
+ * get-or-load holds the InfoBucket RPC count at one per bucket under concurrency
+ * — concurrent cold misses on the same bucket collapse to a single RPC instead
+ * of stampeding — while throughput scales with the added client threads.
+ */
+@Tag("benchmark")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestOfsGetFileStatusCacheBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestOfsGetFileStatusCacheBenchmark.class);
+
+  /** Distinct buckets in the working set (each is one cold miss). */
+  private static final int NUM_BUCKETS = 200;
+  /** getFileStatus calls per bucket: 1 miss + (N-1) hits. */
+  private static final int ACCESSES_PER_BUCKET = 10;
+  /** (ACCESSES_PER_BUCKET - 1) / ACCESSES_PER_BUCKET = 0.90. */
+  private static final double TARGET_HIT_RATIO =
+      (ACCESSES_PER_BUCKET - 1) / (double) ACCESSES_PER_BUCKET;
+  private static final int TOTAL_CALLS = NUM_BUCKETS * ACCESSES_PER_BUCKET;
+  private static final long SHUFFLE_SEED = 20250831L;
+  /** Client threads issuing getFileStatus in the concurrent comparison. */
+  private static final int CONCURRENT_THREADS = 10;
+
+  private MiniOzoneCluster cluster;
+  private OzoneClient client;
+  private OzoneConfiguration conf;
+  private String rootPath;
+
+  private final List<Path> accessSequence = new ArrayList<>(TOTAL_CALLS);
+
+  @BeforeAll
+  void init() throws IOException, InterruptedException, TimeoutException {
+    conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
+    rootPath = String.format("%s://%s/",
+        OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
+
+    // One volume, NUM_BUCKETS FSO buckets, one file per bucket. The access
+    // sequence lists each file ACCESSES_PER_BUCKET times, then is shuffled with
+    // a fixed seed so hits and misses interleave the way a real workload would.
+    ObjectStore objectStore = client.getObjectStore();
+    String volName = "benchvol";
+    objectStore.createVolume(volName);
+    OzoneVolume volume = objectStore.getVolume(volName);
+    BucketArgs fsoArgs = BucketArgs.newBuilder()
+        .setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED).build();
+    try (FileSystem setupFs =
+        FileSystem.newInstance(URI.create(rootPath), conf)) {
+      for (int i = 0; i < NUM_BUCKETS; i++) {
+        String buckName = "benchbucket-" + i;
+        volume.createBucket(buckName, fsoArgs);
+        Path file = new Path("/" + volName + "/" + buckName + "/file");
+        ContractTestUtils.touch(setupFs, file);
+        for (int a = 0; a < ACCESSES_PER_BUCKET; a++) {
+          accessSequence.add(file);
+        }
+      }
+    }
+    Collections.shuffle(accessSequence, new Random(SHUFFLE_SEED));
+  }
+
+  @AfterAll
+  void shutdown() {
+    IOUtils.closeQuietly(client);
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  void benchmarkCacheHitWorkflow() throws Exception {
+    // Prime OM-side state and the JVM so the measured run pays no cold-start.
+    runWorkload(1);
+
+    Result measured = runWorkload(1);
+
+    assertWorkloadInvariants(measured);
+    logResult("single-threaded", measured);
+  }
+
+  @Test
+  void benchmarkConcurrentVsSingleThreaded() throws Exception {
+    // Warm the JVM/OM, then measure the same workload single-threaded and again
+    // across CONCURRENT_THREADS client threads sharing one FileSystem (and thus
+    // one bucket-layout cache). The atomic get-or-load keeps the InfoBucket RPC
+    // count at one per bucket in both cases: concurrent cold misses on the same
+    // bucket collapse to a single InfoBucket RPC rather than stampeding.
+    runWorkload(1);
+
+    Result single = runWorkload(1);
+    Result concurrent = runWorkload(CONCURRENT_THREADS);
+
+    assertWorkloadInvariants(single);
+    assertWorkloadInvariants(concurrent);
+
+    logResult("single-threaded", single);
+    logResult(CONCURRENT_THREADS + " concurrent threads", concurrent);
+    LOG.info(String.format("%n"
+            + "single-threaded vs %d concurrent threads (optimized)%n"
+            + "  InfoBucket RPCs     : %d  ->  %d%n"
+            + "  getFileStatus RPCs  : %d  ->  %d%n"
+            + "  latency mean (ms)   : %.3f  ->  %.3f%n"
+            + "  latency p99 (ms)    : %.3f  ->  %.3f%n"
+            + "  throughput (ops/s)  : %.1f  ->  %.1f  (%.2fx)%n",
+        CONCURRENT_THREADS,
+        single.infoBucketRpcs, concurrent.infoBucketRpcs,
+        single.getFileStatusRpcs, concurrent.getFileStatusRpcs,
+        millis(single.mean()), millis(concurrent.mean()),
+        millis(single.percentile(0.99)), millis(concurrent.percentile(0.99)),
+        single.opsPerSecond(), concurrent.opsPerSecond(),
+        concurrent.opsPerSecond() / single.opsPerSecond()));
+  }
+
+  /**
+   * Invariants that hold on the baseline, the client-cache and the server-side
+   * (-alt) code, so the identical benchmark passes in every worktree: every
+   * getFileStatus still issues its getFileStatus RPC, and the InfoBucket RPCs
+   * lie between the best case (zero — the server-side path removes the RPC) and
+   * the no-cache worst case (one per call).
+   */
+  private void assertWorkloadInvariants(Result r) {
+    assertThat(r.getFileStatusRpcs).isEqualTo(TOTAL_CALLS);
+    assertThat(r.infoBucketRpcs)
+        .isBetween(0L, (long) TOTAL_CALLS);
+  }
+
+  private void logResult(String label, Result r) {
+    double achievedHitRatio =
+        (TOTAL_CALLS - r.infoBucketRpcs) / (double) TOTAL_CALLS;
+    LOG.info(String.format("%n"
+            + "OFS getFileStatus bucket-layout cache benchmark (HDDS-15925) — %s%n"
+            + "  buckets=%d, accesses/bucket=%d, total getFileStatus=%d, "
+            + "threads=%d%n"
+            + "  target cache-hit ratio      : %.0f%%%n"
+            + "  ------------------------------------------------------------%n"
+            + "  InfoBucket RPCs             : %d%n"
+            + "  getFileStatus RPCs          : %d%n"
+            + "  InfoBucket RPCs per call    : %.2f%n"
+            + "  cache-hit ratio achieved    : %.0f%%%n"
+            + "  ------------------------------------------------------------%n"
+            + "  latency mean                : %.3f ms%n"
+            + "  latency p50                 : %.3f ms%n"
+            + "  latency p90                 : %.3f ms%n"
+            + "  latency p99                 : %.3f ms%n"
+            + "  latency max                 : %.3f ms%n"
+            + "  throughput                  : %.1f getFileStatus/s%n",
+        label, NUM_BUCKETS, ACCESSES_PER_BUCKET, TOTAL_CALLS, r.threads,
+        TARGET_HIT_RATIO * 100,
+        r.infoBucketRpcs, r.getFileStatusRpcs,
+        r.infoBucketRpcs / (double) TOTAL_CALLS,
+        achievedHitRatio * 100,
+        millis(r.mean()), millis(r.percentile(0.50)),
+        millis(r.percentile(0.90)), millis(r.percentile(0.99)),
+        millis(r.max()), r.opsPerSecond()));
+  }
+
+  private static double millis(double nanos) {
+    return nanos / (double) TimeUnit.MILLISECONDS.toNanos(1);
+  }
+
+  private Result runWorkload(int threads)
+      throws IOException, InterruptedException {
+    OzoneConfiguration runConf = new OzoneConfiguration(conf);
+    runConf.set(FS_DEFAULT_NAME_KEY, rootPath);
+
+    OMMetrics metrics = cluster.getOzoneManager().getMetrics();
+    long[] latencyNanos = new long[TOTAL_CALLS];
+    try (FileSystem fs = FileSystem.newInstance(URI.create(rootPath), runConf)) {
+      long bucketInfosBefore = metrics.getNumBucketInfos();
+      long getFileStatusBefore = metrics.getNumGetFileStatus();
+      long elapsedNanos = threads == 1
+          ? runSequential(fs, latencyNanos)
+          : runConcurrent(fs, threads, latencyNanos);
+      return new Result(threads,
+          metrics.getNumBucketInfos() - bucketInfosBefore,
+          metrics.getNumGetFileStatus() - getFileStatusBefore,
+          elapsedNanos, latencyNanos);
+    }
+  }
+
+  private long runSequential(FileSystem fs, long[] latencyNanos)
+      throws IOException {
+    long startNanos = System.nanoTime();
+    int i = 0;
+    for (Path path : accessSequence) {
+      long callStart = System.nanoTime();
+      fs.getFileStatus(path);
+      latencyNanos[i++] = System.nanoTime() - callStart;
+    }
+    return System.nanoTime() - startNanos;
+  }
+
+  private long runConcurrent(FileSystem fs, int threads, long[] latencyNanos)
+      throws IOException, InterruptedException {
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch startGate = new CountDownLatch(1);
+    CountDownLatch doneGate = new CountDownLatch(threads);
+    AtomicReference<IOException> failure = new AtomicReference<>();
+    // Disjoint, contiguous slices of the shuffled sequence; each thread writes
+    // only its own latency indices, so no synchronization is needed per call.
+    int chunk = (TOTAL_CALLS + threads - 1) / threads;
+    for (int t = 0; t < threads; t++) {
+      final int from = t * chunk;
+      final int to = Math.min(TOTAL_CALLS, from + chunk);
+      pool.submit(() -> {
+        try {
+          startGate.await();
+          for (int i = from; i < to; i++) {
+            long callStart = System.nanoTime();
+            fs.getFileStatus(accessSequence.get(i));
+            latencyNanos[i] = System.nanoTime() - callStart;
+          }
+        } catch (IOException e) {
+          failure.compareAndSet(null, e);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          doneGate.countDown();
+        }
+      });
+    }
+    long startNanos = System.nanoTime();
+    startGate.countDown();
+    doneGate.await();
+    long elapsedNanos = System.nanoTime() - startNanos;
+    pool.shutdownNow();
+    if (failure.get() != null) {
+      throw failure.get();
+    }
+    return elapsedNanos;
+  }
+
+  private static final class Result {
+    private final int threads;
+    private final long infoBucketRpcs;
+    private final long getFileStatusRpcs;
+    private final long elapsedNanos;
+    private final long[] sortedLatencyNanos;
+
+    Result(int threads, long infoBucketRpcs, long getFileStatusRpcs,
+        long elapsedNanos, long[] latencyNanos) {
+      this.threads = threads;
+      this.infoBucketRpcs = infoBucketRpcs;
+      this.getFileStatusRpcs = getFileStatusRpcs;
+      this.elapsedNanos = elapsedNanos;
+      this.sortedLatencyNanos = latencyNanos.clone();
+      Arrays.sort(this.sortedLatencyNanos);
+    }
+
+    double opsPerSecond() {
+      return TOTAL_CALLS
+          / (elapsedNanos / (double) TimeUnit.SECONDS.toNanos(1));
+    }
+
+    double mean() {
+      long sum = 0;
+      for (long l : sortedLatencyNanos) {
+        sum += l;
+      }
+      return sum / (double) sortedLatencyNanos.length;
+    }
+
+    double percentile(double q) {
+      int idx = (int) Math.ceil(q * sortedLatencyNanos.length) - 1;
+      idx = Math.max(0, Math.min(sortedLatencyNanos.length - 1, idx));
+      return sortedLatencyNanos[idx];
+    }
+
+    double max() {
+      return sortedLatencyNanos[sortedLatencyNanos.length - 1];
+    }
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.IOzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -193,7 +194,8 @@ public class TestOmAcls {
 
   @Test
   public void testGetFileStatusPermissionDenied() throws Exception {
-    OzoneBucket bucket = DataTestUtil.createVolumeAndBucket(client);
+    OzoneBucket bucket = DataTestUtil.createVolumeAndBucket(client,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
     DataTestUtil.createKey(bucket, "testKey", "testcontent".getBytes(StandardCharsets.UTF_8));
 
     authorizer.keyAclAllow = false;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotTests.java
@@ -65,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.google.common.collect.Lists;
@@ -527,6 +528,7 @@ public abstract class OmSnapshotTests {
     KeyInfoWithVolumeContext fileInfo = writeClient.getKeyInfo(keyArgs, false);
     assertEquals(fileInfo.getKeyInfo().getKeyName(), snapshotKeyPrefix + key1);
 
+    assumeFalse(bucketLayout.equals(BucketLayout.OBJECT_STORE));
     OzoneFileStatus ozoneFileStatus = writeClient.getFileStatus(keyArgs);
     assertEquals(ozoneFileStatus.getKeyInfo().getKeyName(),
         snapshotKeyPrefix + key1);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatusLight;
 import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
@@ -307,6 +308,18 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
     args = bucket.update(args);
 
     try {
+      if (bucket.bucketLayout() != null) {
+        try {
+          OzoneFSUtils.validateBucketLayout(bucket.requestedBucket(),
+              bucket.bucketLayout());
+        } catch (IllegalArgumentException e) {
+          // Convert to an OMException so it is returned to the client as a
+          // normal (non-retryable) RPC response instead of escaping the read
+          // handler's IOException catch and triggering a client retry storm.
+          throw new OMException(e.getMessage(),
+              ResultCodes.NOT_SUPPORTED_OPERATION);
+        }
+      }
       if (isAclEnabled) {
         checkAcls(getResourceType(args), StoreType.OZONE, ACLType.READ, bucket, args.getKeyName());
       }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMetadataReader.java
@@ -26,9 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -47,6 +49,7 @@ import org.apache.hadoop.ipc_.Server;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.ListKeysResult;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -702,5 +705,65 @@ public class TestOMMetadataReader {
     private RequestContext getContext() {
       return context;
     }
+  }
+
+  @Test
+  public void getFileStatusRejectsObjectStoreLayout() throws Exception {
+    OzoneManager ozoneManager = mock(OzoneManager.class);
+    KeyManager keyManager = mock(KeyManager.class);
+    when(ozoneManager.getAclsEnabled()).thenReturn(false);
+    when(ozoneManager.getBucketManager()).thenReturn(mock(BucketManager.class));
+    when(ozoneManager.getVolumeManager()).thenReturn(mock(VolumeManager.class));
+    when(ozoneManager.getPerfMetrics()).thenReturn(mock(OMPerformanceMetrics.class));
+    when(ozoneManager.resolveBucketLink(any(OmKeyArgs.class)))
+        .thenReturn(new ResolvedBucket("vol", "obs-bucket", "vol", "obs-bucket",
+            "owner", BucketLayout.OBJECT_STORE));
+
+    OmMetadataReader reader = new OmMetadataReader(keyManager,
+        mock(PrefixManager.class), ozoneManager, mock(org.slf4j.Logger.class),
+        mock(AuditLogger.class), mock(OmMetadataReaderMetrics.class), null);
+
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName("vol")
+        .setBucketName("obs-bucket")
+        .setKeyName("key1")
+        .build();
+
+    OMException exception = assertThrows(OMException.class,
+        () -> reader.getFileStatus(keyArgs));
+    assertEquals(ResultCodes.NOT_SUPPORTED_OPERATION, exception.getResult());
+    assertTrue(exception.getMessage().contains("obs-bucket"));
+    assertTrue(exception.getMessage().contains("OBJECT_STORE"));
+    verify(keyManager, never()).getFileStatus(any(), anyString());
+  }
+
+  @Test
+  public void getFileStatusAllowsLegacyLayout() throws Exception {
+    OzoneManager ozoneManager = mock(OzoneManager.class);
+    KeyManager keyManager = mock(KeyManager.class);
+    when(ozoneManager.getAclsEnabled()).thenReturn(false);
+    when(ozoneManager.getBucketManager()).thenReturn(mock(BucketManager.class));
+    when(ozoneManager.getVolumeManager()).thenReturn(mock(VolumeManager.class));
+    when(ozoneManager.getPerfMetrics()).thenReturn(mock(OMPerformanceMetrics.class));
+    when(ozoneManager.resolveBucketLink(any(OmKeyArgs.class)))
+        .thenReturn(new ResolvedBucket("vol", "legacy-bucket", "vol",
+            "legacy-bucket", "owner", BucketLayout.LEGACY));
+    OzoneFileStatus expectedStatus = new OzoneFileStatus();
+    when(keyManager.getFileStatus(any(OmKeyArgs.class), anyString()))
+        .thenReturn(expectedStatus);
+
+    OmMetadataReader reader = new OmMetadataReader(keyManager,
+        mock(PrefixManager.class), ozoneManager, mock(org.slf4j.Logger.class),
+        mock(AuditLogger.class), mock(OmMetadataReaderMetrics.class), null);
+
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName("vol")
+        .setBucketName("legacy-bucket")
+        .setKeyName("key1")
+        .build();
+
+    OzoneFileStatus status = reader.getFileStatus(keyArgs);
+    assertEquals(expectedStatus, status);
+    verify(keyManager).getFileStatus(any(OmKeyArgs.class), anyString());
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -782,6 +782,12 @@ public class BasicRootedOzoneClientAdapterImpl
         Iterator<? extends OzoneBucket> bucketIter = volume.listBuckets("");
         while (bucketIter.hasNext()) {
           OzoneBucket bucket = bucketIter.next();
+          // OBJECT_STORE buckets have no file system semantics, so no trash
+          // root. Skip them; probing would fail getFileStatus with
+          // IllegalArgumentException and abort the whole scan.
+          if (BucketLayout.OBJECT_STORE.equals(bucket.getBucketLayout())) {
+            continue;
+          }
           Path bucketPath = new Path(volumePath, bucket.getName());
           Path trashRoot = new Path(bucketPath, FileSystem.TRASH_PREFIX);
           if (allUsers) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -722,10 +722,12 @@ public class BasicRootedOzoneClientAdapterImpl
         throw new FileNotFoundException(key + ": No such file or directory!");
       } else if (e.getResult() == OMException.ResultCodes.BUCKET_NOT_FOUND) {
         throw new FileNotFoundException(key + ": Bucket doesn't exist!");
-      }
-      String message = e.getMessage();
-      if (message != null && message.contains("does not support file system semantics")) {
-        throw new IllegalArgumentException(message);
+      } else if (e.getResult()
+          == OMException.ResultCodes.NOT_SUPPORTED_OPERATION) {
+        // OM rejects getFileStatus on an OBJECT_STORE bucket (no file system
+        // semantics). Surface it as IllegalArgumentException, matching the
+        // pre-HDDS-15925 client-side layout check.
+        throw new IllegalArgumentException(e.getMessage());
       }
       throw e;
     }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -76,6 +76,7 @@ import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneFsServerDefaults;
+import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -700,6 +701,13 @@ public class BasicRootedOzoneClientAdapterImpl
    * <p>Non-snapshot paths call OM GetFileStatus directly (HDDS-15925) without a
    * prior InfoBucket RPC. OBJECT_STORE buckets are rejected by OM GetFileStatus.
    * Mutating OFS operations still validate layout via {@link #getBucket(OFSPath, boolean)}.
+   *
+   * <p>The direct call is only safe once the OM performs the server-side
+   * OBJECT_STORE rejection. During a rolling upgrade a new client can talk to an
+   * older OM that lacks that check, so when the negotiated OM version predates
+   * {@link OzoneManagerVersion#GET_FILE_STATUS_REJECTS_OBS} we fall back to the
+   * pre-HDDS-15925 path that fetches the bucket and validates its layout
+   * client-side.
    */
   private FileStatusAdapter getFileStatusForKeyOrSnapshot(
       OFSPath ofsPath, URI uri, Path qualifiedPath, String userName,
@@ -712,8 +720,17 @@ public class BasicRootedOzoneClientAdapterImpl
         return getFileStatusAdapterWithSnapshotIndicator(
             volume, bucket, uri);
       } else {
-        OzoneFileStatus status = proxy.getOzoneFileStatus(ofsPath.getVolumeName(),
-            ofsPath.getBucketName(), key, headOp);
+        OzoneFileStatus status;
+        if (proxy.getOmVersion()
+            .compareTo(OzoneManagerVersion.GET_FILE_STATUS_REJECTS_OBS) >= 0) {
+          status = proxy.getOzoneFileStatus(ofsPath.getVolumeName(),
+              ofsPath.getBucketName(), key, headOp);
+        } else {
+          // Older OM has no server-side OBJECT_STORE check; validate the bucket
+          // layout on the client, matching pre-HDDS-15925 behavior.
+          OzoneBucket bucket = getBucket(ofsPath, false);
+          status = bucket.getFileStatus(key, headOp);
+        }
         return toFileStatusAdapter(status, userName, uri, qualifiedPath,
             ofsPath.getNonKeyPath());
       }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -345,6 +345,12 @@ public class BasicRootedOzoneClientAdapterImpl
         }
         // Try get bucket again
         bucket = proxy.getBucketDetails(volumeStr, bucketStr);
+
+        BucketLayout resolvedBucketLayout =
+            OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
+                new HashSet<>());
+
+        OzoneFSUtils.validateBucketLayout(bucket.getName(), resolvedBucketLayout);
       } else {
         throw ex;
       }
@@ -690,19 +696,24 @@ public class BasicRootedOzoneClientAdapterImpl
    * Return FileStatusAdapter based on OFSPath being a
    * valid bucket path or valid snapshot path.
    * Throws exception in case of failure.
+   *
+   * <p>Non-snapshot paths call OM GetFileStatus directly (HDDS-15925) without a
+   * prior InfoBucket RPC. OBJECT_STORE buckets are rejected by OM GetFileStatus.
+   * Mutating OFS operations still validate layout via {@link #getBucket(OFSPath, boolean)}.
    */
   private FileStatusAdapter getFileStatusForKeyOrSnapshot(
       OFSPath ofsPath, URI uri, Path qualifiedPath, String userName,
       boolean headOp) throws IOException {
     String key = ofsPath.getKeyName();
     try {
-      OzoneBucket bucket = getBucket(ofsPath, false);
       if (ofsPath.isSnapshotPath()) {
+        OzoneBucket bucket = getBucket(ofsPath, false);
         OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
         return getFileStatusAdapterWithSnapshotIndicator(
             volume, bucket, uri);
       } else {
-        OzoneFileStatus status = bucket.getFileStatus(key, headOp);
+        OzoneFileStatus status = proxy.getOzoneFileStatus(ofsPath.getVolumeName(),
+            ofsPath.getBucketName(), key, headOp);
         return toFileStatusAdapter(status, userName, uri, qualifiedPath,
             ofsPath.getNonKeyPath());
       }
@@ -711,6 +722,10 @@ public class BasicRootedOzoneClientAdapterImpl
         throw new FileNotFoundException(key + ": No such file or directory!");
       } else if (e.getResult() == OMException.ResultCodes.BUCKET_NOT_FOUND) {
         throw new FileNotFoundException(key + ": Bucket doesn't exist!");
+      }
+      String message = e.getMessage();
+      if (message != null && message.contains("does not support file system semantics")) {
+        throw new IllegalArgumentException(message);
       }
       throw e;
     }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -62,15 +63,20 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   private BasicRootedOzoneClientAdapterImpl adapter;
   private OzoneBucket bucket;
+  private ClientProtocol proxy;
 
   @BeforeEach
   public void setUp() throws Exception {
     adapter = mock(BasicRootedOzoneClientAdapterImpl.class, CALLS_REAL_METHODS);
     bucket = mock(OzoneBucket.class);
+    proxy = mock(ClientProtocol.class);
     doReturn(bucket).when(adapter).getBucket(any(OFSPath.class), eq(false));
 
-    // Inject a mock object store so the volume/snapshot dispatch branches can
-    // run without a live OM connection.
+    Field proxyField =
+        BasicRootedOzoneClientAdapterImpl.class.getDeclaredField("proxy");
+    proxyField.setAccessible(true);
+    proxyField.set(adapter, proxy);
+
     OzoneVolume volume = mock(OzoneVolume.class);
     when(volume.getName()).thenReturn("vol");
     when(volume.getOwner()).thenReturn("user");
@@ -101,25 +107,26 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void keyPathThreadsHeadOp() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
         .thenReturn(fileStatus(false));
 
     assertFalse(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user", true).isDir());
 
     ArgumentCaptor<Boolean> headOp = ArgumentCaptor.forClass(Boolean.class);
-    verify(bucket).getFileStatus(anyString(), headOp.capture());
+    verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), eq("key"),
+        headOp.capture());
     assertTrue(headOp.getValue());
   }
 
   @Test
   public void fourArgOverloadDoesNotUseHeadOp() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
         .thenReturn(fileStatus(true));
 
     assertTrue(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user").isDir());
-    verify(bucket).getFileStatus(anyString(), eq(false));
+    verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), eq("key"), eq(false));
   }
 
   @Test
@@ -130,7 +137,7 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void fileNotFoundMappedToFileNotFoundException() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
         .thenThrow(new OMException("missing",
             OMException.ResultCodes.FILE_NOT_FOUND));
     assertThrows(FileNotFoundException.class,
@@ -140,7 +147,7 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void otherOMExceptionPropagates() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
         .thenThrow(new OMException("boom",
             OMException.ResultCodes.INTERNAL_ERROR));
     assertThrows(OMException.class,
@@ -150,7 +157,7 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
 
   @Test
   public void bucketNotFoundMappedToFileNotFoundException() throws IOException {
-    when(bucket.getFileStatus(anyString(), anyBoolean()))
+    when(proxy.getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean()))
         .thenThrow(new OMException("no bucket",
             OMException.ResultCodes.BUCKET_NOT_FOUND));
     assertThrows(FileNotFoundException.class,
@@ -169,7 +176,6 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
     when(bucket.getVolumeName()).thenReturn("vol");
     when(bucket.getName()).thenReturn("bucket");
     when(bucket.getCreationTime()).thenReturn(Instant.EPOCH);
-    // keyName == ".snapshot" is the snapshot indicator path.
     assertTrue(adapter.getFileStatus("/vol/bucket/.snapshot", URI_OFS,
         WORKING_DIR, "user", true).isDir());
   }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicRootedOzoneClientAdapterHeadOp.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +41,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OFSPath;
+import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -70,6 +72,8 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
     adapter = mock(BasicRootedOzoneClientAdapterImpl.class, CALLS_REAL_METHODS);
     bucket = mock(OzoneBucket.class);
     proxy = mock(ClientProtocol.class);
+    when(proxy.getOmVersion())
+        .thenReturn(OzoneManagerVersion.GET_FILE_STATUS_REJECTS_OBS);
     doReturn(bucket).when(adapter).getBucket(any(OFSPath.class), eq(false));
 
     Field proxyField =
@@ -127,6 +131,25 @@ public class TestBasicRootedOzoneClientAdapterHeadOp {
     assertTrue(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
         "user").isDir());
     verify(proxy).getOzoneFileStatus(eq("vol"), eq("bucket"), eq("key"), eq(false));
+  }
+
+  @Test
+  public void olderOmFallsBackToClientSideBucketCheck() throws IOException {
+    // An OM older than GET_FILE_STATUS_REJECTS_OBS has no server-side
+    // OBJECT_STORE rejection, so the adapter must use the pre-HDDS-15925 path:
+    // fetch the bucket (which validates layout client-side) and call
+    // OzoneBucket#getFileStatus, without issuing a direct OM GetFileStatus.
+    when(proxy.getOmVersion())
+        .thenReturn(OzoneManagerVersion.S3_BUCKET_TAGGING_API);
+    when(bucket.getFileStatus(anyString(), anyBoolean()))
+        .thenReturn(fileStatus(false));
+
+    assertFalse(adapter.getFileStatus("/vol/bucket/key", URI_OFS, WORKING_DIR,
+        "user", true).isDir());
+
+    verify(bucket).getFileStatus(eq("key"), eq(true));
+    verify(proxy, never())
+        .getOzoneFileStatus(anyString(), anyString(), anyString(), anyBoolean());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneFsServerDefaults;
+import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
@@ -615,6 +616,11 @@ public class ClientProtocolStub implements ClientProtocol {
   @Override
   public TenantStateList listTenant() throws IOException {
     return null;
+  }
+
+  @Override
+  public OzoneManagerVersion getOmVersion() {
+    return OzoneManagerVersion.CURRENT;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

OFS `getFileStatus` on a non-snapshot path used to issue **two** OM RPCs per call:
an `InfoBucket` RPC (only so the client could read the bucket layout and reject
OBJECT_STORE buckets, which have no file system semantics) followed by the actual
`getFileStatus` RPC. On a namespace-walk / listing-heavy workload this doubles the
OM read-RPC volume for no functional gain.

This PR removes the redundant `InfoBucket` RPC by moving the layout check to where
the authoritative bucket metadata already lives — the OM:

* **Client (`BasicRootedOzoneClientAdapterImpl`)** — the non-snapshot `getFileStatus`
  path now calls `proxy.getOzoneFileStatus(...)` directly instead of first fetching
  the bucket. Mutating OFS operations still resolve and validate layout through
  `getBucket(...)`, and snapshot paths are unchanged.
* **Server (`OmMetadataReader.getFileStatus`)** — validates the bucket layout and
  rejects OBJECT_STORE buckets. The `IllegalArgumentException` from
  `OzoneFSUtils.validateBucketLayout` is wrapped as
  `OMException(NOT_SUPPORTED_OPERATION)` so it is returned as a normal
  (non-retryable) RPC response instead of escaping the read handler's `IOException`
  catch and triggering a client-side retry storm.
* **Client error mapping** — on `NOT_SUPPORTED_OPERATION` the adapter re-throws
  `IllegalArgumentException` (preserving the pre-existing OFS behavior and message),
  keyed on the `ResultCode` rather than on the message text so the two sides are not
  coupled through a string.
* **Rolling-upgrade version gate** — the direct call is only taken when the
  negotiated OM version is new enough to perform the server-side check; against an
  older OM the client falls back to the pre-HDDS-15925 path (see the compatibility
  note below).
* **`getTrashRoots` skips OBJECT_STORE buckets** — `getTrashRoots(allUsers=true)`
  iterates every volume/bucket and probes each bucket's trash path with `exists()`.
  OBJECT_STORE buckets have no file system semantics (hence no trash root), and
  `getFileStatus` on them now surfaces `IllegalArgumentException`, which `exists()`
  does not swallow and which would abort the whole scan. The scan now skips
  OBJECT_STORE buckets up front (reusing the `OzoneBucket` already listed, no extra
  RPC). This also hardens the trash emptier against clusters that contain OBS
  buckets, which previously could throw out of `getTrashRoots`.

No protobuf/wire change: RPC signatures and the `GetFileStatus` messages are
unchanged, and `NOT_SUPPORTED_OPERATION` is a pre-existing result code.

### Compatibility note

The OBS-rejection check moves from the client to the OM. In a rolling upgrade, a
**new OFS client talking to an old OM** would otherwise stop rejecting
`getFileStatus` on an OBJECT_STORE bucket, because the old OM has no server-side
check and the new client no longer performs the `InfoBucket`-based one.

This is now handled with a version gate on the already-negotiated OM version:

* A new `OzoneManagerVersion.GET_FILE_STATUS_REJECTS_OBS` marks the server version
  that performs the OBS rejection. This is an additive Java enum constant carried
  over the existing `OMVersion` int in `ServiceInfo` — **no protobuf/wire change**;
  unknown values still map to `FUTURE_VERSION`.
* `ClientProtocol.getOmVersion()` exposes the negotiated version (in HA this is the
  **minimum** across all OMs, so a single old OM forces the safe path), implemented
  by `RpcClient` from the version it already captures during handshake.
* `BasicRootedOzoneClientAdapterImpl.getFileStatusForKeyOrSnapshot` gates on it:
  when the OM is `>= GET_FILE_STATUS_REJECTS_OBS` it issues the direct
  `getOzoneFileStatus` call and relies on the server-side rejection; otherwise it
  falls back to fetching the bucket and validating its layout client-side — the
  exact pre-HDDS-15925 behavior, including rejecting OBS with
  `IllegalArgumentException`.

New-client/new-OM takes the optimized single-RPC path; new-client/old-OM keeps the
old two-RPC behavior with the client-side check; old-client/* is unaffected.

Generated-by: Claude Code (Claude Opus 4.8)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15925

## How was this patch tested?

clean CI run: https://github.com/yandrey321/ozone/actions/runs/34513864283

* Unit: `TestOMMetadataReader` (server-side rejection returns
  `OMException(NOT_SUPPORTED_OPERATION)`, `keyManager.getFileStatus` not called for
  OBS), `TestBasicRootedOzoneClientAdapterHeadOp` (8/8).
* Integration: `TestOFS#testGetFileStatusRejectsObsBucket` — verifies OBS
  `getFileStatus` is rejected over RPC as `IllegalArgumentException` with **0**
  InfoBucket RPCs; the OFS getFileStatus suite in `AbstractRootedOzoneFileSystemTest`.
* Benchmark: `TestOfsGetFileStatusCacheBenchmark` (tagged `benchmark`), numbers above.
* `checkstyle.sh` clean; affected modules build.

### Benchmark

Measured with `TestOfsGetFileStatusCacheBenchmark` (200 buckets × 10 accesses =
2000 getFileStatus calls), same base and machine, against baseline and the
client-side cache alternative (PR #11176):

| Metric | Baseline | #11176 (client cache) | This PR (server-side) |
|---|---|---|---|
| InfoBucket RPCs | 2000 | 200 | **0** |
| getFileStatus RPCs | 2000 | 2000 | 2000 |
| Single-thread p99 | 0.32–0.48 ms | 0.29–0.37 ms | 0.22–0.28 ms |
| Single-thread throughput | ~3.7–4.5k ops/s | ~5.4–6.5k ops/s | ~6.1–7.2k ops/s |
| 10-thread p99 | 1.033 ms | 0.818 ms | 0.719 ms |
| 10-thread throughput | 16.2k ops/s | 26.9k ops/s | 26.1k ops/s |

The `getFileStatus` RPC count is identical everywhere — the change removes only the
redundant `InfoBucket` RPC. This PR removes it entirely (0), giving the lowest RPC
count and the best latency tail with no client-side cache state or new config.



