### PR TITLE
HDDS-16399. Fix flaky testFinalizationEmptyClusterDataDistribution

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmDataDistributionFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmDataDistributionFinalization.java
@@ -79,7 +79,6 @@ import org.apache.hadoop.ozone.common.DeletedBlock;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -161,7 +160,6 @@ public class TestScmDataDistributionFinalization {
    * Test for an empty cluster.
    */
   @Test
-  @Flaky("HDDS-14050")
   public void testFinalizationEmptyClusterDataDistribution() throws Exception {
     init(new OzoneConfiguration());
     assertEquals(EMPTY_SUMMARY, cluster.getStorageContainerLocationClient().getDeletedBlockSummary());
@@ -190,6 +188,11 @@ public class TestScmDataDistributionFinalization {
     StorageContainerManager activeSCM = cluster.getActiveSCM();
     assertEquals(-1, lastTxId, "Last transaction ID should be -1");
 
+    // Stop deleting service so it cannot race the summary assertions below.
+    for (StorageContainerManager scm : cluster.getStorageContainerManagersList()) {
+      scm.getScmBlockManager().getSCMBlockDeletingService().stop();
+    }
+
     // generate old format deletion tx, summary should keep empty, total DB tx 4
     int txCount = 4;
     DeletedBlockLogImpl deletedBlockLog = (DeletedBlockLogImpl) activeSCM.getScmBlockManager().getDeletedBlockLog();
@@ -217,6 +220,11 @@ public class TestScmDataDistributionFinalization {
     assertEquals(txCount * BLOCKS_PER_TX * BLOCK_SIZE, summary.getTotalBlockSize());
     assertEquals(txCount * BLOCKS_PER_TX * BLOCK_SIZE * 3, summary.getTotalBlockReplicatedSize());
 
+    // Restart deleting service so transactions are drained below.
+    for (StorageContainerManager scm : cluster.getStorageContainerManagersList()) {
+      scm.getScmBlockManager().getSCMBlockDeletingService().start();
+    }
+
     // wait for all transactions deleted by SCMBlockDeletingService
     GenericTestUtils.waitFor(() -> {
       try {
@@ -227,6 +235,11 @@ public class TestScmDataDistributionFinalization {
         return false;
       }
     }, 100, 5000);
+
+    // Stop deleting service again to prevent it from racing the summary assertions below.
+    for (StorageContainerManager scm : cluster.getStorageContainerManagersList()) {
+      scm.getScmBlockManager().getSCMBlockDeletingService().stop();
+    }
 
     // generate old format deletion tx, summary should keep the same
     deletedBlockLog.addTransactions(generateDeletedBlocks(txCount, false));


### PR DESCRIPTION
## What changes were proposed in this pull request?

@errose28 found that the test TestScmDataDistributionFinalization.testFinalizationEmptyClusterDataDistribution() fails about 1 time per 100 runs. This was also reported in [HDDS-14050](https://issues.apache.org/jira/browse/HDDS-14050) as the test is marked as flaky in the code.

The issue seems to be caused by race conditions in background services. Pasting directly from Claude:

```
1. Line 209: addTransactions(txList) — incrDeletedBlocksSummary increments totalTxCount to 4 (in-memory, before the DB write), then writes txs + summary to the buffer.
2. Line 210: flushDBTransactionBuffer — the 4 new-format txs are now in RocksDB.
3. SCMBlockDeletingService runs concurrently (every 100ms): calls getTransactions, which calls getTransaction → addTxToTxSizeMap for each sent tx (line 330–335 in DeletedBlockLogImpl) — this populates txSizeMap for those tx IDs.
4. DNs confirm deletion fast in the mini-cluster → commitTransactions → removeTransactions → txSizeMap.remove(txID) returns the TxBlockInfo → descDeletedBlocksSummary × 4 → totalTxCount drops to 0.
5. But: the removal is only in the transaction buffer, not yet committed to RocksDB.
6. Line 212: getRowsInTable reads RocksDB directly → still sees 4 rows. ✓
7. Line 215: getTransactionSummary reads in-memory totalTxCount → 0. ✗txSizeMap is indeed never populated in addTransactions itself — it only gets populated in addTxToTxSizeMap when the block deleting service calls getTransactions and decides to send a tx to a DN. The service is the path that both populates txSizeMap and later drains it.The fix is the same pattern used in testFinalizationNonEmptyClusterDataDistribution: stop the SCMBlockDeletingService before the section that asserts the summary counts, and restart it before the waitFor that expects deletion to complete (line 221). 
```
There was also a second type of failure also caused by race conditions with the background services:

```
 [ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 98.10 s <<< FAILURE! -- in org.apache.hadoop.hdds.upgrade.TestScmDataDistributionFinalization
[ERROR] org.apache.hadoop.hdds.upgrade.TestScmDataDistributionFinalization.testFinalizationEmptyClusterDataDistribution -- Time elapsed: 35.66 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
expected: <totalTransactionCount: 0
totalBlockCount: 0
totalBlockSize: 0
totalBlockReplicatedSize: 0
> but was: <totalTransactionCount: 18446744073709551612
totalBlockCount: 18446744073709551596
totalBlockSize: 18446744073688580096
totalBlockReplicatedSize: 18446744073646637056
>
```

This appears to also be caused by the same background services and stopping it appears to fix it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16399

## How was this patch tested?

Ran the changed test a few times and it passed. 200 runs in the CI workflow all passed:

https://github.com/sodonnel/hadoop-ozone/actions/runs/34502343306/job/102961261439
